### PR TITLE
ESP best practices: WiFi power save off, stack/fragmentation observability, OTA trade-off documented

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,12 @@ many back-to-back 3 s transactions between feeds); `rs485Task` and `loopTask` re
 it, the library tasks do not. `rs485Task` calls `esp_task_wdt_reset()` every cycle, even when
 the poll fails — an unreachable inverter must never cause a reset.
 
+Known trade-off: during an OTA upload, every flash write briefly disables the flash cache,
+which stalls any task executing code from flash — on both cores, core pinning does not help.
+`rs485Task` can therefore miss UART timing mid-upload and lose a poll or two. Accepted:
+uploads are rare, take seconds, and a missed poll is one `consecutiveFailures` tick that the
+next successful poll clears.
+
 ### MQTT task model and thread safety
 
 VERIFIED 2026-07-22 against the vendored espMqttClient 1.7.x sources (not the online docs,

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -21,7 +21,11 @@ struct BridgeInfo {
     uint32_t uptimeSeconds    = 0;
     uint32_t freeHeapBytes    = 0;
     uint32_t minFreeHeapBytes = 0;
-    uint16_t resetReason      = 0;
+    /// Largest single allocatable block. THE fragmentation signal: free heap can look
+    /// healthy while no allocation of consequence fits anymore, which is exactly the
+    /// failure mode a months-uptime device grows into.
+    uint32_t maxAllocHeapBytes = 0;
+    uint16_t resetReason       = 0;
 
     bool    wifiConnected  = false;
     int16_t wifiRssiDbm    = 0;

--- a/src/diagnostics/diagnostics.cpp
+++ b/src/diagnostics/diagnostics.cpp
@@ -22,6 +22,8 @@ DiagnosticsSnapshot Diagnostics::snapshot() const {
     s.modbusClientConnections = modbusClientConnections_.load(std::memory_order_relaxed);
     s.restRequestTotal        = restRequestTotal_.load(std::memory_order_relaxed);
     s.lastSuccessfulPollMs    = lastSuccessfulPollMs_.load(std::memory_order_relaxed);
+    s.rs485StackFreeBytes     = rs485StackFreeBytes_.load(std::memory_order_relaxed);
+    s.loopStackFreeBytes      = loopStackFreeBytes_.load(std::memory_order_relaxed);
     {
         std::lock_guard<std::mutex> lock(errorMutex_);
         s.lastError = lastError_;
@@ -41,6 +43,8 @@ void Diagnostics::reset() {
     modbusClientConnections_.store(0);
     restRequestTotal_.store(0);
     lastSuccessfulPollMs_.store(0);
+    rs485StackFreeBytes_.store(0);
+    loopStackFreeBytes_.store(0);
     std::lock_guard<std::mutex> lock(errorMutex_);
     lastError_.clear();
 }

--- a/src/diagnostics/diagnostics.h
+++ b/src/diagnostics/diagnostics.h
@@ -24,6 +24,12 @@ struct DiagnosticsSnapshot {
     uint32_t modbusClientConnections   = 0;
     uint32_t restRequestTotal          = 0;
     uint64_t lastSuccessfulPollMs      = 0;
+    /// Lowest-ever free stack per application task, in bytes (ESP-IDF's xtensa port defines
+    /// StackType_t as uint8_t, so uxTaskGetStackHighWaterMark already returns bytes). Each
+    /// task samples its own; 0 = not sampled yet, and outputs publish null for it -- a
+    /// monitoring rule on "stack headroom == 0" must not fire at boot.
+    uint32_t rs485StackFreeBytes       = 0;
+    uint32_t loopStackFreeBytes        = 0;
     std::string lastError;
 };
 
@@ -45,6 +51,15 @@ public:
     void recordMqttReconnect() { mqttReconnectTotal_.fetch_add(1, std::memory_order_relaxed); }
     void recordModbusClient() { modbusClientConnections_.fetch_add(1, std::memory_order_relaxed); }
     void recordRestRequest() { restRequestTotal_.fetch_add(1, std::memory_order_relaxed); }
+
+    /// Stack high-water marks, in bytes. Each task reports its OWN mark
+    /// (uxTaskGetStackHighWaterMark(nullptr)) so no task handle ever crosses a boundary.
+    void recordRs485StackFree(uint32_t bytes) {
+        rs485StackFreeBytes_.store(bytes, std::memory_order_relaxed);
+    }
+    void recordLoopStackFree(uint32_t bytes) {
+        loopStackFreeBytes_.store(bytes, std::memory_order_relaxed);
+    }
 
     /// Cheap atomic read for hot-path callers (the boot-confirm check runs every loop()
     /// iteration; a full snapshot() would copy a std::string each time).
@@ -70,6 +85,8 @@ private:
     std::atomic<uint32_t> modbusClientConnections_{0};
     std::atomic<uint32_t> restRequestTotal_{0};
     std::atomic<uint64_t> lastSuccessfulPollMs_{0};
+    std::atomic<uint32_t> rs485StackFreeBytes_{0};
+    std::atomic<uint32_t> loopStackFreeBytes_{0};
 
     mutable std::mutex errorMutex_;
     std::string        lastError_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,8 +128,9 @@ BridgeInfo bridgeInfo() {
     }
     info.bridgeOnline     = true;
     info.uptimeSeconds    = static_cast<uint32_t>(nowMs() / 1000);  // good for 136 years
-    info.freeHeapBytes    = ESP.getFreeHeap();
-    info.minFreeHeapBytes = ESP.getMinFreeHeap();
+    info.freeHeapBytes     = ESP.getFreeHeap();
+    info.minFreeHeapBytes  = ESP.getMinFreeHeap();
+    info.maxAllocHeapBytes = ESP.getMaxAllocHeap();
     info.resetReason      = static_cast<uint16_t>(esp_reset_reason());
     info.wifiConnected    = g_wifi.connected();
     info.wifiRssiDbm      = g_wifi.rssi();
@@ -385,6 +386,12 @@ void rs485Task(void* /*arg*/) {
         // One feed per iteration; the 120 s budget covers the longest legitimate iteration
         // (an extended discovery run). See the watchdog setup in setup().
         esp_task_wdt_reset();
+        // Own stack headroom into diagnostics: the 8192 sizing rests on one measured crash
+        // (2026-07-19); this keeps creeping growth visible in the API instead of leaving
+        // the canary as the only witness. ESP-IDF returns BYTES (StackType_t is uint8_t
+        // on xtensa); the scan only walks the unused region -- microseconds.
+        g_diagnostics.recordRs485StackFree(
+            static_cast<uint32_t>(uxTaskGetStackHighWaterMark(nullptr)));
         // Discovery first, and instead of polling this cycle: probing re-registers every
         // inverter on the bus, so the two must never interleave. This task owns the bus, which
         // is why the web handler only ever *requests* a run.
@@ -628,6 +635,9 @@ void loop() {
     static uint32_t lastReport = 0;
     if (millis() - lastReport > 10000) {
         lastReport = millis();
+        // Same per-task self-report as rs485Task; see the note there.
+        g_diagnostics.recordLoopStackFree(
+            static_cast<uint32_t>(uxTaskGetStackHighWaterMark(nullptr)));
         if (g_state) {
             const auto  s = g_state->snapshot();
             const auto* p = s->measurements.find(measurement_id::kAcPowerTotal);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,8 +128,8 @@ BridgeInfo bridgeInfo() {
     }
     info.bridgeOnline     = true;
     info.uptimeSeconds    = static_cast<uint32_t>(nowMs() / 1000);  // good for 136 years
-    info.freeHeapBytes     = ESP.getFreeHeap();
-    info.minFreeHeapBytes  = ESP.getMinFreeHeap();
+    info.freeHeapBytes    = ESP.getFreeHeap();
+    info.minFreeHeapBytes = ESP.getMinFreeHeap();
     info.maxAllocHeapBytes = ESP.getMaxAllocHeap();
     info.resetReason      = static_cast<uint16_t>(esp_reset_reason());
     info.wifiConnected    = g_wifi.connected();

--- a/src/network/wifi_manager.cpp
+++ b/src/network/wifi_manager.cpp
@@ -137,6 +137,14 @@ void WifiManager::begin(const Configuration& config) {
     WiFi.persistent(false);  // we own the credentials; the SDK must not cache its own copy
     WiFi.setAutoReconnect(false);  // reconnection is this class's job, with bounded back-off
 
+    // Modem power save OFF. The core's default on this chip is WIFI_PS_MIN_MODEM
+    // (WiFiGeneric.cpp): the radio sleeps between DTIM beacons and the AP buffers inbound
+    // packets until the next wake-up. That is right for battery devices and wrong for this
+    // one -- a mains-powered bridge that SERVES Modbus TCP, REST and mDNS, where every
+    // inbound request would eat tens to hundreds of ms of wake-up latency and mDNS gets
+    // flaky. Costs ~50-80 mA, which mains power does not care about.
+    WiFi.setSleep(false);
+
     // All channels, strongest AP. The default WIFI_FAST_SCAN associates with the FIRST BSSID
     // that matches the SSID, in channel-scan order -- on a network with several APs that
     // regularly means a far, weak one, and the device then clings to it until the link dies

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -117,6 +117,7 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     doc["firmware_version"]          = bridge.firmwareVersion;
     doc["free_heap_bytes"]           = bridge.freeHeapBytes;
     doc["minimum_free_heap_bytes"]   = bridge.minFreeHeapBytes;
+    doc["max_alloc_heap_bytes"]      = bridge.maxAllocHeapBytes;
     doc["reset_reason"]              = bridge.resetReason;
     doc["ota_image_state"]           = bridge.otaImageState;
     doc["wifi_connected"]            = bridge.wifiConnected;
@@ -138,6 +139,17 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     doc["modbus_client_connections_total"] = d.modbusClientConnections;
     doc["rest_requests_total"]       = d.restRequestTotal;
     doc["last_successful_poll_ms"]   = d.lastSuccessfulPollMs;
+    // Null until the first sample, not 0: same reasoning as the RSSI field above.
+    if (d.rs485StackFreeBytes > 0) {
+        doc["rs485_stack_free_bytes"] = d.rs485StackFreeBytes;
+    } else {
+        doc["rs485_stack_free_bytes"] = nullptr;
+    }
+    if (d.loopStackFreeBytes > 0) {
+        doc["loop_stack_free_bytes"] = d.loopStackFreeBytes;
+    } else {
+        doc["loop_stack_free_bytes"] = nullptr;
+    }
     // Set from pollResultName() and friends only. Never carries payload bytes or config.
     doc["last_error"] = d.lastError;
     return finish(doc, out, maxBytes);

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -130,6 +130,24 @@ std::string buildMetrics(const DeviceState& state, const BridgeInfo& bridge,
     appendValue(out, "heliograph_uptime_seconds", static_cast<unsigned long>(bridge.uptimeSeconds));
     appendHelp(out, "heliograph_free_heap_bytes", "Free heap", "gauge");
     appendValue(out, "heliograph_free_heap_bytes", static_cast<unsigned long>(bridge.freeHeapBytes));
+    appendHelp(out, "heliograph_max_alloc_heap_bytes",
+               "Largest allocatable heap block (fragmentation signal)", "gauge");
+    appendValue(out, "heliograph_max_alloc_heap_bytes",
+                static_cast<unsigned long>(bridge.maxAllocHeapBytes));
+    // Omitted until the first sample, like the RSSI gauge above: 0 would read as an
+    // exhausted stack to any alerting rule.
+    if (d.rs485StackFreeBytes > 0) {
+        appendHelp(out, "heliograph_rs485_stack_free_bytes",
+                   "rs485Task stack low-water mark", "gauge");
+        appendValue(out, "heliograph_rs485_stack_free_bytes",
+                    static_cast<unsigned long>(d.rs485StackFreeBytes));
+    }
+    if (d.loopStackFreeBytes > 0) {
+        appendHelp(out, "heliograph_loop_stack_free_bytes",
+                   "loopTask stack low-water mark", "gauge");
+        appendValue(out, "heliograph_loop_stack_free_bytes",
+                    static_cast<unsigned long>(d.loopStackFreeBytes));
+    }
 
     return out;
 }

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -236,6 +236,7 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     doc["board"]                   = bridge.boardName;
     doc["free_heap_bytes"]         = bridge.freeHeapBytes;
     doc["minimum_free_heap_bytes"] = bridge.minFreeHeapBytes;
+    doc["max_alloc_heap_bytes"]    = bridge.maxAllocHeapBytes;
     doc["reset_reason"]            = bridge.resetReason;
     doc["ota_image_state"]         = bridge.otaImageState;
     doc["wifi_connected"]          = bridge.wifiConnected;
@@ -257,6 +258,18 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     doc["modbus_client_connections_total"] = d.modbusClientConnections;
     doc["rest_requests_total"]             = d.restRequestTotal;
     doc["last_successful_poll_ms"]         = d.lastSuccessfulPollMs;
+    // Null until the first sample, not 0: a monitoring rule on "stack headroom == 0" must
+    // not fire during the first seconds after boot.
+    if (d.rs485StackFreeBytes > 0) {
+        doc["rs485_stack_free_bytes"] = d.rs485StackFreeBytes;
+    } else {
+        doc["rs485_stack_free_bytes"] = nullptr;
+    }
+    if (d.loopStackFreeBytes > 0) {
+        doc["loop_stack_free_bytes"] = d.loopStackFreeBytes;
+    } else {
+        doc["loop_stack_free_bytes"] = nullptr;
+    }
     doc["last_error"]                      = d.lastError;
     return finish(doc, out, maxBytes);
 }

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -332,6 +332,26 @@ static void test_rssi_is_null_when_wifi_is_down() {
     TEST_ASSERT_TRUE(parse(json)["wifi_rssi_dbm"].isNull());
 }
 
+static void test_diagnostics_report_stack_marks_and_fragmentation() {
+    Rig r;
+    r.diagnostics.recordRs485StackFree(2500);
+    r.diagnostics.recordLoopStackFree(4100);
+    auto bridge              = makeBridge();
+    bridge.maxAllocHeapBytes = 65536;
+    std::string json;
+    TEST_ASSERT_TRUE(buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(2500, doc["rs485_stack_free_bytes"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(4100, doc["loop_stack_free_bytes"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(65536, doc["max_alloc_heap_bytes"].as<uint32_t>());
+
+    // Before the first sample the honest answer is "unknown", not an alarming 0.
+    buildDiagnosticsPayload(DiagnosticsSnapshot{}, bridge, json);
+    doc = parse(json);
+    TEST_ASSERT_TRUE(doc["rs485_stack_free_bytes"].isNull());
+    TEST_ASSERT_TRUE(doc["loop_stack_free_bytes"].isNull());
+}
+
 static void test_diagnostics_never_contain_a_secret() {
     // The last_error string is fed only from pollResultName() and friends.
     Rig r;
@@ -822,6 +842,7 @@ int main(int, char**) {
     RUN_TEST(test_the_mock_hybrid_payload_also_fits);
     RUN_TEST(test_diagnostics_payload);
     RUN_TEST(test_rssi_is_null_when_wifi_is_down);
+    RUN_TEST(test_diagnostics_report_stack_marks_and_fragmentation);
     RUN_TEST(test_diagnostics_never_contain_a_secret);
     RUN_TEST(test_identity_omits_unknown_fields);
     RUN_TEST(test_capabilities_payload_reports_read_only);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -506,6 +506,32 @@ static void test_diagnostics_payload_has_no_secrets() {
     TEST_ASSERT_EQUAL_STRING("Waveshare ESP32-S3-RS485-CAN", doc["board"]);
 }
 
+static void test_diagnostics_report_stack_marks_and_fragmentation() {
+    Rig r;
+    r.diagnostics.recordRs485StackFree(2500);
+    r.diagnostics.recordLoopStackFree(4100);
+    auto bridge              = makeBridge();
+    bridge.maxAllocHeapBytes = 65536;
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(2500, doc["rs485_stack_free_bytes"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(4100, doc["loop_stack_free_bytes"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(65536, doc["max_alloc_heap_bytes"].as<uint32_t>());
+}
+
+static void test_stack_marks_are_null_before_the_first_sample() {
+    // 0 would read as an exhausted stack to any alerting rule; before the tasks have
+    // sampled themselves the honest answer is "unknown".
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(DiagnosticsSnapshot{}, makeBridge(), json));
+    TEST_ASSERT_TRUE(json.find("rs485_stack_free_bytes") != std::string::npos);
+    TEST_ASSERT_TRUE(json.find("loop_stack_free_bytes") != std::string::npos);
+    auto doc = parse(json);
+    TEST_ASSERT_TRUE(doc["rs485_stack_free_bytes"].isNull());
+    TEST_ASSERT_TRUE(doc["loop_stack_free_bytes"].isNull());
+}
+
 static void test_oversized_response_is_refused() {
     Rig        r;
     const auto state = r.poll();
@@ -516,6 +542,24 @@ static void test_oversized_response_is_refused() {
 }
 
 // --- Prometheus ------------------------------------------------------------------------------
+
+static void test_prometheus_stack_and_fragmentation_gauges() {
+    Rig        r;
+    const auto state = r.poll();
+    // Unsampled stack marks: the gauges are omitted entirely, like the RSSI gauge.
+    auto text = prometheus::buildMetrics(state, makeBridge(), r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("rs485_stack_free_bytes") == std::string::npos);
+    TEST_ASSERT_TRUE(text.find("loop_stack_free_bytes") == std::string::npos);
+
+    r.diagnostics.recordRs485StackFree(2500);
+    r.diagnostics.recordLoopStackFree(4100);
+    auto bridge              = makeBridge();
+    bridge.maxAllocHeapBytes = 65536;
+    text = prometheus::buildMetrics(state, bridge, r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("heliograph_rs485_stack_free_bytes 2500\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_loop_stack_free_bytes 4100\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_max_alloc_heap_bytes 65536\n") != std::string::npos);
+}
 
 static void test_prometheus_exports_current_readings() {
     Rig        r;
@@ -634,7 +678,10 @@ int main(int, char**) {
     RUN_TEST(test_capabilities_payload);
     RUN_TEST(test_drivers_payload_drives_the_wizard);
     RUN_TEST(test_diagnostics_payload_has_no_secrets);
+    RUN_TEST(test_diagnostics_report_stack_marks_and_fragmentation);
+    RUN_TEST(test_stack_marks_are_null_before_the_first_sample);
     RUN_TEST(test_oversized_response_is_refused);
+    RUN_TEST(test_prometheus_stack_and_fragmentation_gauges);
     RUN_TEST(test_prometheus_exports_current_readings);
     RUN_TEST(test_prometheus_omits_unknown_rather_than_exporting_zero);
     RUN_TEST(test_prometheus_has_no_high_cardinality_labels);


### PR DESCRIPTION
Implements the three findings from the ESP32 best-practices review, plus the documentation note.

## WiFi modem power save → off

The Arduino core defaults this chip to `WIFI_PS_MIN_MODEM` (verified in `WiFiGeneric.cpp:388` — only the S2 gets `WIFI_PS_NONE`): the radio sleeps between DTIM beacons and the AP buffers inbound packets until the next wake-up. Correct for battery devices, wrong for a mains-powered bridge that *serves* Modbus TCP, REST and mDNS — every inbound request ate tens to hundreds of ms of wake-up latency, and power save is a classic cause of flaky mDNS. `WiFi.setSleep(false)` in `WifiManager::begin()`, next to the other radio-policy calls.

## Stack low-water marks + heap-fragmentation gauge

- Each application task self-reports `uxTaskGetStackHighWaterMark(nullptr)` into `Diagnostics` (atomics, no task handles crossing boundaries). Verified against the vendored FreeRTOS port before implementing: ESP-IDF's xtensa `StackType_t` is `uint8_t`, so the API returns **bytes** — the classic ×4 word-multiplication error does not apply here and would have silently inflated the numbers.
- `ESP.getMaxAllocHeap()` (largest contiguous free block) joins `BridgeInfo`: free heap can look healthy while nothing of consequence fits any more, which is exactly the failure mode months of uptime grows into.

Surfaced in REST `/diagnostics`, the MQTT diagnostics topic, and as Prometheus gauges. The stack marks publish **null** (REST/MQTT) or are **omitted** (Prometheus) until the first sample — a 0 would read as an exhausted stack to any alerting rule watching a freshly booted device, same reasoning as the existing RSSI-null convention. Four new host tests cover both representations.

## OTA flash-stall trade-off documented

Flash writes during an OTA upload briefly disable the flash cache on both cores; `rs485Task` can lose a poll mid-upload. Accepted (uploads are rare, one `consecutiveFailures` tick), now recorded in `docs/architecture.md` instead of being tribal knowledge.

## Verification

- `pio test -e native`: **420/420** passed (4 new tests)
- Firmware builds: rs485-can, relay-6ch, mock — success, zero own-code warnings