### PR TITLE
Review hardening: stuck body buffer, DRM pattern rate limiting, MQTT cross-task state

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,31 +66,53 @@ itself in terms of one driver ("the EverSolar doesn't have this field"), the rul
                │ snapshot()          ← only readers
      ┌─────────┼─────────┬─────────────┬────────────┐
      ▼         ▼         ▼             ▼            ▼
-  mqttTask  AsyncTCP  AsyncTCP     loopTask     eModbus
-  core 0    (REST)    (web/SSE)    core 1       (Modbus TCP)
-  pr 3      pr 3      pr 3         pr 1         pr 3
+  rs485Task AsyncTCP  AsyncTCP     loopTask     eModbus
+  (MQTT     (REST)    (web/SSE)    core 1       (Modbus TCP)
+  publish*) pr 3      pr 3         pr 1         pr 3
 ```
+
+\* MQTT publishing runs on `rs485Task` itself: `MqttOutput::loop()` builds the payloads and
+`publish()` only enqueues into espMqttClient's outbox. The library's own `mqttclient` task
+drives the socket. See "MQTT task model" below.
 
 ### Tasks
 
 | Task | Core | Prio | Stack | Responsible for | WDT |
 |---|---|---|---|---|---|
-| `rs485Task` | 1 | 5 | 8192 | UART1, active driver, poll cycle, discovery. 8192 since the stack-canary crash of 2026-07-19 (TRACE path through newlib vsnprintf); see main.cpp | ✔ |
-| `mqttTask` | 0 | 3 | 4096 | espMqttClient, publishing, HA discovery | ✔ |
+| `rs485Task` | 1 | 5 | 8192 | UART1, active driver, poll cycle, discovery, and pushing snapshots to the outputs (`MqttOutput::loop()`, Modbus refresh, SSE notify). 8192 since the stack-canary crash of 2026-07-19 (TRACE path through newlib vsnprintf); see main.cpp | ✔ |
+| `mqttclient` (library) | 1 | 1 | 5120 | espMqttClient's internal task: socket TX/RX, keepalive, draining the outbox, and running the `onMessage`/`onDisconnect` callbacks | ✖ |
 | `loopTask` (Arduino) | 1 | 1 | 8192 | Wifi supervision, mDNS, diagnostics, relay safety | ✔ |
 | `async_tcp` (library) | 0 | 3 | 8192 | REST, web, SSE — managed by AsyncTCP | ✖ |
 | `eModbus server` (library) | 0 | 3 | 4096 | Modbus TCP clients | ✖ |
 
-Three of our own tasks, two library tasks. Deliberately minimal.
+Two of our own tasks, three library tasks. Deliberately minimal.
 
 Rationale for the core split: wifi/lwIP runs on core 0 by default. By pinning `rs485Task` to
-core 1, network load cannot disturb RS485 timing — exactly the acceptance criterion
-"Modbus client errors do not interrupt inverter polling". Conversely, `mqttTask` sits with the
-network on core 0.
+core 1 **at priority 5**, network load cannot disturb RS485 timing — exactly the acceptance
+criterion "Modbus client errors do not interrupt inverter polling". The `mqttclient` task also
+lives on core 1 (the library's default constructor pins it there at priority 1), but it cannot
+preempt the higher-priority `rs485Task`; the MQTT payload building that runs on `rs485Task`
+itself is microseconds of pure CPU against a protocol with second-scale timeouts.
 
-Watchdog: `esp_task_wdt` with a 30 s timeout; `rs485Task`, `mqttTask` and `loopTask` register
-with it. `rs485Task` calls `esp_task_wdt_reset()` every cycle, even when the poll fails — an
-unreachable inverter must never cause a reset.
+Watchdog: `esp_task_wdt` with a 120 s timeout (an extended discovery scan legitimately runs
+many back-to-back 3 s transactions between feeds); `rs485Task` and `loopTask` register with
+it, the library tasks do not. `rs485Task` calls `esp_task_wdt_reset()` every cycle, even when
+the poll fails — an unreachable inverter must never cause a reset.
+
+### MQTT task model and thread safety
+
+VERIFIED 2026-07-22 against the vendored espMqttClient 1.7.x sources (not the online docs,
+which are silent on this): on ESP32 every `publish()`/`subscribe()` takes a FreeRTOS mutex
+around the outbox (`EMC_SEMAPHORE_TAKE` in `MqttClient.h`/`.cpp`) and the connection state is
+`std::atomic`. Calling `publish()` from a different task than the library's own is therefore
+safe by design — the library exists to be used exactly this way: its `mqttclient` task pumps
+the socket while the application enqueues from wherever it runs.
+
+The flip side: the `onMessage`/`onDisconnect` callbacks run on the `mqttclient` task, so
+anything they touch is cross-task state. `MqttOutput` keeps those callbacks down to atomics
+(`relayAckRequested_`, `resyncRequested_`, `lastDisconnectReason_`) and the mutex-guarded
+`Diagnostics::setLastError()`; the state owned by `loop()` (throttle, discovery bookkeeping)
+is only ever mutated on the task that calls `loop()`.
 
 ### Shared resources and locking
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,8 +156,10 @@ BridgeInfo bridgeInfo() {
 }
 
 /// Applies a named DRM mode: the role's relays energised, everything else released.
-/// OFFs first (never throttled), then the ONs; if any ON is refused mid-pattern the
-/// whole pattern is released again -- a half-asserted mode is worse than none.
+/// The controller applies the pattern atomically behind its gates, charging ONE rate-limit
+/// token for the whole mode switch. Charging per relay (the previous shape) made any role
+/// spanning more relays than the burst impossible to assert, ever: the tail ONs always hit
+/// the throttle and the rollback released the mode again.
 CommandResult applyDrmMode(const std::string& mode) {
     std::vector<std::string> roles;
     {
@@ -170,24 +172,7 @@ CommandResult applyDrmMode(const std::string& mode) {
         return CommandResult::OutOfRange;
     }
     std::lock_guard<std::mutex> lock(g_relayMutex);
-    for (uint8_t i = 0; i < g_relays.count(); ++i) {
-        if (!pattern[i]) {
-            const CommandResult r = g_relays.set(i, false);
-            if (r != CommandResult::Ok) {
-                return r;  // gate closed: nothing moved yet (OFF is never rate-limited)
-            }
-        }
-    }
-    for (uint8_t i = 0; i < g_relays.count(); ++i) {
-        if (pattern[i]) {
-            const CommandResult r = g_relays.set(i, true);
-            if (r != CommandResult::Ok) {
-                g_relays.allOff();
-                return r;
-            }
-        }
-    }
-    return CommandResult::Ok;
+    return g_relays.applyPattern(pattern);
 }
 
 std::string scanNetworksJson() {

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -52,9 +52,11 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
     g_client.setWill(willTopic_.c_str(), 1, true, kPayloadOffline);
 
     g_client.onDisconnect([this](espMqttClientTypes::DisconnectReason reason) {
-        // Retained messages may not survive; force a full republish once back.
-        throttle_.reset();
-        discoveryPublished_ = false;
+        // Runs on the library's 'mqttclient' task while loop() runs on the caller's task, so
+        // only atomics and the mutex-guarded diagnostics may be touched here. The actual
+        // resync (throttle reset + discovery republish) happens in loop(), which owns that
+        // state -- same pattern as relayAckRequested_.
+        resyncRequested_ = true;
         // NOTE: the reconnect counter is NOT bumped here. espMqttClient fires onDisconnect
         // on every failed connect *attempt* too, so counting here inflated the total with
         // each back-off retry during an outage and, worse, never ticked on the actual
@@ -217,6 +219,15 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
             diagnostics_->recordMqttReconnect();
         }
         everConnected_ = true;
+    }
+
+    // Retained messages may not have survived the broker outage; force a full republish.
+    // Consumed here rather than done in onDisconnect: nothing publishes while disconnected
+    // anyway, and this way throttle_ and discoveryPublished_ are only ever touched on the
+    // task that runs loop().
+    if (resyncRequested_.exchange(false)) {
+        throttle_.reset();
+        discoveryPublished_ = false;
     }
 
     // Re-announce when the measurement model has grown since the last discovery publish.

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -102,8 +102,14 @@ private:
     uint64_t nextReconnectMs_    = 0;
     /// Exponential back-off, capped. An unreachable broker must not turn into a busy loop.
     uint32_t reconnectDelayMs_ = 1000;
-    /// espMqttClientTypes::DisconnectReason of the last drop, for diagnostics.
-    uint8_t lastDisconnectReason_ = 0;
+    /// espMqttClientTypes::DisconnectReason of the last drop, for diagnostics. Atomic:
+    /// written by onDisconnect on the library's task, read from the caller's task.
+    std::atomic<uint8_t> lastDisconnectReason_{0};
+    /// Set by onDisconnect (library task), consumed by loop() (caller's task): forces a
+    /// throttle reset and a discovery republish after a reconnect, because retained
+    /// messages may not have survived the broker outage. The disconnect callback itself
+    /// must not touch throttle_/discoveryPublished_ -- those belong to loop()'s task.
+    std::atomic<bool> resyncRequested_{false};
     /// Edge detection for the reconnect counter. `wasConnected_` tracks the previous loop's
     /// link state so a false→true transition is counted once; `everConnected_` makes the
     /// FIRST connect at boot not count as a reconnect. See loop().

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -66,6 +66,16 @@ bool RestApi::collectBody(AsyncWebServerRequest* request, const uint8_t* data, s
         bodyOwner_ = request;
         bodyBuffer_.clear();
         bodyBuffer_.reserve(total);
+        // A client that vanishes mid-body (WiFi drop on the setup AP is the realistic case)
+        // never reaches the request handler, so nothing would release the buffer: every later
+        // body-carrying request then answered 409 "busy" until a reboot. Same lesson the OTA
+        // route already learned. After a normal completion the handler has already released
+        // and the owner check makes this a no-op.
+        request->onDisconnect([this, request] {
+            if (bodyOwner_ == request) {
+                releaseBody();
+            }
+        });
     }
     if (bodyOwner_ != request) {
         return false;

--- a/src/relays/relay_controller.cpp
+++ b/src/relays/relay_controller.cpp
@@ -74,4 +74,51 @@ CommandResult RelayController::set(uint8_t index, bool energised) {
     return CommandResult::Ok;
 }
 
+CommandResult RelayController::applyPattern(const std::vector<bool>& pattern) {
+    if (readOnly_) {
+        return CommandResult::ReadOnlyMode;
+    }
+    if (!enabled_) {
+        return CommandResult::Rejected;
+    }
+    if (pattern.size() != static_cast<size_t>(count_)) {
+        return CommandResult::OutOfRange;
+    }
+    bool assertsAny = false;
+    for (uint8_t i = 0; i < count_; ++i) {
+        if (pattern[i]) {
+            assertsAny = true;
+            break;
+        }
+    }
+    // One token for the whole pattern, and only when it asserts anything: a release-only
+    // pattern is the safe direction and passes unconditionally, like set(index, false).
+    if (assertsAny) {
+        const uint64_t now = clock_ ? clock_() : 0;
+        if (!allowedByRateLimit(now)) {
+            return CommandResult::RateLimited;
+        }
+    }
+    // All gates passed: nothing below can refuse, so the pattern lands whole. OFFs first --
+    // when switching modes, releasing the old role's contacts must precede asserting the
+    // new one's.
+    for (uint8_t i = 0; i < count_; ++i) {
+        if (!pattern[i]) {
+            state_[i] = false;
+            if (apply_) {
+                apply_(i, false);
+            }
+        }
+    }
+    for (uint8_t i = 0; i < count_; ++i) {
+        if (pattern[i]) {
+            state_[i] = true;
+            if (apply_) {
+                apply_(i, true);
+            }
+        }
+    }
+    return CommandResult::Ok;
+}
+
 }  // namespace heliograph

--- a/src/relays/relay_controller.h
+++ b/src/relays/relay_controller.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <vector>
 
 #include "commands/command_dispatcher.h"  // RateLimitPolicy
 #include "device/clock.h"
@@ -48,6 +49,15 @@ public:
     /// rate limit -- only then does the apply hook run. Turning a relay OFF passes the
     /// rate limiter unconditionally: releasing curtailment must never be throttled.
     CommandResult set(uint8_t index, bool energised);
+
+    /// Applies a full relay pattern (a DRM mode) as ONE command: same gates as set(), but a
+    /// single rate-limit token for the whole pattern, however many relays it spans. Charging
+    /// per relay made any pattern wider than the burst impossible to assert -- the tail ONs
+    /// were refused by the throttle that exists to stop relay chatter, not an atomic mode
+    /// switch. Releases (OFF) are written before asserts (ON), and an all-off pattern is
+    /// never throttled, matching set()'s safe direction. `pattern` must be exactly count()
+    /// entries.
+    CommandResult applyPattern(const std::vector<bool>& pattern);
 
     /// Failsafe: everything de-energised, immediately, regardless of gates. For shutdown
     /// paths and for disabling the feature at runtime.

--- a/test/test_relays/test_main.cpp
+++ b/test/test_relays/test_main.cpp
@@ -113,6 +113,70 @@ static void test_rate_limit_throttles_on_but_never_off() {
     TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(0, true));
 }
 
+static void test_pattern_wider_than_burst_asserts_in_one_command() {
+    // The bug this guards against: charging the rate limiter per relay made a role spanning
+    // more relays than the burst (default 3) impossible to assert -- the 4th ON was always
+    // throttled and the rollback released the whole mode again.
+    auto c = makeController(6);
+    c.setReadOnlyMode(false);
+    c.setEnabled(true);
+    g_writes.clear();
+    TEST_ASSERT_EQUAL(CommandResult::Ok,
+                      c.applyPattern({true, true, true, true, false, false}));
+    for (uint8_t i = 0; i < 4; ++i) {
+        TEST_ASSERT_TRUE(c.energised(i));
+    }
+    TEST_ASSERT_FALSE(c.energised(4));
+    TEST_ASSERT_FALSE(c.energised(5));
+    // OFFs are written before ONs: releasing the old role precedes asserting the new one.
+    TEST_ASSERT_EQUAL_UINT32(6, g_writes.size());
+    TEST_ASSERT_FALSE(g_writes[0].energised);
+    TEST_ASSERT_FALSE(g_writes[1].energised);
+    for (size_t i = 2; i < 6; ++i) {
+        TEST_ASSERT_TRUE(g_writes[i].energised);
+    }
+}
+
+static void test_pattern_charges_one_token_and_throttles_as_a_whole() {
+    RateLimitPolicy policy;
+    policy.minIntervalMs = 1000;
+    policy.burst         = 1;
+    RelayController c(&fakeClock, policy);
+    c.begin(2, [](uint8_t i, bool on) { g_writes.push_back({i, on}); });
+    c.setReadOnlyMode(false);
+    c.setEnabled(true);
+
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.applyPattern({true, false}));
+    // Burst spent, no time passed: a second asserting pattern is refused BEFORE any relay
+    // moves -- no half-applied mode, no sneaky release of the current one.
+    g_writes.clear();
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited, c.applyPattern({false, true}));
+    TEST_ASSERT_TRUE(g_writes.empty());
+    TEST_ASSERT_TRUE(c.energised(0));
+    TEST_ASSERT_FALSE(c.energised(1));
+    // An all-off pattern is the safe direction and passes the throttle unconditionally.
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.applyPattern({false, false}));
+    TEST_ASSERT_FALSE(c.energised(0));
+    // After the interval the allowance refills.
+    g_now += 1000;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.applyPattern({false, true}));
+    TEST_ASSERT_TRUE(c.energised(1));
+}
+
+static void test_pattern_honours_gates_and_size() {
+    auto c = makeController(2);
+    // Kill switch first, exactly like set().
+    TEST_ASSERT_EQUAL(CommandResult::ReadOnlyMode, c.applyPattern({true, false}));
+    c.setReadOnlyMode(false);
+    TEST_ASSERT_EQUAL(CommandResult::Rejected, c.applyPattern({true, false}));
+    c.setEnabled(true);
+    // A pattern that does not match the relay count is a caller bug, not a partial apply.
+    g_writes.clear();
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, c.applyPattern({true}));
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, c.applyPattern({true, false, true}));
+    TEST_ASSERT_TRUE(g_writes.empty());
+}
+
 static void test_all_off_ignores_every_gate() {
     auto c = makeController(3);
     c.setReadOnlyMode(false);
@@ -150,6 +214,9 @@ int main(int, char**) {
     RUN_TEST(test_switching_works_when_both_gates_open);
     RUN_TEST(test_out_of_range_index_is_refused);
     RUN_TEST(test_rate_limit_throttles_on_but_never_off);
+    RUN_TEST(test_pattern_wider_than_burst_asserts_in_one_command);
+    RUN_TEST(test_pattern_charges_one_token_and_throttles_as_a_whole);
+    RUN_TEST(test_pattern_honours_gates_and_size);
     RUN_TEST(test_all_off_ignores_every_gate);
     RUN_TEST(test_count_is_clamped_and_zero_count_is_inert);
     return UNITY_END();


### PR DESCRIPTION
Three findings from a fundamentals review of the codebase, each verified before fixing.

## REST: stuck body buffer after a mid-upload disconnect

`collectBody()` handed ownership of the shared body buffer to a request at chunk 0, but only the request handlers released it. A client vanishing mid-body (WiFi drop on the setup AP is the realistic case) never reached the handler, so every later body-carrying request — provision, config PATCH — answered 409 `busy` until a reboot. The buffer owner now registers an `onDisconnect` hook, mirroring the fix the OTA route already had.

## Relays: a DRM role wider than the burst could never assert

`applyDrmMode()` charged one rate-limit token per relay, all within the same millisecond. With the default burst of 3, any role spanning 4+ relays hit the throttle on the tail ONs — every time, including retries — and the rollback released the whole mode again. The pattern application moved into `RelayController::applyPattern()`: same gate order as `set()`, one token for the whole pattern, charged only when the pattern asserts anything (all-off stays unthrottled, matching the safe direction). All gates decide before the first relay moves, so the half-applied/rollback path is gone; OFFs still land before ONs. Three new host tests cover it, including the exact 4-relays-at-burst-3 scenario.

## MQTT: cross-task callback state + stale architecture doc

The `onDisconnect` callback (espMqttClient's task) mutated the publish throttle and discovery flag that `loop()` (rs485Task) owns. It now only sets an atomic `resyncRequested_` consumed by `loop()` — the existing `relayAckRequested_` pattern — with unchanged behaviour, since nothing publishes while disconnected. `lastDisconnectReason_` became atomic for the same reason.

`docs/architecture.md` described a `mqttTask` that does not exist and placed MQTT on core 0. Verified against the vendored espMqttClient 1.7.x sources: `publish()` from another task is safe by design (FreeRTOS mutex around the outbox, atomic connection state), and the library's own `mqttclient` task is default-pinned to core 1 at priority 1 — below `rs485Task`, so polling cannot be preempted. The task table, core-split rationale and watchdog description now match the code, plus a new section recording the verified thread-safety contract.

## Verification

- `pio test -e native`: 416/416 passed
- `pio run` for waveshare-rs485-can, waveshare-relay-6ch and mock: success
- `tools/check_layering.sh`: RESULT: PASS
- `pio check -e native` (cppcheck): passed