### PR TITLE
Document the SolaX X1 RJ45 pinout and the X1-Mini-G1 field findings

### DIFF
--- a/docs/solax-x1-protocol.md
+++ b/docs/solax-x1-protocol.md
@@ -147,18 +147,43 @@ Eliminated, in order:
   onwards.
 
 **Remaining hypothesis: on the G1 the PMU serial line runs to the USB dongle port, and the
-RJ45 pins 4/5 are not on that bus.** The Pocket WiFi demonstrably speaks PMU to the
-inverter (it reports to SolaX Cloud), yet a listener on pins 4/5 hears neither the dongle's
-polling nor any reply. The reference project lists Mini G1 as supported over RJ45, so this
-may be revision-specific — unconfirmed either way.
+RJ45 pins 4/5 are not on that bus.** A listener on pins 4/5 hears neither our own polling
+nor any reply. The reference project lists Mini G1 as supported over RJ45, so this may be
+revision-specific — unconfirmed either way. (Note: this session did **not** establish that
+the dongle is actively polling the inverter. It was found in AP mode, i.e. not joined to
+any WiFi, so "it reports to SolaX Cloud" was never verified — only that it is powered.)
 
 Two tests would settle it, both with a scope on pins 4/5: (a) with the dongle removed and
 the bridge polling, do our own differential bursts appear? (confirms the board drives the
-bus — this board is a second, hardware-unproven unit); (b) with the dongle inserted and
-actively polling, does *its* traffic appear on pins 4/5? If it does not, the RJ45 is
-provably not the PMU bus on this unit, and the way in is to tap the USB dongle line
-instead (reference: xdubx/Solax-Pocket-USB-reverse-engineering) — the payload decoder in
-this driver stays valid, only the physical tap changes.
+bus — this board is a second, hardware-unproven unit); (b) with the dongle inserted, does
+*its* traffic appear on pins 4/5? If it does not, the RJ45 is provably not the PMU bus on
+this unit.
+
+## Reading the Pocket WiFi dongle over the network instead (preferred over any hardware tap)
+
+For a G1 whose RS485 stays silent there is a far less invasive path than tapping a serial
+line: the SolaX Pocket WiFi/LAN dongle exposes a **local HTTP REST API**. It is reachable on
+the dongle's own broadcast SSID (`WiFi_SW<serial>`, open network) at the fixed address
+**`http://5.8.8.8/`**. Newer dongle firmware serves this API *only* on that own SSID and no
+longer over the LAN it joins; older firmware also answers on the LAN address.
+
+Two request shapes exist depending on firmware age:
+
+- older: `GET http://5.8.8.8/api/realTimeData.htm`
+- newer: `POST http://5.8.8.8/` with `optType=ReadRealTimeData&pwd=<dongle serial>`
+  (the password is the dongle's "Backup password", visible in SolaX Cloud under the WiFi
+  dongle)
+
+Known limits: the local API refreshes roughly every 5 minutes — fine for energy totals,
+useless for anything wanting live power. Reference implementation: squishykid/solax, which
+is what the built-in Home Assistant "SolaX Power" integration uses.
+
+**Architectural caveat for this bridge:** an ESP32 has a single station radio, so a bridge
+that must join the dongle's own AP cannot simultaneously stay on the house WiFi that serves
+MQTT/REST/Modbus TCP. That makes an HTTP-polling SolaX driver viable only where the dongle
+still answers on the LAN. Where it does not, the honest answer is that this bridge adds
+nothing over polling the dongle directly from Home Assistant — the same reasoning applied
+to SolarEdge units that already speak SunSpec Modbus TCP locally.
 
 ## Export control (future, separate mode — not this driver)
 

--- a/docs/solax-x1-protocol.md
+++ b/docs/solax-x1-protocol.md
@@ -7,7 +7,8 @@ sum checksum, response = request function | 0x80).
 **STATUS: transcribed, not hardware-confirmed.** Sources: syssi/esphome-solax-x1-mini
 (Apache-2.0; hardware-tested against X1 Mini G1/G2/G3; protocol knowledge re-implemented,
 no code copied) and the official "SolaxPower Single Phase External Communication Protocol
-X1 Series V1.2" document. First hardware target: an X1-1.1-S-D (planned 2026-07).
+X1 Series V1.2" document. First hardware attempt (X1-1.1-S-D / X1-Mini-G1, 2026-07-23)
+produced **no data over the RJ45** — see "Field findings" below before wiring anything.
 
 ## Session flow
 
@@ -71,6 +72,36 @@ channels appear only once PV2 shows real voltage (> 1 V) and then stay.
 Known quirk (reference project): some firmware returns identical serial numbers across
 units — do not key multi-device logic on this serial.
 
+## Communication port (RJ45) pinout
+
+The X1 Mini has **no local display**, so all verification happens over the wire or via
+SolaX Cloud. The RS485 lines live on the RJ45 COM port. Note that the port carrying the
+SolaX Pocket WiFi/LAN/4G stick is **not necessarily the same connector**: on an
+X1-1.1-S-D (field session 2026-07-23) the dongle sits on a separate **USB** port and the
+RJ45 stays free. Pinout, from the hardware-tested reference (syssi/esphome-solax-x1-mini)
+and the official X1 external-communication doc:
+
+| RJ45 pin | Signal      | Standard T568B colour |
+|----------|-------------|-----------------------|
+| 1        | RefGen      | white/orange          |
+| 2        | Com / DRM0  | orange                |
+| 3        | GND_COM     | white/green           |
+| **4**    | **RS485 A+ (D+)** | **blue**        |
+| **5**    | **RS485 B- (D-)** | **white/blue**  |
+| 6        | E_Stop      | green                 |
+| 7        | GND_COM     | white/brown           |
+| 8        | —           | brown                 |
+
+Wire three conductors: **A+ = pin 4 (blue)**, **B- = pin 5 (white/blue)**, **GND = pin 3
+or 7**. The RS485 pair is the standard middle (blue) pair, so a cut Ethernet patch cable
+is the easiest source. GND is recommended on the X1, not optional folklore: total silence
+that does NOT change when A/B are swapped means you are not on pins 4/5 at all (the usual
+first-session mistake), not that the polarity is wrong.
+
+**Pin 2 is Com/DRM0** — the inverter's DRM0 curtailment input lives on this same connector.
+That is the wire the relay-board actuator (see docs/drm.md) drives; a monitoring RJ45 and a
+DRM0 RJ45 can therefore be split out of one connector later.
+
 ## Bring-up runbook (first hardware session)
 
 Same script as the other drivers (see docs/growatt-sph-protocol.md for the long form):
@@ -79,14 +110,55 @@ Same script as the other drivers (see docs/growatt-sph-protocol.md for the long 
    drivers may answer, the margin rule then asks for a manual confirm; pick `solax_x1`).
 2. Log level `trace`; watch `/api/v1/logs` for `SOLAX ...` transaction lines and payload
    hex dumps.
-3. Wire RS485 A/B to the inverter's COM port. No reply → swap A/B first, then check the
-   connector pinout against the X1 manual.
-4. Verify against the inverter display/app: AC power, voltage, energy today. **First
-   suspects when something is off:** the two u32 endianness assumptions (energy total,
-   runtime) and the AC power scale (1 W assumed, not 0.1).
+3. Wire RS485 to the RJ45 dongle port per the pinout above: A+ = pin 4, B- = pin 5, GND =
+   pin 3/7. No reply → first confirm you are on pins 4/5 (swapping A/B does nothing if you
+   are not), then swap A/B, then check GND.
+4. Verify against SolaX Cloud (the Mini has no local display): AC power, voltage, energy
+   today. **First suspects when something is off:** the two u32 endianness assumptions
+   (energy total, runtime) and the AC power scale (1 W assumed, not 0.1).
 5. Payload length in the trace tells the generation (50/52/56). Record it here.
 6. After validation: update the STATUS lines here and in solax_parser.h / solax_driver.h,
    and promote the driver Experimental → Beta.
+
+## Field findings — X1-Mini-G1, 2026-07-23 (unresolved: no data over RJ45)
+
+First on-site attempt against an **X1-1.1-S-D**, which SolaX support identified as an
+**X1-Mini-G1**. Result: the bridge transmits byte-perfect discovery
+(`AA 55 01 00 00 00 10 00 00 01 10`, matching the reference request exactly) and receives
+**zero bytes**, every cycle, for the whole session.
+
+Eliminated, in order:
+
+- **Wiring** — RJ45 plug (not bare wires into the socket), pins 4/5 = A+/B-, GND on 3/7,
+  verified by a qualified electrical engineer. Both A/B polarities tried *with GND
+  connected* — note that polarity swaps done before GND was attached prove nothing.
+- **Bus address** — the `10 00` discovery broadcast is address-agnostic by design: an
+  unregistered inverter must answer regardless of its address.
+- **Dongle contention** — on this unit the Pocket WiFi sits on a separate **USB** port, so
+  it does not occupy the RJ45. Removing it changed nothing.
+- **Our transmit path** — `rs485_transport` drives the SP3485 DE/RE from the UART in
+  `UART_MODE_RS485_HALF_DUPLEX` (auto-RTS) and blocks on `flush()` until the last bit is
+  out. The same code polls a real EverSolar inverter continuously.
+- **Modbus RTU as an alternative** — ruled out authoritatively: SolaX support (2026-07-23)
+  states Modbus was never implemented for the X1-Mini-G1 ("destijds was er geen marktvraag
+  naar Modbus-connectiviteit"), and the product is end-of-life for both hardware and
+  software. Do not build a Modbus driver for this generation; it has no Modbus stack to
+  talk to. Standard Modbus RTU on SolaX X1 exists only from the Air/Boost/Mini **Gen3/Gen4**
+  onwards.
+
+**Remaining hypothesis: on the G1 the PMU serial line runs to the USB dongle port, and the
+RJ45 pins 4/5 are not on that bus.** The Pocket WiFi demonstrably speaks PMU to the
+inverter (it reports to SolaX Cloud), yet a listener on pins 4/5 hears neither the dongle's
+polling nor any reply. The reference project lists Mini G1 as supported over RJ45, so this
+may be revision-specific — unconfirmed either way.
+
+Two tests would settle it, both with a scope on pins 4/5: (a) with the dongle removed and
+the bridge polling, do our own differential bursts appear? (confirms the board drives the
+bus — this board is a second, hardware-unproven unit); (b) with the dongle inserted and
+actively polling, does *its* traffic appear on pins 4/5? If it does not, the RJ45 is
+provably not the PMU bus on this unit, and the way in is to tap the USB dongle line
+instead (reference: xdubx/Solax-Pocket-USB-reverse-engineering) — the payload decoder in
+this driver stays valid, only the physical tap changes.
 
 ## Export control (future, separate mode — not this driver)
 


### PR DESCRIPTION
## What does this change?

Docs only — no code, no behaviour change.

The SolaX bring-up runbook told the reader to *\"check the connector pinout against the X1
manual\"* without ever stating that pinout. That gap cost a full on-site session: with no
pinout written down, **\"no reply\" is indistinguishable from \"not on the data pins\"**, and
swapping A/B proves nothing if you were never on pins 4/5 to begin with.

**Added:**

- **The verified RJ45 pinout** — `A+ = pin 4`, `B- = pin 5`, `GND = pin 3/7`, including the
  T568B colours, so a cut Ethernet patch cable is all the hardware you need. Sourced from
  the hardware-tested reference (syssi/esphome-solax-x1-mini) plus the official X1
  external-communication document.
- **Pin 2 = Com/DRM0** is called out: the inverter's DRM0 curtailment input sits on this
  same connector, which is the line the relay-board actuator (`docs/drm.md`) will drive.
  Monitoring and DRM0 can be split out of one connector later.
- **A \"Field findings\" section** recording the 2026-07-23 session against an X1-1.1-S-D
  (identified by SolaX support as an **X1-Mini-G1**): byte-perfect discovery frames out,
  **zero bytes** in, for the entire session. Wiring, bus address, dongle contention and our
  own transmit path are each eliminated in turn, with the reasoning, so the next attempt
  starts where this one stopped instead of repeating it.

**The finding most worth having in the repo:** SolaX support confirmed that **Modbus RTU was
never implemented for the X1-Mini-G1** and that the product is end-of-life for both hardware
and software. Standard Modbus on SolaX X1 begins at Air/Boost/Mini **Gen3/Gen4**. Writing
that down should stop someone (including us — it was actively under consideration) from
building a Modbus driver for a generation that has no Modbus stack to answer it.

The remaining hypothesis — that on the G1 the PMU serial runs to the **USB dongle port**
rather than the RJ45 — is stated explicitly as a hypothesis, together with the two scope
measurements that would settle it. Not presented as fact.

**Two errors corrected along the way**, both mine, both introduced earlier in the same
session:

- The Pocket WiFi dongle does **not** necessarily occupy the RJ45. On this unit it sits on a
  separate USB port and the RJ45 stays free.
- The runbook told the reader to verify against \"the inverter display/app\" — the X1 Mini has
  no local display. Now points at SolaX Cloud.

## Checklist

- [x] \`pio test -e native\` passes — unchanged, no code touched
- [x] \`bash tools/check_layering.sh\` passes — unchanged, no code touched
- [ ] For a new device profile — n/a
- [ ] For web UI changes — n/a
- [x] Tested on real hardware? Yes, and that is the point of this PR: an X1-1.1-S-D /
      X1-Mini-G1 on 2026-07-23. **It did not yield data.** The `solax_x1` driver therefore
      stays **Experimental** — this PR documents a failed bring-up honestly rather than
      claiming support.
