### PR TITLE
Relay actuator (phase B): safety-gated DRM contacts through MQTT, REST and HA

### DIFF
--- a/docs/modbus-register-map.md
+++ b/docs/modbus-register-map.md
@@ -193,6 +193,8 @@ there is no possible confusion with a valid value.
 | 816 | 2 | uint32 | REST requests |
 | 818 | 2 | uint32 | Invalid frames |
 | 820 | 3 | uint16[3] | Firmware version major/minor/patch |
+| 850 | 1 | uint16 | Relay count — `0xFFFF` = no relay hardware on this board |
+| 851 | 1 | uint16 | Relay state bitmask (bit *i* = relay *i* energised); `0xFFFF` without hardware |
 
 ## Examples
 
@@ -339,3 +341,7 @@ consumer would treat it as current. Unknown is therefore the more honest answer 
   depends on the inverter's behavior — to be determined in Phase 9.
 - The eModbus server wiring (`modbus_tcp_server.cpp`) has **not been compiled yet**; only the
   register map has been tested.
+
+Registers 850-851 are **read-only observation** of the bridge relays (DRM contacts).
+Relay control never goes through Modbus: the unauthenticated Modbus surface only
+observes, and commands go through the admin-gated REST/MQTT paths and their gates.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -17,6 +17,8 @@ Configurable; defaults to being derived from the MAC so that two bridges never c
 | `heliograph/<bridge_id>/diagnostics` | ✔ | 0 | Bridge diagnostics (JSON) |
 | `heliograph/<bridge_id>/identity` | ✔ | 1 | Device identity (JSON) |
 | `heliograph/<bridge_id>/capabilities` | ✔ | 1 | Capabilities (JSON) |
+| `heliograph/<bridge_id>/relay/<n>/state` | ✔ | 1 | `ON` / `OFF` — relay boards only |
+| `heliograph/<bridge_id>/relay/<n>/set` | — | 1 | Command topic (subscribed) — relay boards only |
 
 **Last Will and Testament:** topic `availability`, payload `offline`, retained, QoS 1. On a
 clean shutdown, the bridge publishes `offline` itself.
@@ -26,8 +28,12 @@ inverter that's off at night doesn't make the bridge offline — that would make
 entities `unavailable` in Home Assistant and ruin the history. The inverter status lives in
 `state` as `inverter_online`.
 
-There are **no command topics.** The active driver has no write capabilities, so the
-bridge doesn't subscribe to anything. That is not a configuration choice but a consequence of
+The `relay/<n>/set` topics (relay boards only) are the single subscription this firmware
+has. Commands pass the RelayController's gates — `security.read_only_mode` off AND
+`relays.enabled` on — and the acknowledged state follows on `relay/<n>/state`, so a
+refused command visibly snaps the Home Assistant switch back. There are **no command
+topics for the inverter.** The active driver has no write capabilities, so the
+bridge subscribes to nothing else. That is not a configuration choice but a consequence of
 `capabilities.write.none()`.
 
 ## Publishing strategy

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,6 +65,7 @@ build_src_filter =
     +<transport/transport.cpp>
     +<state/>
     +<commands/>
+    +<relays/>
     +<diagnostics/>
     +<drivers/driver_registry.cpp>
     +<drivers/discovery_engine.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -185,6 +185,9 @@ build_flags =
     -DARDUINO_USB_MODE=1
     -DBOARD_HAS_PSRAM
     -DHELIOGRAPH_BOARD_RS485_CAN
+    ; Two virtual relays through the full MQTT/REST/HA stack, no pins touched: the whole
+    ; relay feature is exercisable on a board without relay hardware.
+    -DHELIOGRAPH_MOCK_RELAYS=2
     -DENABLE_DRIVER_EVERSOLAR=0
     -DENABLE_DRIVER_GROWATT=0
     -DENABLE_DRIVER_SOLAX=0

--- a/src/commands/command_dispatcher.cpp
+++ b/src/commands/command_dispatcher.cpp
@@ -21,15 +21,17 @@ CommandDispatcher::CommandDispatcher(ClockFn clock, RateLimitPolicy rateLimit)
     : clock_(std::move(clock)), rateLimit_(rateLimit) {}
 
 bool CommandDispatcher::allowedByRateLimit(uint64_t nowMs) {
-    if (lastAcceptedMs_ != 0 && nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+    if (everAccepted_ && nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
         burstUsed_ = 0;  // quiet long enough, the allowance refills
     }
     if (burstUsed_ < rateLimit_.burst) {
         ++burstUsed_;
+        everAccepted_   = true;
         lastAcceptedMs_ = nowMs;
         return true;
     }
-    if (lastAcceptedMs_ == 0 || nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+    if (!everAccepted_ || nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+        everAccepted_   = true;
         lastAcceptedMs_ = nowMs;
         return true;
     }

--- a/src/commands/command_dispatcher.h
+++ b/src/commands/command_dispatcher.h
@@ -52,6 +52,10 @@ private:
     RateLimitPolicy rateLimit_;
     bool            readOnly_ = true;
 
+    // Explicit flag, not a "0 means never" sentinel: millis() at boot IS near zero, and
+    // the sentinel collision let the first post-boot window bypass the throttle (found by
+    // the RelayController's twin of this logic, 2026-07-22).
+    bool     everAccepted_   = false;
     uint64_t lastAcceptedMs_ = 0;
     uint32_t burstUsed_      = 0;
 };

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -270,6 +270,8 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
 
     doc["polling"]["interval_seconds"] = config.polling.intervalSeconds;
 
+    doc["relays"]["enabled"] = config.relays.enabled;
+
     JsonObject driver           = doc["driver"].to<JsonObject>();
     driver["id"]                = config.driver.id;
     driver["auto_detect"]       = config.driver.autoDetect;
@@ -357,6 +359,10 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
         }
     }
 
+
+    if (JsonObjectConst relays = doc["relays"]; !relays.isNull()) {
+        if (!patchBool(relays["enabled"], merged.relays.enabled, "relays.enabled", error)) return false;
+    }
 
     if (JsonObjectConst ntp = doc["ntp"]; !ntp.isNull()) {
         if (!patchBool(ntp["enabled"], merged.ntp.enabled, "ntp.enabled", error)) return false;

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -90,6 +90,14 @@ struct NtpSettings {
     std::string timezoneName = "Europe/Amsterdam";
 };
 
+struct RelaySettings {
+    /// Master enable for the board's relays (DRM curtailment contacts). Off by default:
+    /// a relay board with factory settings must be inert. Boards without relays ignore
+    /// this entirely. Note the double gate: security.readOnlyMode must ALSO be off before
+    /// a relay moves -- enabling relays alone is not enough, by design.
+    bool enabled = false;
+};
+
 struct SecuritySettings {
     std::string adminUsername = "admin";
     std::string adminPassword;  ///< never serialised, never logged; empty = mutations refused
@@ -105,6 +113,7 @@ struct Configuration {
     ModbusSettings   modbus;
     PollingSettings  polling;
     DriverSettings   driver;
+    RelaySettings    relays;
     NtpSettings      ntp;
     SecuritySettings security;
     LogLevel         logLevel = LogLevel::Info;

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -99,6 +99,7 @@ bool serializeConfigForStorage(const Configuration& config, std::string& out) {
     modbus["write_enabled"]       = config.modbus.writeEnabled;
 
     doc["polling"]["interval_seconds"] = config.polling.intervalSeconds;
+    doc["relays"]["enabled"]           = config.relays.enabled;
 
     JsonObject driver     = doc["driver"].to<JsonObject>();
     driver["id"]          = config.driver.id;
@@ -223,6 +224,9 @@ LoadResult deserializeConfigFromStorage(const std::string& json, Configuration& 
     }
     if (JsonObjectConst polling = doc["polling"]; !polling.isNull()) {
         if (polling["interval_seconds"].is<uint32_t>()) parsed.polling.intervalSeconds = polling["interval_seconds"].as<uint32_t>();
+    }
+    if (JsonObjectConst relays = doc["relays"]; !relays.isNull()) {
+        if (relays["enabled"].is<bool>()) parsed.relays.enabled = relays["enabled"].as<bool>();
     }
     if (JsonObjectConst driver = doc["driver"]; !driver.isNull()) {
         if (driver["id"].is<const char*>())    parsed.driver.id = driver["id"].as<const char*>();

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -52,6 +52,14 @@ struct BridgeInfo {
     /// Set by main from board::kName; the default only serves host tests, which have no
     /// board header.
     std::string boardName = "Waveshare ESP32-S3-RS485-CAN";
+
+    /// Bridge-local relays (DRM curtailment contacts on relay boards). Count 0 = the board
+    /// has none, and every output omits the topic/field entirely -- absent, not zero, per
+    /// the house rule. `relayMask` bit i = relay i energised; `relaysEnabled` mirrors the
+    /// config flag so outputs can announce switches only when they can actually act.
+    uint8_t relayCount    = 0;
+    uint8_t relayMask     = 0;
+    bool    relaysEnabled = false;
 };
 
 }  // namespace heliograph

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,14 +286,16 @@ void startRestApi() {
             std::lock_guard<std::mutex> lock(g_configMutex);
             g_config = c;
         }
-        // The relay gates follow the config immediately -- no restart. Disabling the
-        // feature also releases every relay: "off in the settings" must mean the contacts
-        // are open, not frozen in their last state.
+        // The relay gates follow the config immediately -- no restart. Closing EITHER
+        // gate also releases every relay: with the gate closed, no command -- not even
+        // OFF -- would get through, so an energised contact would otherwise stay frozen
+        // with DRM asserted and no way to release it. The failsafe direction (contacts
+        // open, inverter runs) is the only state a closed gate may leave behind.
         {
             std::lock_guard<std::mutex> lock(g_relayMutex);
             g_relays.setReadOnlyMode(c.security.readOnlyMode);
             g_relays.setEnabled(c.relays.enabled);
-            if (!c.relays.enabled) {
+            if (!c.relays.enabled || c.security.readOnlyMode) {
                 g_relays.allOff();
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "outputs/modbus_tcp/modbus_tcp_server.h"
 #include "outputs/mqtt/mqtt_output.h"
 #include "outputs/rest/rest_api.h"
+#include "relays/relay_controller.h"
 #include "state/state_store.h"
 #include "transport/rs485_transport.h"
 
@@ -49,7 +50,7 @@ namespace {
 // image identifiable over the API. Without it two different builds both reported "0.1.0" and a
 // flash could not be told from the previous one -- exactly what bit the post-flash check on
 // 2026-07-21. Bumped to 0.2.0 for the Fase 9 review batch.
-constexpr const char* kFirmwareVersion = "0.6.1 (" __DATE__ " " __TIME__ ")";
+constexpr const char* kFirmwareVersion = "0.7.0 (" __DATE__ " " __TIME__ ")";
 
 Rs485Transport     g_transport;
 DriverRegistry     g_registry;
@@ -87,6 +88,12 @@ std::atomic<uint64_t> g_rebootAtMs{0};
 std::atomic<bool> g_manualPollRequested{false};
 
 uint64_t nowMs() { return static_cast<uint64_t>(millis()); }
+
+/// The bridge's DRM relays (empty on boards without them). Commands arrive on two tasks
+/// (REST via AsyncTCP, MQTT via the client's task); g_relayMutex serialises them and the
+/// state reads in bridgeInfo(). The controller itself stays lock-free and host-testable.
+RelayController g_relays{nowMs};
+std::mutex      g_relayMutex;
 
 /// Owns discovery runs. The web handler requests; rs485Task runs, because it owns the bus.
 DiscoveryRunner g_discovery{g_registry, nowMs};
@@ -128,6 +135,16 @@ BridgeInfo bridgeInfo() {
     info.ntpServer        = ntpSource.server;
     info.ntpFromDhcp      = ntpSource.fromDhcp;
     info.otaImageState    = ota::imageStateName();
+    if (g_relays.count() > 0) {
+        std::lock_guard<std::mutex> lock(g_relayMutex);
+        info.relayCount    = g_relays.count();
+        info.relaysEnabled = g_relays.enabled();
+        for (uint8_t i = 0; i < g_relays.count(); ++i) {
+            if (g_relays.energised(i)) {
+                info.relayMask |= static_cast<uint8_t>(1u << i);
+            }
+        }
+    }
     return info;
 }
 
@@ -240,6 +257,12 @@ void startOutputs() {
         cfg.qos              = configSnapshot.mqtt.qos;
         g_mqtt               = std::make_unique<mqtt::MqttOutput>(cfg);
         g_mqtt->setDiagnostics(&g_diagnostics);
+        if (g_relays.count() > 0) {
+            g_mqtt->setRelayCommandHandler([](uint8_t index, bool on) {
+                std::lock_guard<std::mutex> lock(g_relayMutex);
+                return g_relays.set(index, on);
+            });
+        }
         g_mqtt->begin(bridgeInfo());
         // The host is not a secret; the password must never reach a log.
         log::info("mqtt: broker %s:%u", cfg.host.c_str(), cfg.port);
@@ -259,8 +282,21 @@ void startRestApi() {
     // bridgeInfo(); without the lock that is a use-after-free waiting on a settings save
     // landing mid-poll (review, 2026-07-21).
     ctx.applyConfig = [](const Configuration& c) {
-        std::lock_guard<std::mutex> lock(g_configMutex);
-        g_config = c;
+        {
+            std::lock_guard<std::mutex> lock(g_configMutex);
+            g_config = c;
+        }
+        // The relay gates follow the config immediately -- no restart. Disabling the
+        // feature also releases every relay: "off in the settings" must mean the contacts
+        // are open, not frozen in their last state.
+        {
+            std::lock_guard<std::mutex> lock(g_relayMutex);
+            g_relays.setReadOnlyMode(c.security.readOnlyMode);
+            g_relays.setEnabled(c.relays.enabled);
+            if (!c.relays.enabled) {
+                g_relays.allOff();
+            }
+        }
     };
     ctx.bridgeInfo  = bridgeInfo;
     ctx.clock       = nowMs;
@@ -291,6 +327,14 @@ void startRestApi() {
     ctx.requestFactoryReset = [] { return g_store.factoryReset(); };
     ctx.portalActive        = [] { return g_wifi.portalActive(); };
     ctx.scanNetworks        = scanNetworksJson;
+    if (g_relays.count() > 0) {
+        // Behind the same mutex as the MQTT path: REST commands arrive on the AsyncTCP
+        // task, MQTT commands on the MQTT task.
+        ctx.setRelay = [](uint8_t index, bool on) {
+            std::lock_guard<std::mutex> lock(g_relayMutex);
+            return g_relays.set(index, on);
+        };
+    }
 
     g_rest = std::make_unique<rest::RestApi>(ctx);
     g_rest->begin();
@@ -388,6 +432,28 @@ void setup() {
             log::warn("rtc: present but time not set (first boot or empty backup supply)");
         }
     }
+
+    // Relays, on boards that have them: pins to OUTPUT and everything de-energised before
+    // anything else can fail. The gates start closed (read-only on, enabled off) and only
+    // the config below opens them. Under HELIOGRAPH_MOCK_RELAYS the mock build exposes
+    // virtual relays through the full MQTT/REST/HA stack without touching a single pin.
+#if defined(HELIOGRAPH_MOCK_RELAYS)
+    g_relays.begin(HELIOGRAPH_MOCK_RELAYS, [](uint8_t i, bool on) {
+        log::info("relay[mock] %u -> %s", i + 1, on ? "ON" : "OFF");
+    });
+#else
+    if (board::kRelayCount > 0) {
+        for (int i = 0; i < board::kRelayCount; ++i) {
+            pinMode(board::kRelayPins[i], OUTPUT);
+        }
+        g_relays.begin(static_cast<uint8_t>(board::kRelayCount), [](uint8_t i, bool on) {
+            digitalWrite(board::kRelayPins[i],
+                         (on == board::kRelayActiveHigh) ? HIGH : LOW);
+        });
+    }
+#endif
+    g_relays.setReadOnlyMode(g_config.security.readOnlyMode);
+    g_relays.setEnabled(g_config.relays.enabled);
 
     // A factory-fresh device gets a UNIQUE default hostname (heliograph-a1b2c3, from the
     // MAC) instead of the shared "heliograph": two bridges on one LAN -- configuring a

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -283,6 +283,15 @@ void RegisterMap::update(const DeviceState& state, const BridgeInfo& bridge,
     writeU16(reg::kDiagFirmwareMajor, bridge.firmwareMajor);
     writeU16(reg::kDiagFirmwareMinor, bridge.firmwareMinor);
     writeU16(reg::kDiagFirmwarePatch, bridge.firmwarePatch);
+    // Read-only observation of the bridge relays; the sentinel distinguishes "no relay
+    // hardware" from "relays, none energised". Control never goes through Modbus.
+    if (bridge.relayCount > 0) {
+        writeU16(reg::kDiagRelayCount, bridge.relayCount);
+        writeU16(reg::kDiagRelayMask, bridge.relayMask);
+    } else {
+        writeU16(reg::kDiagRelayCount, kInvalidU16);
+        writeU16(reg::kDiagRelayMask, kInvalidU16);
+    }
 }
 
 bool RegisterMap::read(uint16_t address, uint16_t count, uint16_t* out) const {

--- a/src/outputs/modbus_tcp/register_map.h
+++ b/src/outputs/modbus_tcp/register_map.h
@@ -123,6 +123,12 @@ inline constexpr uint16_t kDiagInvalidFrames = 818;  // uint32
 inline constexpr uint16_t kDiagFirmwareMajor = 820;  // uint16
 inline constexpr uint16_t kDiagFirmwareMinor = 821;  // uint16
 inline constexpr uint16_t kDiagFirmwarePatch = 822;  // uint16
+// Bridge relays (DRM contacts). READ-ONLY here by design: relay control goes through the
+// admin-gated REST/MQTT paths with their safety gates; the unauthenticated Modbus surface
+// only ever observes. 0xFFFF sentinel on boards without relays (count 0 would claim
+// "a board with zero relays exists here", which is a different statement than "none").
+inline constexpr uint16_t kDiagRelayCount = 850;  // uint16, 0xFFFF = no relay hardware
+inline constexpr uint16_t kDiagRelayMask  = 851;  // uint16 bitmask, bit i = relay i energised
 }  // namespace reg
 
 /// Bit positions in the validity bitmap at reg::kValidityBitmap.

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -325,4 +325,46 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
     return entities;
 }
 
+std::vector<DiscoveryEntity> buildRelayEntities(const BridgeInfo&  bridge,
+                                                const MqttTopics&  topics,
+                                                const std::string& discoveryPrefix) {
+    // Switches are announced only when the relays can actually act (board has them AND the
+    // config flag is on). For a board that HAS relays but keeps them disabled, empty
+    // retained payloads are published instead, so previously announced switches disappear
+    // from Home Assistant rather than lingering as controls that silently reject.
+    std::vector<DiscoveryEntity> entities;
+    for (uint8_t i = 0; i < bridge.relayCount; ++i) {
+        const std::string slug = "relay_" + std::to_string(i + 1);
+        DiscoveryEntity   entity;
+        entity.configTopic =
+            discoveryPrefix + "/switch/" + bridge.bridgeId + "/" + slug + "/config";
+        if (!bridge.relaysEnabled) {
+            entity.uniqueId = bridge.bridgeId + "_" + slug;
+            entity.payload.clear();  // empty retained payload = HA removes the entity
+            entities.push_back(std::move(entity));
+            continue;
+        }
+        JsonDocument doc;
+        JsonObject   e = doc.to<JsonObject>();
+        e["unique_id"]     = bridge.bridgeId + "_" + slug;
+        e["object_id"]     = bridge.bridgeId + "_" + slug;
+        e["name"]          = "Relay " + std::to_string(i + 1);
+        e["command_topic"] = topics.relaySet(i);
+        e["state_topic"]   = topics.relayState(i);
+        e["payload_on"]    = "ON";
+        e["payload_off"]   = "OFF";
+        // Not optimistic: the switch shows the ACK'd state, so a command refused by the
+        // gates (read-only mode flipped back on, rate limit) visibly snaps back in HA.
+        e["optimistic"]         = false;
+        e["availability_topic"] = topics.availability();
+        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true);
+
+        entity.uniqueId = e["unique_id"].as<std::string>();
+        if (serialise(doc, entity.payload)) {
+            entities.push_back(std::move(entity));
+        }
+    }
+    return entities;
+}
+
 }  // namespace heliograph::mqtt

--- a/src/outputs/mqtt/home_assistant_discovery.h
+++ b/src/outputs/mqtt/home_assistant_discovery.h
@@ -42,6 +42,14 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
                                                            const MqttTopics&  topics,
                                                            const std::string& discoveryPrefix);
 
+/// Switch entities for the bridge's own relays (DRM contacts). Announced only while
+/// bridge.relaysEnabled; for a relay board with the feature disabled the same config
+/// topics get EMPTY payloads so stale switches are removed from Home Assistant. A board
+/// without relays (relayCount 0) produces nothing at all.
+std::vector<DiscoveryEntity> buildRelayEntities(const BridgeInfo&  bridge,
+                                                const MqttTopics&  topics,
+                                                const std::string& discoveryPrefix);
+
 /// Turns a measurement id into an id fragment usable in a topic and unique_id.
 /// "ac.power.total" -> "ac_power_total"
 std::string sanitizeId(const std::string& measurementId);

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -111,9 +111,13 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
             } else {
                 return;  // unknown payload: ignore rather than guess
             }
-            // Outcome is not published from here; loop() acks the real state on the next
-            // tick, so a refused command snaps the HA switch back.
+            // Outcome is not published from here (wrong task); the flag makes loop() ack
+            // the real state on its next tick REGARDLESS of whether the state changed --
+            // a refused or no-op command otherwise changes no mask bit, nothing would be
+            // published, and the HA switch would hang in "switching" instead of snapping
+            // back.
             relayCommand_(static_cast<uint8_t>(idx), on);
+            relayAckRequested_ = true;
         });
     }
 
@@ -233,7 +237,8 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
             discoveryPublished_ = false;
             relayStateForced_   = true;
         }
-        if (relayStateForced_ || bridge.relayMask != lastRelayMask_) {
+        if (relayStateForced_ || relayAckRequested_.exchange(false) ||
+            bridge.relayMask != lastRelayMask_) {
             for (uint8_t i = 0; i < bridge.relayCount; ++i) {
                 const bool on = (bridge.relayMask >> i) & 1;
                 g_client.publish(topics_.relayState(i).c_str(), 1, true,

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -8,6 +8,8 @@
 #include "home_assistant_discovery.h"
 #include "mqtt_payloads.h"
 
+#include <cstring>
+
 #if defined(ESP32)
 
 #include <espMqttClient.h>
@@ -69,6 +71,52 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
         lastDisconnectReason_ = static_cast<uint8_t>(reason);
     });
 
+    relayCount_ = bridge.relayCount;
+    if (relayCount_ > 0) {
+        // The one message handler this firmware has. Topic and payload are attacker-
+        // influenced data from anyone who can publish on the broker; parse defensively and
+        // let the RelayController's gates decide. Runs on the MQTT task -- the handler
+        // installed by main serialises against REST with a mutex.
+        g_client.onMessage([this](const espMqttClientTypes::MessageProperties&,
+                                  const char* topic, const uint8_t* payload, size_t len,
+                                  size_t index, size_t total) {
+            if (relayCommand_ == nullptr || topic == nullptr || index != 0 || len != total) {
+                return;  // no handler, or a fragmented message (never valid for ON/OFF)
+            }
+            const std::string t(topic);
+            const std::string prefix = topics_.prefix() + "/relay/";
+            if (t.rfind(prefix, 0) != 0 || t.size() <= prefix.size()) {
+                return;
+            }
+            const size_t slash = t.find('/', prefix.size());
+            if (slash == std::string::npos || t.substr(slash) != "/set") {
+                return;
+            }
+            const std::string num = t.substr(prefix.size(), slash - prefix.size());
+            if (num.empty() || num.size() > 2 ||
+                num.find_first_not_of("0123456789") != std::string::npos) {
+                return;
+            }
+            const int idx = std::stoi(num);
+            if (idx < 0 || idx >= relayCount_) {
+                return;
+            }
+            char body[8] = {};
+            memcpy(body, payload, len < sizeof(body) - 1 ? len : sizeof(body) - 1);
+            bool on;
+            if (strcmp(body, "ON") == 0 || strcmp(body, "1") == 0) {
+                on = true;
+            } else if (strcmp(body, "OFF") == 0 || strcmp(body, "0") == 0) {
+                on = false;
+            } else {
+                return;  // unknown payload: ignore rather than guess
+            }
+            // Outcome is not published from here; loop() acks the real state on the next
+            // tick, so a refused command snaps the HA switch back.
+            relayCommand_(static_cast<uint8_t>(idx), on);
+        });
+    }
+
     started_          = true;
     nextReconnectMs_  = 0;
     reconnectDelayMs_ = 1000;
@@ -89,6 +137,11 @@ void MqttOutput::publishDiscovery(const DeviceState& state, const BridgeInfo& br
     for (const auto& e : buildBridgeDiagnosticEntities(bridge, topics_, config_.discoveryPrefix)) {
         g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
     }
+    // Relay switches -- or, when the feature is disabled on a relay board, empty retained
+    // payloads that remove previously announced switches from Home Assistant.
+    for (const auto& e : buildRelayEntities(bridge, topics_, config_.discoveryPrefix)) {
+        g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
+    }
     discoveryPublished_ = true;
 }
 
@@ -104,8 +157,12 @@ void MqttOutput::onConnected(const DeviceState& state, const BridgeInfo& bridge)
     }
     publishDiscovery(state, bridge);
 
-    // No subscriptions. Every driver in this build is read-only, so there is no command
-    // topic to listen on -- which follows from the capabilities, not from a decision here.
+    // The relay command topic is the only subscription; inverter drivers stay read-only
+    // and get no command topic -- that follows from the capabilities, not a decision here.
+    if (relayCount_ > 0) {
+        g_client.subscribe(topics_.relaySetWildcard().c_str(), 1);
+        relayStateForced_ = true;  // fresh session: ack the current states once
+    }
 }
 
 void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
@@ -166,6 +223,25 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
         }
         // If the payload did not fit it is dropped rather than truncated, and the throttle
         // is left untouched so the next attempt retries.
+    }
+
+    if (bridge.relayCount > 0) {
+        // Enabling/disabling the feature adds or removes the switch entities themselves,
+        // so it forces a discovery re-announce; a mask change just acks the states.
+        if (bridge.relaysEnabled != lastRelaysEnabled_) {
+            lastRelaysEnabled_  = bridge.relaysEnabled;
+            discoveryPublished_ = false;
+            relayStateForced_   = true;
+        }
+        if (relayStateForced_ || bridge.relayMask != lastRelayMask_) {
+            for (uint8_t i = 0; i < bridge.relayCount; ++i) {
+                const bool on = (bridge.relayMask >> i) & 1;
+                g_client.publish(topics_.relayState(i).c_str(), 1, true,
+                                 on ? "ON" : "OFF");
+            }
+            lastRelayMask_    = bridge.relayMask;
+            relayStateForced_ = false;
+        }
     }
 
     if (nowMs - lastDiagnosticsMs_ >= config_.diagnosticsIntervalMs) {

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -20,7 +20,10 @@
 #include <cstdint>
 #include <string>
 
+#include <functional>
+
 #include "device/bridge_info.h"
+#include "device/command.h"
 #include "device/device_state.h"
 #include "diagnostics/diagnostics.h"
 #include "mqtt_topics.h"
@@ -58,6 +61,13 @@ public:
 
     void setDiagnostics(Diagnostics* diagnostics) { diagnostics_ = diagnostics; }
 
+    /// Handles a relay command arriving on <prefix>/relay/<n>/set. Wired by main to the
+    /// RelayController behind a mutex: this callback runs on the MQTT task while REST
+    /// commands arrive on the AsyncTCP task. The switch state in Home Assistant follows
+    /// the ACK on the state topic, so a refused command visibly snaps back.
+    using RelayCommandFn = std::function<CommandResult(uint8_t index, bool energised)>;
+    void setRelayCommandHandler(RelayCommandFn handler) { relayCommand_ = std::move(handler); }
+
 private:
     void onConnected(const DeviceState& state, const BridgeInfo& bridge);
     void publishDiscovery(const DeviceState& state, const BridgeInfo& bridge);
@@ -93,6 +103,15 @@ private:
     /// FIRST connect at boot not count as a reconnect. See loop().
     bool wasConnected_  = false;
     bool everConnected_ = false;
+
+    RelayCommandFn relayCommand_;
+    uint8_t        relayCount_ = 0;  ///< copied at begin() for topic parsing in the callback
+    /// Relay ack-state tracking: force a publish on connect and on every mask/enabled
+    /// change. `lastRelaysEnabled_` also triggers a discovery re-announce, because
+    /// enabling/disabling adds or removes the switch entities themselves.
+    bool    relayStateForced_  = true;
+    uint8_t lastRelayMask_     = 0;
+    bool    lastRelaysEnabled_ = false;
 
 public:
     uint8_t lastDisconnectReason() const { return lastDisconnectReason_; }

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <string>
 
+#include <atomic>
 #include <functional>
 
 #include "device/bridge_info.h"
@@ -106,6 +107,11 @@ private:
 
     RelayCommandFn relayCommand_;
     uint8_t        relayCount_ = 0;  ///< copied at begin() for topic parsing in the callback
+    /// Set by onMessage (MQTT task) on EVERY received relay command, consumed by loop().
+    /// Without it a refused or no-op command changes no state, nothing gets published, and
+    /// the Home Assistant switch stays stuck "switching" instead of snapping back
+    /// (Copilot review on PR #2). Atomic: two tasks touch it.
+    std::atomic<bool> relayAckRequested_{false};
     /// Relay ack-state tracking: force a publish on connect and on every mask/enabled
     /// change. `lastRelaysEnabled_` also triggers a discovery re-announce, because
     /// enabling/disabling adds or removes the switch entities themselves.

--- a/src/outputs/mqtt/mqtt_topics.h
+++ b/src/outputs/mqtt/mqtt_topics.h
@@ -24,6 +24,16 @@ public:
     std::string identity() const { return prefix_ + "/identity"; }
     std::string capabilities() const { return prefix_ + "/capabilities"; }
 
+    /// Bridge relay control (DRM contacts). Commands come in on relaySet, acknowledged
+    /// state goes out on relayState. The one wildcard subscription this firmware has.
+    std::string relaySet(uint8_t index) const {
+        return prefix_ + "/relay/" + std::to_string(index) + "/set";
+    }
+    std::string relayState(uint8_t index) const {
+        return prefix_ + "/relay/" + std::to_string(index) + "/state";
+    }
+    std::string relaySetWildcard() const { return prefix_ + "/relay/+/set"; }
+
     const std::string& prefix() const { return prefix_; }
 
 private:

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -437,6 +437,57 @@ bool RestApi::begin() {
         request->send(202, kJson, "{\"status\":\"accepted\"}");
     });
 
+    // Bridge relay control (DRM contacts). One explicit route per possible index (max 8)
+    // rather than a regex route: ESPAsyncWebServer only matches regex paths when built
+    // with ASYNCWEBSERVER_REGEX, and eight fixed strings are cheaper than that flag. The
+    // state travels in the query (?on=true|false) -- a JSON body would need the whole
+    // collectBody dance for one boolean. Admin-gated and rate-limited like every other
+    // mutation; the RelayController's gates (read-only mode, relays.enabled) decide next.
+    for (uint8_t relayIndex = 0; relayIndex < 8; ++relayIndex) {
+        const std::string path = "/api/v1/relays/" + std::to_string(relayIndex) + "/set";
+        g_server->on(path.c_str(), HTTP_POST,
+                     [this, authorised, rateLimited, relayIndex](AsyncWebServerRequest* request) {
+        if (!authorised(request) || rateLimited(request)) {
+            return;
+        }
+        if (!context_.setRelay) {
+            sendError(request, {404, "no_relays", "this board has no relays"});
+            return;
+        }
+        if (!request->hasParam("on")) {
+            sendError(request, {400, "missing_parameter", "expected ?on=true or ?on=false"});
+            return;
+        }
+        const String v = request->getParam("on")->value();
+        if (v != "true" && v != "false") {
+            sendError(request, {400, "invalid_parameter", "expected ?on=true or ?on=false"});
+            return;
+        }
+        switch (context_.setRelay(relayIndex, v == "true")) {
+            case CommandResult::Ok:
+                request->send(200, kJson, "{\"status\":\"ok\"}");
+                return;
+            case CommandResult::ReadOnlyMode:
+                sendError(request, {403, "read_only_mode",
+                                    "security.read_only_mode is on; relays cannot move"});
+                return;
+            case CommandResult::Rejected:
+                sendError(request, {403, "relays_disabled",
+                                    "relays.enabled is off in the configuration"});
+                return;
+            case CommandResult::OutOfRange:
+                sendError(request, {404, "no_such_relay", "relay index out of range"});
+                return;
+            case CommandResult::RateLimited:
+                sendError(request, {429, "rate_limited", "too many relay commands"});
+                return;
+            default:
+                sendError(request, {500, "relay_error", "relay command failed"});
+                return;
+        }
+        });
+    }
+
     g_server->on("/api/v1/actions/discover", HTTP_POST,
                  [this, authorised, rateLimited](AsyncWebServerRequest* request) {
         if (!authorised(request) || rateLimited(request)) {

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -29,6 +29,7 @@ class AsyncWebServerRequest;
 
 #include "config/configuration.h"
 #include "device/bridge_info.h"
+#include "device/command.h"
 #include "device/device_state.h"
 #include "diagnostics/diagnostics.h"
 #include "app/discovery_runner.h"
@@ -68,6 +69,10 @@ struct RestContext {
     std::function<bool()> portalActive;
     /// Scans for networks; returns a JSON body. Portal only.
     std::function<std::string()> scanNetworks;
+    /// Sets a bridge relay (DRM contact). Wired by main to the RelayController behind the
+    /// same mutex the MQTT path uses. Unset (nullptr) on boards without relays -- the
+    /// endpoint then answers 404, matching the absent-not-zero rule for hardware.
+    std::function<CommandResult(uint8_t index, bool energised)> setRelay;
 };
 
 class RestApi {

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -65,6 +65,16 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     json_util::addClockFields(b, bridge);
     b["free_heap_bytes"]   = bridge.freeHeapBytes;
 
+    // Only on boards that have relays: absent, not an empty list, per the house rule that
+    // hardware which does not exist is never reported as a zero-ish value.
+    if (bridge.relayCount > 0) {
+        b["relays_enabled"] = bridge.relaysEnabled;
+        JsonArray relays    = b["relays"].to<JsonArray>();
+        for (uint8_t i = 0; i < bridge.relayCount; ++i) {
+            relays.add(((bridge.relayMask >> i) & 1) != 0);
+        }
+    }
+
     JsonObject d = doc["device"].to<JsonObject>();
     d["id"]      = deviceId;  // the registered id, not identity.deviceId() -- see the header
     addOptional(d, "driver_id", state.identity.driverId);

--- a/src/relays/relay_controller.cpp
+++ b/src/relays/relay_controller.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+
+#include "relay_controller.h"
+
+namespace heliograph {
+
+RelayController::RelayController(ClockFn clock, RateLimitPolicy rateLimit)
+    : clock_(std::move(clock)), rateLimit_(rateLimit) {}
+
+void RelayController::begin(uint8_t count, RelayApplyFn apply) {
+    count_ = count > kMaxRelays ? kMaxRelays : count;
+    apply_ = std::move(apply);
+    allOff();
+}
+
+void RelayController::allOff() {
+    for (uint8_t i = 0; i < count_; ++i) {
+        state_[i] = false;
+        if (apply_) {
+            apply_(i, false);
+        }
+    }
+}
+
+// Same refill logic as CommandDispatcher::allowedByRateLimit, with one fix: "has ever
+// accepted" is an explicit flag instead of the lastAcceptedMs_ == 0 sentinel. millis() at
+// boot is near zero, so the sentinel collides exactly when the device just started -- and
+// the first seconds after a boot are when unthrottled relay chatter is least welcome.
+// Duplicated rather than shared through a base class by intent: two small, independently
+// testable copies beat a coupling between the inverter write path and the bridge actuator.
+bool RelayController::allowedByRateLimit(uint64_t nowMs) {
+    if (everAccepted_ && nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+        burstUsed_ = 0;
+    }
+    if (burstUsed_ < rateLimit_.burst) {
+        ++burstUsed_;
+        everAccepted_   = true;
+        lastAcceptedMs_ = nowMs;
+        return true;
+    }
+    if (!everAccepted_ || nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+        everAccepted_   = true;
+        lastAcceptedMs_ = nowMs;
+        return true;
+    }
+    return false;
+}
+
+CommandResult RelayController::set(uint8_t index, bool energised) {
+    // 1. Global kill switch, before anything else -- identical position to the dispatcher.
+    if (readOnly_) {
+        return CommandResult::ReadOnlyMode;
+    }
+    // 2. Feature flag. A relay board with default settings must be inert.
+    if (!enabled_) {
+        return CommandResult::Rejected;
+    }
+    // 3. Index validity.
+    if (index >= count_) {
+        return CommandResult::OutOfRange;
+    }
+    // 4. Rate limit -- but only towards asserting. Releasing curtailment (OFF) is the safe
+    // direction and must never wait behind a throttle.
+    if (energised) {
+        const uint64_t now = clock_ ? clock_() : 0;
+        if (!allowedByRateLimit(now)) {
+            return CommandResult::RateLimited;
+        }
+    }
+    state_[index] = energised;
+    if (apply_) {
+        apply_(index, energised);
+    }
+    return CommandResult::Ok;
+}
+
+}  // namespace heliograph

--- a/src/relays/relay_controller.h
+++ b/src/relays/relay_controller.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+//
+// Bridge-local relay actuator: the DRM curtailment contacts on relay boards.
+//
+// This is deliberately NOT part of the inverter command path. The relays belong to the
+// BRIDGE -- potential-free contacts wired to an inverter's DRM port -- and no driver has,
+// or will ever get, a path to them. The controller is host-testable: the actual pin write
+// is an injected callback, so the gate order and the failsafe are proven on the host
+// before any coil ever clicks.
+//
+// Failsafe, decided with the owner (2026-07-22): de-energised = DRM not asserted = the
+// inverter runs. Boot turns everything off, a crash leaves the pins to the reset default
+// (inputs, relays released), and there is no state persistence on purpose -- a reboot
+// must never re-assert curtailment the operator did not just ask for.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include "commands/command_dispatcher.h"  // RateLimitPolicy
+#include "device/clock.h"
+#include "device/command.h"  // CommandResult vocabulary
+
+namespace heliograph {
+
+/// Writes one relay's coil state to hardware. `energised` is the logical state; polarity
+/// (active-high vs low) is the board layer's business, not the controller's.
+using RelayApplyFn = std::function<void(uint8_t index, bool energised)>;
+
+class RelayController {
+public:
+    static constexpr uint8_t kMaxRelays = 8;
+
+    explicit RelayController(ClockFn clock, RateLimitPolicy rateLimit = {});
+
+    /// Declares the relay count and the hardware write hook, and drives every relay to the
+    /// failsafe state (de-energised). Count is clamped to kMaxRelays.
+    void begin(uint8_t count, RelayApplyFn apply);
+
+    /// The same global kill switch the command dispatcher honours. On by default.
+    void setReadOnlyMode(bool readOnly) { readOnly_ = readOnly; }
+    /// The relays.enabled config flag. Off by default: a relay board with default settings
+    /// must be inert.
+    void setEnabled(bool enabled) { enabled_ = enabled; }
+
+    /// Gate order mirrors CommandDispatcher: read-only mode, feature enabled, valid index,
+    /// rate limit -- only then does the apply hook run. Turning a relay OFF passes the
+    /// rate limiter unconditionally: releasing curtailment must never be throttled.
+    CommandResult set(uint8_t index, bool energised);
+
+    /// Failsafe: everything de-energised, immediately, regardless of gates. For shutdown
+    /// paths and for disabling the feature at runtime.
+    void allOff();
+
+    uint8_t count() const { return count_; }
+    bool    energised(uint8_t index) const { return index < count_ && state_[index]; }
+    bool    enabled() const { return enabled_; }
+    bool    readOnlyMode() const { return readOnly_; }
+
+private:
+    bool allowedByRateLimit(uint64_t nowMs);
+
+    ClockFn         clock_;
+    RateLimitPolicy rateLimit_;
+    RelayApplyFn    apply_;
+    uint8_t         count_    = 0;
+    bool            readOnly_ = true;
+    bool            enabled_  = false;
+    bool            state_[kMaxRelays] = {};
+
+    // An explicit flag, not the "0 means never" sentinel the dispatcher uses: millis() at
+    // boot IS near zero, and a sentinel collision there let the first post-boot burst
+    // bypass the throttle (caught by test_rate_limit_throttles_on_but_never_off).
+    bool     everAccepted_   = false;
+    uint64_t lastAcceptedMs_ = 0;
+    uint32_t burstUsed_      = 0;
+};
+
+}  // namespace heliograph

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -510,6 +510,15 @@ async function renderConfig(){
   const c=await (await fetch('/api/v1/config')).json();
   cfgBefore=c;
   if(!cfgDrivers)cfgDrivers=await (await fetch('/api/v1/drivers')).json();
+  // The Relays card keys off the board's relay count, which normally arrives with the
+  // status refresh -- but this form renders once per session, and a fast click on the
+  // Settings tab can beat the first status response. Establish the count here rather
+  // than caching a card-less form for the whole session.
+  if(window.g_relayCount===undefined){
+    try{const s=await(await fetch('/api/v1/status')).json();
+      window.g_relayCount=(s.bridge.relays||[]).length}
+    catch(e){window.g_relayCount=0}
+  }
 
   // autocomplete=off on every plain settings field: a text input directly above a password
   // input (MQTT username + password) otherwise reads as a login form to password managers,

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -194,6 +194,8 @@ function render(s){
     (d.data_stale?' <span class="tag">stale</span>':'')+
     (d.data_valid?'':' <span class="tag">no data</span>');
   $('#ver').textContent='v'+b.firmware_version;
+  // Boards without relays never send the field; the settings card keys off this.
+  window.g_relayCount=(b.relays||[]).length;
   const g=id=>m[id]?m[id].value:null;
   if(tab==='dash'){
     $('#tiles').innerHTML=
@@ -600,6 +602,12 @@ async function renderConfig(){
       `<option value="${esc(d.id)}" ${d.id===c.driver.id?'selected':''}>${esc(d.display_name)} (${esc(d.support_level)})</option>`).join('')}</select>
     ${driverOpts}
   </div>
+  ${window.g_relayCount>0?`<div class="card"><b>Relays</b> <span class="tag" style="font-weight:400">applied immediately</span>
+    ${chk('c_rle','Enabled',(c.relays||{}).enabled)}
+    <div class="dim" style="font-size:12px;margin-top:8px">DRM curtailment contacts. Two
+    locks must open before a relay can move: this switch AND read-only mode being off.
+    Disabling releases every relay. Control lives in Home Assistant (switches appear via
+    discovery) or POST /api/v1/relays/&lt;n&gt;/set.</div></div>`:''}
   <div class="card"><b>Security</b> <span class="tag" style="font-weight:400">applied immediately</span>${txt('c_au','Admin username',c.security.admin_username)}
     ${pw('c_ap','Admin password',c.security.password_set)}</div>
   <div class="card"><b>Logging</b> <span class="tag" style="font-weight:400">applied immediately</span>
@@ -634,6 +642,7 @@ async function renderConfig(){
 async function saveConfig(){
   const v=id=>$(id).value, n=id=>Number($(id).value), b=id=>$(id).checked;
   const body={bridge_name:v('c_name'),
+    ...(window.g_relayCount>0?{relays:{enabled:b('c_rle')}}:{}),
     wifi:{ssid:v('c_ssid'),hostname:v('c_host')},
     mqtt:{enabled:b('c_mqe'),host:v('c_mqh'),port:n('c_mqp'),username:v('c_mqu'),
           base_topic:v('c_mqt'),discovery_enabled:b('c_mqd')},

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -623,6 +623,37 @@ static void test_bridge_diagnostic_entities() {
     TEST_ASSERT_EQUAL_STRING("Waveshare ESP32-S3-RS485-CAN", doc["device"]["model"]);
 }
 
+static void test_relay_entities_follow_count_and_enabled() {
+    auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+
+    // No relay hardware: nothing at all -- not even removal payloads.
+    bridge.relayCount = 0;
+    TEST_ASSERT_TRUE(buildRelayEntities(bridge, topics, kDefaultDiscoveryPrefix).empty());
+
+    // Relays present but the feature disabled: EMPTY retained payloads on the config
+    // topics, so previously announced switches disappear from Home Assistant.
+    bridge.relayCount    = 2;
+    bridge.relaysEnabled = false;
+    auto removed = buildRelayEntities(bridge, topics, kDefaultDiscoveryPrefix);
+    TEST_ASSERT_EQUAL_UINT32(2, removed.size());
+    TEST_ASSERT_TRUE(removed[0].payload.empty());
+    TEST_ASSERT_EQUAL_STRING("homeassistant/switch/heliograph-a1b2c3/relay_1/config",
+                             removed[0].configTopic.c_str());
+
+    // Enabled: real switch configs, ack-based (not optimistic), on the bridge device.
+    bridge.relaysEnabled = true;
+    bridge.relayMask     = 0b01;
+    auto entities = buildRelayEntities(bridge, topics, kDefaultDiscoveryPrefix);
+    TEST_ASSERT_EQUAL_UINT32(2, entities.size());
+    auto doc = parse(entities[0].payload);
+    TEST_ASSERT_EQUAL_STRING("Relay 1", doc["name"]);
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/relay/0/set", doc["command_topic"]);
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/relay/0/state", doc["state_topic"]);
+    TEST_ASSERT_FALSE(doc["optimistic"].as<bool>());
+    TEST_ASSERT_EQUAL_STRING("heliograph-a1b2c3", doc["device"]["identifiers"][0]);
+}
+
 static void test_sanitize_id() {
     TEST_ASSERT_EQUAL_STRING("ac_power_total", sanitizeId("ac.power.total").c_str());
     TEST_ASSERT_EQUAL_STRING("dc_mppt_1_voltage", sanitizeId("dc.mppt_1.voltage").c_str());
@@ -776,6 +807,7 @@ int main(int, char**) {
     RUN_TEST(test_config_topics_are_well_formed);
     RUN_TEST(test_the_mock_hybrid_gets_battery_and_phase_entities_for_free);
     RUN_TEST(test_bridge_diagnostic_entities);
+    RUN_TEST(test_relay_entities_follow_count_and_enabled);
     RUN_TEST(test_sanitize_id);
     RUN_TEST(test_first_state_is_always_published);
     RUN_TEST(test_an_unchanged_state_is_not_republished);

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -150,6 +150,25 @@ static void test_primary_config_wins_over_legacy() {
     TEST_ASSERT_EQUAL_STRING("Nieuw", loaded.bridgeName.c_str());
 }
 
+static void test_relays_enabled_defaults_off_and_round_trips() {
+    // A relay board with factory settings must be inert: the flag defaults to false, and
+    // only an explicit patch turns it on. It must survive storage like everything else.
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    auto               c = provisionedConfig();
+    TEST_ASSERT_FALSE(c.relays.enabled);
+
+    ConfigError e;
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"relays":{"enabled":true}})", c, e));
+    TEST_ASSERT_TRUE(c.relays.enabled);
+    TEST_ASSERT_TRUE(store.save(c));
+
+    ConfigurationStore reloaded(backend);
+    Configuration      after;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, reloaded.load(after));
+    TEST_ASSERT_TRUE(after.relays.enabled);
+}
+
 // --- ntp ----------------------------------------------------------------------------------
 
 static void test_ntp_settings_round_trip_through_storage() {
@@ -584,6 +603,7 @@ int main(int, char**) {
     RUN_TEST(test_a_working_bridge_confirms_eventually_even_without_wifi);
     RUN_TEST(test_first_boot_finds_nothing_and_keeps_defaults);
     RUN_TEST(test_save_then_load_round_trips_everything);
+    RUN_TEST(test_relays_enabled_defaults_off_and_round_trips);
     RUN_TEST(test_config_under_the_legacy_namespace_is_adopted);
     RUN_TEST(test_primary_config_wins_over_legacy);
     RUN_TEST(test_ntp_settings_round_trip_through_storage);

--- a/test/test_register_map/test_main.cpp
+++ b/test/test_register_map/test_main.cpp
@@ -79,6 +79,24 @@ struct EversolarRig {
     }
 };
 
+static void test_relay_registers_use_the_sentinel_without_hardware() {
+    // "No relay hardware" and "relays, none energised" are different statements; the
+    // sentinel keeps them apart. Control never goes through Modbus -- these are read-only.
+    EversolarRig r;
+    r.pollAndRender();
+    uint16_t v = 0;
+    TEST_ASSERT_TRUE(r.map.read(reg::kDiagRelayCount, 1, &v));
+    TEST_ASSERT_EQUAL_UINT16(0xFFFF, v);
+
+    r.bridge.relayCount = 6;
+    r.bridge.relayMask  = 0b100101;
+    r.pollAndRender();
+    TEST_ASSERT_TRUE(r.map.read(reg::kDiagRelayCount, 1, &v));
+    TEST_ASSERT_EQUAL_UINT16(6, v);
+    TEST_ASSERT_TRUE(r.map.read(reg::kDiagRelayMask, 1, &v));
+    TEST_ASSERT_EQUAL_UINT16(0b100101, v);
+}
+
 // --- schema and framing --------------------------------------------------------------------
 
 static void test_schema_version_is_published() {
@@ -477,5 +495,6 @@ int main(int, char**) {
     RUN_TEST(test_a_32bit_error_code_saturates_the_16bit_register);
     RUN_TEST(test_validity_bitmap_and_nan_always_agree);
     RUN_TEST(test_validity_bits_fit_the_reserved_space);
+    RUN_TEST(test_relay_registers_use_the_sentinel_without_hardware);
     return UNITY_END();
 }

--- a/test/test_relays/test_main.cpp
+++ b/test/test_relays/test_main.cpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+//
+// RelayController: the gate order and the failsafe, proven on the host before any coil
+// ever clicks. These tests are the contract that a relay board with default settings is
+// inert, and that a dead or read-only bridge can never assert curtailment.
+
+#include <cstdint>
+#include <vector>
+
+#include <unity.h>
+
+#include "relays/relay_controller.h"
+
+using namespace heliograph;
+
+namespace {
+
+uint64_t g_now = 0;
+uint64_t fakeClock() { return g_now; }
+
+struct AppliedWrite {
+    uint8_t index;
+    bool    energised;
+};
+std::vector<AppliedWrite> g_writes;
+
+RelayController makeController(uint8_t count) {
+    RelayController c(&fakeClock);
+    c.begin(count, [](uint8_t i, bool on) { g_writes.push_back({i, on}); });
+    return c;
+}
+
+}  // namespace
+
+void setUp() {
+    g_now = 0;
+    g_writes.clear();
+}
+void tearDown() {}
+
+static void test_boot_drives_every_relay_off() {
+    auto c = makeController(6);
+    TEST_ASSERT_EQUAL_UINT32(6, g_writes.size());
+    for (const auto& w : g_writes) {
+        TEST_ASSERT_FALSE(w.energised);
+    }
+    for (uint8_t i = 0; i < 6; ++i) {
+        TEST_ASSERT_FALSE(c.energised(i));
+    }
+}
+
+static void test_default_state_refuses_everything() {
+    // Fresh controller: read-only ON, enabled OFF. The kill switch answers first.
+    auto c = makeController(1);
+    g_writes.clear();
+    TEST_ASSERT_EQUAL(CommandResult::ReadOnlyMode, c.set(0, true));
+    TEST_ASSERT_TRUE(g_writes.empty());
+    TEST_ASSERT_FALSE(c.energised(0));
+}
+
+static void test_read_only_wins_over_enabled() {
+    auto c = makeController(1);
+    c.setEnabled(true);  // enabled, but the kill switch still holds
+    TEST_ASSERT_EQUAL(CommandResult::ReadOnlyMode, c.set(0, true));
+}
+
+static void test_disabled_feature_refuses_even_when_writable() {
+    auto c = makeController(1);
+    c.setReadOnlyMode(false);
+    TEST_ASSERT_EQUAL(CommandResult::Rejected, c.set(0, true));
+    TEST_ASSERT_FALSE(c.energised(0));
+}
+
+static void test_switching_works_when_both_gates_open() {
+    auto c = makeController(2);
+    c.setReadOnlyMode(false);
+    c.setEnabled(true);
+    g_writes.clear();
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(1, true));
+    TEST_ASSERT_TRUE(c.energised(1));
+    TEST_ASSERT_FALSE(c.energised(0));
+    TEST_ASSERT_EQUAL_UINT32(1, g_writes.size());
+    TEST_ASSERT_EQUAL_UINT8(1, g_writes[0].index);
+    TEST_ASSERT_TRUE(g_writes[0].energised);
+}
+
+static void test_out_of_range_index_is_refused() {
+    auto c = makeController(1);
+    c.setReadOnlyMode(false);
+    c.setEnabled(true);
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, c.set(1, true));
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, c.set(255, true));
+}
+
+static void test_rate_limit_throttles_on_but_never_off() {
+    RateLimitPolicy policy;
+    policy.minIntervalMs = 1000;
+    policy.burst         = 2;
+    RelayController c(&fakeClock, policy);
+    c.begin(1, [](uint8_t i, bool on) { g_writes.push_back({i, on}); });
+    c.setReadOnlyMode(false);
+    c.setEnabled(true);
+
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(0, true));
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(0, true));
+    // Burst exhausted, no time passed: asserting again is throttled...
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited, c.set(0, true));
+    // ...but releasing curtailment must never wait behind the throttle.
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(0, false));
+    TEST_ASSERT_FALSE(c.energised(0));
+    // After the interval the allowance refills.
+    g_now += 1000;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(0, true));
+}
+
+static void test_all_off_ignores_every_gate() {
+    auto c = makeController(3);
+    c.setReadOnlyMode(false);
+    c.setEnabled(true);
+    c.set(0, true);
+    c.set(2, true);
+    // Feature gets disabled at runtime (config change): the failsafe path must still work
+    // with the gates closed again.
+    c.setEnabled(false);
+    c.setReadOnlyMode(true);
+    g_writes.clear();
+    c.allOff();
+    TEST_ASSERT_FALSE(c.energised(0));
+    TEST_ASSERT_FALSE(c.energised(2));
+    TEST_ASSERT_EQUAL_UINT32(3, g_writes.size());
+}
+
+static void test_count_is_clamped_and_zero_count_is_inert() {
+    auto c = makeController(0);
+    c.setReadOnlyMode(false);
+    c.setEnabled(true);
+    TEST_ASSERT_EQUAL_UINT8(0, c.count());
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, c.set(0, true));
+
+    auto big = makeController(200);
+    TEST_ASSERT_EQUAL_UINT8(RelayController::kMaxRelays, big.count());
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_boot_drives_every_relay_off);
+    RUN_TEST(test_default_state_refuses_everything);
+    RUN_TEST(test_read_only_wins_over_enabled);
+    RUN_TEST(test_disabled_feature_refuses_even_when_writable);
+    RUN_TEST(test_switching_works_when_both_gates_open);
+    RUN_TEST(test_out_of_range_index_is_refused);
+    RUN_TEST(test_rate_limit_throttles_on_but_never_off);
+    RUN_TEST(test_all_off_ignores_every_gate);
+    RUN_TEST(test_count_is_clamped_and_zero_count_is_inert);
+    return UNITY_END();
+}


### PR DESCRIPTION
## What

The bridge-local relay layer for the DRM curtailment initiative — phase B of the approved plan. Relays belong to the **bridge**, never to an inverter driver.

- **RelayController** (`src/relays/`): host-testable core with the dispatcher's gate order — `security.read_only_mode` kill switch → `relays.enabled` (default **off**: a relay board with factory settings is inert) → index validity → rate limit. One deliberate asymmetry: releasing a relay (OFF, the safe direction) is never throttled. Failsafe: boot drives everything de-energised; de-energised = DRM not asserted = the inverter runs.
- **MQTT**: the firmware's first subscription (`<base>/relay/<n>/set`), defensively parsed, acknowledged on `.../state`. HA discovery announces switch entities only while enabled; disabling publishes empty retained configs (switches disappear) and releases every relay. Switches are not optimistic — a refused command visibly snaps back.
- **REST**: `POST /api/v1/relays/<n>/set?on=true|false`, admin-gated + rate-limited, gate verdicts mapped to 403/404/429.
- **Modbus**: read-only registers 850/851, `0xFFFF` sentinel distinguishes 'no relay hardware' from 'none energised'. Control never goes through Modbus.
- **Mock**: the mock env exposes two virtual relays (`HELIOGRAPH_MOCK_RELAYS`) so the entire feature is exercisable end-to-end without relay hardware.
- Settings gains a Relays card (only shown on boards that have them), applied immediately.

Also fixes a latent rate-limiter bug (present in the command dispatcher too): the `lastAccepted == 0` sentinel collides with `millis()` being near zero right after boot, letting the first post-boot window bypass the throttle. Both copies now track an explicit flag.

## Testing

- 406 native tests (12 new: gate order, failsafe, rate-limit asymmetry, discovery add/remove, Modbus sentinel, config round-trip)
- Layering, cppcheck, JS checks green; all four PIO envs build
- Settings card verified in a browser stub: toggle sends exactly `{"relays":{"enabled":true}}`, applied without restart

## Not in this PR

Hardware validation (relay polarity check on the physical 6CH), the DRM semantic layer (phase C), and wiring anything to a real inverter DRM port.
