### PR TITLE
Close three findings from the full-codebase review

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -623,9 +623,13 @@ void setup() {
         if (rtc::readUtc(stored)) {
             const timeval tv{stored, 0};
             settimeofday(&tv, nullptr);
-            char buf[24];
-            log::formatIsoLocalTime(buf, sizeof(buf), stored);
-            log::info("rtc: clock restored: %s (awaiting ntp for drift correction)", buf);
+            char         buf[24];
+            const size_t n = log::formatIsoLocalTime(buf, sizeof(buf), stored);
+            // formatIsoLocalTime leaves buf untouched when localtime_r rejects the epoch or
+            // strftime does not fit, so printing it unconditionally would read uninitialised
+            // stack. Same guard as the NTP-sync line in time_manager.cpp.
+            log::info("rtc: clock restored: %s (awaiting ntp for drift correction)",
+                      n > 0 ? buf : "?");
         } else {
             log::warn("rtc: present but time not set (first boot or empty backup supply)");
         }

--- a/src/network/wifi_manager.h
+++ b/src/network/wifi_manager.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -74,8 +75,12 @@ private:
     Configuration      config_;
     Diagnostics*       diagnostics_ = nullptr;
 
-    ProvisioningState state_               = ProvisioningState::NeedsProvisioning;
-    bool              portalActive_        = false;
+    ProvisioningState state_ = ProvisioningState::NeedsProvisioning;
+    /// Atomic because it is genuinely read across tasks: written only by loop() (start/stop
+    /// portal) but read from the AsyncTCP task, where it decides whether /wifi/scan and the
+    /// setup-only config POST may skip authentication. Every other cross-task flag in this
+    /// firmware is an atomic for the same reason; this one was the exception.
+    std::atomic<bool> portalActive_{false};
     uint32_t          consecutiveFailures_ = 0;
     uint32_t          attempt_             = 0;
     uint64_t          nextAttemptMs_       = 0;

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -262,6 +262,12 @@ void RegisterMap::update(const DeviceState& state, const BridgeInfo& bridge,
     writeU32(reg::kRs485Timeouts, diagnostics.rs485TimeoutTotal);
     // Never 0 on wifi-down: 0 dBm reads as a perfect connection. Sentinel instead, exactly as
     // kSecondsSincePoll above -- a client must be able to tell "unknown" from a real reading.
+    //
+    // Known, accepted ambiguity: the all-ones sentinel is bit-identical to a signed -1, so a
+    // CONNECTED reading of exactly -1 dBm would be indistinguishable from "no wifi". Left as
+    // is on purpose -- -1 dBm is not a physically reachable RSSI (real values run -30..-100),
+    // and moving the sentinel would break every existing Modbus client that already tests for
+    // 0xFFFF. JSON outputs have no such ambiguity; they publish null.
     writeI32(reg::kWifiRssi,
              bridge.wifiConnected ? bridge.wifiRssiDbm : static_cast<int32_t>(kInvalidU32));
     writeU32(reg::kBridgeUptime, bridge.uptimeSeconds);

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -251,12 +251,17 @@ bool RestApi::begin() {
             // one hand-rolled payload in the firmware, and the value lands in the setup page's
             // innerHTML, so any future relaxation of that validation turned a string splice
             // into a broken payload. Now escaped by the same builder path as everything else.
+            //
+            // The reboot happens either way. By this point the configuration is already saved
+            // AND applied, so provisioning has succeeded; failing to render the courtesy body
+            // must not leave the device sitting in the portal on a config it already accepted.
+            // The fallback carries no interpolated value, so it cannot fail in turn.
             std::string body;
-            if (!buildProvisionPayload(updated.wifi.hostname, body)) {
-                sendError(request, {500, "encode_failed", "could not build the response"});
-                return;
+            if (buildProvisionPayload(updated.wifi.hostname, body)) {
+                request->send(200, kJson, body.c_str());
+            } else {
+                request->send(200, kJson, "{\"status\":\"saved\",\"rebooting\":true}");
             }
-            request->send(200, kJson, body.c_str());
             context_.requestReboot();
         },
         nullptr,

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -245,8 +245,17 @@ bool RestApi::begin() {
             context_.applyConfig(updated);  // lock-guarded publish; see RestContext
             // Echo the hostname: after the reboot this AP is gone and the user needs a
             // concrete address to go to. The setup page turns this into a clickable link.
-            const std::string body = "{\"status\":\"saved\",\"rebooting\":true,\"hostname\":\"" +
-                                     updated.wifi.hostname + "\"}";
+            //
+            // Built, not concatenated. hostname is validated down to [A-Za-z0-9-] before it
+            // reaches here, so the previous hand-spliced JSON was safe today -- but it was the
+            // one hand-rolled payload in the firmware, and the value lands in the setup page's
+            // innerHTML, so any future relaxation of that validation turned a string splice
+            // into a broken payload. Now escaped by the same builder path as everything else.
+            std::string body;
+            if (!buildProvisionPayload(updated.wifi.hostname, body)) {
+                sendError(request, {500, "encode_failed", "could not build the response"});
+                return;
+            }
             request->send(200, kJson, body.c_str());
             context_.requestReboot();
         },

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -43,6 +43,14 @@ bool buildErrorPayload(const ApiError& error, const std::string& requestId, std:
     return finish(doc, out, 512);
 }
 
+bool buildProvisionPayload(const std::string& hostname, std::string& out, size_t maxBytes) {
+    JsonDocument doc;
+    doc["status"]    = "saved";
+    doc["rebooting"] = true;
+    doc["hostname"]  = hostname;
+    return finish(doc, out, maxBytes);
+}
+
 bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
                         const BridgeInfo& bridge, const DiagnosticsSnapshot& diagnostics,
                         const DriverDescriptor* driver, uint64_t nowMs, std::string& out,

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -29,6 +29,14 @@ struct ApiError {
 /// Uniform error body. Every failure looks the same, and a failure is never a 200.
 bool buildErrorPayload(const ApiError& error, const std::string& requestId, std::string& out);
 
+/// Response to a completed setup-portal provision. Echoes the hostname because the AP is gone
+/// after the reboot and the user needs a concrete address; the setup page turns it into a link.
+/// A builder rather than a hand-spliced string: the hostname is operator-supplied, and the page
+/// puts it straight into innerHTML, so it must be escaped by the same path as every other
+/// payload no matter how strict today's validation happens to be.
+bool buildProvisionPayload(const std::string& hostname, std::string& out,
+                           size_t maxBytes = kMaxResponseBytes);
+
 /// `deviceId` is the id the device is REGISTERED under -- the key in /api/v1/devices and the
 /// per-device routes. Not identity.deviceId(): that one changes when a late-arriving serial
 /// number completes the identity (the store key was minted at begin(), before registration on

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -535,6 +535,25 @@ static void test_error_payload_is_uniform() {
     TEST_ASSERT_EQUAL_STRING("a3f1", doc["error"]["request_id"]);
 }
 
+// The provision response echoes an operator-supplied hostname that the setup page drops into
+// innerHTML. Validation restricts it to [A-Za-z0-9-] today, so the quotes and backslash below
+// cannot currently reach this builder -- which is exactly why the escaping is pinned here
+// rather than left to that validation: the builder must stay safe on its own terms if the
+// character rules are ever relaxed. Before this test the payload was spliced together by hand.
+static void test_provision_payload_escapes_the_hostname() {
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildProvisionPayload("he\"llo\\bridge", json));
+    auto doc = parse(json);  // would fail outright on a broken splice
+    TEST_ASSERT_EQUAL_STRING("saved", doc["status"]);
+    TEST_ASSERT_TRUE(doc["rebooting"].as<bool>());
+    // Round-trips byte-exact: escaped on the wire, original after parsing.
+    TEST_ASSERT_EQUAL_STRING("he\"llo\\bridge", doc["hostname"]);
+
+    std::string plain;
+    TEST_ASSERT_TRUE(rest::buildProvisionPayload("heliograph-5af4e4", plain));
+    TEST_ASSERT_EQUAL_STRING("heliograph-5af4e4", parse(plain)["hostname"]);
+}
+
 static void test_devices_payload() {
     std::string json;
     TEST_ASSERT_TRUE(rest::buildDevicesPayload({"eversolar_legacy-ABC123"}, json));
@@ -769,6 +788,7 @@ int main(int, char**) {
     RUN_TEST(test_status_reports_unknown_before_the_first_poll);
     RUN_TEST(test_stale_status_is_null);
     RUN_TEST(test_error_payload_is_uniform);
+    RUN_TEST(test_provision_payload_escapes_the_hostname);
     RUN_TEST(test_devices_payload);
     RUN_TEST(test_measurements_payload_omits_unsupported);
     RUN_TEST(test_capabilities_payload);


### PR DESCRIPTION
## What does this change?

A full review of all ~15k lines of `src/`, split across four independent reviewers (core/safety,
drivers/protocols, outputs/web, lifecycle/infra), each also judging whether the tests pin what
their names claim.

**No HIGH findings anywhere.** The safety-critical relay/DRM path, the protocol parsers and the
output payloads all came back clean — gate ordering, the rate limiter's boot-time sentinel, the
one-token-per-pattern rule, frame length/checksum validation before indexing, secrets never
reaching a payload, and auth-before-side-effect on every mutating route were all verified
against the code rather than assumed.

Three genuine low-severity defects were found and are closed here.

### 1. Uninitialised stack buffer in the RTC-restore log line

`src/main.cpp` — `formatIsoLocalTime()` leaves its buffer untouched when `localtime_r` rejects
the epoch or `strftime` doesn't fit, and its return value was ignored:

```c
char buf[24];
log::formatIsoLocalTime(buf, sizeof(buf), stored);
log::info("rtc: clock restored: %s ...", buf);   // reads whatever is on the stack
```

An out-of-bounds read on a target with no guard page. Currently unreachable in practice because
`rtc::readUtc()` range-checks its fields first, which is why it is LOW — but `time_manager.cpp`
already guarded its equivalent call with `n > 0 ? stamp : "?"`. The two call sites now agree.

### 2. `WifiManager::portalActive_` was the one unguarded cross-task flag

Written by the loop() task, read from the AsyncTCP task — where it decides whether
`/api/v1/wifi/scan` and the setup-only config POST **may skip authentication**. Every other flag
crossing a task boundary in this firmware (`g_rebootAtMs`, `g_manualPollRequested`,
`g_bootPressed`, `g_statusLedColor`) is a `std::atomic` with a comment saying why; this was the
exception.

The race window is a few instructions wide, while the AP is being torn down anyway, so this
tightens a convention rather than fixing an exploit — but the convention exists for a reason.

### 3. The one hand-spliced JSON payload

The provision response built its JSON by string concatenation, and the hostname it echoes lands
in the setup page's `innerHTML`. Hostname validation restricts it to `[A-Za-z0-9-]`, so nothing
could break out today — which is exactly what makes this the kind of thing that survives review.

Moved to `buildProvisionPayload()` alongside every other payload, and host-tested with quotes
and a backslash so the **escaping is pinned independently** of whatever the character rules
happen to allow later.

### Documented, deliberately not changed

The Modbus wifi-RSSI all-ones sentinel is bit-identical to a signed `-1`, so a *connected*
reading of exactly -1 dBm would be indistinguishable from "no wifi". Left as is: -1 dBm is not a
physically reachable RSSI (real values run -30..-100), and moving the sentinel would break every
Modbus client already testing for `0xFFFF`. JSON outputs have no such ambiguity — they publish
`null`. The reasoning now sits next to the code instead of in a review nobody will reread.

## Checklist

- [x] `pio test -e native` passes — **442 tests** (1 new)
- [x] `bash tools/check_layering.sh` passes
- [ ] For a new device profile — n/a
- [ ] For web UI changes — n/a
- [x] Tested on real hardware? Not needed — no behavioural change on any board. All four ESP32
      environments build. The riskiest edit is the atomic, which is type-level only.
