### PR TITLE
ci: stop rebuilding firmware unnecessarily (concurrency, PR-only, docs-skip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: MIT
 #
-# The same verification ritual that runs locally before every release:
-# native tests, the layering invariants, embedded-JS syntax, profile schema
-# validation, and both firmware builds. A PR that adds a device profile gets
-# its TOML validated here without a maintainer lifting a finger.
+# The same verification ritual that runs locally before every release: native tests, the
+# layering invariants, embedded-JS syntax, and profile schema validation -- on every push to
+# main and every pull request. The firmware itself (one build per supported board) is compiled
+# only on pull requests that touch build inputs; see the `changes` and `firmware` jobs for why.
+# A PR that adds a device profile gets its TOML validated here without a maintainer lifting a
+# finger.
 
 name: CI
 
@@ -101,6 +103,12 @@ jobs:
     name: Detect build-affecting changes
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    # dorny/paths-filter lists the PR's changed files through the API (no checkout). Spelling
+    # the scopes out keeps this working if the repo's default token permissions are ever
+    # tightened; contents:read covers the compare call, pull-requests:read the file listing.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       firmware: ${{ steps.filter.outputs.firmware }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,16 +88,52 @@ jobs:
       - name: Native test suite
         run: pio test -e native
 
+  # Does this PR touch anything the firmware is built from? A docs-only change (Markdown,
+  # docs/, licences) cannot alter a single byte of the image, so compiling four boards to
+  # prove it is pure waste. This gate answers that once; the firmware job keys off it.
+  #
+  # The filter lives in a JOB with a job-level `if`, deliberately NOT in a workflow-level
+  # `on.*.paths` filter. A path-filtered-out workflow posts no check run at all, so a required
+  # status check would sit in "Pending" forever and block the merge (documented GitHub
+  # behaviour). A skipped job still reports its check, so this stays safe if the firmware
+  # builds are ever made required. PR-only: firmware never runs on push, so neither must this.
+  changes:
+    name: Detect build-affecting changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      firmware: ${{ steps.filter.outputs.firmware }}
+    steps:
+      # No checkout: on a pull_request dorny/paths-filter reads the changed-file list from the
+      # API, which is cheaper and needs no working tree.
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          # Positive list = default-deny: a change matching none of these (docs, README,
+          # LICENSE, the flasher site) leaves `firmware` false and skips the build. Keep this
+          # in step with what `pio run` actually consumes -- err towards listing a path, since
+          # a wrongly-skipped build ships nothing but a wrongly-run one only costs minutes.
+          filters: |
+            firmware:
+              - 'src/**'
+              - 'profiles/**'
+              - 'platformio.ini'
+              - 'partitions_*.csv'
+              - 'tools/gen_profiles.py'
+              - '.github/workflows/ci.yml'
+
   firmware:
     name: Firmware (${{ matrix.env }})
     runs-on: ubuntu-latest
-    # PR-only: the firmware compile is the gate that must pass BEFORE code reaches main, so it
-    # belongs on the pull_request event. A push to main is the same tree the PR already built;
-    # rebuilding it proved nothing and, on a release tag's bump commit, ran a second full matrix
-    # next to release.yml's own build. lint + test still run on main as the trunk gate; the
-    # release workflow re-verifies and builds the shipping images before publishing. (Direct
-    # pushes to main bypass this compile check -- acceptable because all changes land via PR.)
-    if: github.event_name == 'pull_request'
+    # PR-only, and only when the PR touches build inputs. The firmware compile is the gate that
+    # must pass BEFORE code reaches main, so it belongs on the pull_request event. A push to
+    # main is the same tree the PR already built; rebuilding it proved nothing and, on a release
+    # tag's bump commit, ran a second full matrix next to release.yml's own build. lint + test
+    # still run on main as the trunk gate; the release workflow re-verifies and builds the
+    # shipping images before publishing. (Direct pushes to main bypass this compile check --
+    # acceptable because all changes land via PR.)
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.firmware == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ on:
     branches: [main]
   pull_request:
 
+# Cancel superseded PR runs, never a main-branch run. head_ref is set only on
+# pull_request events, so PR pushes share a group and the older run is cancelled the
+# moment a newer push lands; a push to main falls back to the unique run_id, so every
+# trunk commit is still verified end to end. Before this, six pushes to one PR meant six
+# full firmware matrices stacked in parallel.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint + static analysis
@@ -82,6 +91,13 @@ jobs:
   firmware:
     name: Firmware (${{ matrix.env }})
     runs-on: ubuntu-latest
+    # PR-only: the firmware compile is the gate that must pass BEFORE code reaches main, so it
+    # belongs on the pull_request event. A push to main is the same tree the PR already built;
+    # rebuilding it proved nothing and, on a release tag's bump commit, ran a second full matrix
+    # next to release.yml's own build. lint + test still run on main as the trunk gate; the
+    # release workflow re-verifies and builds the shipping images before publishing. (Direct
+    # pushes to main bypass this compile check -- acceptable because all changes land via PR.)
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
De firmware werd vaker gebouwd dan nodig. Drie oorzaken, drie fixes.

## Oorzaken (uit de Actions-historie)

- **Geen concurrency**: de `feat/boot-reset-status-led` PR is 6× gepusht en draaide **6 volledige firmware-matrices** parallel; superseded runs werden niet gecanceld.
- **Firmware-matrix op zowel PR als push-main**: een merge herbouwde exact de tree die de PR al had gebouwd. Bij een release landt de bump-commit op main → volle matrix in `ci.yml`, náást `release.yml`'s eigen build → firmware **2× gebouwd per release** (bevestigd: `Release 0.10.0`).
- **Docs-only PR's bouwden firmware**: een pure Markdown/`docs/`-wijziging compileerde alsnog vier boards.

## Fixes

1. **Concurrency-group** op `head_ref` (PR) of `run_id` (push). PR-pushes cancelen elkaar; elke main-commit krijgt een unieke groep en draait volledig af.
2. **Firmware-job gated op `pull_request`**. Het is de pre-merge gate. `lint` + `test` blijven op main als trunk-gate; `release.yml` verifieert en bouwt de shipping-images vóór publicatie.
3. **`changes`-gate (dorny/paths-filter@v4)** slaat de firmware-matrix over op docs-only PR's. Positieve lijst = default-deny: firmware draait alleen bij wijziging in `src/`, `profiles/`, `platformio.ini`, `partitions_*.csv`, `tools/gen_profiles.py` of deze workflow.

## Waarom de paths-filter in een job zit, niet op workflow-niveau

Een workflow die via `on.*.paths` wordt weggefilterd post **géén check-run** → een required status check blijft eeuwig "Pending" en blokkeert de merge ([bevestigd in de GitHub-docs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs)). Een *geskipte job* rapporteert zijn check wél, dus dit blijft veilig als de firmware-builds ooit *required* worden. **Main is nu niet protected** (geverifieerd: `Branch not protected`, geen rulesets), dus vandaag gate't niets — dit is puur future-proofing.

## Trade-off (expliciet)

Directe pushes naar main slaan de firmware-compile over. Acceptabel: alles komt via PR binnen (daar draait de matrix), en de release-workflow verifieert opnieuw vóór shipping. Bij squash/merge of racende PR's kan main-tree ≠ PR-head — dan vangt de release-build het vóór er iets de deur uitgaat.

## Netto-effect

| Event | Firmware-builds vóór | ná |
|---|---|---|
| PR-push (code) | 4, stapelend | 4, oude gecanceld |
| PR-push (docs-only) | 4 | 0 |
| Merge naar main | 4 | 0 |
| Release | 7 (4 CI + 3 release) | 3 |

## Verificatie

- `ci.yml` geparsed met PyYAML: jobs `lint`/`test`/`changes`/`firmware`, `changes.outputs.firmware`, `firmware.needs: changes` en de gecombineerde `if` correct gezet.
- `dorny/paths-filter` laatste versie = v4.0.2 → gepind op major `v4`.
- Filter gecontroleerd tegen de repo: `gen_profiles.py` gebruikt alleen stdlib (geen andere tools/-build-input), en de enige top-level build-inputs zijn `platformio.ini` + `partitions_*.csv`. Compleet.
- `release.yml` en `dependency-check.yml` ongemoeid.
