### PR TITLE
ci: move firmware builds to a PR-only workflow (fix skipped-check name)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: MIT
 #
-# The same verification ritual that runs locally before every release: native tests, the
-# layering invariants, embedded-JS syntax, and profile schema validation -- on every push to
-# main and every pull request. The firmware itself (one build per supported board) is compiled
-# only on pull requests that touch build inputs; see the `changes` and `firmware` jobs for why.
-# A PR that adds a device profile gets its TOML validated here without a maintainer lifting a
-# finger.
+# Fast trunk checks: ruff + static analysis, native tests, the layering invariants, embedded-JS
+# syntax, and device-profile schema validation. Runs on every push to main and every pull
+# request. A PR that adds a device profile gets its TOML validated here without a maintainer
+# lifting a finger.
+#
+# The firmware compile lives in its own pull-request-only workflow (firmware.yml), so a push to
+# main posts no firmware check and a release does not rebuild what the PR already built. See
+# that file for the reasoning.
 
 name: CI
 
@@ -14,11 +16,10 @@ on:
     branches: [main]
   pull_request:
 
-# Cancel superseded PR runs, never a main-branch run. head_ref is set only on
-# pull_request events, so PR pushes share a group and the older run is cancelled the
-# moment a newer push lands; a push to main falls back to the unique run_id, so every
-# trunk commit is still verified end to end. Before this, six pushes to one PR meant six
-# full firmware matrices stacked in parallel.
+# Cancel superseded PR runs, never a main-branch run. head_ref is set only on pull_request
+# events, so PR pushes share a group and the older run is cancelled the moment a newer push
+# lands; a push to main falls back to the unique run_id, so every trunk commit runs to
+# completion. (firmware.yml carries the same guard for the builds.)
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -89,90 +90,3 @@ jobs:
 
       - name: Native test suite
         run: pio test -e native
-
-  # Does this PR touch anything the firmware is built from? A docs-only change (Markdown,
-  # docs/, licences) cannot alter a single byte of the image, so compiling four boards to
-  # prove it is pure waste. This gate answers that once; the firmware job keys off it.
-  #
-  # The filter lives in a JOB with a job-level `if`, deliberately NOT in a workflow-level
-  # `on.*.paths` filter. A path-filtered-out workflow posts no check run at all, so a required
-  # status check would sit in "Pending" forever and block the merge (documented GitHub
-  # behaviour). A skipped job still reports its check, so this stays safe if the firmware
-  # builds are ever made required. PR-only: firmware never runs on push, so neither must this.
-  changes:
-    name: Detect build-affecting changes
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    # dorny/paths-filter lists the PR's changed files through the API (no checkout). Spelling
-    # the scopes out keeps this working if the repo's default token permissions are ever
-    # tightened; contents:read covers the compare call, pull-requests:read the file listing.
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      firmware: ${{ steps.filter.outputs.firmware }}
-    steps:
-      # No checkout: on a pull_request dorny/paths-filter reads the changed-file list from the
-      # API, which is cheaper and needs no working tree.
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          # Positive list = default-deny: a change matching none of these (docs, README,
-          # LICENSE, the flasher site) leaves `firmware` false and skips the build. Keep this
-          # in step with what `pio run` actually consumes -- err towards listing a path, since
-          # a wrongly-skipped build ships nothing but a wrongly-run one only costs minutes.
-          filters: |
-            firmware:
-              - 'src/**'
-              - 'profiles/**'
-              - 'platformio.ini'
-              - 'partitions_*.csv'
-              - 'tools/gen_profiles.py'
-              - '.github/workflows/ci.yml'
-
-  firmware:
-    name: Firmware (${{ matrix.env }})
-    runs-on: ubuntu-latest
-    # PR-only, and only when the PR touches build inputs. The firmware compile is the gate that
-    # must pass BEFORE code reaches main, so it belongs on the pull_request event. A push to
-    # main is the same tree the PR already built; rebuilding it proved nothing and, on a release
-    # tag's bump commit, ran a second full matrix next to release.yml's own build. lint + test
-    # still run on main as the trunk gate; the release workflow re-verifies and builds the
-    # shipping images before publishing. (Direct pushes to main bypass this compile check --
-    # acceptable because all changes land via PR.)
-    needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.firmware == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        env: [waveshare-rs485-can, waveshare-relay-1ch, waveshare-relay-6ch, mock]
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Cache PlatformIO
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.platformio
-            ~/.cache/pip
-          key: pio-fw-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
-
-      - name: Install PlatformIO
-        run: pip install platformio
-
-      - name: Build ${{ matrix.env }}
-        run: pio run -e ${{ matrix.env }}
-
-      - name: Upload firmware artifacts
-        if: matrix.env != 'mock'
-        uses: actions/upload-artifact@v7
-        with:
-          name: firmware-${{ matrix.env }}-${{ github.sha }}
-          path: |
-            .pio/build/${{ matrix.env }}/firmware.bin
-            .pio/build/${{ matrix.env }}/firmware.factory.bin
-          retention-days: 14

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+#
+# Firmware compile gate. Split out from ci.yml deliberately: this workflow triggers ONLY on
+# pull_request, so a push to main -- a merge, a release bump -- runs nothing here and posts no
+# firmware check. The tree was already built on the PR, and release.yml builds the shipping
+# images. Keeping firmware a separate workflow, rather than a push-skipped job inside ci.yml,
+# is what stops a "Firmware (${{ matrix.env }}) — skipped" check appearing on every main commit:
+# a matrix job skipped by a job-level `if` reports one check with its name un-interpolated, but
+# a workflow that does not trigger on an event contributes no check for that event at all.
+#
+# The board list is computed, not static. `changes` emits the full list only when the PR touches
+# something the image is built from, and an empty list otherwise; fromJSON turns it into the
+# build matrix. An empty array expands to zero matrix jobs, so a docs-only PR compiles nothing
+# and shows no build check -- without a job-level `if`, which is precisely the skip that would
+# render `${{ matrix.env }}` as a check name.
+
+name: Firmware
+
+on:
+  pull_request:
+
+concurrency:
+  group: firmware-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect build-affecting changes
+    runs-on: ubuntu-latest
+    # dorny/paths-filter lists the PR's changed files through the API (no checkout). Spelling the
+    # scopes out keeps this working if the repo's default token permissions are ever tightened;
+    # contents:read covers the compare call, pull-requests:read the file listing.
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      # A JSON array the build job reads as its matrix: every board when a build input changed,
+      # [] otherwise. [] is valid JSON and expands to zero jobs.
+      envs: ${{ steps.envs.outputs.envs }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          # Positive list = default-deny: a change matching none of these (docs, README, LICENSE,
+          # the flasher site) leaves the list empty and builds nothing. Keep this in step with
+          # what `pio run` actually consumes -- err towards listing a path, since a wrongly-skipped
+          # build ships nothing but a wrongly-run one only costs minutes.
+          filters: |
+            firmware:
+              - 'src/**'
+              - 'profiles/**'
+              - 'platformio.ini'
+              - 'partitions_*.csv'
+              - 'tools/gen_profiles.py'
+              - '.github/workflows/firmware.yml'
+      - id: envs
+        env:
+          AFFECTED: ${{ steps.filter.outputs.firmware }}
+        run: |
+          if [ "$AFFECTED" = "true" ]; then
+            echo 'envs=["waveshare-rs485-can","waveshare-relay-1ch","waveshare-relay-6ch","mock"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'envs=[]' >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build (${{ matrix.env }})
+    needs: changes
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJSON(needs.changes.outputs.envs) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-fw-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Build ${{ matrix.env }}
+        run: pio run -e ${{ matrix.env }}
+
+      - name: Upload firmware artifacts
+        if: matrix.env != 'mock'
+        uses: actions/upload-artifact@v7
+        with:
+          name: firmware-${{ matrix.env }}-${{ github.sha }}
+          path: |
+            .pio/build/${{ matrix.env }}/firmware.bin
+            .pio/build/${{ matrix.env }}/firmware.factory.bin
+          retention-days: 14


### PR DESCRIPTION
## Probleem

Na #13 toont elke **push naar main** een skipped check die letterlijk `Firmware (${{ matrix.env }})` heet — de matrix-variabele ongeïnterpoleerd:

```
Firmware (${{ matrix.env }})     skipped
Detect build-affecting changes   skipped
Lint + static analysis           success
Native tests + checks            success
```

**Oorzaak:** een matrix-job die via een job-level `if` wordt geskipt, expandt de matrix niet, dus GitHub rapporteert één check met de naam ongeïnterpoleerd. Onschuldig (skipped, niet failed), maar lelijk — en het landt op elke main-commit.

## Fix

Firmware verhuist naar een **eigen workflow** (`firmware.yml`) die **alleen op `pull_request`** triggert. Een workflow die niet op een event triggert, levert geen check voor dat event — dus een push naar main toont voortaan uitsluitend de CI-checks (`lint`, `test`). Niks firmware-gerelateerds meer.

De docs-only-skip gaat nu **zonder** job-level `if`: de `changes`-gate geeft een JSON-board-lijst terug (alle boards bij een build-input-wijziging, `[]` anders), en de build-matrix is `fromJSON(...)` daarvan. Een lege array expandt naar **nul** matrix-jobs → een docs-only PR bouwt niks en post geen build-check, zónder ergens een rauwe `${{ matrix.env }}`-naam.

## Gedrag ongewijzigd t.o.v. de vorige ci.yml-jobs

Zelfde board-matrix, zelfde paths-filter (nu zelf-refererend naar `firmware.yml`), zelfde token-scope-pinning, zelfde artifacts. `ci.yml` houdt `lint` + `test` als trunk-gate op push én PR.

## Check-namen wijzigen

| Vóór | Ná |
|---|---|
| `CI / Firmware (waveshare-relay-6ch)` | `Firmware / Build (waveshare-relay-6ch)` |
| `CI / Detect build-affecting changes` | `Firmware / Detect build-affecting changes` |

Relevant als je ooit branch protection aanzet: vereis dan de nieuwe namen (of blijf bij `lint`/`test`, die altijd draaien).

## Verificatie

- Beide workflows geparsed met PyYAML: `ci.yml` heeft nog enkel `lint` + `test`; `firmware.yml` triggert alleen op `pull_request`, `build.matrix.env = fromJSON(needs.changes.outputs.envs)`, geen job-level `if`.
- Deze PR raakt `firmware.yml` (een build-input) → de matrix draait vol op alle vier boards, wat de nieuwe workflow meteen end-to-end test.
- **De push-naar-main fix is fundamenteel zeker** (niet-getriggerde workflow = geen check). De docs-only-PR-schoonheid leunt op "lege matrix = nul jobs, geen check" — het idioom hiervoor; te bevestigen op de eerstvolgende echte docs-only PR.
