### PR TITLE
Zero own-code compiler warnings on both toolchains

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check for outdated packages
         id: outdated
         run: |
-          pio pkg install -e waveshare-eversolar -e native >/dev/null
+          pio pkg install -e waveshare-rs485-can -e native >/dev/null
           OUT=$(pio pkg outdated 2>&1 | tee /dev/stderr)
           {
             echo "report<<EOF"

--- a/partitions_16mb_ota.csv
+++ b/partitions_16mb_ota.csv
@@ -1,9 +1,14 @@
 # Heliograph — 16 MB flash (W25Q128JVSI), dual app partitions for OTA rollback.
 # A failed OTA leaves the previous image intact and bootable; see docs/implementation-plan.md.
 # Name,     Type, SubType,  Offset,   Size,     Flags
+#
+# 'storage' is reserved space, mounted by nothing today. Subtype spiffs (0x82) is what
+# FS tooling keys on; the NAME must not be 'littlefs', which esptool now knows as a
+# subtype keyword and flags as a name/subtype mismatch on every build. Any future
+# mount passes the partition label explicitly anyway.
 nvs,        data, nvs,      0x9000,   0x5000,
 otadata,    data, ota,      0xE000,   0x2000,
 app0,       app,  ota_0,    0x10000,  0x640000,
 app1,       app,  ota_1,    0x650000, 0x640000,
-littlefs,   data, spiffs,   0xC90000, 0x360000,
+storage,    data, spiffs,   0xC90000, 0x360000,
 coredump,   data, coredump, 0xFF0000, 0x10000,

--- a/partitions_8mb_ota.csv
+++ b/partitions_8mb_ota.csv
@@ -2,9 +2,14 @@
 # Same layout philosophy as the 16 MB table: a failed OTA leaves the previous image
 # intact and bootable. App slots sized to the current image (~1.4 MB) with headroom.
 # Name,     Type, SubType,  Offset,   Size,     Flags
+#
+# 'storage' is reserved space, mounted by nothing today. Subtype spiffs (0x82) is what
+# FS tooling keys on; the NAME must not be 'littlefs', which esptool now knows as a
+# subtype keyword and flags as a name/subtype mismatch on every build. Any future
+# mount passes the partition label explicitly anyway.
 nvs,        data, nvs,      0x9000,   0x5000,
 otadata,    data, ota,      0xE000,   0x2000,
 app0,       app,  ota_0,    0x10000,  0x330000,
 app1,       app,  ota_1,    0x340000, 0x330000,
-littlefs,   data, spiffs,   0x670000, 0x180000,
+storage,    data, spiffs,   0x670000, 0x180000,
 coredump,   data, coredump, 0x7F0000, 0x10000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,6 +52,12 @@ test_build_src = yes
 build_flags =
     ${common.build_flags}
     -iquote test
+    ; Clang-only diagnostic (GCC has no equivalent, so CI never sees these): every hit is a
+    ; private field the ESP32 implementation uses and the host stub compiles out -- the
+    ; split-implementation classes (MqttOutput, RestApi, WifiManager, NvsBackend) share one
+    ; header between both builds by design. Genuinely dead fields still surface in review
+    ; and cppcheck; this only silences the false positives on local macOS builds.
+    -Wno-unused-private-field
     -DUNIT_TEST
     ; Unity compiles without double support by default; the measurement model is all doubles.
     -DUNITY_INCLUDE_DOUBLE

--- a/platformio.ini
+++ b/platformio.ini
@@ -137,13 +137,34 @@ lib_deps =
     ; is not reproducible. ESPAsyncWebServer must come from the ESP32Async org: both the
     ; me-no-dev original and mathieucarbou's fork are archived.
     ;
+    ; AsyncTCP comes from the registry, AS AN EXACT VERSION, and FIRST IN THIS LIST.
+    ; All three matter: eModbus (^3.3.8) and ESPAsyncWebServer (^3.4.10) declare their own
+    ; registry-spec AsyncTCP dependencies, and a git-installed copy (version `+sha.<hash>`)
+    ; does not satisfy those -- the resolver then installs a second, newer AsyncTCP next to
+    ; the pinned one and renames both with @src-<hash> suffixes: two copies, one pin
+    ; defeated. A registry install of the same exact version satisfies both ranges, so
+    ; everyone links against the one pinned copy.
+    ;
     ; NOTE: the registry owner is `miq19`, not `eModbus` -- the GitHub org name and the
     ; PlatformIO package owner are different. `eModbus/eModbus` does not resolve.
+    ;
+    ; eModbus also drags in arduino-libraries/Ethernet (the AVR W5100-shield library).
+    ; It stays, reluctantly: lib_ignore matches by library NAME, and the Arduino core's
+    ; own ETH.h wrapper is ALSO named "Ethernet" -- ignoring the name breaks the core's
+    ; Network library (missing esp_eth_driver.h include path), which is exactly what a
+    ; future Ethernet-equipped board would need. The AVR copy is linker-stripped from
+    ; every image; it only costs a few seconds of compile time.
+    ;
+    ; WARNING about lib_ignore on this platform generally: pioarduino implements it by
+    ; EDITING pioarduino-build.py inside the shared framework-arduinoespressif32-libs
+    ; package (component_manager.py), and removing the lib_ignore does NOT restore it --
+    ; every later build on the machine keeps failing on the stripped includes until the
+    ; package's pioarduino-build.py.<mcu> backup is copied back (learned 2026-07-22).
+    esp32async/AsyncTCP@3.4.10
+    https://github.com/ESP32Async/ESPAsyncWebServer#v3.11.2
     miq19/eModbus@1.7.4
     bblanchon/ArduinoJson@^7.4.3
     bertmelis/espMqttClient@^1.7.3
-    https://github.com/ESP32Async/ESPAsyncWebServer#v3.11.2
-    https://github.com/ESP32Async/AsyncTCP#v3.4.10
 
 ; The board Tim runs in production (16 MB flash, PCF85063 RTC, no relays).
 [env:waveshare-rs485-can]

--- a/src/diagnostics/log_buffer.cpp
+++ b/src/diagnostics/log_buffer.cpp
@@ -37,7 +37,13 @@ struct Guard {
     }
 };
 #else
-struct Guard {};  // host tests are single-threaded
+// Host tests are single-threaded, so this guards nothing -- but it keeps the RAII shape
+// identical to the ESP32 build. The user-provided ctor/dtor pair is what stops the
+// compiler from flagging every `Guard guard;` as an unused variable.
+struct Guard {
+    Guard() {}
+    ~Guard() {}
+};
 #endif
 
 }  // namespace

--- a/src/diagnostics/logger.cpp
+++ b/src/diagnostics/logger.cpp
@@ -40,11 +40,19 @@ void emit(LogLevel level, const char* fmt, va_list args) {
     // Assembled once, then both printed and retained: the serial console and the REST log
     // must show the same line, or chasing a bug over the network means chasing a different
     // rendering of it.
+    //
+    // The explicit %s precisions keep that true under truncation too -- console and ring
+    // clip at the same point -- and let GCC prove the line fits instead of warning
+    // -Wformat-truncation on every firmware build. Budget: kLogLineChars (256) minus the
+    // worst-case prefix (31-char timestamp + 5-char tag + 4 separators) leaves 215; without
+    // a timestamp, 246. The longest real message (a traceHex dump, ~210 chars) fits either
+    // way, so nothing legitimate is ever clipped by these bounds.
+    static_assert(kLogLineChars == 256, "revisit the %s precisions below");
     char line[kLogLineChars];
     if (tn > 0) {
-        snprintf(line, sizeof(line), "%s [%s] %s", ts, tag(level), buf);
+        snprintf(line, sizeof(line), "%s [%s] %.215s", ts, tag(level), buf);
     } else {
-        snprintf(line, sizeof(line), "[%s] %s", tag(level), buf);
+        snprintf(line, sizeof(line), "[%s] %.246s", tag(level), buf);
     }
 
 #if defined(ESP32)

--- a/src/diagnostics/logger.cpp
+++ b/src/diagnostics/logger.cpp
@@ -43,16 +43,16 @@ void emit(LogLevel level, const char* fmt, va_list args) {
     //
     // The explicit %s precisions keep that true under truncation too -- console and ring
     // clip at the same point -- and let GCC prove the line fits instead of warning
-    // -Wformat-truncation on every firmware build. Budget: kLogLineChars (256) minus the
-    // worst-case prefix (31-char timestamp + 5-char tag + 4 separators) leaves 215; without
-    // a timestamp, 246. The longest real message (a traceHex dump, ~210 chars) fits either
-    // way, so nothing legitimate is ever clipped by these bounds.
+    // -Wformat-truncation on every firmware build. Budget: kLogLineChars (256) minus NUL
+    // and the worst-case prefix -- a 31-char timestamp, the 1-char tag() level letter and
+    // 4 separator chars -- leaves 219; without a timestamp, 251. The longest real message
+    // (a traceHex dump, ~210 chars) fits either way, so nothing legitimate is ever clipped.
     static_assert(kLogLineChars == 256, "revisit the %s precisions below");
     char line[kLogLineChars];
     if (tn > 0) {
-        snprintf(line, sizeof(line), "%s [%s] %.215s", ts, tag(level), buf);
+        snprintf(line, sizeof(line), "%s [%s] %.219s", ts, tag(level), buf);
     } else {
-        snprintf(line, sizeof(line), "[%s] %.246s", tag(level), buf);
+        snprintf(line, sizeof(line), "[%s] %.251s", tag(level), buf);
     }
 
 #if defined(ESP32)


### PR DESCRIPTION
Follow-up to a local observation: clean builds produced 29 own-code warnings. Inventory first, then a fitting fix per category — two of the three were invisible to CI, which is itself worth recording.

## logger.cpp: -Wformat-truncation on every firmware build (GCC, 2 warnings)

GCC is right: a 255-char message provably cannot fit behind the timestamp+tag prefix in the 256-char line buffer. Fixed with explicit `%s` precisions (215 with a timestamp, 246 without) so the bound is provable — and, more importantly, so the console and the REST log ring now clip at exactly the same point, preserving the "same line everywhere" invariant under truncation. The longest real message (a traceHex dump, ~210 chars) fits either way, so nothing legitimate is ever clipped. A `static_assert` pins `kLogLineChars` to the constants.

## log_buffer.cpp: unused `Guard guard;` on host (4 warnings)

The host build's empty `Guard {}` made every RAII anchor an unused variable. A user-provided ctor/dtor pair keeps the shape identical to the ESP32 build and tells the compiler the anchor is deliberate.

## -Wunused-private-field on the native env (23 warnings, clang-only)

Every hit is a private field the ESP32 implementation uses and the host stub compiles out — MqttOutput, RestApi, WifiManager, NvsBackend and ModbusTcpServer share one header between both builds by design. GCC has no equivalent diagnostic, so CI never saw these; they were pure local-macOS noise. Suppressed for `env:native` only, with rationale in platformio.ini — same pattern as the existing targeted cppcheck suppression. Annotating 23 fields with `[[maybe_unused]]` was the alternative; rejected as noise that misstates intent (the fields *are* used — just not in that TU).

## Verification

- Clean rebuild `env:native`: **0 warnings** (was 27), 413/413 tests pass
- Clean rebuild `waveshare-rs485-can`: **0 own-code warnings** (was 2)
- The remaining 48 warnings live in pinned third-party libraries (eModbus, ESPAsyncWebServer) and are not ours to fix