### PR TITLE
DRM semantic layer (phase C): roles, mode select, wiring docs

### DIFF
--- a/docs/drm.md
+++ b/docs/drm.md
@@ -1,0 +1,86 @@
+# DRM curtailment — relays as demand-response contacts
+
+Status: **software complete, not yet validated on relay hardware.** Nothing in this
+document has touched a real inverter DRM port yet; the relay polarity check and the first
+wired test are pending the physical Relay-6CH board.
+
+## What this is
+
+AS/NZS 4777.2 defines **demand response modes (DRM)** for inverters: a set of dry-contact
+signal lines on a dedicated port (usually an RJ45 socket labelled DRM/DRED). Closing a
+line's circuit asserts a mode — DRM0 demands shutdown, DRM1-4 limit consumption/charge,
+DRM5-8 limit generation/discharge. Heliograph's relay boards can drive those lines as
+**potential-free contacts**: the bridge becomes the "demand response enabling device"
+for an inverter that cannot be curtailed over RS485.
+
+**These are signal contacts. Never switch mains voltage on relays assigned a DRM role.**
+
+## The safety model
+
+Three layers, all of which must agree before a contact moves:
+
+1. `security.read_only_mode` — the global kill switch, on by default.
+2. `relays.enabled` — the feature flag, off by default. A relay board with factory
+   settings is inert.
+3. The rate limiter — asserting is throttled; **releasing is never throttled**.
+
+Closing either gate (read-only on, or relays off) releases every relay immediately: a
+closed gate can only leave the failsafe state behind. On boot everything starts released.
+
+## Failsafe and the NO/NC wiring rule
+
+Firmware semantics are fixed: **relay energised = DRM line asserted**. The failsafe
+decision (made for this project and baked into the firmware) is: *a dead bridge must
+leave the inverter running normally.*
+
+That decides which relay terminal to use per line:
+
+| DRM line behaviour at your inverter | Terminal to use |
+|---|---|
+| Line asserted when circuit **closed** (typical for DRM1-8) | **NO** (normally open) — de-energised = open = not asserted |
+| Line asserted when circuit **open** (some DRM0 implementations expect a closed loop to run) | **NC** (normally closed) — de-energised = closed = running |
+
+**Verify against your inverter's manual which convention it uses — implementations
+differ per manufacturer, and this document deliberately does not claim a universal
+pinout.** A wrong choice inverts the failsafe: a dead bridge would then hold your
+inverter down. Check with a multimeter before connecting anything.
+
+## Configuration
+
+Each relay gets a role in *Settings → Relays* (or `relays.roles` over the API):
+`none`, or `drm0`..`drm8`. Roles do three things:
+
+- the Home Assistant switch is named after the role ("Relay 1 (DRM0)");
+- a **DRM Mode select** appears in Home Assistant with `normal` + every configured role;
+- the current mode is derived and reported (`drm_mode` in the status payload,
+  `<base>/drm/state` on MQTT). Hand-toggled combinations report as `custom`.
+
+Selecting a mode asserts exactly that role's relay(s) and releases everything else;
+`normal` releases all. A mode that fails halfway is rolled back to fully released —
+a half-asserted mode is worse than none.
+
+## Control surfaces
+
+| Surface | Path | Notes |
+|---|---|---|
+| Home Assistant | `select.<bridge>_drm_mode` + per-relay switches | via MQTT discovery |
+| MQTT | `<base>/<bridge_id>/drm/set` (mode name), state on `.../drm/state` | QoS 1 |
+| REST | `POST /api/v1/drm/set?mode=<name>` | admin-gated |
+| Modbus | registers 850/851 | **observation only**, never control |
+
+## Board capabilities
+
+| Board | Relays | Realistic use |
+|---|---|---|
+| RS485-CAN | none | monitoring only |
+| Relay-1CH | 1 | a single line — typically DRM0 |
+| Relay-6CH | 6 | multiple lines, e.g. DRM0 + DRM5 + DRM6 |
+
+## Before first use on a real inverter
+
+1. Flash the board, enable relays, and click the switches with **nothing connected**:
+   you should hear the coils and see the states follow in Home Assistant.
+2. Confirm polarity with a multimeter across NO/COM: de-energised must read open.
+3. Pull the bridge's power mid-assertion: every contact must return to its de-energised
+   state (that is the whole failsafe).
+4. Only then wire the DRM port, per the NO/NC table above and your inverter's manual.

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -2,6 +2,8 @@
 
 #include "configuration.h"
 
+#include "relays/drm.h"
+
 #include <ArduinoJson.h>
 
 #include <cstring>
@@ -197,6 +199,16 @@ bool validate(const Configuration& config, ConfigError& error) {
     // driver.id may be empty: that means "pick the highest-priority driver compiled in".
     // Whether a non-empty id exists is the registry's business, not this validator's -- it
     // has no way to know which drivers were built into this firmware.
+    if (config.relays.roles.size() > 8) {
+        error = {"relays.roles", "at most 8 entries"};
+        return false;
+    }
+    for (const auto& role : config.relays.roles) {
+        if (!drm::isValidRole(role)) {
+            error = {"relays.roles", "each entry must be 'none' or 'drm0'..'drm8'"};
+            return false;
+        }
+    }
     if (config.security.adminUsername.empty()) {
         error = {"security.admin_username", "must not be empty"};
         return false;
@@ -271,6 +283,10 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     doc["polling"]["interval_seconds"] = config.polling.intervalSeconds;
 
     doc["relays"]["enabled"] = config.relays.enabled;
+    JsonArray relayRoles     = doc["relays"]["roles"].to<JsonArray>();
+    for (const auto& role : config.relays.roles) {
+        relayRoles.add(role);
+    }
 
     JsonObject driver           = doc["driver"].to<JsonObject>();
     driver["id"]                = config.driver.id;
@@ -362,6 +378,16 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
 
     if (JsonObjectConst relays = doc["relays"]; !relays.isNull()) {
         if (!patchBool(relays["enabled"], merged.relays.enabled, "relays.enabled", error)) return false;
+        if (JsonArrayConst roles = relays["roles"]; !roles.isNull()) {
+            merged.relays.roles.clear();
+            for (JsonVariantConst v : roles) {
+                if (!v.is<const char*>()) {
+                    error = {"relays.roles", "each entry must be a string"};
+                    return false;
+                }
+                merged.relays.roles.emplace_back(v.as<const char*>());
+            }
+        }
     }
 
     if (JsonObjectConst ntp = doc["ntp"]; !ntp.isNull()) {

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "drivers/driver_descriptor.h"
 
@@ -96,6 +97,11 @@ struct RelaySettings {
     /// this entirely. Note the double gate: security.readOnlyMode must ALSO be off before
     /// a relay moves -- enabling relays alone is not enough, by design.
     bool enabled = false;
+    /// Per-relay DRM role ("none", or "drm0".."drm8"), index-aligned with the board's
+    /// relays. Entries beyond the board's relay count are ignored; missing entries mean
+    /// "none". Roles drive the Home Assistant switch names and the DRM mode select --
+    /// see src/relays/drm.h.
+    std::vector<std::string> roles;
 };
 
 struct SecuritySettings {

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -100,6 +100,10 @@ bool serializeConfigForStorage(const Configuration& config, std::string& out) {
 
     doc["polling"]["interval_seconds"] = config.polling.intervalSeconds;
     doc["relays"]["enabled"]           = config.relays.enabled;
+    JsonArray storedRoles              = doc["relays"]["roles"].to<JsonArray>();
+    for (const auto& role : config.relays.roles) {
+        storedRoles.add(role);
+    }
 
     JsonObject driver     = doc["driver"].to<JsonObject>();
     driver["id"]          = config.driver.id;
@@ -227,6 +231,11 @@ LoadResult deserializeConfigFromStorage(const std::string& json, Configuration& 
     }
     if (JsonObjectConst relays = doc["relays"]; !relays.isNull()) {
         if (relays["enabled"].is<bool>()) parsed.relays.enabled = relays["enabled"].as<bool>();
+        if (JsonArrayConst roles = relays["roles"]; !roles.isNull()) {
+            for (JsonVariantConst v : roles) {
+                if (v.is<const char*>()) parsed.relays.roles.emplace_back(v.as<const char*>());
+            }
+        }
     }
     if (JsonObjectConst driver = doc["driver"]; !driver.isNull()) {
         if (driver["id"].is<const char*>())    parsed.driver.id = driver["id"].as<const char*>();

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace heliograph {
 
@@ -60,6 +61,9 @@ struct BridgeInfo {
     uint8_t relayCount    = 0;
     uint8_t relayMask     = 0;
     bool    relaysEnabled = false;
+    /// Per-relay DRM role from the configuration (index-aligned; may be shorter than
+    /// relayCount, missing = "none"). Drives switch names and the DRM mode select.
+    std::vector<std::string> relayRoles;
 };
 
 }  // namespace heliograph

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "outputs/modbus_tcp/modbus_tcp_server.h"
 #include "outputs/mqtt/mqtt_output.h"
 #include "outputs/rest/rest_api.h"
+#include "relays/drm.h"
 #include "relays/relay_controller.h"
 #include "state/state_store.h"
 #include "transport/rs485_transport.h"
@@ -50,7 +51,7 @@ namespace {
 // image identifiable over the API. Without it two different builds both reported "0.1.0" and a
 // flash could not be told from the previous one -- exactly what bit the post-flash check on
 // 2026-07-21. Bumped to 0.2.0 for the Fase 9 review batch.
-constexpr const char* kFirmwareVersion = "0.7.0 (" __DATE__ " " __TIME__ ")";
+constexpr const char* kFirmwareVersion = "0.8.0 (" __DATE__ " " __TIME__ ")";
 
 Rs485Transport     g_transport;
 DriverRegistry     g_registry;
@@ -136,16 +137,57 @@ BridgeInfo bridgeInfo() {
     info.ntpFromDhcp      = ntpSource.fromDhcp;
     info.otaImageState    = ota::imageStateName();
     if (g_relays.count() > 0) {
-        std::lock_guard<std::mutex> lock(g_relayMutex);
-        info.relayCount    = g_relays.count();
-        info.relaysEnabled = g_relays.enabled();
-        for (uint8_t i = 0; i < g_relays.count(); ++i) {
-            if (g_relays.energised(i)) {
-                info.relayMask |= static_cast<uint8_t>(1u << i);
+        {
+            std::lock_guard<std::mutex> lock(g_relayMutex);
+            info.relayCount    = g_relays.count();
+            info.relaysEnabled = g_relays.enabled();
+            for (uint8_t i = 0; i < g_relays.count(); ++i) {
+                if (g_relays.energised(i)) {
+                    info.relayMask |= static_cast<uint8_t>(1u << i);
+                }
             }
+        }
+        {
+            std::lock_guard<std::mutex> lock(g_configMutex);
+            info.relayRoles = g_config.relays.roles;
         }
     }
     return info;
+}
+
+/// Applies a named DRM mode: the role's relays energised, everything else released.
+/// OFFs first (never throttled), then the ONs; if any ON is refused mid-pattern the
+/// whole pattern is released again -- a half-asserted mode is worse than none.
+CommandResult applyDrmMode(const std::string& mode) {
+    std::vector<std::string> roles;
+    {
+        std::lock_guard<std::mutex> lock(g_configMutex);
+        roles = g_config.relays.roles;
+    }
+    roles.resize(g_relays.count(), "none");
+    std::vector<bool> pattern;
+    if (!drm::patternFor(roles, mode, pattern)) {
+        return CommandResult::OutOfRange;
+    }
+    std::lock_guard<std::mutex> lock(g_relayMutex);
+    for (uint8_t i = 0; i < g_relays.count(); ++i) {
+        if (!pattern[i]) {
+            const CommandResult r = g_relays.set(i, false);
+            if (r != CommandResult::Ok) {
+                return r;  // gate closed: nothing moved yet (OFF is never rate-limited)
+            }
+        }
+    }
+    for (uint8_t i = 0; i < g_relays.count(); ++i) {
+        if (pattern[i]) {
+            const CommandResult r = g_relays.set(i, true);
+            if (r != CommandResult::Ok) {
+                g_relays.allOff();
+                return r;
+            }
+        }
+    }
+    return CommandResult::Ok;
 }
 
 std::string scanNetworksJson() {
@@ -262,6 +304,8 @@ void startOutputs() {
                 std::lock_guard<std::mutex> lock(g_relayMutex);
                 return g_relays.set(index, on);
             });
+            g_mqtt->setDrmCommandHandler(
+                [](const std::string& mode) { return applyDrmMode(mode) == CommandResult::Ok; });
         }
         g_mqtt->begin(bridgeInfo());
         // The host is not a secret; the password must never reach a log.
@@ -336,6 +380,7 @@ void startRestApi() {
             std::lock_guard<std::mutex> lock(g_relayMutex);
             return g_relays.set(index, on);
         };
+        ctx.setDrmMode = applyDrmMode;
     }
 
     g_rest = std::make_unique<rest::RestApi>(ctx);

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -4,6 +4,10 @@
 
 #include <ArduinoJson.h>
 
+#include <cctype>
+
+#include "relays/drm.h"
+
 namespace heliograph::mqtt {
 namespace {
 
@@ -346,9 +350,20 @@ std::vector<DiscoveryEntity> buildRelayEntities(const BridgeInfo&  bridge,
         }
         JsonDocument doc;
         JsonObject   e = doc.to<JsonObject>();
-        e["unique_id"]     = bridge.bridgeId + "_" + slug;
-        e["object_id"]     = bridge.bridgeId + "_" + slug;
-        e["name"]          = "Relay " + std::to_string(i + 1);
+        e["unique_id"] = bridge.bridgeId + "_" + slug;
+        e["object_id"] = bridge.bridgeId + "_" + slug;
+        // The configured DRM role lands in the entity name, so the HA UI says what the
+        // contact MEANS ("Relay 1 (DRM0)") instead of only where it is.
+        std::string name = "Relay " + std::to_string(i + 1);
+        if (i < bridge.relayRoles.size() && bridge.relayRoles[i] != "none" &&
+            !bridge.relayRoles[i].empty()) {
+            std::string role = bridge.relayRoles[i];
+            for (auto& ch : role) {
+                ch = static_cast<char>(toupper(ch));
+            }
+            name += " (" + role + ")";
+        }
+        e["name"]          = name;
         e["command_topic"] = topics.relaySet(i);
         e["state_topic"]   = topics.relayState(i);
         e["payload_on"]    = "ON";
@@ -360,6 +375,43 @@ std::vector<DiscoveryEntity> buildRelayEntities(const BridgeInfo&  bridge,
         addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true);
 
         entity.uniqueId = e["unique_id"].as<std::string>();
+        if (serialise(doc, entity.payload)) {
+            entities.push_back(std::move(entity));
+        }
+    }
+
+    // DRM mode select: one entity for "which demand-response mode is active", derived
+    // entirely from the configured roles. Removal payload when disabled or role-less, so
+    // reconfiguring never leaves a stale select behind.
+    if (bridge.relayCount > 0) {
+        std::vector<std::string> roles = bridge.relayRoles;
+        roles.resize(bridge.relayCount, "none");
+        const auto options = drm::optionsFor(roles);
+
+        DiscoveryEntity entity;
+        entity.uniqueId    = bridge.bridgeId + "_drm_mode";
+        entity.configTopic = discoveryPrefix + "/select/" + bridge.bridgeId + "/drm_mode/config";
+        if (!bridge.relaysEnabled || options.empty()) {
+            entity.payload.clear();
+            entities.push_back(std::move(entity));
+            return entities;
+        }
+        JsonDocument doc;
+        JsonObject   e = doc.to<JsonObject>();
+        e["unique_id"]     = entity.uniqueId;
+        e["object_id"]     = entity.uniqueId;
+        e["name"]          = "DRM Mode";
+        e["command_topic"] = topics.drmSet();
+        e["state_topic"]   = topics.drmState();
+        JsonArray opts     = e["options"].to<JsonArray>();
+        for (const auto& o : options) {
+            opts.add(o);
+        }
+        // "custom" is reportable state (hand-toggled switch combinations) but never a
+        // command; HA requires the state to be one of the options, so it is listed.
+        opts.add(drm::kModeCustom);
+        e["availability_topic"] = topics.availability();
+        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true);
         if (serialise(doc, entity.payload)) {
             entities.push_back(std::move(entity));
         }

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -81,8 +81,8 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
         g_client.onMessage([this](const espMqttClientTypes::MessageProperties&,
                                   const char* topic, const uint8_t* payload, size_t len,
                                   size_t index, size_t total) {
-            if (relayCommand_ == nullptr || topic == nullptr || index != 0 || len != total) {
-                return;  // no handler, or a fragmented message (never valid for ON/OFF)
+            if (topic == nullptr || index != 0 || len != total) {
+                return;  // fragmented messages are never valid for these short payloads
             }
             const std::string t(topic);
             if (t == topics_.drmSet()) {
@@ -95,7 +95,8 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
                 return;
             }
             const std::string prefix = topics_.prefix() + "/relay/";
-            if (t.rfind(prefix, 0) != 0 || t.size() <= prefix.size()) {
+            if (relayCommand_ == nullptr || t.rfind(prefix, 0) != 0 ||
+                t.size() <= prefix.size()) {
                 return;
             }
             const size_t slash = t.find('/', prefix.size());

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -243,9 +243,16 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
 
     if (bridge.relayCount > 0) {
         // Enabling/disabling the feature adds or removes the switch entities themselves,
-        // so it forces a discovery re-announce; a mask change just acks the states.
-        if (bridge.relaysEnabled != lastRelaysEnabled_) {
+        // and a ROLE change renames switches, rebuilds the select options and changes the
+        // derived mode -- both force a discovery re-announce; a mask change just acks.
+        std::string rolesSig;
+        for (const auto& role : bridge.relayRoles) {
+            rolesSig += role;
+            rolesSig += '\n';
+        }
+        if (bridge.relaysEnabled != lastRelaysEnabled_ || rolesSig != lastRelayRolesSig_) {
             lastRelaysEnabled_  = bridge.relaysEnabled;
+            lastRelayRolesSig_  = rolesSig;
             discoveryPublished_ = false;
             relayStateForced_   = true;
         }

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -270,7 +270,6 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
             if (!drm::optionsFor(roles).empty()) {
                 const std::string mode = drm::modeFrom(roles, bridge.relayMask);
                 g_client.publish(topics_.drmState().c_str(), 1, true, mode.c_str());
-                lastDrmMode_ = mode;
             }
             lastRelayMask_    = bridge.relayMask;
             relayStateForced_ = false;

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -7,6 +7,7 @@
 
 #include "home_assistant_discovery.h"
 #include "mqtt_payloads.h"
+#include "relays/drm.h"
 
 #include <cstring>
 
@@ -84,6 +85,15 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
                 return;  // no handler, or a fragmented message (never valid for ON/OFF)
             }
             const std::string t(topic);
+            if (t == topics_.drmSet()) {
+                if (drmCommand_ == nullptr || len == 0 || len > 16) {
+                    return;  // mode names are short; anything longer is not one
+                }
+                std::string mode(reinterpret_cast<const char*>(payload), len);
+                drmCommand_(mode);
+                relayAckRequested_ = true;  // ack states + mode, accepted or not
+                return;
+            }
             const std::string prefix = topics_.prefix() + "/relay/";
             if (t.rfind(prefix, 0) != 0 || t.size() <= prefix.size()) {
                 return;
@@ -165,6 +175,7 @@ void MqttOutput::onConnected(const DeviceState& state, const BridgeInfo& bridge)
     // and get no command topic -- that follows from the capabilities, not a decision here.
     if (relayCount_ > 0) {
         g_client.subscribe(topics_.relaySetWildcard().c_str(), 1);
+        g_client.subscribe(topics_.drmSet().c_str(), 1);
         relayStateForced_ = true;  // fresh session: ack the current states once
     }
 }
@@ -243,6 +254,15 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
                 const bool on = (bridge.relayMask >> i) & 1;
                 g_client.publish(topics_.relayState(i).c_str(), 1, true,
                                  on ? "ON" : "OFF");
+            }
+            // The DRM mode is derived state over the same mask; ack it in the same breath
+            // so the HA select and the switches can never disagree for long.
+            std::vector<std::string> roles = bridge.relayRoles;
+            roles.resize(bridge.relayCount, "none");
+            if (!drm::optionsFor(roles).empty()) {
+                const std::string mode = drm::modeFrom(roles, bridge.relayMask);
+                g_client.publish(topics_.drmState().c_str(), 1, true, mode.c_str());
+                lastDrmMode_ = mode;
             }
             lastRelayMask_    = bridge.relayMask;
             relayStateForced_ = false;

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -69,6 +69,11 @@ public:
     using RelayCommandFn = std::function<CommandResult(uint8_t index, bool energised)>;
     void setRelayCommandHandler(RelayCommandFn handler) { relayCommand_ = std::move(handler); }
 
+    /// Handles a DRM mode command from <prefix>/drm/set. Same task/locking rules as the
+    /// relay handler; returns false for a mode that is not an option.
+    using DrmCommandFn = std::function<bool(const std::string& mode)>;
+    void setDrmCommandHandler(DrmCommandFn handler) { drmCommand_ = std::move(handler); }
+
 private:
     void onConnected(const DeviceState& state, const BridgeInfo& bridge);
     void publishDiscovery(const DeviceState& state, const BridgeInfo& bridge);
@@ -106,6 +111,8 @@ private:
     bool everConnected_ = false;
 
     RelayCommandFn relayCommand_;
+    DrmCommandFn   drmCommand_;
+    std::string    lastDrmMode_;  ///< last acked mode; republished on change
     uint8_t        relayCount_ = 0;  ///< copied at begin() for topic parsing in the callback
     /// Set by onMessage (MQTT task) on EVERY received relay command, consumed by loop().
     /// Without it a refused or no-op command changes no state, nothing gets published, and

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -125,6 +125,11 @@ private:
     bool    relayStateForced_  = true;
     uint8_t lastRelayMask_     = 0;
     bool    lastRelaysEnabled_ = false;
+    /// Signature of the configured roles at the last publish. Roles rename the switches,
+    /// rebuild the select options AND change the derived mode, so a role change must
+    /// re-announce discovery and re-ack state -- "applied immediately" would otherwise
+    /// only be true after the next reconnect (self-review of PR #3).
+    std::string lastRelayRolesSig_;
 
 public:
     uint8_t lastDisconnectReason() const { return lastDisconnectReason_; }

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -112,7 +112,6 @@ private:
 
     RelayCommandFn relayCommand_;
     DrmCommandFn   drmCommand_;
-    std::string    lastDrmMode_;  ///< last acked mode; republished on change
     uint8_t        relayCount_ = 0;  ///< copied at begin() for topic parsing in the callback
     /// Set by onMessage (MQTT task) on EVERY received relay command, consumed by loop().
     /// Without it a refused or no-op command changes no state, nothing gets published, and

--- a/src/outputs/mqtt/mqtt_topics.h
+++ b/src/outputs/mqtt/mqtt_topics.h
@@ -34,6 +34,10 @@ public:
     }
     std::string relaySetWildcard() const { return prefix_ + "/relay/+/set"; }
 
+    /// DRM mode select (relay boards with configured roles). Mode name in, mode name out.
+    std::string drmSet() const { return prefix_ + "/drm/set"; }
+    std::string drmState() const { return prefix_ + "/drm/state"; }
+
     const std::string& prefix() const { return prefix_; }
 
 private:

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -488,6 +488,47 @@ bool RestApi::begin() {
         });
     }
 
+    // DRM mode: assert one named demand-response mode, release everything else. The mode
+    // vocabulary comes from the configured relay roles (src/relays/drm.h).
+    g_server->on("/api/v1/drm/set", HTTP_POST,
+                 [this, authorised, rateLimited](AsyncWebServerRequest* request) {
+        if (!authorised(request) || rateLimited(request)) {
+            return;
+        }
+        if (!context_.setDrmMode) {
+            sendError(request, {404, "no_relays", "this board has no relays"});
+            return;
+        }
+        if (!request->hasParam("mode")) {
+            sendError(request, {400, "missing_parameter", "expected ?mode=<name>"});
+            return;
+        }
+        const std::string mode = request->getParam("mode")->value().c_str();
+        switch (context_.setDrmMode(mode)) {
+            case CommandResult::Ok:
+                request->send(200, kJson, "{\"status\":\"ok\"}");
+                return;
+            case CommandResult::ReadOnlyMode:
+                sendError(request, {403, "read_only_mode",
+                                    "security.read_only_mode is on; relays cannot move"});
+                return;
+            case CommandResult::Rejected:
+                sendError(request, {403, "relays_disabled",
+                                    "relays.enabled is off in the configuration"});
+                return;
+            case CommandResult::OutOfRange:
+                sendError(request, {400, "invalid_mode",
+                                    "not a mode for the configured relay roles"});
+                return;
+            case CommandResult::RateLimited:
+                sendError(request, {429, "rate_limited", "too many relay commands"});
+                return;
+            default:
+                sendError(request, {500, "relay_error", "drm command failed"});
+                return;
+        }
+    });
+
     g_server->on("/api/v1/actions/discover", HTTP_POST,
                  [this, authorised, rateLimited](AsyncWebServerRequest* request) {
         if (!authorised(request) || rateLimited(request)) {

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -503,7 +503,14 @@ bool RestApi::begin() {
             sendError(request, {400, "missing_parameter", "expected ?mode=<name>"});
             return;
         }
-        const std::string mode = request->getParam("mode")->value().c_str();
+        // Same bound as the MQTT path: mode names are short ("normal", "drm0".."drm8"),
+        // so anything empty or oversized is rejected before it is copied around.
+        const String& raw = request->getParam("mode")->value();
+        if (raw.length() == 0 || raw.length() > 16) {
+            sendError(request, {400, "invalid_mode", "mode names are short strings"});
+            return;
+        }
+        const std::string mode = raw.c_str();
         switch (context_.setDrmMode(mode)) {
             case CommandResult::Ok:
                 request->send(200, kJson, "{\"status\":\"ok\"}");

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -73,6 +73,10 @@ struct RestContext {
     /// same mutex the MQTT path uses. Unset (nullptr) on boards without relays -- the
     /// endpoint then answers 404, matching the absent-not-zero rule for hardware.
     std::function<CommandResult(uint8_t index, bool energised)> setRelay;
+    /// Applies a named DRM mode (see src/relays/drm.h): the role's relays energised,
+    /// everything else released, atomically behind the relay mutex. Returns the gate
+    /// verdict; OutOfRange doubles as "not a valid mode for the configured roles".
+    std::function<CommandResult(const std::string& mode)> setDrmMode;
 };
 
 class RestApi {

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -5,6 +5,7 @@
 #include <ArduinoJson.h>
 
 #include "outputs/json_util.h"
+#include "relays/drm.h"
 #include "outputs/mqtt/mqtt_payloads.h"  // capabilityName, shared vocabulary
 
 namespace heliograph::rest {
@@ -72,6 +73,12 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
         JsonArray relays    = b["relays"].to<JsonArray>();
         for (uint8_t i = 0; i < bridge.relayCount; ++i) {
             relays.add(((bridge.relayMask >> i) & 1) != 0);
+        }
+        // Derived DRM mode, only when roles make one meaningful.
+        std::vector<std::string> roles = bridge.relayRoles;
+        roles.resize(bridge.relayCount, "none");
+        if (!drm::optionsFor(roles).empty()) {
+            b["drm_mode"] = drm::modeFrom(roles, bridge.relayMask);
         }
     }
 

--- a/src/relays/drm.cpp
+++ b/src/relays/drm.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+
+#include "drm.h"
+
+namespace heliograph::drm {
+
+bool isValidRole(const std::string& role) {
+    if (role == "none") {
+        return true;
+    }
+    if (role.size() != 4 || role.rfind("drm", 0) != 0) {
+        return false;
+    }
+    return role[3] >= '0' && role[3] <= '8';
+}
+
+std::vector<std::string> optionsFor(const std::vector<std::string>& roles) {
+    std::vector<std::string> options;
+    for (const auto& role : roles) {
+        if (role == "none" || !isValidRole(role)) {
+            continue;
+        }
+        bool seen = false;
+        for (const auto& existing : options) {
+            if (existing == role) {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen) {
+            options.push_back(role);
+        }
+    }
+    if (!options.empty()) {
+        options.insert(options.begin(), kModeNormal);
+    }
+    return options;
+}
+
+bool patternFor(const std::vector<std::string>& roles, const std::string& mode,
+                std::vector<bool>& outPattern) {
+    outPattern.assign(roles.size(), false);
+    if (mode == kModeNormal) {
+        // Valid only when a select exists at all; "normal" on a role-less board is
+        // meaningless and refused rather than silently accepted.
+        return !optionsFor(roles).empty();
+    }
+    if (!isValidRole(mode) || mode == "none") {
+        return false;
+    }
+    bool found = false;
+    for (size_t i = 0; i < roles.size(); ++i) {
+        if (roles[i] == mode) {
+            outPattern[i] = true;
+            found         = true;
+        }
+    }
+    return found;
+}
+
+std::string modeFrom(const std::vector<std::string>& roles, uint8_t mask) {
+    if (mask == 0) {
+        return kModeNormal;
+    }
+    // Exactly one role's relays energised, and nothing outside that role?
+    for (const auto& option : optionsFor(roles)) {
+        if (option == kModeNormal) {
+            continue;
+        }
+        uint8_t expected = 0;
+        for (size_t i = 0; i < roles.size() && i < 8; ++i) {
+            if (roles[i] == option) {
+                expected |= static_cast<uint8_t>(1u << i);
+            }
+        }
+        if (mask == expected) {
+            return option;
+        }
+    }
+    return kModeCustom;
+}
+
+}  // namespace heliograph::drm

--- a/src/relays/drm.h
+++ b/src/relays/drm.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+//
+// DRM semantics on top of the relay layer (AS/NZS 4777.2 demand response modes).
+//
+// The RelayController knows contacts; this layer knows what the contacts MEAN. The user
+// assigns each relay a role in the configuration (drm0..drm8, or none), and from those
+// roles this module derives the selectable modes, the relay pattern for a mode, and the
+// mode implied by a relay mask. Everything here is pure and host-tested; asserting the
+// pattern goes through the RelayController and its gates like any other relay command.
+//
+// Firmware semantics are fixed: relay ENERGISED = that DRM line ASSERTED. Whether
+// "asserted" closes or opens the actual circuit at the inverter is a WIRING choice
+// (NO vs NC terminal) documented in docs/drm.md -- the failsafe rule (bridge dead =>
+// inverter runs) decides which terminal to use per line.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace heliograph::drm {
+
+/// Sentinel mode names, next to the drm0..drm8 role names themselves.
+inline constexpr const char* kModeNormal = "normal";  ///< nothing asserted
+inline constexpr const char* kModeCustom = "custom";  ///< a mask no single mode explains
+
+/// True for a valid per-relay role string: "none" or "drm0".."drm8".
+bool isValidRole(const std::string& role);
+
+/// The selectable modes for a role assignment: "normal" plus every non-"none" role, in
+/// relay order. Empty when no relay has a role -- callers then publish no select at all.
+std::vector<std::string> optionsFor(const std::vector<std::string>& roles);
+
+/// The relay pattern that realises `mode`: exactly the relay(s) carrying that role are
+/// energised, everything else released. Returns false for a mode that is not an option
+/// (including "custom", which is a state, not a command).
+bool patternFor(const std::vector<std::string>& roles, const std::string& mode,
+                std::vector<bool>& outPattern);
+
+/// The mode a relay mask implies: "normal" when nothing is energised, the role name when
+/// exactly the relays of one role (and nothing else) are energised, "custom" otherwise
+/// (e.g. hand-toggled combinations via the individual switches).
+std::string modeFrom(const std::vector<std::string>& roles, uint8_t mask);
+
+}  // namespace heliograph::drm

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -613,10 +613,15 @@ async function renderConfig(){
   </div>
   ${window.g_relayCount>0?`<div class="card"><b>Relays</b> <span class="tag" style="font-weight:400">applied immediately</span>
     ${chk('c_rle','Enabled',(c.relays||{}).enabled)}
+    ${Array.from({length:window.g_relayCount},(_, i)=>`
+      <label for="c_rlr${i}">Relay ${i+1} role</label>
+      <select id="c_rlr${i}" data-role="${i}">${['none','drm0','drm1','drm2','drm3','drm4','drm5','drm6','drm7','drm8'].map(r=>
+        `<option ${r===(((c.relays||{}).roles||[])[i]||'none')?'selected':''}>${r}</option>`).join('')}</select>`).join('')}
     <div class="dim" style="font-size:12px;margin-top:8px">DRM curtailment contacts. Two
     locks must open before a relay can move: this switch AND read-only mode being off.
-    Disabling releases every relay. Control lives in Home Assistant (switches appear via
-    discovery) or POST /api/v1/relays/&lt;n&gt;/set.</div></div>`:''}
+    Disabling releases every relay. Roles name the switches in Home Assistant and build
+    the DRM Mode select; see docs/drm.md for the wiring rules (failsafe: a dead bridge
+    must leave the inverter running).</div></div>`:''}
   <div class="card"><b>Security</b> <span class="tag" style="font-weight:400">applied immediately</span>${txt('c_au','Admin username',c.security.admin_username)}
     ${pw('c_ap','Admin password',c.security.password_set)}</div>
   <div class="card"><b>Logging</b> <span class="tag" style="font-weight:400">applied immediately</span>
@@ -651,7 +656,8 @@ async function renderConfig(){
 async function saveConfig(){
   const v=id=>$(id).value, n=id=>Number($(id).value), b=id=>$(id).checked;
   const body={bridge_name:v('c_name'),
-    ...(window.g_relayCount>0?{relays:{enabled:b('c_rle')}}:{}),
+    ...(window.g_relayCount>0?{relays:{enabled:b('c_rle'),
+      roles:Array.from({length:window.g_relayCount},(_,i)=>v('c_rlr'+i))}}:{}),
     wifi:{ssid:v('c_ssid'),hostname:v('c_host')},
     mqtt:{enabled:b('c_mqe'),host:v('c_mqh'),port:n('c_mqp'),username:v('c_mqu'),
           base_topic:v('c_mqt'),discovery_enabled:b('c_mqd')},

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -685,6 +685,14 @@ async function saveConfig(){
   // Passwords are exempt: they are only in the body when typed, and GET never returns them.
   const same=(a,b)=>JSON.stringify(a)===JSON.stringify(b);
   if(same(body.bridge_name,cfgBefore.bridge_name))delete body.bridge_name;
+  // Roles render as 'none' for entries the stored config never had -- comparing the
+  // rendered defaults against the shorter stored array would mark every save as a roles
+  // change (same class as the driver-options default bug, 2026-07-22). Compare against
+  // the stored array padded with the same defaults.
+  if(body.relays){
+    const before=Array.from({length:window.g_relayCount},(_,i)=>(((cfgBefore.relays||{}).roles||[])[i]||'none'));
+    if(same(body.relays.roles,before))delete body.relays.roles;
+  }
   // Driver options travel only when the driver card was touched; an untouched card must not
   // re-assert its rendered options either. Compare per rendered key, not whole objects: the
   // stored map may carry stale keys from a previously active driver (the pre-fix stacking bug),

--- a/test/test_drm/test_main.cpp
+++ b/test/test_drm/test_main.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+//
+// DRM semantics: roles -> selectable modes, mode -> relay pattern, mask -> mode. Pure
+// logic, so every edge that could ever assert the wrong contact is pinned here.
+
+#include <unity.h>
+
+#include "relays/drm.h"
+
+using namespace heliograph::drm;
+
+void setUp() {}
+void tearDown() {}
+
+static void test_role_validation() {
+    TEST_ASSERT_TRUE(isValidRole("none"));
+    TEST_ASSERT_TRUE(isValidRole("drm0"));
+    TEST_ASSERT_TRUE(isValidRole("drm8"));
+    TEST_ASSERT_FALSE(isValidRole("drm9"));
+    TEST_ASSERT_FALSE(isValidRole("drm"));
+    TEST_ASSERT_FALSE(isValidRole("DRM0"));
+    TEST_ASSERT_FALSE(isValidRole(""));
+    TEST_ASSERT_FALSE(isValidRole("normal"));  // a mode, never a role
+}
+
+static void test_options_derive_from_roles() {
+    // No roles: no options, so no select entity exists at all.
+    TEST_ASSERT_TRUE(optionsFor({"none", "none"}).empty());
+
+    const auto options = optionsFor({"drm0", "none", "drm5"});
+    TEST_ASSERT_EQUAL_UINT32(3, options.size());
+    TEST_ASSERT_EQUAL_STRING("normal", options[0].c_str());
+    TEST_ASSERT_EQUAL_STRING("drm0", options[1].c_str());
+    TEST_ASSERT_EQUAL_STRING("drm5", options[2].c_str());
+
+    // Duplicate roles (two relays on one line) appear once.
+    TEST_ASSERT_EQUAL_UINT32(2, optionsFor({"drm0", "drm0"}).size());
+}
+
+static void test_pattern_asserts_exactly_the_role() {
+    std::vector<bool> pattern;
+    TEST_ASSERT_TRUE(patternFor({"drm0", "none", "drm5"}, "drm5", pattern));
+    TEST_ASSERT_FALSE(pattern[0]);
+    TEST_ASSERT_FALSE(pattern[1]);
+    TEST_ASSERT_TRUE(pattern[2]);
+
+    // "normal" releases everything.
+    TEST_ASSERT_TRUE(patternFor({"drm0", "none", "drm5"}, "normal", pattern));
+    for (const bool on : pattern) {
+        TEST_ASSERT_FALSE(on);
+    }
+
+    // A duplicated role energises every relay carrying it.
+    TEST_ASSERT_TRUE(patternFor({"drm0", "drm0"}, "drm0", pattern));
+    TEST_ASSERT_TRUE(pattern[0]);
+    TEST_ASSERT_TRUE(pattern[1]);
+}
+
+static void test_invalid_modes_are_refused() {
+    std::vector<bool> pattern;
+    // A role no relay carries.
+    TEST_ASSERT_FALSE(patternFor({"drm0"}, "drm5", pattern));
+    // "custom" is a reported state, never a command.
+    TEST_ASSERT_FALSE(patternFor({"drm0"}, "custom", pattern));
+    // "none" is a role, never a mode.
+    TEST_ASSERT_FALSE(patternFor({"drm0"}, "none", pattern));
+    // "normal" without any roles is meaningless.
+    TEST_ASSERT_FALSE(patternFor({"none"}, "normal", pattern));
+    // Refusal always leaves a released pattern behind, so a caller that ignores the
+    // return value can still never assert something by accident.
+    for (const bool on : pattern) {
+        TEST_ASSERT_FALSE(on);
+    }
+}
+
+static void test_mode_from_mask() {
+    const std::vector<std::string> roles = {"drm0", "none", "drm5"};
+    TEST_ASSERT_EQUAL_STRING("normal", modeFrom(roles, 0b000).c_str());
+    TEST_ASSERT_EQUAL_STRING("drm0", modeFrom(roles, 0b001).c_str());
+    TEST_ASSERT_EQUAL_STRING("drm5", modeFrom(roles, 0b100).c_str());
+    // The role-less relay energised, or a combination: no single mode explains it.
+    TEST_ASSERT_EQUAL_STRING("custom", modeFrom(roles, 0b010).c_str());
+    TEST_ASSERT_EQUAL_STRING("custom", modeFrom(roles, 0b101).c_str());
+
+    // Duplicated role: BOTH its relays energised is the mode; one of the two is custom.
+    const std::vector<std::string> dup = {"drm0", "drm0"};
+    TEST_ASSERT_EQUAL_STRING("drm0", modeFrom(dup, 0b11).c_str());
+    TEST_ASSERT_EQUAL_STRING("custom", modeFrom(dup, 0b01).c_str());
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_role_validation);
+    RUN_TEST(test_options_derive_from_roles);
+    RUN_TEST(test_pattern_asserts_exactly_the_role);
+    RUN_TEST(test_invalid_modes_are_refused);
+    RUN_TEST(test_mode_from_mask);
+    return UNITY_END();
+}

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -632,26 +632,57 @@ static void test_relay_entities_follow_count_and_enabled() {
     TEST_ASSERT_TRUE(buildRelayEntities(bridge, topics, kDefaultDiscoveryPrefix).empty());
 
     // Relays present but the feature disabled: EMPTY retained payloads on the config
-    // topics, so previously announced switches disappear from Home Assistant.
+    // topics (switches AND the select), so previously announced entities disappear.
     bridge.relayCount    = 2;
     bridge.relaysEnabled = false;
     auto removed = buildRelayEntities(bridge, topics, kDefaultDiscoveryPrefix);
-    TEST_ASSERT_EQUAL_UINT32(2, removed.size());
+    TEST_ASSERT_EQUAL_UINT32(3, removed.size());
     TEST_ASSERT_TRUE(removed[0].payload.empty());
+    TEST_ASSERT_TRUE(removed[2].payload.empty());
     TEST_ASSERT_EQUAL_STRING("homeassistant/switch/heliograph-a1b2c3/relay_1/config",
                              removed[0].configTopic.c_str());
+    TEST_ASSERT_EQUAL_STRING("homeassistant/select/heliograph-a1b2c3/drm_mode/config",
+                             removed[2].configTopic.c_str());
 
-    // Enabled: real switch configs, ack-based (not optimistic), on the bridge device.
+    // Enabled without roles: real switches, plain names, and a select REMOVAL (no roles =
+    // no modes to offer).
     bridge.relaysEnabled = true;
     bridge.relayMask     = 0b01;
     auto entities = buildRelayEntities(bridge, topics, kDefaultDiscoveryPrefix);
-    TEST_ASSERT_EQUAL_UINT32(2, entities.size());
+    TEST_ASSERT_EQUAL_UINT32(3, entities.size());
     auto doc = parse(entities[0].payload);
     TEST_ASSERT_EQUAL_STRING("Relay 1", doc["name"]);
     TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/relay/0/set", doc["command_topic"]);
     TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/relay/0/state", doc["state_topic"]);
     TEST_ASSERT_FALSE(doc["optimistic"].as<bool>());
     TEST_ASSERT_EQUAL_STRING("heliograph-a1b2c3", doc["device"]["identifiers"][0]);
+    TEST_ASSERT_TRUE(entities[2].payload.empty());
+}
+
+static void test_drm_select_and_role_names_follow_the_roles() {
+    auto bridge          = makeBridge();
+    bridge.relayCount    = 2;
+    bridge.relaysEnabled = true;
+    bridge.relayRoles    = {"drm0", "none"};
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+
+    const auto entities = buildRelayEntities(bridge, topics, kDefaultDiscoveryPrefix);
+    TEST_ASSERT_EQUAL_UINT32(3, entities.size());
+
+    // The role lands in the switch name; the role-less relay keeps the plain name.
+    auto sw = parse(entities[0].payload);
+    TEST_ASSERT_EQUAL_STRING("Relay 1 (DRM0)", sw["name"]);
+    TEST_ASSERT_EQUAL_STRING("Relay 2", parse(entities[1].payload)["name"]);
+
+    // The select offers normal + the configured role, plus "custom" as reportable state.
+    auto sel = parse(entities[2].payload);
+    TEST_ASSERT_EQUAL_STRING("DRM Mode", sel["name"]);
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/drm/set", sel["command_topic"]);
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/drm/state", sel["state_topic"]);
+    TEST_ASSERT_EQUAL_UINT32(3, sel["options"].size());
+    TEST_ASSERT_EQUAL_STRING("normal", sel["options"][0]);
+    TEST_ASSERT_EQUAL_STRING("drm0", sel["options"][1]);
+    TEST_ASSERT_EQUAL_STRING("custom", sel["options"][2]);
 }
 
 static void test_sanitize_id() {
@@ -808,6 +839,7 @@ int main(int, char**) {
     RUN_TEST(test_the_mock_hybrid_gets_battery_and_phase_entities_for_free);
     RUN_TEST(test_bridge_diagnostic_entities);
     RUN_TEST(test_relay_entities_follow_count_and_enabled);
+    RUN_TEST(test_drm_select_and_role_names_follow_the_roles);
     RUN_TEST(test_sanitize_id);
     RUN_TEST(test_first_state_is_always_published);
     RUN_TEST(test_an_unchanged_state_is_not_republished);

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -169,6 +169,28 @@ static void test_relays_enabled_defaults_off_and_round_trips() {
     TEST_ASSERT_TRUE(after.relays.enabled);
 }
 
+static void test_relay_roles_validate_and_round_trip() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    auto               c = provisionedConfig();
+    ConfigError        e;
+
+    // A bad role never lands: the patch is refused as a whole.
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"relays":{"roles":["drm9"]}})", c, e));
+    TEST_ASSERT_EQUAL_STRING("relays.roles", e.field.c_str());
+    TEST_ASSERT_TRUE(c.relays.roles.empty());
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"relays":{"roles":["drm0","none"]}})", c, e));
+    TEST_ASSERT_TRUE(store.save(c));
+
+    ConfigurationStore reloaded(backend);
+    Configuration      after;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, reloaded.load(after));
+    TEST_ASSERT_EQUAL_UINT32(2, after.relays.roles.size());
+    TEST_ASSERT_EQUAL_STRING("drm0", after.relays.roles[0].c_str());
+    TEST_ASSERT_EQUAL_STRING("none", after.relays.roles[1].c_str());
+}
+
 // --- ntp ----------------------------------------------------------------------------------
 
 static void test_ntp_settings_round_trip_through_storage() {
@@ -604,6 +626,7 @@ int main(int, char**) {
     RUN_TEST(test_first_boot_finds_nothing_and_keeps_defaults);
     RUN_TEST(test_save_then_load_round_trips_everything);
     RUN_TEST(test_relays_enabled_defaults_off_and_round_trips);
+    RUN_TEST(test_relay_roles_validate_and_round_trip);
     RUN_TEST(test_config_under_the_legacy_namespace_is_adopted);
     RUN_TEST(test_primary_config_wins_over_legacy);
     RUN_TEST(test_ntp_settings_round_trip_through_storage);


### PR DESCRIPTION
## What

Phase C of the DRM initiative: relays get **meaning**. Draft until self-review + Copilot have run.

- **Roles**: each relay is assigned `none` or `drm0`..`drm8` in Settings (validated, persisted; bad roles refuse the whole patch).
- **Pure DRM module** (`src/relays/drm.h`): roles → selectable modes, mode → relay pattern, mask → reported mode (`normal`/role/`custom`). Host-tested.
- **Mode application**: OFFs first (never throttled), then ONs; a refusal mid-pattern rolls back to fully released.
- **Surfaces**: HA `select` (options derived from roles, removal payloads on disable), role names in switch labels, MQTT `drm/set`+`drm/state`, REST `POST /api/v1/drm/set?mode=`, `drm_mode` in the status payload.
- **docs/drm.md**: the NO/NC wiring rule that keeps the failsafe true, an explicit per-manufacturer-verification warning (no universal pinout is claimed), and a pre-flight checklist.

## Testing

413 native tests (7 new: role validation, option derivation, pattern assertion/refusal, mask→mode, config round-trip; extended discovery tests for the select). Layering, cppcheck, JS checks green; all four envs build.

## Not in this PR

Hardware validation — the Relay-6CH is ordered; polarity check and the first coil-click test happen when it arrives.
