### PR TITLE
Relay-6CH first hardware bring-up: verify the board, fix its PSRAM config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A heliograph signalled messages with sunlight. This one translates what your solar
 > inverter is saying into languages the rest of your network speaks.
 
-Firmware for the **Waveshare ESP32-S3-RS485-CAN** that reads solar inverters and hybrid
+Firmware for **Waveshare ESP32-S3 boards** that reads solar inverters and hybrid
 systems over RS485 and republishes everything in the formats your tooling already speaks:
 **MQTT + Home Assistant discovery, Modbus TCP, REST/JSON, Prometheus**. One box next to
 the inverter, every integration for free.
@@ -17,7 +17,7 @@ Built for devices whose vendor tooling is dead, cloud-bound or closed — starti
 |---|---|---|
 | EverSolar / Zeversolar legacy (TL series) | PMU (AA55) over RS485 | **Beta** — running in production, multi-day soak toward Stable |
 | Growatt SPH hybrid (3–6 kW) | Modbus RTU | Experimental — register map transcribed, hardware validation in progress |
-| SolaX X1 series (X1 Mini G1/G2/G3) | PMU (AA55) over RS485 | Experimental — awaiting first hardware session |
+| SolaX X1 series (X1 Mini G1/G2/G3) | PMU (AA55) over RS485 | Experimental — first hardware attempt (X1-Mini-G1) returned no data; see [docs/solax-x1-protocol.md](docs/solax-x1-protocol.md) before wiring |
 
 All drivers are **read-only**. Writing setpoints to somebody's inverter requires a
 hardware-verified register map and a deliberate driver-level write path; neither is
@@ -31,12 +31,21 @@ enabled today (see `docs/device-profiles/schema.md` for how write support is sta
 | Board | Extras | Status |
 |---|---|---|
 | Waveshare ESP32-S3-RS485-CAN | battery-backed RTC, CAN (unused) | **Production** — the reference board |
-| Waveshare ESP32-S3-Relay-1CH | 1 relay (DRM0 curtailment, planned), RTC | Builds; awaiting hardware validation |
-| Waveshare ESP32-S3-Relay-6CH | 6 relays (DRM modes, planned), 8 MB flash | Builds; pins verified, awaiting hardware validation |
+| Waveshare ESP32-S3-Relay-1CH | 1 relay (DRM0 curtailment), RTC | Builds; awaiting hardware validation |
+| Waveshare ESP32-S3-Relay-6CH | 6 relays (DRM modes), 8 MB flash | **Hardware-verified** — relays, polarity and failsafe measured 2026-07-23; RS485 on this board not yet exercised |
 
 One firmware image per board; the web installer asks which one you have. The relay
 boards are for **DRM demand-response curtailment** of inverters that cannot be limited
-over RS485 — that control layer is under construction and ships disabled by default.
+over RS485 — useful precisely where a driver is read-only, which is all of them today.
+
+The relay layer ships **inert**: it needs two independent gates opened (`relays.enabled`
+*and* `security.read_only_mode` off) before a coil can move. On the 6CH this has been
+measured rather than assumed — channel order maps one-to-one, driving a GPIO high closes
+COM-NO, cutting power releases the contact immediately, and the board boots with every
+relay de-energised. No relay state is persisted anywhere, deliberately: a reboot must
+never restore a curtailment nobody just asked for. Because a de-energised relay leaves NO
+open *and* NC closed, "bridge dead means the inverter keeps producing" stays a wiring
+choice rather than a firmware flag — see [docs/drm.md](docs/drm.md).
 
 ## Quickstart
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -117,14 +117,18 @@ board = esp32-s3-devkitc-1
 framework = arduino
 board_build.mcu = esp32s3
 board_build.flash_mode = qio
-board_build.arduino.memory_type = qio_opi   ; octal PSRAM (R8)
 monitor_speed = 115200
 extra_scripts = ${common.extra_scripts}
+; PSRAM is deliberately NOT set here: it is a per-module property, not a family one, and
+; the boards this firmware targets genuinely differ. Declaring octal PSRAM for a module
+; that has none makes the bootloader probe for a chip that is not there and log
+; "octal_psram: PSRAM chip is not connected ... Bailing out." on every single boot
+; (observed on the Relay-6CH, 2026-07-23). It boots on regardless, so this hides easily --
+; each env states its own memory_type and BOARD_HAS_PSRAM below.
 build_flags =
     ${common.build_flags}
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DARDUINO_USB_MODE=1
-    -DBOARD_HAS_PSRAM
     ; All hardware drivers in one image: the flash has room, discovery picks the right
     ; one, and one binary per BOARD beats one per brand.
     -DENABLE_DRIVER_EVERSOLAR=1
@@ -171,11 +175,15 @@ lib_deps =
 extends = esp32common
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
+; N16R8: 16 MB flash + 8 MB OCTAL PSRAM. Verified on hardware -- this is the board in
+; production and it boots without a PSRAM complaint.
+board_build.arduino.memory_type = qio_opi
 ; Two app partitions so a failed OTA falls back to the previous image. Without this line
 ; PlatformIO silently uses the board default (~3.2 MB single app, no rollback).
 board_build.partitions = partitions_16mb_ota.csv
 build_flags =
     ${esp32common.build_flags}
+    -DBOARD_HAS_PSRAM
     -DHELIOGRAPH_BOARD_RS485_CAN
 
 ; 16 MB flash, one relay (DRM0 actuator), PCF85063 RTC.
@@ -184,18 +192,28 @@ extends = esp32common
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
 board_build.partitions = partitions_16mb_ota.csv
+; UNVERIFIED: assumed N16R8 (octal PSRAM) by analogy with the RS485-CAN, never checked on
+; hardware -- nobody here owns this board. If a 1CH ever logs "octal_psram: PSRAM chip is
+; not connected" at boot, the module is a plain N16 and these two lines come out, exactly
+; as they did for the 6CH.
+board_build.arduino.memory_type = qio_opi
 build_flags =
     ${esp32common.build_flags}
+    -DBOARD_HAS_PSRAM
     -DHELIOGRAPH_BOARD_RELAY_1CH
 
 ; 8 MB flash (own partition table), six relays (DRM0-8 actuators), no RTC.
-; STUB until the physical board is in hand: the RS485 direction-pin GPIO is unverified
-; (see the board header) -- do not rely on RS485 on this build yet.
 [env:waveshare-relay-6ch]
 extends = esp32common
 board_upload.flash_size = 8MB
 board_upload.maximum_size = 8388608
 board_build.partitions = partitions_8mb_ota.csv
+; ESP32-S3-WROOM-1U-N8: 8 MB flash, NO PSRAM. Hence no memory_type override to qio_opi and
+; no BOARD_HAS_PSRAM -- inheriting those (as this env did until 2026-07-23) made every boot
+; log "octal_psram: PSRAM chip is not connected, or wrong PSRAM line mode / Bailing out."
+; before continuing without it. Confirmed against the Waveshare product listing and the
+; ESPHome device config for this board, and by the first boot of real hardware.
+board_build.arduino.memory_type = qio_qspi
 build_flags =
     ${esp32common.build_flags}
     -DHELIOGRAPH_BOARD_RELAY_6CH
@@ -206,6 +224,8 @@ extends = esp32common
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
 board_build.partitions = partitions_16mb_ota.csv
+; Mirrors the RS485-CAN it stands in for (N16R8, octal PSRAM).
+board_build.arduino.memory_type = qio_opi
 build_flags =
     ${common.build_flags}
     -DARDUINO_USB_CDC_ON_BOOT=1

--- a/src/boards/waveshare_esp32_s3_relay_6ch.h
+++ b/src/boards/waveshare_esp32_s3_relay_6ch.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 //
 // Waveshare ESP32-S3-Relay-6CH board definition. STATUS: pins verified from the official
-// schematic AND the official demo source; this firmware has not run on the physical board
-// yet (relay polarity check pending).
+// schematic AND the official demo source, and CONFIRMED ON HARDWARE 2026-07-23 -- all six
+// relays actuate, and the active-high polarity below was measured, not assumed.
 //
 // Sources (2026-07-22): official schematic (ESP32-S3-Relay-6CH-Sch.pdf), official demo
 // (ESP32-S3-Relay-6CH-Demo.zip, WS_GPIO.h/WS_Serial.cpp), community ESPHome configuration
@@ -13,6 +13,12 @@
 // The six relays are the multi-mode DRM actuators (DRM0-8 combinations) for inverters
 // that cannot be curtailed over RS485. Failsafe by wiring: de-energised = DRM not
 // asserted -- a dead bridge never blocks production.
+//
+// The failsafe is MEASURED, not merely designed (2026-07-23): with a relay energised,
+// cutting power released the contact immediately, and the board came back up with all six
+// de-energised. That second half matters as much as the first -- begin() drives every
+// relay off and no relay state is persisted anywhere on purpose, so a reboot can never
+// restore a curtailment nobody just asked for.
 
 #pragma once
 
@@ -40,8 +46,14 @@ inline constexpr int kRs485UartNum = 1;
 // --- Relays --------------------------------------------------------------------------------
 // Schematic nets CH1..CH6 -> GPIO1, GPIO2, GPIO41, GPIO42, GPIO45, GPIO46 (45/46 are
 // strapping pins; they only matter at reset, and the relays are driven afterwards).
-// Community configuration drives HIGH to energise; treat active-high as unconfirmed
-// polarity until the first hardware session.
+// Order CONFIRMED ON HARDWARE 2026-07-23: relay index 0..5 drives CH1..CH6 one-to-one.
+// Worth checking rather than assuming -- a shifted mapping would silently switch the
+// wrong DRM line on an inverter.
+// Active-high VERIFIED ON HARDWARE 2026-07-23, multimeter on the changeover contacts:
+// driving the GPIO high energises the coil, closing COM-NO and opening COM-NC. So a
+// de-energised relay leaves NO open and NC closed -- which is what makes the failsafe a
+// wiring choice rather than a firmware one (docs/drm.md): whichever sense an inverter's
+// DRM input needs, one of the two contacts keeps "bridge dead = inverter runs" true.
 inline constexpr int  kRelayCount      = 6;
 inline constexpr int  kRelayPins[6]    = {1, 2, 41, 42, 45, 46};
 inline constexpr bool kRelayActiveHigh = true;


### PR DESCRIPTION
## What does this change?

The Waveshare Relay-6CH arrived, so the board that was supported blind has now actually run
this firmware. Two commits: what the hardware taught us, and a config bug it exposed.

### The board is verified, not assumed

Four things were assumptions while the board was supported without owning one. All four now
have hardware behind them:

- **All six relays actuate**, and **relay index 0..5 drives CH1..CH6 one-to-one**. Worth
  checking rather than trusting the schematic: a shifted mapping would silently switch the
  *wrong DRM line* on someone's inverter.
- **Active-high polarity is correct** — measured with a multimeter on the changeover
  contacts, not inferred from the community config it came from. Driving the GPIO high
  energises the coil, closing COM-NO and opening COM-NC.
- **Cutting power with a relay energised releases the contact immediately.**
- **The board boots with all six de-energised.**

Those last two are the safety claim this entire feature rests on, and until today they were
design intent rather than a measurement. `begin()` drives every relay off and no relay state
is persisted anywhere on purpose, so a reboot cannot restore a curtailment nobody just asked
for — now demonstrated rather than asserted.

A practical consequence worth recording: because a de-energised relay leaves NO open **and**
NC closed, the failsafe stays a *wiring* decision rather than a firmware one. Whichever sense
an inverter's DRM input expects, one of the two contacts preserves "bridge dead means the
inverter keeps producing" — no code change, no polarity flag.

### PSRAM was declared family-wide, and that was wrong

The 6CH carries an **ESP32-S3-WROOM-1U-N8**: 8 MB flash, **no PSRAM**. It inherited
`[esp32common]`'s octal-PSRAM settings anyway, so every boot probed for a chip that is not on
the board:

```
octal_psram: PSRAM chip is not connected, or wrong PSRAM line mode
esp_psram: PSRAM enabled but initialization failed. Bailing out.
```

It continues without it, which is exactly why this would have sat there unnoticed. It showed
up in the first boot log of real hardware.

PSRAM is a property of the module, not of the family, and the three target boards genuinely
differ — so `[esp32common]` no longer decides it. Each env states its own `memory_type` and
`BOARD_HAS_PSRAM`: octal for the RS485-CAN (the board in production, verified booting clean)
and for the mock standing in for it, none for the 6CH. **The 1CH keeps the octal assumption
but is now explicitly labelled unverified** — nobody here owns one, and that same boot line
will give it away if the guess is wrong.

## Checklist

- [x] `pio test -e native` passes — 423 tests
- [x] `bash tools/check_layering.sh` passes
- [ ] For a new device profile — n/a
- [ ] For web UI changes — n/a
- [x] Tested on real hardware? **Yes — Waveshare ESP32-S3-Relay-6CH, 2026-07-23.** That is
      the entire point of this PR. All four ESP32 environments build.

Not covered here: `BOOT` is still assumed to be GPIO0 and remains unmeasured, and RS485 on
this board has not been exercised against a real device yet.
