### PR TITLE
Long-uptime stability: monotonic clock, bounded SSE, non-blocking CDC, allocation-free MQTT loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -436,6 +436,11 @@ void setup() {
     while (!Serial && millis() < serialDeadline) {
         delay(10);
     }
+    // Headless operation is the normal state: no USB host for months. HWCDC's default TX
+    // timeout is 100 ms PER WRITE once the 256-byte ring fills with nobody draining it, and
+    // the logger runs on rs485Task too -- every log line would then stall polling for up to
+    // that timeout. Zero means drop-when-full: the REST log ring keeps every line anyway.
+    Serial.setTxTimeoutMs(0);
 
     Serial.printf("\nHeliograph %s\nboard: %s\nreset reason: %d\n", kFirmwareVersion,
                   board::kName, static_cast<int>(esp_reset_reason()));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <Arduino.h>
 #include <WiFi.h>
 #include <esp_task_wdt.h>
+#include <esp_timer.h>
 
 #include <atomic>
 #include <memory>
@@ -88,7 +89,14 @@ std::atomic<uint64_t> g_rebootAtMs{0};
 /// only ever asks. See the note at ctx.requestPoll.
 std::atomic<bool> g_manualPollRequested{false};
 
-uint64_t nowMs() { return static_cast<uint64_t>(millis()); }
+/// esp_timer, NOT millis(): millis() is uint32 and wraps every 49.7 days, and casting the
+/// wrapped value to uint64 does not un-wrap it. Every `now < deadline` comparison downstream
+/// (MQTT reconnect back-off, WiFi retry schedule, poll due-time, relay rate limiter) would
+/// see time jump backwards once per wrap and could stall until the next one — on a device
+/// that is up for months, that is a scheduled outage. esp_timer_get_time() is a true 64-bit
+/// microsecond counter: monotonic for ~292k years. Same fix in Rs485Transport::nowMs() and
+/// the log-timestamp provider.
+uint64_t nowMs() { return static_cast<uint64_t>(esp_timer_get_time() / 1000); }
 
 /// The bridge's DRM relays (empty on boards without them). Commands arrive on two tasks
 /// (REST via AsyncTCP, MQTT via the client's task); g_relayMutex serialises them and the
@@ -119,7 +127,7 @@ BridgeInfo bridgeInfo() {
         info.name = g_config.bridgeName;
     }
     info.bridgeOnline     = true;
-    info.uptimeSeconds    = static_cast<uint32_t>(millis() / 1000);
+    info.uptimeSeconds    = static_cast<uint32_t>(nowMs() / 1000);  // good for 136 years
     info.freeHeapBytes    = ESP.getFreeHeap();
     info.minFreeHeapBytes = ESP.getMinFreeHeap();
     info.resetReason      = static_cast<uint16_t>(esp_reset_reason());
@@ -351,7 +359,7 @@ void startRestApi() {
         // blocking delay() in this callback stalls the whole web server.
         //
         // Hand it to loop() instead, with enough time for the socket to flush.
-        g_rebootAtMs = static_cast<uint64_t>(millis()) + 1500;
+        g_rebootAtMs = nowMs() + 1500;
     };
     ctx.requestDiscovery    = [](bool extended) { return g_discovery.request(extended); };
     ctx.discoveryReport     = [] { return g_discovery.report(); };

--- a/src/network/time_manager.cpp
+++ b/src/network/time_manager.cpp
@@ -10,6 +10,7 @@
 
 #include <Arduino.h>
 #include <esp_sntp.h>
+#include <esp_timer.h>
 
 #include <atomic>
 #include <ctime>
@@ -28,7 +29,10 @@ constexpr time_t kSaneEpoch = 1704067200;
 
 size_t provideTimestamp(char* buf, size_t n) {
     const time_t now = time(nullptr);
-    return log::formatLogTimestamp(buf, n, now > kSaneEpoch, now, millis());
+    // esp_timer, not millis(): the uptime stamp on a never-synced clock must keep counting
+    // past 49.7 days instead of restarting at zero. See the note at main.cpp's nowMs().
+    return log::formatLogTimestamp(buf, n, now > kSaneEpoch, now,
+                                   static_cast<uint64_t>(esp_timer_get_time() / 1000));
 }
 
 // Written from the SNTP task via the notification callback, read from the main loop and

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -154,16 +154,42 @@ std::string sanitizeId(const std::string& measurementId) {
     return out;
 }
 
-std::string discoverySignature(const DeviceState& state) {
+namespace {
+
+// FNV-1a, 64-bit. The '\n' fed between items keeps the hash order- and boundary-sensitive:
+// {"ab","c"} and {"a","bc"} must not collide by construction.
+constexpr uint64_t kFnvOffset = 14695981039346656037ull;
+constexpr uint64_t kFnvPrime  = 1099511628211ull;
+
+uint64_t fnv1aAppend(uint64_t hash, const char* s) {
+    for (; *s != '\0'; ++s) {
+        hash ^= static_cast<uint8_t>(*s);
+        hash *= kFnvPrime;
+    }
+    hash ^= static_cast<uint8_t>('\n');
+    hash *= kFnvPrime;
+    return hash;
+}
+
+}  // namespace
+
+uint64_t discoverySignature(const DeviceState& state) {
     // Only supported channels count: unsupported ones produce no entity (see below), so a
     // change in them must not trigger a republish.
-    std::string sig;
+    uint64_t sig = kFnvOffset;
     for (const auto& m : state.measurements.all()) {
         if (!m.supported) {
             continue;
         }
-        sig += m.id;
-        sig += '\n';
+        sig = fnv1aAppend(sig, m.id);
+    }
+    return sig;
+}
+
+uint64_t stringListFingerprint(const std::vector<std::string>& items) {
+    uint64_t sig = kFnvOffset;
+    for (const auto& item : items) {
+        sig = fnv1aAppend(sig, item.c_str());
     }
     return sig;
 }

--- a/src/outputs/mqtt/home_assistant_discovery.h
+++ b/src/outputs/mqtt/home_assistant_discovery.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/outputs/mqtt/home_assistant_discovery.h
+++ b/src/outputs/mqtt/home_assistant_discovery.h
@@ -57,6 +57,15 @@ std::string sanitizeId(const std::string& measurementId);
 /// Fingerprint of the discovery-relevant measurement model: the ordered ids of supported
 /// measurements. The MQTT output republishes discovery when this changes; comparing a bare
 /// count would miss a same-size swap of one channel for another.
-std::string discoverySignature(const DeviceState& state);
+///
+/// A 64-bit FNV-1a hash rather than a concatenated string: the MQTT loop evaluates this
+/// every pass (~4 Hz), and a std::string here meant a heap allocation per pass, forever --
+/// ~350k/day of steady churn on a months-uptime device for a value that only ever gets
+/// compared. Collisions are theoretical at the scale of "a few dozen short ids".
+uint64_t discoverySignature(const DeviceState& state);
+
+/// Same idea for an ordered list of strings (the configured relay roles): order-sensitive,
+/// allocation-free change detection.
+uint64_t stringListFingerprint(const std::vector<std::string>& items);
 
 }  // namespace heliograph::mqtt

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -256,11 +256,7 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
         // Enabling/disabling the feature adds or removes the switch entities themselves,
         // and a ROLE change renames switches, rebuilds the select options and changes the
         // derived mode -- both force a discovery re-announce; a mask change just acks.
-        std::string rolesSig;
-        for (const auto& role : bridge.relayRoles) {
-            rolesSig += role;
-            rolesSig += '\n';
-        }
+        const uint64_t rolesSig = stringListFingerprint(bridge.relayRoles);
         if (bridge.relaysEnabled != lastRelaysEnabled_ || rolesSig != lastRelayRolesSig_) {
             lastRelaysEnabled_  = bridge.relaysEnabled;
             lastRelayRolesSig_  = rolesSig;

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -97,7 +97,8 @@ private:
     /// discoverySignature() at the last discovery publish. Discovery re-announces when the
     /// model changes: the first MQTT connect often beats the first successful poll of a real
     /// inverter. A signature rather than a count, so a same-size swap of channels is caught.
-    std::string discoveredSignature_;
+    /// 0 = never published; the FNV offset basis makes a real signature never 0 in practice.
+    uint64_t discoveredSignature_ = 0;
     uint64_t lastDiagnosticsMs_  = 0;
     uint64_t nextReconnectMs_    = 0;
     /// Exponential back-off, capped. An unreachable broker must not turn into a busy loop.
@@ -130,11 +131,11 @@ private:
     bool    relayStateForced_  = true;
     uint8_t lastRelayMask_     = 0;
     bool    lastRelaysEnabled_ = false;
-    /// Signature of the configured roles at the last publish. Roles rename the switches,
+    /// Fingerprint of the configured roles at the last publish. Roles rename the switches,
     /// rebuild the select options AND change the derived mode, so a role change must
     /// re-announce discovery and re-ack state -- "applied immediately" would otherwise
     /// only be true after the next reconnect (self-review of PR #3).
-    std::string lastRelayRolesSig_;
+    uint64_t lastRelayRolesSig_ = 0;
 
 public:
     uint8_t lastDisconnectReason() const { return lastDisconnectReason_; }

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -116,6 +116,12 @@ bool RestApi::begin() {
     }
     g_server = new AsyncWebServer(port_);
     g_events = new AsyncEventSource("/api/v1/events");
+    // Enforce the client bound instead of merely declaring it: every SSE client holds a TCP
+    // socket and a send queue for as long as the tab lives, and a device that is up for
+    // months meets a lot of abandoned tabs. Refused clients fall back to polling /status --
+    // SSE is an optimisation, not a contract (see notifyState).
+    g_events->authorizeConnect(
+        [](AsyncWebServerRequest*) { return g_events->count() < kMaxSseClients; });
 
     // Authentication for every mutating endpoint. Without a configured password these are
     // refused outright rather than left open -- an unprovisioned device must not be

--- a/src/transport/rs485_transport.cpp
+++ b/src/transport/rs485_transport.cpp
@@ -5,6 +5,7 @@
 #if defined(ESP32)
 
 #include <Arduino.h>
+#include <esp_timer.h>
 
 #include "boards/board.h"
 #include "diagnostics/logger.h"
@@ -128,7 +129,10 @@ bool Rs485Transport::lock(uint32_t timeoutMs) {
 
 void Rs485Transport::unlock() { busMutex_.unlock(); }
 
-uint64_t Rs485Transport::nowMs() const { return static_cast<uint64_t>(millis()); }
+// esp_timer, not millis(): the drivers build absolute transaction deadlines from this
+// (`nowMs() + 3000`), and a wrapped uint32 source would let a deadline armed just before
+// the 49.7-day mark never fire. See the note at main.cpp's nowMs().
+uint64_t Rs485Transport::nowMs() const { return static_cast<uint64_t>(esp_timer_get_time() / 1000); }
 
 }  // namespace heliograph
 


### PR DESCRIPTION
Stability pass focused on the actual deployment profile: a headless device that stays up for months. Four findings, each with a distinct failure mode at that timescale.

## 1. The 49.7-day clock wrap (the big one)

`nowMs()` was `millis()` cast to uint64 — which widens the already-wrapped uint32 rather than un-wrapping it. Every absolute-time comparison downstream (MQTT reconnect back-off, WiFi retry schedule, poll due-time, relay rate limiter, SSE throttle, the drivers' 3 s transaction deadlines built from `Transport::nowMs()`) would see time jump backwards once per 49.7 days and could stall for up to another 49.7 days. A WiFi drop landing near the wrap could leave the bridge offline until someone power-cycles it — a scheduled outage with a phase nobody can reproduce.

All three time sources (`main.cpp`, `Rs485Transport::nowMs()`, the log-timestamp provider) now use `esp_timer_get_time()`: a true 64-bit microsecond counter, monotonic for ~292k years. Uptime display and log stamps also keep counting past day 49 instead of resetting.

## 2. SSE client bound was declared, not enforced

`kMaxSseClients = 4` existed as a constant next to a comment claiming the library caps the count; nothing did. Each SSE client holds a TCP socket and a send queue for as long as the tab lives, and months of uptime collect abandoned dashboard tabs. `authorizeConnect` now refuses the fifth client; the web UI falls back to polling `/status` by design.

## 3. Full CDC buffer could stall the poll task

With no USB host attached — the normal state — HWCDC's default TX timeout blocks each write up to 100 ms once its 256-byte ring fills. The logger prints from rs485Task among others, so every log line could cost the poll loop a stall. TX timeout 0 = drop-when-full; the REST log ring keeps every line regardless.

## 4. Steady-state heap churn in the MQTT loop

`discoverySignature()` built a `std::string` every loop pass (~4 Hz), plus a roles-string on relay boards: ~700k short-lived allocations per day, forever, for values that only ever get compared. Both are now 64-bit FNV-1a fingerprints with identical change-detection semantics and zero steady-state allocations.

## Checked and deliberately left alone

- Rate limiters and dispatcher already use an explicit `everAccepted_` flag (no boot-zero sentinel).
- NVS is only written on user action (no flash wear); the hourly RTC sync is I2C, not flash.
- Log ring, request bodies, OTA sizes, SSE send queues: all bounded.
- `bridgeInfo()` string churn at 4 Hz: small, uniform allocations; restructuring it buys little at real risk.

## Verification

- `pio test -e native`: 416/416 passed
- Firmware builds: rs485-can, relay-6ch, mock — success, zero own-code warnings