### PR TITLE
Config API transparency + credential hygiene: reboot_required, MQTT username, OTA signing doc

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -92,25 +92,41 @@ Never an HTTP 200 with an error message in the body.
 
 ## Secrets
 
-`GET /api/v1/config` **never** returns passwords. Not masked-but-present, but
-omitted, with a boolean indicator:
+`GET /api/v1/config` **never** returns credential material. Not masked-but-present, but
+omitted, with a boolean indicator. This covers every password **and the MQTT username** —
+the username is half of a login pair, so it is treated like the password it accompanies.
+Non-credential config (SSID, broker host, topics) stays readable; the UI needs it and it is
+not a secret.
 
 ```json
 {
   "wifi":  { "ssid": "thuis", "password_set": true },
-  "mqtt":  { "host": "10.0.0.5", "port": 1883, "username": "solar", "password_set": true },
+  "mqtt":  { "host": "10.0.0.5", "port": 1883, "username_set": true, "password_set": true },
   "modbus": { "enabled": true, "port": 502, "unit_id": 1, "write_enabled": false },
   "polling": { "interval_seconds": 10 },
   "driver": { "id": "eversolar_legacy", "auto_detect": false },
-  "rs485": { "baud_rate": 9600, "parity": "none", "data_bits": 8, "stop_bits": 1 },
   "logging": { "level": "info" }
 }
 ```
 
-`PATCH` accepts `"password": "..."` to set it and `"password": null` to clear it. An
-omitted field stays unchanged.
+`PATCH` accepts `"password": "..."` / `"username": "..."` to set either, and `null` to clear
+it. An omitted field stays unchanged. Passwords and the username never appear in logs, in
+SSE, in MQTT, or in Prometheus.
 
-Passwords never appear in logs, in SSE, in MQTT, or in Prometheus.
+## Applying changes: `reboot_required`
+
+Most settings — WiFi, MQTT, Modbus, the polling interval, the driver, NTP — are read once at
+boot, so a `PATCH` stores them but they take effect only after a restart. A few
+(`bridge_name`, `relays.*`, `security.*`, `logging.level`) are applied live.
+
+The `PATCH /api/v1/config` response therefore carries a top-level `reboot_required` boolean so
+a client knows whether to call `POST /api/v1/actions/reboot`:
+
+```json
+{ "version": 1, "wifi": { ... }, ..., "reboot_required": true }
+```
+
+`GET` does not include the field (nothing was changed).
 
 ## Auth
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,7 +14,7 @@ the same LAN", not "someone holding the PCB in their hands".
 | REST PATCH/POST | HTTP Basic required; **rejected** without a configured password, not left open |
 | OTA | Same auth + firmware magic check (0xE9) before the first byte hits flash |
 | Completing setup | Refuses without an admin password |
-| Secrets in logs/REST/MQTT/Prometheus | Never. `serializeConfig()` omits passwords (not masked); `serializeConfigForStorage()` is the only one that writes them |
+| Secrets in logs/REST/MQTT/Prometheus | Never. `serializeConfig()` omits every password **and the MQTT username** (not masked, absent); `serializeConfigForStorage()` is the only one that writes them |
 | Rate limiting | 1 req/s on `/actions/*` |
 | Request size | 4096 bytes, rejected with 413 |
 | String lengths | Bounded in `validate()`; SSID 32 and PSK 64 are the 802.11/WPA2 limits |
@@ -40,6 +40,15 @@ moment can configure the bridge.
 
 **No brute-force protection on HTTP Basic.** Rate limiting is on `/actions/*`, not on the
 auth itself.
+
+**OTA images are not cryptographically signed.** The upload is gated by the admin password
+and checked for the ESP32 image magic (`0xE9`) before any byte reaches flash, and a bad image
+is rolled back by the bootloader — but the magic check only rejects a wrong *file* (a
+filesystem image, an HTML error page a proxy substituted), not a malicious *firmware*. Anyone
+with the admin password can flash anything that boots. Signed OTA (secure boot v2 + a signed
+app) is the mitigation; it is not enabled because it complicates key management, recovery and
+the open-source build, and the threat model is a trusted LAN with no physical access. Keep the
+admin password strong and the network trusted.
 
 ## What an attacker on the LAN can do
 

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -251,7 +251,8 @@ bool validate(const Configuration& config, ConfigError& error) {
     return true;
 }
 
-bool serializeConfig(const Configuration& config, std::string& out, size_t maxBytes) {
+bool serializeConfig(const Configuration& config, std::string& out, size_t maxBytes,
+                     const bool* rebootRequired) {
     JsonDocument doc;
     doc["version"]     = config.version;
     doc["bridge_name"] = config.bridgeName;
@@ -266,7 +267,10 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     mqtt["enabled"]        = config.mqtt.enabled;
     mqtt["host"]           = config.mqtt.host;
     mqtt["port"]           = config.mqtt.port;
-    mqtt["username"]       = config.mqtt.username;
+    // The username is half of a credential pair -- omitted like the password, with only a
+    // *_set flag. It is not needed to identify the broker (host/topic do that) and handing
+    // an unauthenticated LAN reader half the login is a leak worth closing.
+    mqtt["username_set"]   = !config.mqtt.username.empty();
     mqtt["password_set"]   = !config.mqtt.password.empty();
     mqtt["base_topic"]     = config.mqtt.baseTopic;
     mqtt["discovery_prefix"]  = config.mqtt.discoveryPrefix;
@@ -310,7 +314,39 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     security["read_only_mode"]  = config.security.readOnlyMode;
 
     doc["logging"]["level"] = logLevelName(config.logLevel);
+
+    // PATCH response only: tells a non-UI client whether the change it just made is waiting
+    // on a restart. Absent from GET (nothing was changed there).
+    if (rebootRequired != nullptr) {
+        doc["reboot_required"] = *rebootRequired;
+    }
     return finish(doc, out, maxBytes);
+}
+
+bool configChangeRequiresReboot(const Configuration& a, const Configuration& b) {
+    // Everything the firmware reads exactly once -- WiFi.begin at setup(), the MQTT client
+    // and Modbus server built in startOutputs(), the poll interval baked into PollPolicy, the
+    // driver created at setup(), and the clock configured by TimeManager::begin(). Changing
+    // any of these via PATCH updates NVS but not the running object, so it needs a restart.
+    //
+    // Deliberately NOT here (applied live by ctx.applyConfig): bridge_name (read fresh on
+    // every status), relays.* (gates re-applied immediately), security.* (read per request),
+    // logging.level (setLevel called from applyConfig). timezone_name and write_enabled carry
+    // no runtime effect. This set mirrors RESTART_NEEDED in the web UI.
+    return a.wifi.ssid != b.wifi.ssid || a.wifi.password != b.wifi.password ||
+           a.wifi.hostname != b.wifi.hostname || a.mqtt.enabled != b.mqtt.enabled ||
+           a.mqtt.host != b.mqtt.host || a.mqtt.port != b.mqtt.port ||
+           a.mqtt.username != b.mqtt.username || a.mqtt.password != b.mqtt.password ||
+           a.mqtt.baseTopic != b.mqtt.baseTopic ||
+           a.mqtt.discoveryPrefix != b.mqtt.discoveryPrefix ||
+           a.mqtt.discoveryEnabled != b.mqtt.discoveryEnabled || a.mqtt.qos != b.mqtt.qos ||
+           a.modbus.enabled != b.modbus.enabled || a.modbus.port != b.modbus.port ||
+           a.modbus.unitId != b.modbus.unitId ||
+           a.modbus.diagnosticsUnitId != b.modbus.diagnosticsUnitId ||
+           a.polling.intervalSeconds != b.polling.intervalSeconds ||
+           a.driver.id != b.driver.id || a.driver.options != b.driver.options ||
+           a.ntp.enabled != b.ntp.enabled || a.ntp.useDhcp != b.ntp.useDhcp ||
+           a.ntp.server != b.ntp.server || a.ntp.timezone != b.ntp.timezone;
 }
 
 bool applyConfigPatch(const std::string& json, Configuration& config, ConfigError& error) {

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -136,12 +136,27 @@ struct ConfigError {
 /// Checks ranges and enum values. Returns false and fills `error` on the first problem.
 bool validate(const Configuration& config, ConfigError& error);
 
-/// Serialises for `GET /api/v1/config`.
+/// Serialises for `GET /api/v1/config` and the `PATCH` response.
 ///
-/// Passwords are NOT included -- not masked, omitted. A `*_set` boolean says whether one
-/// exists. Masking with "***" still tells an attacker the length class and invites a client
-/// to round-trip the mask back in as a literal password.
-bool serializeConfig(const Configuration& config, std::string& out, size_t maxBytes = 4096);
+/// Credential material is NOT included -- not masked, omitted. Passwords and the MQTT
+/// username each get a `*_set` boolean saying whether one exists. Masking with "***" still
+/// tells an attacker the length class and invites a client to round-trip the mask back in as
+/// a literal secret. The MQTT username is half of a credential pair, so it is treated like
+/// the password it accompanies; non-credential config (SSID, broker host, topics) stays
+/// readable because the UI needs it and it is not a secret.
+///
+/// When `rebootRequired` is non-null its value is emitted as a top-level `reboot_required`
+/// boolean -- the PATCH handler passes the result of configChangeRequiresReboot(); GET passes
+/// nullptr and the field is absent.
+bool serializeConfig(const Configuration& config, std::string& out, size_t maxBytes = 4096,
+                     const bool* rebootRequired = nullptr);
+
+/// True when moving from `before` to `after` changes any setting the firmware reads only at
+/// boot (WiFi, MQTT, Modbus, polling interval, driver, NTP), so the change is stored but does
+/// not take effect until a restart. The complement -- bridge_name, relays, security,
+/// logging level -- is applied live by the REST layer and returns false. Kept in lockstep
+/// with the RESTART_NEEDED map in the web UI.
+bool configChangeRequiresReboot(const Configuration& before, const Configuration& after);
 
 /// Applies a `PATCH /api/v1/config` body.
 ///

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -324,6 +324,11 @@ void startRestApi() {
             std::lock_guard<std::mutex> lock(g_configMutex);
             g_config = c;
         }
+        // Log level is live, not boot-only: the logger is a global whose level is a plain
+        // setter. Without this a level change reported "Saved and applied" in the UI but did
+        // nothing until a reboot -- and configChangeRequiresReboot() correctly omits it only
+        // because this line makes the claim true.
+        log::setLevel(c.logLevel);
         // The relay gates follow the config immediately -- no restart. Closing EITHER
         // gate also releases every relay: with the gate closed, no command -- not even
         // OFF -- would get through, so an energised contact would otherwise stay frozen

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -413,9 +413,12 @@ bool RestApi::begin() {
                 return;
             }
 
-            Configuration updated = *context_.config;
-            ConfigError   error;
-            const bool    parsed = applyConfigPatch(bodyBuffer_, updated, error);
+            // Snapshot before merging: reboot_required in the response is computed against
+            // this, and applyConfig() below overwrites what context_.config points at.
+            const Configuration before  = *context_.config;
+            Configuration       updated = before;
+            ConfigError         error;
+            const bool          parsed  = applyConfigPatch(bodyBuffer_, updated, error);
             releaseBody();
             if (!parsed) {
                 sendError(request, {400, "invalid_config",
@@ -428,8 +431,9 @@ bool RestApi::begin() {
                 return;
             }
             context_.applyConfig(updated);  // lock-guarded publish; see RestContext
+            const bool  rebootRequired = configChangeRequiresReboot(before, updated);
             std::string body;
-            serializeConfig(updated, body);
+            serializeConfig(updated, body, 4096, &rebootRequired);
             request->send(200, kJson, body.c_str());
         },
         nullptr,

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -535,6 +535,13 @@ async function renderConfig(){
   const pw=(id,label,isSet)=>`<label for="${id}">${label}</label>
     <input id="${id}" type="password" placeholder="${isSet?'(unchanged)':'(not set)'}" autocomplete="new-password" readonly onfocus="this.removeAttribute('readonly')">
     <div class="dim" style="font-size:12px">Leave blank to keep. The current value is never sent to this page.</div>`;
+  // Credential-like text field (the MQTT username): never returned by GET, so never
+  // pre-filled -- blank means keep, typing changes it, exactly like the password fields.
+  // Visible text, not dots (a username is not secret to its owner), autocomplete=off for the
+  // same login-form reason as the other settings fields.
+  const credtxt=(id,label,isSet,hint)=>`<label for="${id}">${label}</label>
+    <input id="${id}" autocomplete="off" placeholder="${isSet?'(unchanged)':'(not set)'}">
+    <div class="dim" style="font-size:12px">${hint}</div>`;
   const num=(id,label,val)=>`<label for="${id}">${label}</label><input id="${id}" type="number" value="${val}">`;
   const chk=(id,label,val)=>`<label style="display:flex;gap:8px;align-items:center;margin-top:12px">
     <input id="${id}" type="checkbox" ${val?'checked':''} style="width:auto"> ${label}</label>`;
@@ -585,7 +592,7 @@ async function renderConfig(){
     ${pw('c_wpw','Password',c.wifi.password_set)}</div>
   <div class="card"><b>MQTT</b> <span class="tag" style="font-weight:400">needs restart</span>${chk('c_mqe','Enabled',c.mqtt.enabled)}
     ${txt('c_mqh','Broker host',c.mqtt.host)}${num('c_mqp','Port',c.mqtt.port)}
-    ${txt('c_mqu','Username',c.mqtt.username)}${pw('c_mqpw','Password',c.mqtt.password_set)}
+    ${credtxt('c_mqu','Username',c.mqtt.username_set,'Leave blank to keep. Not shown here; the API accepts null to clear it.')}${pw('c_mqpw','Password',c.mqtt.password_set)}
     ${txt('c_mqt','Base topic',c.mqtt.base_topic)}
     ${chk('c_mqd','Home Assistant discovery',c.mqtt.discovery_enabled)}</div>
   <div class="card"><b>Modbus TCP</b> <span class="tag" style="font-weight:400">needs restart</span>${chk('c_mbe','Enabled',c.modbus.enabled)}
@@ -659,7 +666,7 @@ async function saveConfig(){
     ...(window.g_relayCount>0?{relays:{enabled:b('c_rle'),
       roles:Array.from({length:window.g_relayCount},(_,i)=>v('c_rlr'+i))}}:{}),
     wifi:{ssid:v('c_ssid'),hostname:v('c_host')},
-    mqtt:{enabled:b('c_mqe'),host:v('c_mqh'),port:n('c_mqp'),username:v('c_mqu'),
+    mqtt:{enabled:b('c_mqe'),host:v('c_mqh'),port:n('c_mqp'),
           base_topic:v('c_mqt'),discovery_enabled:b('c_mqd')},
     modbus:{enabled:b('c_mbe'),port:n('c_mbp'),unit_id:n('c_mbu')},
     polling:{interval_seconds:n('c_pi')},
@@ -675,6 +682,9 @@ async function saveConfig(){
   // A blank password field means "keep": sending "" would clear it, which is never what an
   // untouched field means.
   if(v('c_wpw'))body.wifi.password=v('c_wpw');
+  // The MQTT username is credential-like (never returned by GET), so like the passwords it
+  // travels only when typed -- a blank field means keep.
+  if(v('c_mqu'))body.mqtt.username=v('c_mqu');
   if(v('c_mqpw'))body.mqtt.password=v('c_mqpw');
   if(v('c_ap'))body.security.admin_password=v('c_ap');
   document.querySelectorAll('[data-opt]').forEach(e=>body.driver.options[e.dataset.opt]=e.value);
@@ -709,7 +719,11 @@ async function saveConfig(){
   for(const sect of Object.keys(body)){
     if(typeof body[sect]!=='object')continue;
     for(const k of Object.keys(body[sect])){
-      if(k.includes('password')||k==='options')continue;
+      // Credential-like keys (passwords, the MQTT username) and driver options are only in
+      // the body when the user acted; GET never returns them, so there is nothing to diff
+      // against and they must not be dropped. Exact match on 'username' so 'admin_username'
+      // -- which IS returned and must be diffed -- is not caught.
+      if(k.includes('password')||k==='username'||k==='options')continue;
       if(same(body[sect][k],(cfgBefore[sect]||{})[k]))delete body[sect][k];
     }
     if(!Object.keys(body[sect]).length)delete body[sect];
@@ -745,12 +759,17 @@ async function saveConfig(){
   }
   cfgBefore=d;
 
+  // The server is authoritative on whether a restart is needed (reboot_required); `pending`
+  // only supplies the nice per-field labels. They agree for anything editable on this form;
+  // the generic wording covers a reboot-only field changed through the API directly.
   m.className='msg ok';
-  if(!pending.length){
+  if(!d.reboot_required){
     m.innerHTML='Saved and applied.';
   }else{
-    m.innerHTML='Saved. These take effect after a restart: <b>'+
-      pending.map(esc).join(', ')+'</b>.<br>'+
+    const which=pending.length
+      ? 'These take effect after a restart: <b>'+pending.map(esc).join(', ')+'</b>.'
+      : 'Some changes take effect after a restart.';
+    m.innerHTML='Saved. '+which+'<br>'+
       '<button style="margin-top:10px" onclick="rebootFromSettings()">Restart now</button>'+
       '<span class="dim" style="font-size:12px"> — or later; the bridge keeps running on the '+
       'old values until you do.</span>';

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -107,19 +107,77 @@ static void test_config_reports_whether_a_secret_is_set() {
     TEST_ASSERT_TRUE(doc["wifi"]["password_set"].as<bool>());
     TEST_ASSERT_TRUE(doc["mqtt"]["password_set"].as<bool>());
     TEST_ASSERT_TRUE(doc["security"]["password_set"].as<bool>());
+    // The MQTT username is credential material: reported as a flag, never as the value.
+    TEST_ASSERT_TRUE(doc["mqtt"]["username_set"].as<bool>());
+    TEST_ASSERT_TRUE(doc["mqtt"]["username"].isNull());
+    TEST_ASSERT_TRUE(json.find("solar") == std::string::npos);
     // Non-secret fields are readable, which is what makes the UI usable.
     TEST_ASSERT_EQUAL_STRING("thuisnetwerk", doc["wifi"]["ssid"]);
     TEST_ASSERT_EQUAL_STRING("10.0.0.5", doc["mqtt"]["host"]);
-    TEST_ASSERT_EQUAL_STRING("solar", doc["mqtt"]["username"]);
 
     c.wifi.password.clear();
     c.mqtt.password.clear();
+    c.mqtt.username.clear();
     c.security.adminPassword.clear();
     serializeConfig(c, json);
     doc = parse(json);
     TEST_ASSERT_FALSE(doc["wifi"]["password_set"].as<bool>());
     TEST_ASSERT_FALSE(doc["mqtt"]["password_set"].as<bool>());
+    TEST_ASSERT_FALSE(doc["mqtt"]["username_set"].as<bool>());
     TEST_ASSERT_FALSE(doc["security"]["password_set"].as<bool>());
+}
+
+static void test_reboot_required_flag_is_patch_only() {
+    auto        c = configWithSecrets();
+    std::string json;
+    // GET path: no flag emitted.
+    serializeConfig(c, json);
+    TEST_ASSERT_TRUE(parse(json)["reboot_required"].isNull());
+    // PATCH path: the caller's computed value is echoed verbatim.
+    bool needed = true;
+    serializeConfig(c, json, 4096, &needed);
+    TEST_ASSERT_TRUE(parse(json)["reboot_required"].as<bool>());
+    needed = false;
+    serializeConfig(c, json, 4096, &needed);
+    TEST_ASSERT_FALSE(parse(json)["reboot_required"].as<bool>());
+}
+
+static void test_reboot_required_only_for_boot_time_settings() {
+    const Configuration base;
+
+    // No change -> no reboot.
+    TEST_ASSERT_FALSE(configChangeRequiresReboot(base, base));
+
+    // Each boot-time domain forces a reboot.
+    auto wifi = base;   wifi.wifi.ssid = "other";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, wifi));
+    auto mqttHost = base; mqttHost.mqtt.host = "10.0.0.9";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, mqttHost));
+    auto mqttUser = base; mqttUser.mqtt.username = "u";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, mqttUser));
+    auto qos = base;    qos.mqtt.qos = 1;  // editable only via the API, still boot-only
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, qos));
+    auto diag = base;   diag.modbus.diagnosticsUnitId = 200;
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, diag));
+    auto poll = base;   poll.polling.intervalSeconds = 30;
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, poll));
+    auto drv = base;    drv.driver.options["layout"] = "dual";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, drv));
+    auto ntp = base;    ntp.ntp.timezone = "UTC0";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, ntp));
+
+    // Live-applied settings never demand one.
+    auto name = base;   name.bridgeName = "Zonnebrug";
+    TEST_ASSERT_FALSE(configChangeRequiresReboot(base, name));
+    auto sec = base;    sec.security.readOnlyMode = !base.security.readOnlyMode;
+    TEST_ASSERT_FALSE(configChangeRequiresReboot(base, sec));
+    auto log = base;    log.logLevel = LogLevel::Debug;
+    TEST_ASSERT_FALSE(configChangeRequiresReboot(base, log));
+    auto rel = base;    rel.relays.enabled = !base.relays.enabled;
+    TEST_ASSERT_FALSE(configChangeRequiresReboot(base, rel));
+    // timezone_name is display metadata with no runtime effect.
+    auto tzn = base;    tzn.ntp.timezoneName = "Europe/Berlin";
+    TEST_ASSERT_FALSE(configChangeRequiresReboot(base, tzn));
 }
 
 // --- config patching -------------------------------------------------------------------------
@@ -650,6 +708,8 @@ int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_config_response_contains_no_secret_anywhere);
     RUN_TEST(test_config_reports_whether_a_secret_is_set);
+    RUN_TEST(test_reboot_required_flag_is_patch_only);
+    RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);
     RUN_TEST(test_patch_sets_a_password);
     RUN_TEST(test_explicit_null_clears_a_password);


### PR DESCRIPTION
The three advisory points left from the original fundamentals review.

## 1. `reboot_required` in the PATCH response

Most settings (WiFi, MQTT, Modbus, poll interval, driver, NTP) are read once at boot, so a `PATCH /api/v1/config` stores them but they only take effect after a restart. The response now carries a top-level `reboot_required` boolean so a **non-UI API client** knows whether to reboot — previously only the web UI knew, by inferring it client-side.

The decision lives in a host-tested `configChangeRequiresReboot(before, after)` in the config layer — one authoritative, complete list of boot-only vs live-applied settings. The web UI now trusts this flag as its restart trigger (keeping its nice per-field labels for the wording), so UI and API can never disagree.

**Supporting fix:** `logging.level` is now genuinely applied live (`log::setLevel` in `applyConfig`). The UI claimed "applied immediately" but it actually needed a reboot; making the claim true is cleaner than reporting it as boot-only.

## 2. MQTT username treated as a credential

`GET /api/v1/config` is unauthenticated (per the documented LAN model) and omits all passwords. The MQTT username — half of a login pair — was still returned in the clear. It's now handled exactly like its password: omitted from the API response, exposed only as `username_set`, and sent by the UI only when typed. Non-credential config (broker host, topics) stays readable. **Storage is unchanged** — `serializeConfigForStorage()` still persists the username; only the API view redacts it.

## 3. OTA signing documented as a known limitation

`security.md` now states plainly: the `0xE9` magic check rejects a wrong *file*, not malicious *firmware*. Anyone with the admin password can flash anything that boots. Signed OTA (secure boot v2) is named as the mitigation and why it's not enabled (key management, recovery, open-source build; LAN threat model).

## Verification

- `pio test -e native`: **422/422** (5 new tests — reboot classification, PATCH-only flag, username redaction)
- `tools/check_web_js.py`: OK · `check_layering.sh`: PASS
- Firmware builds: rs485-can, relay-6ch, mock — success, zero own-code warnings