### PR TITLE
Expose read-only mode in the settings UI

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -587,7 +587,7 @@ Elaborated in `docs/security.md`. Core:
 
 | Topic | MVP |
 |---|---|
-| Global read-only mode | **On**, cannot be disabled (no driver can write) |
+| Global read-only mode | **On** by default; opt-out in *Settings → Security*, which unlocks the relay/DRM outputs (no driver can write to an inverter) |
 | Modbus writing | Off; FC6/16 → exception 0x01 |
 | Raw TCP bridge | Off (not implemented) |
 | REST GET | Unsecured (local network) |

--- a/docs/drm.md
+++ b/docs/drm.md
@@ -19,9 +19,11 @@ for an inverter that cannot be curtailed over RS485.
 
 Three layers, all of which must agree before a contact moves:
 
-1. `security.read_only_mode` — the global kill switch, on by default.
+1. `security.read_only_mode` — the global kill switch, on by default. Turn it off in
+   *Settings → Security* (or `{"security":{"read_only_mode":false}}` over the API).
 2. `relays.enabled` — the feature flag, off by default. A relay board with factory
-   settings is inert.
+   settings is inert. *Settings → Relays* warns while this one is open and the first
+   is still closed; enabling relays alone actuates nothing.
 3. The rate limiter — asserting is throttled; **releasing is never throttled**.
 
 Closing either gate (read-only on, or relays off) releases every relay immediately: a
@@ -78,7 +80,8 @@ a half-asserted mode is worse than none.
 
 ## Before first use on a real inverter
 
-1. Flash the board, enable relays, and click the switches with **nothing connected**:
+1. Flash the board, turn off read-only mode, enable relays, and click the switches with
+   **nothing connected**:
    you should hear the coils and see the states follow in Home Assistant.
 2. Confirm polarity with a multimeter across NO/COM: de-energised must read open.
 3. Pull the bridge's power mid-assertion: every contact must return to its de-energised

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,7 +7,7 @@ the same LAN", not "someone holding the PCB in their hands".
 
 | Topic | Status |
 |---|---|
-| Global read-only mode | On, and cannot be turned off: no driver can write |
+| Global read-only mode | On by default; a deliberate opt-out in *Settings → Security*. While on, every inverter command and every relay move is refused. Turning it off unlocks the relay/DRM contacts — no driver in this build can write to an inverter, so nothing reaches the inverter either way |
 | Modbus writes | Off; FC6/FC16 → exception 0x01. `write_enabled=true` is rejected by config validation |
 | Raw TCP bridge | Not implemented |
 | REST GET | Unsecured (local network) |

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -227,7 +227,10 @@ function render(s){
     add('Online',d.online);add('Data valid',d.data_valid);add('Data stale',d.data_stale);
     if(caps){
       r+=`<tr><th>Capability</th><th></th></tr>`;
-      r+=`<tr><td class="dim">Read-only</td><td>${caps.read_only}</td></tr>`;
+      // "Driver read-only", not "Read-only": this is the driver's own write capability, a
+      // different thing from the security.read_only_mode switch under Settings. Two rows named
+      // "Read-only" meaning different things is how someone looks for the kill switch here.
+      r+=`<tr><td class="dim">Driver read-only</td><td>${caps.read_only}</td></tr>`;
       r+=`<tr><td class="dim">Phases / MPPTs</td><td>${caps.phase_count} / ${caps.mppt_count}</td></tr>`;
       r+=`<tr><td class="dim">Battery</td><td>${caps.has_battery}</td></tr>`;
       r+=`<tr><td class="dim">Read</td><td>${(caps.read||[]).map(esc).join(', ')||'—'}</td></tr>`;
@@ -624,7 +627,7 @@ async function renderConfig(){
          on is a silent dead end: the card looks configured, the switches appear in Home
          Assistant, and nothing ever actuates (live, first Relay-6CH bring-up 2026-07-23).
          Shown/hidden from the live checkboxes below, not from the saved config. -->
-    <div id="rlgate" class="msg err" style="display:none;font-size:13px">Relays are enabled, but
+    <div id="rlgate" class="msg err" role="alert" style="display:none;font-size:13px">Relays are enabled, but
       read-only mode is still on — no relay will move. Turn off
       <a href="#" onclick="return focusReadOnly()">Read-only mode</a> under Security below and save.</div>
     ${Array.from({length:window.g_relayCount},(_, i)=>`
@@ -639,7 +642,13 @@ async function renderConfig(){
     must leave the inverter running).</div></div>`:''}
   <div class="card"><b>Security</b> <span class="tag" style="font-weight:400">applied immediately</span>${txt('c_au','Admin username',c.security.admin_username)}
     ${pw('c_ap','Admin password',c.security.password_set)}
-    ${chk('c_ro','Read-only mode',c.security.read_only_mode)}
+    <!-- !==false, not a plain truthiness test: a missing field must render as ON. If GET ever
+         stops carrying read_only_mode (a serialiser regression, an older firmware behind a
+         proxy), a truthy test renders the box unchecked, and the diff below then reads that as
+         a deliberate change and PATCHes read_only_mode:false -- pressing Save without touching
+         anything would silently open the global write gate. Absent means on; the only way past
+         this switch stays a deliberate click. -->
+    ${chk('c_ro','Read-only mode',c.security.read_only_mode!==false)}
     <div class="dim" style="font-size:12px;margin-top:4px">The global write kill switch, on by
     default, and the outermost gate on everything this bridge can change. While it is on the
     bridge only observes: every inverter command is refused and no relay moves, whatever the

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -620,17 +620,32 @@ async function renderConfig(){
   </div>
   ${window.g_relayCount>0?`<div class="card"><b>Relays</b> <span class="tag" style="font-weight:400">applied immediately</span>
     ${chk('c_rle','Enabled',(c.relays||{}).enabled)}
+    <!-- The second gate, named where it bites. Enabling relays while read-only mode is still
+         on is a silent dead end: the card looks configured, the switches appear in Home
+         Assistant, and nothing ever actuates (live, first Relay-6CH bring-up 2026-07-23).
+         Shown/hidden from the live checkboxes below, not from the saved config. -->
+    <div id="rlgate" class="msg err" style="display:none;font-size:13px">Relays are enabled, but
+      read-only mode is still on — no relay will move. Turn off
+      <a href="#" onclick="return focusReadOnly()">Read-only mode</a> under Security below and save.</div>
     ${Array.from({length:window.g_relayCount},(_, i)=>`
       <label for="c_rlr${i}">Relay ${i+1} role</label>
       <select id="c_rlr${i}" data-role="${i}">${['none','drm0','drm1','drm2','drm3','drm4','drm5','drm6','drm7','drm8'].map(r=>
         `<option ${r===(((c.relays||{}).roles||[])[i]||'none')?'selected':''}>${r}</option>`).join('')}</select>`).join('')}
     <div class="dim" style="font-size:12px;margin-top:8px">DRM curtailment contacts. Two
-    locks must open before a relay can move: this switch AND read-only mode being off.
+    locks must open before a relay can move: this switch AND read-only mode (under Security,
+    below) being off.
     Disabling releases every relay. Roles name the switches in Home Assistant and build
     the DRM Mode select; see docs/drm.md for the wiring rules (failsafe: a dead bridge
     must leave the inverter running).</div></div>`:''}
   <div class="card"><b>Security</b> <span class="tag" style="font-weight:400">applied immediately</span>${txt('c_au','Admin username',c.security.admin_username)}
-    ${pw('c_ap','Admin password',c.security.password_set)}</div>
+    ${pw('c_ap','Admin password',c.security.password_set)}
+    ${chk('c_ro','Read-only mode',c.security.read_only_mode)}
+    <div class="dim" style="font-size:12px;margin-top:4px">The global write kill switch, on by
+    default, and the outermost gate on everything this bridge can change. While it is on the
+    bridge only observes: every inverter command is refused and no relay moves, whatever the
+    Relays card says. <b>Turning it off permits writes to the inverter and to the relay
+    outputs.</b> No driver in this build can write to an inverter, so today this unlocks the
+    relay/DRM contacts — leave it on unless you are deliberately using them.</div></div>
   <div class="card"><b>Logging</b> <span class="tag" style="font-weight:400">applied immediately</span>
     <label for="c_lg">Level</label><select id="c_lg">${['error','warn','info','debug','trace'].map(l=>
       `<option ${l===c.logging.level?'selected':''}>${l}</option>`).join('')}</select></div>
@@ -658,6 +673,23 @@ async function renderConfig(){
     bad configuration, as long as you can still reach it.</p>
     <button style="background:var(--bad)" onclick="factoryReset()">Erase and restart</button>
   </div>`;
+
+  // Keep the Relays card's gate warning in step with both checkboxes as they are clicked --
+  // the user is told the combination is dead before saving it, not after wondering why the
+  // relays are silent.
+  if(window.g_relayCount>0){
+    const upd=()=>{$('#rlgate').style.display=($('#c_rle').checked&&$('#c_ro').checked)?'block':'none'};
+    $('#c_rle').onchange=upd;$('#c_ro').onchange=upd;upd();
+  }
+}
+
+// The Relays card's link to the switch that is actually blocking it. Focus as well as scroll:
+// on a long settings page a jump alone leaves the user hunting for which control was meant.
+function focusReadOnly(){
+  const e=$('#c_ro');
+  e.scrollIntoView({block:'center',behavior:'smooth'});
+  e.focus();
+  return false;
 }
 
 async function saveConfig(){
@@ -677,7 +709,9 @@ async function saveConfig(){
              ?{timezone:v('c_ntptzc'),timezone_name:''}
              :{timezone:TZBYNAME[v('c_ntptz')],timezone_name:v('c_ntptz')})},
     driver:{id:v('c_drv'),options:{}},
-    security:{admin_username:v('c_au')},
+    // read_only_mode is rendered from the stored value, so the generic per-key diff below is
+    // enough: no rendered default to mistake for a change (unlike driver options / relay roles).
+    security:{admin_username:v('c_au'),read_only_mode:b('c_ro')},
     logging:{level:v('c_lg')}};
   // A blank password field means "keep": sending "" would clear it, which is never what an
   // untouched field means.

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -206,6 +206,40 @@ static void test_explicit_null_clears_a_password() {
     TEST_ASSERT_TRUE(c.mqtt.password.empty());
 }
 
+// The settings page renders its Read-only checkbox from this field and diffs the saved value
+// against it, so both halves are a contract, not an implementation detail. If GET stopped
+// emitting it the box would render from an absent value; if PATCH stopped accepting it the
+// switch would be unreachable from the UI again -- which is the hole this pair closes.
+static void test_read_only_mode_survives_a_get_patch_round_trip() {
+    auto        c = configWithSecrets();
+    std::string json;
+    TEST_ASSERT_TRUE(serializeConfig(c, json));
+    TEST_ASSERT_TRUE(parse(json)["security"]["read_only_mode"].as<bool>());
+
+    ConfigError e;
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"security":{"read_only_mode":false}})", c, e));
+    TEST_ASSERT_FALSE(c.security.readOnlyMode);
+    TEST_ASSERT_TRUE(serializeConfig(c, json));
+    TEST_ASSERT_FALSE(parse(json)["security"]["read_only_mode"].as<bool>());
+
+    // And back on: the kill switch must be re-armable over the same path it was opened.
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"security":{"read_only_mode":true}})", c, e));
+    TEST_ASSERT_TRUE(c.security.readOnlyMode);
+}
+
+static void test_read_only_mode_is_untouched_by_an_unrelated_patch() {
+    // The UI omits unchanged fields; a patch that never mentions the gate must leave it alone.
+    auto c = configWithSecrets();
+    c.security.readOnlyMode = false;
+    ConfigError e;
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"logging":{"level":"debug"}})", c, e));
+    TEST_ASSERT_FALSE(c.security.readOnlyMode);
+
+    c.security.readOnlyMode = true;
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"security":{"admin_username":"tim"}})", c, e));
+    TEST_ASSERT_TRUE(c.security.readOnlyMode);
+}
+
 static void test_a_rejected_patch_changes_nothing() {
     // The merge-then-validate rule: a bad field must not leave earlier fields applied.
     auto        c = configWithSecrets();
@@ -712,6 +746,8 @@ int main(int, char**) {
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);
     RUN_TEST(test_patch_sets_a_password);
+    RUN_TEST(test_read_only_mode_survives_a_get_patch_round_trip);
+    RUN_TEST(test_read_only_mode_is_untouched_by_an_unrelated_patch);
     RUN_TEST(test_explicit_null_clears_a_password);
     RUN_TEST(test_a_rejected_patch_changes_nothing);
     RUN_TEST(test_invalid_json_is_refused);


### PR DESCRIPTION
## Why

The relay/DRM feature is behind a deliberate double gate: `relays.enabled` **and**
`security.read_only_mode` off. Only the first was reachable from the web UI. The second was
display-only — a "Read-only" row in the device capabilities table — so the only way to open
it was a hand-written `PATCH /api/v1/config` with `{"security":{"read_only_mode":false}}`.

Hit during the first hardware bring-up of the Waveshare Relay-6CH board (2026-07-23): the
Relays card appeared in Settings, relays could be enabled there, nothing actuated, and the UI
gave no indication why or how to fix it.

## What changed

- **Settings → Security** gets a `Read-only mode` checkbox. It sits in Security rather than on
  the Relays card because it is a global write kill switch that also gates the inverter command
  dispatcher, not a relay-only setting. The copy states plainly that turning it off permits
  writes to the inverter and to the relay outputs, and that today (no driver in this build can
  write) what it actually unlocks are the relay/DRM contacts.
- **The Relays card surfaces the gate.** With relays enabled and read-only mode still on, a
  warning appears naming the blocking switch, with a link that scrolls to and focuses it. It is
  driven by the live checkboxes rather than the saved config, so the dead combination is flagged
  before saving.
- Docs: `security.md` and `architecture.md` still claimed read-only mode "cannot be turned off",
  which stopped being true when relay outputs arrived; `drm.md` now names where the gate lives
  and adds it to the pre-flight checklist.

## Change detection

No special-casing needed, and that is deliberate: the checkbox renders from the **stored**
value, so the existing generic per-key diff compares stored-vs-submitted. There is no rendered
default that could be mistaken for a change — the failure mode that produced phantom "Driver
options" and relay-roles diffs.

## Verification

- `python3 tools/check_web_js.py` → OK (both assets)
- `pio test -e native` → 423/423 passed
- The page was rendered locally against a stubbed REST API (6 relays, `relays.enabled: true`,
  `read_only_mode: true`) and driven through the DOM:
  - warning visible only for enabled-relays + read-only-on; hidden for the other three
    combinations, and it follows the checkboxes live
  - the link focuses `#c_ro`
  - save with nothing touched → `Nothing changed.` (no phantom diff)
  - unchecking read-only and saving → PATCH body exactly
    `{"security":{"read_only_mode":false}}`, no restart claimed (correct: `security.*` is
    applied live by `applyConfig`)

Not yet exercised on the device — worth a click-through on the Relay-6CH board before merge.
