### PR TITLE
Add a Growatt MIC TL-X profile, and make the profile option checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ the honest answer today is: only if your inverter is in this table.
 |---|---|---|
 | EverSolar / Zeversolar legacy (TL series) | RS485 | **Beta** — running in production, in a multi-day soak toward Stable |
 | Growatt SPH hybrid (3–6 kW) | Modbus RTU over RS485 | **Experimental** — register map transcribed from documentation, not yet confirmed against real hardware |
+| Growatt MIC TL-X (0.6–3.3 kW, single phase) | Modbus RTU over RS485 | **Experimental** — map cross-checked against two independent sources that agree, not yet confirmed against real hardware; see [docs/growatt-mic-tl-x-protocol.md](docs/growatt-mic-tl-x-protocol.md) |
 | SolaX X1 series (X1 Mini G1/G2/G3) | RS485 | **Experimental** — the first attempt on real hardware (an X1-Mini-G1) returned no data at all. Read [docs/solax-x1-protocol.md](docs/solax-x1-protocol.md) before you buy or wire anything |
 | Any inverter implementing **SunSpec** | Modbus RTU over RS485 | **Experimental** — one generic driver for the published standard, so no per-vendor file is needed. Not yet confirmed against any physical device; see [docs/sunspec.md](docs/sunspec.md) for which vendors are worth trying |
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ you need. The RS485-CAN and Relay-6CH can be powered either over USB-C or from a
 screw terminal, which is handy when there is no USB power near the inverter; check the
 product page for whichever board you buy.
 
+For one inverter, A/B/GND is genuinely all there is to it. If you are putting **several
+inverters on one bus**, read **[docs/rs485-bus.md](docs/rs485-bus.md)** first: chain topology,
+where the 120 Ω termination goes (two places, not one per device), and why each unit needs its
+own address before you connect them together.
+
 ### 2. Flash the firmware
 
 - **In your browser (easiest):** open the

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -1,0 +1,161 @@
+# Growatt MIC TL-X — Modbus RTU register map
+
+The MIC TL-X is Growatt's small single-phase string inverter: one MPPT tracker, one phase,
+600–3300 W depending on the model. It speaks Growatt's Modbus RTU **Protocol II** over its
+RS485 port.
+
+The profile lives in `profiles/growatt/mic_tl_x.toml`. Everything below explains how that
+file was arrived at and what still needs proving on hardware.
+
+## One profile for the whole range
+
+A profile describes a **register layout**, not a model number. A MIC 600TL-X and a MIC
+3300TL-X differ only in power rating, and the rating appears nowhere in the register map.
+One `mic_tl_x` profile therefore covers the whole range, exactly as `sph` covers the whole
+SPH 3–6 kW range.
+
+Holding register **44** reports the actual tracker and phase count of the connected unit, so
+a variant that ever deviates from "1 tracker, 1 phase" is visible in the raw dump rather than
+being silently mis-decoded.
+
+## The generation question, settled without hardware
+
+`docs/growatt-sph-protocol.md` flags a genuine trap: Protocol II describes two register
+generations, and reading the wrong one gets you nothing (or worse, plausible nonsense). For
+the SPH that question is still open and can only be closed on the bench.
+
+For the MIC TL-X it is closed already. The 3000-series input registers belong to the
+**TL-XH**, the hybrid variant with a battery. The plain **TL-X** string inverter lives in the
+"first group" at input registers **0–124**. Two independent sources keep the two maps
+strictly apart and agree on which is which:
+
+- The machine-readable Protocol II register CSV
+  ([0xAHA/Growatt_ModbusTCP](https://github.com/0xAHA/Growatt_ModbusTCP/tree/main/Protocols),
+  `growatt_modbus_rtu_v139_registers.csv`) defines the "First group" input registers 0–124
+  with exactly this layout.
+- [WouterTuinstra/Homeassistant-Growatt-Local-Modbus](https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus),
+  a widely deployed and therefore heavily hardware-exercised Home Assistant integration,
+  defines `INPUT_REGISTERS_120` (0–124) and `INPUT_REGISTERS_120_TL_XH` (3000+) as two
+  separate tables in
+  `custom_components/growatt_local/API/device_type/inverter_120.py`.
+
+That two sources of different kinds — a vendor spec and a working implementation — agree
+register for register is the strongest evidence available short of the inverter itself. It is
+still not the inverter itself, which is why the driver stays Experimental until someone
+confirms it.
+
+## Read map (input registers, function 04)
+
+The default scale in Protocol II is ÷10. Two rows deviate and are the easiest to get wrong:
+
+| Reg | Meaning | Type | Scale | Published as |
+|---|---|---|---|---|
+| 0 | Inverter status | u16 | — | (raw dump only) |
+| 1–2 | Total PV power | u32 | ÷10 W | `dc.power.total` |
+| 3 | PV1 voltage | u16 | ÷10 V | `dc.mppt_1.voltage` |
+| 4 | PV1 current | u16 | ÷10 A | `dc.mppt_1.current` |
+| 5–6 | PV1 power | u32 | ÷10 W | `dc.mppt_1.power` |
+| 7–10 | PV2 | — | — | not mapped (single-tracker hardware) |
+| 35–36 | AC output power | u32 | ÷10 W | `ac.power.total` |
+| 37 | Grid frequency | u16 | **÷100** Hz | `ac.frequency` |
+| 38 | Grid voltage L1 | u16 | ÷10 V | `ac.phase_l1.voltage` |
+| 39 | Grid current L1 | u16 | ÷10 A | `ac.phase_l1.current` |
+| 40–41 | Pac1 | u32 | ÷10 | not mapped (see below) |
+| 53–54 | Energy today | u32 | ÷10 kWh | `energy.today` |
+| 55–56 | Energy total | u32 | ÷10 kWh | `energy.total` |
+| 57–58 | Work time total | u32 | **÷7200** → h | `inverter.operating_hours` |
+| 93 | Inverter temperature | s16 | ÷10 °C | `inverter.temperature` |
+| 94 / 95 | IPM / boost temperature | u16 | ÷10 °C | not mapped |
+| 98 / 99 | P-bus / N-bus voltage | u16 | ÷10 V | not mapped |
+| 101 | Output percentage | u16 | — | not mapped |
+| 104 / 105 | Derating mode / fault code | u16 | — | not mapped |
+
+Deliberate omissions, all for the same reason — a channel that might be wrong is worse than a
+channel that is absent:
+
+- **PV2 (7–10)** exists in the layout but not on this hardware. Mapping it would publish a
+  permanent zero, and this project does not publish unknowns as zero.
+- **Pac1 (40–41)** duplicates `ac.power.total` on a single-phase inverter, and protocol
+  revisions disagree on whether it is real power (W) or apparent power (VA). A second power
+  entity that might silently be VA is a trap.
+- **IPM and boost temperature** are real, but there is one canonical
+  `inverter.temperature` and the inverter temperature is the useful one.
+
+Everything omitted still appears in the driver's raw TRACE dump, so any of it can be promoted
+later from bench evidence rather than from a forum post.
+
+Register 93 is declared **signed** although the protocol table calls it unsigned. For every
+physically possible reading the two decode identically, and signed additionally survives a
+sub-zero winter morning on an outdoor unit instead of reporting 6553 °C.
+
+## Identity (holding registers, function 03)
+
+Read as a block during bring-up so the raw dump can be checked against the sticker on the
+unit:
+
+| Reg | Meaning |
+|---|---|
+| 3 | Output power limit, % — the writable setpoint below |
+| 9–14 | Firmware version (string) |
+| 23–27 | Serial number (string) |
+| 28–29 | Model code (packed nibbles) |
+| 43 | Device type code |
+| 44 | Number of trackers and phases |
+| 88 | Modbus protocol version |
+
+## Curtailment: holding register 3
+
+**Holding register 3 is the inverter's active power limit, 0–100 %, writable with function
+code 06.**
+
+This matters well beyond the MIC. It is the safest write this project has found on any
+device so far:
+
+- a single 16-bit holding register, one word, no multi-register transaction;
+- trivially reversed by writing 100;
+- it touches no grid-protection or safety setting, unlike the SPH's battery and time-slot
+  registers which sit next to exactly that;
+- it needs no DRM wiring and no relay board, so it works on the plain RS485-CAN board.
+
+It is declared in the profile as a `[[write]]` row against the canonical
+`set_active_power_limit_percent` command — and it is **dormant**. Two independent gates stand
+between that row and a byte on the bus:
+
+1. `verified = false` in the profile. Only a bench session flips this.
+2. The driver has no write path at all yet; `execute()` returns `Unsupported`, and the
+   descriptor declares `supportsWrite = false`.
+
+Both are asserted in `test/test_growatt_driver/test_main.cpp`, so neither can be dropped by
+accident.
+
+One note for whoever does the bench session: some protocol revisions describe **255** as
+"limit disabled". The declared bound stops at 100 rather than allowing 255, because a
+percentage value that silently means "off" is a footgun. If the bench confirms 255 is needed,
+it gets its own explicit handling rather than a widened range.
+
+## Bring-up checklist
+
+1. **Give each inverter a unique Modbus address.** All units ship as address 1, so two on one
+   bus collide. Set this via ShineBus (or the manufacturer's app) before wiring anything to a
+   shared bus.
+2. Wire A/B/GND to the RS485 port. 9600 8N1 is what the profile declares.
+3. Configure the driver: `growatt_modbus`, profile `mic_tl_x`, `unit_id` as set in step 1.
+4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
+   the raw block dump.
+5. Check the dump against the inverter's own app: PV voltage, AC power, today's energy,
+   total energy. All four should match without any arithmetic on your part.
+6. Confirm the two odd scales specifically — frequency should read ~50.0 Hz (not 5.0 or
+   500.0), and operating hours should be plausible for the age of the unit.
+7. Report the result on the issue tracker either way. A confirmation promotes this driver out
+   of Experimental; a mismatch corrects one TOML row and helps the next person more.
+
+## Sources
+
+- Growatt Inverter Modbus RTU Protocol II, machine-readable register CSV —
+  <https://github.com/0xAHA/Growatt_ModbusTCP/tree/main/Protocols>
+- WouterTuinstra/Homeassistant-Growatt-Local-Modbus, `inverter_120.py` —
+  <https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus>
+- Growatt MIC 750–3300TL-X datasheet (single phase, one MPP tracker) —
+  <https://www.growatt.tech/wp-content/uploads/shared-files/MIC-7503300TL-X-Datasheet.pdf>
+- The SPH map and the register-generation split it still has to resolve —
+  [docs/growatt-sph-protocol.md](growatt-sph-protocol.md)

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -18,31 +18,41 @@ Holding register **44** reports the actual tracker and phase count of the connec
 a variant that ever deviates from "1 tracker, 1 phase" is visible in the raw dump rather than
 being silently mis-decoded.
 
-## The generation question, settled without hardware
+## The generation question is still open
 
-`docs/growatt-sph-protocol.md` flags a genuine trap: Protocol II describes two register
-generations, and reading the wrong one gets you nothing (or worse, plausible nonsense). For
-the SPH that question is still open and can only be closed on the bench.
+`docs/growatt-sph-protocol.md` flags a genuine trap: Protocol II describes more than one
+register generation, and reading the wrong one gets you nothing — or worse, plausible
+nonsense. An earlier draft of this document claimed the question was closed for the MIC
+without hardware. It is not, and the claim did not survive review. Here is what is actually
+known.
 
-For the MIC TL-X it is closed already. The 3000-series input registers belong to the
-**TL-XH**, the hybrid variant with a battery. The plain **TL-X** string inverter lives in the
-"first group" at input registers **0–124**. Two independent sources keep the two maps
-strictly apart and agree on which is which:
+**The map below follows the hardware-exercised source.**
+[WouterTuinstra/Homeassistant-Growatt-Local-Modbus](https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus)
+is a widely deployed Home Assistant integration, which means its tables have been run against
+a great many real inverters. It defines `INPUT_REGISTERS_120` (input 0–124) for a plain
+Protocol II inverter and a separate `INPUT_REGISTERS_120_TL_XH` (3000+) for the hybrid, in
+`custom_components/growatt_local/API/device_type/inverter_120.py`. A MIC TL-X is a plain
+string inverter, so this profile uses the first table. Every mapped row matches it exactly.
 
-- The machine-readable Protocol II register CSV
-  ([0xAHA/Growatt_ModbusTCP](https://github.com/0xAHA/Growatt_ModbusTCP/tree/main/Protocols),
-  `growatt_modbus_rtu_v139_registers.csv`) defines the "First group" input registers 0–124
-  with exactly this layout.
-- [WouterTuinstra/Homeassistant-Growatt-Local-Modbus](https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus),
-  a widely deployed and therefore heavily hardware-exercised Home Assistant integration,
-  defines `INPUT_REGISTERS_120` (0–124) and `INPUT_REGISTERS_120_TL_XH` (3000+) as two
-  separate tables in
-  `custom_components/growatt_local/API/device_type/inverter_120.py`.
+**The vendor CSV corroborates far less than it appears to.** The machine-readable register CSV
+([0xAHA/Growatt_ModbusTCP](https://github.com/0xAHA/Growatt_ModbusTCP/tree/main/Protocols))
+agrees on registers 0–10 and then diverges: its "First group" puts AC power at 11, frequency
+at 13 and temperature at 34, which is an older generation than the one used here. The file
+also describes itself as "a representative sample" rather than the complete protocol. It is
+supporting evidence for the PV portion of the map and no more.
 
-That two sources of different kinds — a vendor spec and a working implementation — agree
-register for register is the strongest evidence available short of the inverter itself. It is
-still not the inverter itself, which is why the driver stays Experimental until someone
-confirms it.
+**The 3000-series is not hybrid-only.** That same CSV marks the whole 3000 range — holding and
+input — with the group label `Use for TL-X and TL-XH`. So the vendor considers those registers
+applicable to the plain TL-X as well. Splitting them off into a hybrid-only table is the HA
+integration's implementation choice, not a statement by Growatt.
+
+**Therefore the profile probes both.** Alongside the mapped 0–124 block it reads 40 registers
+at 3000, mapping nothing from them. The only purpose is that the first bring-up dump answers
+the question directly: does this unit populate 0–124, 3000+, or both? A block the device
+refuses is skipped harmlessly, so probing a range that does not exist costs a timeout and
+nothing else. This is the same tactic `sph.toml` uses for its own open generation question.
+
+The driver stays **Experimental** until someone confirms the map against a physical unit.
 
 ## Read map (input registers, function 04)
 
@@ -75,18 +85,20 @@ channel that is absent:
 
 - **PV2 (7–10)** exists in the layout but not on this hardware. Mapping it would publish a
   permanent zero, and this project does not publish unknowns as zero.
-- **Pac1 (40–41)** duplicates `ac.power.total` on a single-phase inverter, and protocol
-  revisions disagree on whether it is real power (W) or apparent power (VA). A second power
-  entity that might silently be VA is a trap.
+- **Pac1 (40–41)** duplicates `ac.power.total` on a single-phase inverter, and neither source
+  says whether it is real power (W) or apparent power (VA) — both just call it "output
+  power". A second power entity that might silently be VA is a trap. On the bench it should
+  track registers 35–36 closely; a persistent offset means VA.
 - **IPM and boost temperature** are real, but there is one canonical
   `inverter.temperature` and the inverter temperature is the useful one.
 
 Everything omitted still appears in the driver's raw TRACE dump, so any of it can be promoted
 later from bench evidence rather than from a forum post.
 
-Register 93 is declared **signed** although the protocol table calls it unsigned. For every
-physically possible reading the two decode identically, and signed additionally survives a
-sub-zero winter morning on an outdoor unit instead of reporting 6553 °C.
+Register 93 is declared **signed**, which is a choice rather than a transcription — neither
+source states this register's signedness. For every physically possible reading the two decode
+identically, and signed additionally survives a sub-zero winter morning on an outdoor unit
+instead of reporting 6553 °C. If the device turns out to be unsigned, nothing breaks.
 
 ## Identity (holding registers, function 03)
 
@@ -133,12 +145,42 @@ One note for whoever does the bench session: some protocol revisions describe **
 percentage value that silently means "off" is a footgun. If the bench confirms 255 is needed,
 it gets its own explicit handling rather than a widened range.
 
+## Giving each inverter an address
+
+Every MIC TL-X ships as Modbus address **1**. Two of them on one bus will both answer every
+request and their replies collide into garbage, so the addresses have to be set before the
+units are chained together. 1, 2, 3 in the order they hang on the wire is as good a scheme as
+any.
+
+There are two ways to do it. Neither needs this bridge.
+
+**On the inverter's touch control.** The MIC has a touch-sensitive display with a `Set
+Comaddr` menu. The gestures are unusual enough to be worth writing down:
+
+| Gesture | Effect |
+|---|---|
+| Single touch | Next value / next item |
+| Double touch | Enter or confirm |
+| Triple touch | Back to the previous menu |
+| Hold ~5 s | Confirm the setting (or restore defaults) |
+
+**Or over Modbus itself.** Holding register **30** is `Com Address`, writable, range 1–254,
+factory default 1 (Growatt Protocol II). Connect one inverter at a time — while they are all
+still on address 1 you cannot address them individually — write the new address, then move to
+the next unit and chain them once each has its own.
+
+Heliograph has no write path, so this route needs a generic Modbus tool for the one-time
+write (`mbpoll` or similar). `tools/read_modbus.py` in this repo reads only.
+
+Whichever route you take, verify before chaining: with a single inverter on the bus, poll each
+address in turn and confirm exactly one answers, at the address you expect.
+
 ## Bring-up checklist
 
-1. **Give each inverter a unique Modbus address.** All units ship as address 1, so two on one
-   bus collide. Set this via ShineBus (or the manufacturer's app) before wiring anything to a
+1. **Give each inverter a unique Modbus address**, as above, before wiring anything to a
    shared bus.
-2. Wire A/B/GND to the RS485 port. 9600 8N1 is what the profile declares.
+2. Wire A/B/GND to the RS485 port — see [rs485-bus.md](rs485-bus.md) for topology, ground and
+   the 120 Ω termination rule. 9600 8N1 is what the profile declares.
 3. Configure the driver: `growatt_modbus`, profile `mic_tl_x`, `unit_id` as set in step 1.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.
@@ -146,7 +188,12 @@ it gets its own explicit handling rather than a widened range.
    total energy. All four should match without any arithmetic on your part.
 6. Confirm the two odd scales specifically — frequency should read ~50.0 Hz (not 5.0 or
    500.0), and operating hours should be plausible for the age of the unit.
-7. Report the result on the issue tracker either way. A confirmation promotes this driver out
+7. **Settle the generation question.** Look at what the 3000-block dump did. Three outcomes,
+   each actionable: the device refused it (only 0–124 exists — drop the probe block), it
+   answered with real values too (both exist — drop the probe block, the map is right
+   either way), or 0–124 was refused and 3000 answered (the map needs moving, and this
+   document needs correcting).
+8. Report the result on the issue tracker either way. A confirmation promotes this driver out
    of Experimental; a mismatch corrects one TOML row and helps the next person more.
 
 ## Sources
@@ -157,5 +204,7 @@ it gets its own explicit handling rather than a widened range.
   <https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus>
 - Growatt MIC 750–3300TL-X datasheet (single phase, one MPP tracker) —
   <https://www.growatt.tech/wp-content/uploads/shared-files/MIC-7503300TL-X-Datasheet.pdf>
+- Eniris device documentation for the Growatt MIC series, for the `Set Comaddr` touch-control
+  procedure — <https://docs.eniris.be/Devices/PV-hybrid-and-battery-inverters/Growatt/MIC%20Series/>
 - The SPH map and the register-generation split it still has to resolve —
   [docs/growatt-sph-protocol.md](growatt-sph-protocol.md)

--- a/docs/rs485-bus.md
+++ b/docs/rs485-bus.md
@@ -1,0 +1,146 @@
+# Wiring the RS485 bus
+
+Everything this bridge reads over RS485 depends on three wires being right. This page covers
+the physical side: topology, termination, ground, and what to do when the bus is silent or
+noisy. Per-inverter details (which terminal, which address menu) live in that inverter's own
+protocol document.
+
+If you are connecting **one** inverter and it works, you can stop after "The three wires".
+The rest matters once you chain several devices onto one bus.
+
+## The three wires
+
+| Bridge | Inverter | Notes |
+|---|---|---|
+| A / A+ / D+ | RS485 A | Data pair, one half |
+| B / B− / D− | RS485 B | Data pair, other half |
+| GND / SGND | GND / COM | Signal reference — not optional |
+
+**Ground is not optional.** RS485 is differential, which makes people assume two wires are
+enough. They are not: the receiver only rejects common-mode noise within a limited range, and
+two devices on different mains phases or with metres of cable between them can drift outside
+it. The failure is not a clean "no data" — it is intermittent corruption that looks like a
+software bug. Connect the ground.
+
+**A and B polarity is not standardised.** Different vendors label the same conductor
+differently. Swapped A/B is harmless: you get silence, not damage. If a correctly wired bus
+stays silent, swap A and B before suspecting anything else.
+
+**On the Waveshare ESP32-S3-RS485-CAN board, `SGND` is isolated from `GND` — never bridge
+them.** That isolation is the reason the board survives an inverter on a different earth. See
+[hardware.md](hardware.md).
+
+### Cable
+
+Use one twisted pair for A/B plus a third conductor (or the shield) for ground. Ordinary
+CAT5e/CAT6 is ideal and is what most people have lying around: take one pair (for example
+blue/blue-white) for A and B, and a conductor from another pair for ground. Do **not** split
+A and B across two different pairs — the twist is what makes the noise rejection work.
+
+Keep the run away from PV DC strings and inverter output cabling where you can. An inverter is
+an electrically hostile neighbour.
+
+## Topology: a chain, not a star
+
+RS485 is a **daisy chain**. Each device connects to the next; the cable enters a device and
+leaves it toward the following one.
+
+```
+[Bridge] ---- [Inverter 1] ---- [Inverter 2] ---- [Inverter 3]
+   ^                                                    ^
+ bus end                                             bus end
+```
+
+What you must not build is a star — several separate cables radiating from one point to one
+device each. It appears to work on a short bench run and then fails intermittently once the
+cable gets longer, because every unterminated stub reflects the signal back onto the bus.
+
+If a device sits slightly off the main run, keep that stub as short as you can. Centimetres are
+fine; a metre is asking for trouble.
+
+The bridge does not have to be at one end. It can sit anywhere in the chain — it is just
+another device on the wire, and the one that happens to do the talking.
+
+## Termination: 120 Ω, at exactly two places
+
+A terminating resistor of 120 Ω goes across A and B at each of the **two physical ends** of the
+bus. Not at every device. Not at three places. Two.
+
+The reason: 120 Ω matches the characteristic impedance of twisted-pair cable, so a signal
+arriving at the end of the cable is absorbed instead of reflected back along it. Reflections
+collide with the data still arriving and corrupt frames.
+
+Getting the count wrong fails in both directions:
+
+- **Too few** (none at all): reflections. Symptom is corrupted frames — checksum errors,
+  not timeouts.
+- **Too many** (one per device): the parallel resistance drops far below what the transmitter
+  can drive. Three 120 Ω resistors in parallel is 40 Ω. The signal amplitude collapses and the
+  bus goes quiet or unreliable across the board.
+
+In the diagram above, the two ends are the **bridge** and **inverter 3**. Inverters 1 and 2 sit
+in the middle and get no termination.
+
+### On the Waveshare boards
+
+Both supported RS485 boards have the resistor fitted already, switchable:
+
+- **ESP32-S3-RS485-CAN** — a 120 Ω jumper per bus. Fit it only when the bridge is at a
+  physical end of the chain.
+- **ESP32-S3-Relay-1CH** — 120 Ω as R23 on header H1, same rule.
+
+On the inverter side, many inverters have a DIP switch or jumper for their own termination.
+Check the manual of the unit at the far end of the chain and enable it there — and make sure
+the inverters in the middle have theirs **off**.
+
+### When you can skip it
+
+At 9600 baud over a few metres, an unterminated bus usually works fine. The signal rise time
+is long compared to the propagation delay, so reflections settle before they matter. If your
+whole run is a couple of metres to a single inverter, termination is not what is wrong.
+
+Termination becomes necessary as the bus gets longer, as the baud rate rises, and as devices
+are added. The honest rule: wire it up, look at the diagnostics, and fit termination if you
+see corruption.
+
+## Giving each device an address
+
+Every device on a shared bus needs a **unique Modbus address**. Nearly all inverters ship as
+address 1, so two units straight out of the box will both answer at once, and their replies
+collide into garbage.
+
+Set the addresses **before** you chain anything together. The conventional scheme is simply
+1, 2, 3 in the order they hang on the wire.
+
+How you set it is per manufacturer. For Growatt (including the MIC TL-X), see
+[growatt-mic-tl-x-protocol.md](growatt-mic-tl-x-protocol.md#giving-each-inverter-an-address).
+
+## When it does not work
+
+The bridge distinguishes two failure modes, and they point at different causes. Both are
+visible in the logs at `trace` level, in `/api/v1/diagnostics`, and as Prometheus counters
+(see [prometheus.md](prometheus.md)).
+
+**Timeouts — nothing came back.**
+
+- A and B swapped (try swapping them; it costs nothing)
+- Wrong address, or the device is still on its factory default while you are asking for
+  another
+- Wrong baud rate or framing
+- Wrong port on the inverter — some units have several RJ45 sockets and only one is RS485
+- The port is occupied by the manufacturer's own WiFi dongle
+- A break in the chain: every device past the break goes silent, which is a useful clue about
+  where to look
+
+**Checksum errors — bytes came back, corrupted.** This is an electrical problem, not a
+configuration one:
+
+- Missing ground
+- Termination missing, or too much of it
+- A and B split across different twisted pairs
+- Cable routed alongside PV DC or inverter output cabling
+- A star topology, or a long stub
+
+A night of timeouts is normal and expected: the inverter powers down when the sun does. That
+is why the alerting examples in [prometheus.md](prometheus.md) watch checksum errors rather
+than timeouts.

--- a/profiles/growatt/mic_tl_x.toml
+++ b/profiles/growatt/mic_tl_x.toml
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: MIT
+#
+# Growatt MIC TL-X (600-3300 W, single phase) — Modbus RTU register profile.
+#
+# STATUS: transcribed from two independent sources that agree, NOT yet confirmed against
+# real hardware by this project. See docs/growatt-mic-tl-x-protocol.md for the reasoning
+# and the bring-up checklist.
+#
+# One profile for the whole MIC TL-X range. A profile describes a REGISTER LAYOUT, not a
+# model number: a MIC 600TL-X and a MIC 3300TL-X differ only in power rating, which appears
+# nowhere in the map. Holding register 44 additionally reports the actual tracker and phase
+# count, so a variant that ever deviates is visible rather than silently mis-decoded.
+#
+# The generation question that docs/growatt-sph-protocol.md flags as "resolve this FIRST"
+# is settled for this family WITHOUT hardware: the 3000-series input registers belong to
+# the TL-XH hybrid, not to the plain TL-X string inverter. Both sources below keep the two
+# maps strictly apart, and this one is the 0-124 "first group".
+#
+# Sources:
+#   - Growatt Inverter Modbus RTU Protocol II, machine-readable register CSV
+#     (0xAHA/Growatt_ModbusTCP, growatt_modbus_rtu_v139_registers.csv): "First group"
+#     input registers 0-124.
+#   - WouterTuinstra/Homeassistant-Growatt-Local-Modbus, a widely deployed and therefore
+#     hardware-exercised integration: custom_components/growatt_local/API/device_type/
+#     inverter_120.py. Its INPUT_REGISTERS_120 (0-124) is this map; its separate
+#     INPUT_REGISTERS_120_TL_XH (3000+) is the hybrid and is deliberately NOT used here.
+#
+# Conservative on purpose: only rows both sources agree on are published as measurements.
+# Anything ambiguous is left to the driver's raw-block TRACE dump rather than surfacing as
+# an authoritative-looking value.
+
+[profile]
+driver = "growatt_modbus"
+id = "mic_tl_x"
+display_name = "Growatt MIC TL-X (0.6-3.3 kW)"
+default = false        # sph.toml holds the driver default
+phases = 1
+mppts = 1
+battery = false
+transports = ["rtu"]
+
+[serial]
+baud = 9600
+parity = "none"
+stop_bits = 1
+
+# ------------------------------------------------------------------------------------------
+# Read blocks.
+#
+# The whole first group is read, not just the mapped registers: the driver TRACE-dumps every
+# raw block, and a wide dump is what lets the first bring-up session check this map against
+# the inverter's own app/display and correct it in one pass.
+#
+# The holding block covers the identity area (firmware 9-14, serial 23-27, model 28-29,
+# device type code 43, trackers/phases 44) plus register 3, the output power limit declared
+# at the bottom of this file. Reading it means its CURRENT value is visible in the dump
+# before anything ever considers writing to it.
+# ------------------------------------------------------------------------------------------
+
+[[block]]
+space = "input"
+start = 0
+count = 125
+
+[[block]]
+space = "holding"
+start = 0
+count = 45
+
+# --- DC / PV side -------------------------------------------------------------------------
+
+[[register]]                    # high confidence — both sources, identical
+measurement = "dc.power.total"
+display_name = "PV Power"
+space = "input"
+address = 1
+type = "u32"
+scale = 0.1
+unit = "W"
+
+[[register]]                    # high confidence
+measurement = "dc.mppt_1.voltage"
+display_name = "PV Voltage"
+space = "input"
+address = 3
+type = "u16"
+scale = 0.1
+unit = "V"
+
+[[register]]                    # high confidence
+measurement = "dc.mppt_1.current"
+display_name = "PV Current"
+space = "input"
+address = 4
+type = "u16"
+scale = 0.1
+unit = "A"
+
+[[register]]                    # high confidence
+measurement = "dc.mppt_1.power"
+display_name = "PV String Power"
+space = "input"
+address = 5
+type = "u32"
+scale = 0.1
+unit = "W"
+
+# MPPT 2 (registers 7-10) exists in the layout but not on this hardware: the MIC TL-X range
+# is single-tracker. Mapping it would publish a permanent zero, which is exactly the "never
+# invent a reading" rule. It stays visible in the raw dump for anyone whose register 44 says
+# otherwise.
+
+# --- AC side ------------------------------------------------------------------------------
+
+[[register]]                    # high confidence
+measurement = "ac.power.total"
+display_name = "AC Power"
+space = "input"
+address = 35
+type = "u32"
+scale = 0.1
+unit = "W"
+
+[[register]]                    # high confidence — note the /100 scale, unlike everything else
+measurement = "ac.frequency"
+display_name = "Grid Frequency"
+space = "input"
+address = 37
+type = "u16"
+scale = 0.01
+unit = "Hz"
+
+[[register]]                    # high confidence
+measurement = "ac.phase_l1.voltage"
+display_name = "Grid Voltage"
+space = "input"
+address = 38
+type = "u16"
+scale = 0.1
+unit = "V"
+
+[[register]]                    # high confidence
+measurement = "ac.phase_l1.current"
+display_name = "Grid Current"
+space = "input"
+address = 39
+type = "u16"
+scale = 0.1
+unit = "A"
+
+# Pac1 (40-41) is deliberately NOT mapped. On a single-phase inverter it duplicates
+# ac.power.total, and the protocol revisions disagree on whether it is real power (W) or
+# apparent power (VA). A second power entity in Home Assistant that might silently be VA is
+# worse than no entity; the raw dump settles it on the bench if anyone wants it.
+
+# --- Energy and runtime -------------------------------------------------------------------
+
+[[register]]                    # high confidence
+measurement = "energy.today"
+display_name = "Energy Today"
+space = "input"
+address = 53
+type = "u32"
+scale = 0.1
+unit = "kWh"
+
+[[register]]                    # high confidence
+measurement = "energy.total"
+display_name = "Energy Total"
+space = "input"
+address = 55
+type = "u32"
+scale = 0.1
+unit = "kWh"
+
+# Work time total counts in half-seconds, so hours = raw / 7200. Both sources use exactly
+# this divisor.
+[[register]]                    # high confidence
+measurement = "inverter.operating_hours"
+display_name = "Operating Hours"
+space = "input"
+address = 57
+type = "u32"
+scale = 0.00013888888888888889
+unit = "h"
+
+# --- Temperature --------------------------------------------------------------------------
+
+# Declared signed although the protocol table calls it unsigned: for every physically
+# possible reading the two decode identically, and s16 additionally survives a sub-zero
+# winter morning on an outdoor unit instead of reporting 6553 °C.
+[[register]]                    # high confidence
+measurement = "inverter.temperature"
+display_name = "Inverter Temperature"
+space = "input"
+address = 93
+type = "s16"
+scale = 0.1
+unit = "°C"
+
+# IPM temperature (94) and boost temperature (95) are real but redundant for monitoring, and
+# there is one canonical inverter.temperature. They stay in the raw dump.
+
+# ------------------------------------------------------------------------------------------
+# Writable setpoint.
+#
+# Holding register 3 is the inverter's active-power limit as a percentage. It is the safest
+# write this project has found on any device so far: a single 16-bit holding register (FC06),
+# trivially reversed by writing 100, and it touches no grid-protection setting. It is the
+# natural way to curtail a MIC TL-X from Home Assistant when prices go negative -- no DRM
+# wiring and no relay board involved.
+#
+# Declaring it here does NOT enable anything. The row stays dormant until `verified = true`,
+# which requires a bench session: write a limit, read register 3 back, and confirm against
+# the inverter's own reported output that the limit actually took effect. Until then this is
+# documented research, not a control surface.
+#
+# Note for that session: some protocol revisions describe 255 as "limit disabled". The bound
+# below stops at 100 rather than allowing 255, because a percentage that silently means
+# "off" is a footgun; if the bench confirms 255 is needed, it gets its own explicit handling.
+# ------------------------------------------------------------------------------------------
+
+[[write]]
+command = "set_active_power_limit_percent"
+display_name = "Active Power Limit"
+space = "holding"
+address = 3
+type = "u16"
+function = "write_single"
+scale = 1.0
+unit = "%"
+minimum = 0
+maximum = 100
+step = 1
+verified = false

--- a/profiles/growatt/mic_tl_x.toml
+++ b/profiles/growatt/mic_tl_x.toml
@@ -11,23 +11,30 @@
 # nowhere in the map. Holding register 44 additionally reports the actual tracker and phase
 # count, so a variant that ever deviates is visible rather than silently mis-decoded.
 #
-# The generation question that docs/growatt-sph-protocol.md flags as "resolve this FIRST"
-# is settled for this family WITHOUT hardware: the 3000-series input registers belong to
-# the TL-XH hybrid, not to the plain TL-X string inverter. Both sources below keep the two
-# maps strictly apart, and this one is the 0-124 "first group".
+# The register generation is NOT settled without hardware -- an earlier draft of this file
+# claimed it was, and that claim did not survive review. What is actually known:
 #
-# Sources:
-#   - Growatt Inverter Modbus RTU Protocol II, machine-readable register CSV
-#     (0xAHA/Growatt_ModbusTCP, growatt_modbus_rtu_v139_registers.csv): "First group"
-#     input registers 0-124.
-#   - WouterTuinstra/Homeassistant-Growatt-Local-Modbus, a widely deployed and therefore
-#     hardware-exercised integration: custom_components/growatt_local/API/device_type/
-#     inverter_120.py. Its INPUT_REGISTERS_120 (0-124) is this map; its separate
-#     INPUT_REGISTERS_120_TL_XH (3000+) is the hybrid and is deliberately NOT used here.
+#   - The mapped rows below follow WouterTuinstra/Homeassistant-Growatt-Local-Modbus
+#     (custom_components/growatt_local/API/device_type/inverter_120.py), a widely deployed
+#     and therefore hardware-exercised integration. Its INPUT_REGISTERS_120 table is what
+#     it uses for a plain (non-hybrid) Protocol II inverter, which is what a MIC TL-X is.
+#     This is the strongest source available and every row below matches it exactly.
+#   - The vendor's machine-readable register CSV (0xAHA/Growatt_ModbusTCP) corroborates
+#     only registers 0-10. Its "First group" table describes an OLDER generation from
+#     register 11 onward (Pac at 11, Fac at 13, temperature at 34), and it says of itself
+#     that it is "a representative sample" rather than the complete protocol.
+#   - That same CSV marks the 3000-series "Use for TL-X and TL-XH" -- so those registers
+#     are NOT exclusive to the hybrid. Splitting them off is the HA integration's own
+#     implementation choice, not something the vendor states.
 #
-# Conservative on purpose: only rows both sources agree on are published as measurements.
-# Anything ambiguous is left to the driver's raw-block TRACE dump rather than surfacing as
-# an authoritative-looking value.
+# Hence the third read block below: the 3000 range is probed during bring-up so the first
+# hardware session settles which range this firmware actually populates, exactly as
+# profiles/growatt/sph.toml does for the same open question. A block the device refuses is
+# skipped harmlessly, so probing a range that does not exist costs nothing but a timeout.
+#
+# Conservative on purpose: only rows the hardware-exercised source states outright are
+# published as measurements. Anything ambiguous is left to the driver's raw-block TRACE
+# dump rather than surfacing as an authoritative-looking value.
 
 [profile]
 driver = "growatt_modbus"
@@ -52,9 +59,15 @@ stop_bits = 1
 # the inverter's own app/display and correct it in one pass.
 #
 # The holding block covers the identity area (firmware 9-14, serial 23-27, model 28-29,
-# device type code 43, trackers/phases 44) plus register 3, the output power limit declared
-# at the bottom of this file. Reading it means its CURRENT value is visible in the dump
-# before anything ever considers writing to it.
+# device type code 43, trackers/phases 44, Modbus protocol version 88) plus register 3, the
+# output power limit declared at the bottom of this file. Reading it means its CURRENT value
+# is visible in the dump before anything ever considers writing to it.
+#
+# The third block probes the 3000 range, which the vendor CSV marks as applying to TL-X and
+# not just to the hybrid TL-XH. Nothing is mapped from it: it exists purely so the first
+# bring-up dump answers "does this unit populate 0-124, 3000+, or both?". 40 registers is
+# enough to see whether real values appear there without spending a full extra 125-register
+# transaction on every poll. Narrow or drop this block once the answer is known.
 # ------------------------------------------------------------------------------------------
 
 [[block]]
@@ -65,7 +78,12 @@ count = 125
 [[block]]
 space = "holding"
 start = 0
-count = 45
+count = 89
+
+[[block]]
+space = "input"
+start = 3000
+count = 40
 
 # --- DC / PV side -------------------------------------------------------------------------
 
@@ -148,10 +166,11 @@ type = "u16"
 scale = 0.1
 unit = "A"
 
-# Pac1 (40-41) is deliberately NOT mapped. On a single-phase inverter it duplicates
-# ac.power.total, and the protocol revisions disagree on whether it is real power (W) or
-# apparent power (VA). A second power entity in Home Assistant that might silently be VA is
-# worse than no entity; the raw dump settles it on the bench if anyone wants it.
+# Pac1 (40-41) is deliberately NOT mapped: on a single-phase inverter it duplicates
+# ac.power.total, and neither source states whether it is real power (W) or apparent power
+# (VA) -- both just call it "output power". A second power entity in Home Assistant that
+# might silently be VA is worse than no entity. The raw dump settles it on the bench: on one
+# phase it should track register 35-36 closely, and a persistent offset means VA.
 
 # --- Energy and runtime -------------------------------------------------------------------
 
@@ -186,9 +205,10 @@ unit = "h"
 
 # --- Temperature --------------------------------------------------------------------------
 
-# Declared signed although the protocol table calls it unsigned: for every physically
-# possible reading the two decode identically, and s16 additionally survives a sub-zero
-# winter morning on an outdoor unit instead of reporting 6553 °C.
+# Declared signed. Neither source states the signedness of this register, so this is a
+# choice rather than a transcription: for every physically possible reading the two decode
+# identically, and s16 additionally survives a sub-zero winter morning on an outdoor unit
+# instead of reporting 6553 °C. If the device turns out to be unsigned, nothing breaks.
 [[register]]                    # high confidence
 measurement = "inverter.temperature"
 display_name = "Inverter Temperature"

--- a/src/drivers/growatt_modbus/descriptor.cpp
+++ b/src/drivers/growatt_modbus/descriptor.cpp
@@ -1,8 +1,27 @@
 // SPDX-License-Identifier: MIT
 
+#include <string>
+#include <vector>
+
 #include "growatt_driver.h"
 
 namespace heliograph::growatt {
+namespace {
+
+/// The `profile` option's allowed values: every compiled-in profile id, plus the empty
+/// string, which keeps meaning "use the default profile" rather than becoming a rejected
+/// value the moment this list stops being empty.
+std::vector<std::string> profileOptionValues() {
+    std::vector<std::string> values;
+    values.reserve(profileCount() + 1);
+    values.emplace_back("");
+    for (size_t i = 0; i < profileCount(); ++i) {
+        values.emplace_back(profileAt(i).id);
+    }
+    return values;
+}
+
+}  // namespace
 
 const DriverDescriptor& descriptor() {
     static const DriverDescriptor d = [] {
@@ -14,7 +33,7 @@ const DriverDescriptor& descriptor() {
         x.description =
             "Growatt string and hybrid inverters over Modbus RTU (Protocol II). Read-only "
             "until the register map is confirmed on hardware; battery control follows. "
-            "Table-driven per model family -- SPH first.";
+            "Table-driven per model family -- pick the profile that matches your model.";
         x.supportedTransports = {TransportType::Rs485, TransportType::Mock};
         // Growatt's two documented line speeds. Discovery tries both; the SPH default is 9600
         // but some units ship at 115200, and guessing wrong on a live bus just looks like
@@ -44,7 +63,7 @@ const DriverDescriptor& descriptor() {
                          "Which Growatt register map to use (profiles/growatt/). "
                          "Empty = the default profile.",
                          "",
-                         {}},
+                         profileOptionValues()},
         };
         return x;
     }();

--- a/src/drivers/growatt_modbus/growatt_registers.h
+++ b/src/drivers/growatt_modbus/growatt_registers.h
@@ -100,6 +100,15 @@ const GrowattProfile* findProfile(const char* id);
 /// option is not set. Implemented in profiles_generated.cpp.
 const GrowattProfile& defaultProfile();
 
+/// Enumerates the compiled-in profiles, so the descriptor can offer them as the option's
+/// allowed values instead of accepting free-form text. With more than one profile in the
+/// build, a typo that falls back to the default silently applies ANOTHER family's register
+/// map — readings that look plausible and are wrong. Rejecting the value at configuration
+/// time is the only point where that is still visible to the user.
+/// Both implemented in profiles_generated.cpp.
+size_t                profileCount();
+const GrowattProfile& profileAt(size_t index);
+
 /// Raw register data read back from the device, one entry per block.
 struct BlockData {
     RegSpace space;

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -440,6 +440,28 @@ bool RestApi::begin() {
                                                         : error.field + ": " + error.message});
                 return;
             }
+
+            // Driver options are checked HERE and not in validate(): the config layer knows
+            // nothing about drivers by design, and only the registry can say what a given
+            // driver accepts. Refusing at the point of saving is the last moment a mistake is
+            // still visible to whoever made it -- at boot a driver can only warn and fall back
+            // to its default, and for an option that selects a register map that fallback
+            // means quietly reading a different inverter family's registers and publishing
+            // values that look entirely plausible.
+            //
+            // Only the PATCH path is gated. A config already in flash is deliberately still
+            // loaded with the warn-and-fall-back behaviour: refusing it at boot would turn a
+            // bad option into an unbootable bridge.
+            if (const DriverDescriptor* d = context_.registry->find(updated.driver.id)) {
+                DriverOptionError optionError;
+                if (!validateDriverOptions(*d, updated.driver.options, optionError)) {
+                    sendError(request, {400, "invalid_config",
+                                        "driver.options." + optionError.key + ": " +
+                                            optionError.message});
+                    return;
+                }
+            }
+
             if (!context_.saveConfig(updated)) {
                 sendError(request, {500, "save_failed", "could not persist the configuration"});
                 return;

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -568,9 +568,21 @@ async function renderConfig(){
       const stored=id===c.driver.id?(c.driver.options||{})[o.key]:undefined;
       const cur=stored??o.default_value;
       if(o.allowed_values&&o.allowed_values.length){
+        // A stored value the firmware does not recognise -- a hand-edited config, or an
+        // option value that disappeared in a firmware update -- gets its own selected entry
+        // so it stays VISIBLE and stays the select's value. Without it the browser silently
+        // selects the first option, and the untouched-card diffing in the save path then
+        // sees a difference and writes that fallback into the config on the next unrelated
+        // save: a setting the user never looked at, quietly changed. Reachable since the
+        // driver profile option became an enumerated list (2026-07-24).
+        const known=o.allowed_values.includes(cur);
+        // Explicit value= on every option: without it the browser takes the option's TEXT as
+        // its value, so the annotated entry below would submit its own label.
         return `<label for="opt_${o.key}">${esc(o.display_name)}</label>
-          <select id="opt_${o.key}" data-opt="${esc(o.key)}">${o.allowed_values.map(v=>
-            `<option ${v===cur?'selected':''}>${esc(v)}</option>`).join('')}</select>
+          <select id="opt_${o.key}" data-opt="${esc(o.key)}">${
+            (known?'':`<option value="${esc(cur)}" selected>${esc(cur)} — not recognised</option>`)+
+            o.allowed_values.map(v=>
+            `<option value="${esc(v)}" ${v===cur?'selected':''}>${v===''?'(driver default)':esc(v)}</option>`).join('')}</select>
           <div class="dim" style="font-size:12px">${esc(o.description||'')}</div>`;
       }
       return `<label for="opt_${o.key}">${esc(o.display_name)}</label>

--- a/test/test_growatt_driver/test_main.cpp
+++ b/test/test_growatt_driver/test_main.cpp
@@ -6,7 +6,9 @@
 
 #include <unity.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "device/device_state.h"
@@ -336,6 +338,170 @@ static void test_the_profile_registry_finds_sph_and_rejects_unknown_ids() {
     TEST_ASSERT_EQUAL_PTR(sph, &defaultProfile());
 }
 
+// --- MIC TL-X profile -----------------------------------------------------------------------
+
+// A second profile in the build is the moment the `profile` option stops being cosmetic: pick
+// the wrong one and you get another family's map applied to your inverter. The descriptor now
+// enumerates the ids so validateDriverOptions refuses a typo at configuration time, instead of
+// optionsFrom() silently falling back to SPH.
+static void test_the_profile_option_enumerates_every_compiled_profile() {
+    TEST_ASSERT_EQUAL_UINT32(2, profileCount());
+
+    bool sawSph = false;
+    bool sawMic = false;
+    for (size_t i = 0; i < profileCount(); ++i) {
+        const std::string id = profileAt(i).id;
+        sawSph               = sawSph || id == "sph";
+        sawMic               = sawMic || id == "mic_tl_x";
+    }
+    TEST_ASSERT_TRUE(sawSph);
+    TEST_ASSERT_TRUE(sawMic);
+
+    // Out of range folds to the first entry rather than reading past the array.
+    TEST_ASSERT_EQUAL_PTR(&profileAt(0), &profileAt(profileCount()));
+
+    const auto& allowed = descriptor().options[1].allowedValues;
+    TEST_ASSERT_EQUAL_STRING("profile", descriptor().options[1].key.c_str());
+    TEST_ASSERT_EQUAL_UINT32(profileCount() + 1, allowed.size());
+    // "" must survive as an allowed value: it is the documented default meaning "use the
+    // default profile", and validateDriverOptions checks values it finds, empty or not.
+    TEST_ASSERT_TRUE(std::find(allowed.begin(), allowed.end(), "") != allowed.end());
+    TEST_ASSERT_TRUE(std::find(allowed.begin(), allowed.end(), "mic_tl_x") != allowed.end());
+
+    DriverOptions     values{{"profile", "mic_tlx"}};  // the plausible typo
+    DriverOptionError err;
+    TEST_ASSERT_FALSE(validateDriverOptions(descriptor(), values, err));
+    TEST_ASSERT_EQUAL_STRING("profile", err.key.c_str());
+
+    values["profile"] = "mic_tl_x";
+    TEST_ASSERT_TRUE(validateDriverOptions(descriptor(), values, err));
+    values["profile"] = "";
+    TEST_ASSERT_TRUE(validateDriverOptions(descriptor(), values, err));
+}
+
+static void test_the_mic_profile_describes_a_single_phase_single_tracker_string_inverter() {
+    const GrowattProfile* mic = findProfile("mic_tl_x");
+    TEST_ASSERT_NOT_NULL(mic);
+    TEST_ASSERT_FALSE(mic->hasBattery);
+    TEST_ASSERT_EQUAL_UINT8(1, mic->phaseCount);
+    TEST_ASSERT_EQUAL_UINT8(1, mic->mpptCount);
+    // 9600 8N1 comes from the profile's own [serial] block, not the descriptor's candidates.
+    TEST_ASSERT_TRUE(mic->hasSerial);
+    TEST_ASSERT_EQUAL_UINT32(9600, mic->serial.baudRate);
+    TEST_ASSERT_EQUAL(SerialParity::None, mic->serial.parity);
+}
+
+// The MIC map lives in Protocol II's "first group" (input 0-124). The 3000-series belongs to
+// the TL-XH hybrid and must not leak in here: pointing a plain TL-X at it reads nothing.
+static void test_the_mic_profile_reads_only_the_first_group() {
+    const GrowattProfile* mic = findProfile("mic_tl_x");
+    TEST_ASSERT_NOT_NULL(mic);
+    for (size_t i = 0; i < mic->blockCount; ++i) {
+        TEST_ASSERT_TRUE(mic->blocks[i].start < 3000);
+    }
+    for (size_t i = 0; i < mic->mappingCount; ++i) {
+        TEST_ASSERT_TRUE(mic->mappings[i].address < 3000);
+    }
+}
+
+// One frame of plausible mid-afternoon values, decoded through the real table. This pins the
+// scaling decisions that differ from the rest of the map -- frequency is /100 where almost
+// everything else is /10, and the runtime counter is in half-seconds.
+static void test_the_mic_profile_decodes_a_realistic_frame() {
+    BlockData blocks[2];
+    blocks[0] = {RegSpace::Input, 0, 125, {}};
+    blocks[1] = {RegSpace::Holding, 0, 45, {}};
+
+    setReg(blocks[0], 1, 0);       // Ppv high
+    setReg(blocks[0], 2, 12040);   // Ppv low   -> 1204.0 W
+    setReg(blocks[0], 3, 3105);    // Vpv1      -> 310.5 V
+    setReg(blocks[0], 4, 39);      // Ipv1      -> 3.9 A
+    setReg(blocks[0], 35, 0);      // Pac high
+    setReg(blocks[0], 36, 11880);  // Pac low   -> 1188.0 W
+    setReg(blocks[0], 37, 5001);   // Fac       -> 50.01 Hz  (/100, not /10)
+    setReg(blocks[0], 38, 2314);   // Vac1      -> 231.4 V
+    setReg(blocks[0], 53, 0);      // E-today high
+    setReg(blocks[0], 54, 87);     // E-today low -> 8.7 kWh
+    setReg(blocks[0], 93, 412);    // Temp      -> 41.2 °C
+
+    MeasurementSet m;
+    applyProfile(*findProfile("mic_tl_x"), blocks, 2, m, 1000);
+
+    const auto* pv = m.find(measurement_id::kDcPowerTotal);
+    TEST_ASSERT_NOT_NULL(pv);
+    TEST_ASSERT_EQUAL_DOUBLE(1204.0, pv->value);
+
+    const auto* vpv = m.find(measurement_id::kDcMppt1Voltage);
+    TEST_ASSERT_NOT_NULL(vpv);
+    TEST_ASSERT_EQUAL_DOUBLE(310.5, vpv->value);
+
+    const auto* ac = m.find(measurement_id::kAcPowerTotal);
+    TEST_ASSERT_NOT_NULL(ac);
+    TEST_ASSERT_EQUAL_DOUBLE(1188.0, ac->value);
+
+    const auto* hz = m.find(measurement_id::kAcFrequency);
+    TEST_ASSERT_NOT_NULL(hz);
+    TEST_ASSERT_EQUAL_DOUBLE(50.01, hz->value);
+
+    const auto* vac = m.find(measurement_id::kAcL1Voltage);
+    TEST_ASSERT_NOT_NULL(vac);
+    TEST_ASSERT_EQUAL_DOUBLE(231.4, vac->value);
+
+    const auto* today = m.find(measurement_id::kEnergyToday);
+    TEST_ASSERT_NOT_NULL(today);
+    TEST_ASSERT_EQUAL_DOUBLE(8.7, today->value);
+
+    const auto* temp = m.find(measurement_id::kTemperature);
+    TEST_ASSERT_NOT_NULL(temp);
+    TEST_ASSERT_EQUAL_DOUBLE(41.2, temp->value);
+
+    // A string inverter has no battery and no second tracker. Neither may appear as a
+    // confident zero -- an undeclared channel is the honest answer.
+    TEST_ASSERT_NULL(m.find(measurement_id::kBatterySoc));
+    TEST_ASSERT_NULL(m.find(measurement_id::kDcMppt2Voltage));
+}
+
+// Work time total counts half-seconds; 7200 of them is one hour. Its own test because the
+// scale is a repeating fraction in the TOML and therefore the easiest row to get subtly wrong.
+static void test_the_mic_profile_converts_half_seconds_to_hours() {
+    BlockData blocks[2];
+    blocks[0] = {RegSpace::Input, 0, 125, {}};
+    blocks[1] = {RegSpace::Holding, 0, 45, {}};
+
+    // 12 345 hours = 88 884 000 half-seconds = 0x054C_4320.
+    setReg(blocks[0], 57, 0x054C);
+    setReg(blocks[0], 58, 0x4320);
+
+    MeasurementSet m;
+    applyProfile(*findProfile("mic_tl_x"), blocks, 2, m, 1000);
+
+    const auto* hours = m.find(measurement_id::kOperatingHours);
+    TEST_ASSERT_NOT_NULL(hours);
+    TEST_ASSERT_DOUBLE_WITHIN(0.01, 12345.0, hours->value);
+}
+
+// The active-power-limit row is research, not a control surface: it stays dormant until a
+// bench session sets verified = true AND the driver grows a write path (execute() still
+// returns Unsupported). Both gates are asserted here so neither can be dropped unnoticed.
+static void test_the_mic_power_limit_write_row_is_declared_but_dormant() {
+    const GrowattProfile* mic = findProfile("mic_tl_x");
+    TEST_ASSERT_NOT_NULL(mic);
+    TEST_ASSERT_EQUAL_UINT32(1, mic->writeCount);
+
+    const WriteMapping& w = mic->writes[0];
+    TEST_ASSERT_EQUAL(InverterCommandType::SetActivePowerLimitPercent, w.command);
+    TEST_ASSERT_EQUAL(RegSpace::Holding, w.space);
+    TEST_ASSERT_EQUAL_UINT16(3, w.address);
+    TEST_ASSERT_EQUAL_UINT8(1, w.words);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0, w.minimum);
+    // Deliberately 100, not 255: some revisions read 255 as "limit disabled", and a percentage
+    // that silently means "off" needs explicit handling, not a widened bound.
+    TEST_ASSERT_EQUAL_DOUBLE(100.0, w.maximum);
+    TEST_ASSERT_FALSE(w.verified);
+
+    TEST_ASSERT_FALSE(descriptor().supportsWrite);
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_soc_is_decoded_as_a_plain_percent);
@@ -355,5 +521,11 @@ int main(int, char**) {
     RUN_TEST(test_begin_configures_the_serial_line);
     RUN_TEST(test_a_profile_declared_serial_overrides_the_descriptor_default);
     RUN_TEST(test_the_profile_registry_finds_sph_and_rejects_unknown_ids);
+    RUN_TEST(test_the_profile_option_enumerates_every_compiled_profile);
+    RUN_TEST(test_the_mic_profile_describes_a_single_phase_single_tracker_string_inverter);
+    RUN_TEST(test_the_mic_profile_reads_only_the_first_group);
+    RUN_TEST(test_the_mic_profile_decodes_a_realistic_frame);
+    RUN_TEST(test_the_mic_profile_converts_half_seconds_to_hours);
+    RUN_TEST(test_the_mic_power_limit_write_row_is_declared_but_dormant);
     return UNITY_END();
 }

--- a/test/test_growatt_driver/test_main.cpp
+++ b/test/test_growatt_driver/test_main.cpp
@@ -391,16 +391,28 @@ static void test_the_mic_profile_describes_a_single_phase_single_tracker_string_
     TEST_ASSERT_EQUAL(SerialParity::None, mic->serial.parity);
 }
 
-// The MIC map lives in Protocol II's "first group" (input 0-124). The 3000-series belongs to
-// the TL-XH hybrid and must not leak in here: pointing a plain TL-X at it reads nothing.
-static void test_the_mic_profile_reads_only_the_first_group() {
+// Which register generation a MIC populates is NOT settled: the vendor CSV marks the 3000
+// range "Use for TL-X and TL-XH", so it is not hybrid-only the way an earlier draft of the
+// profile claimed. The profile therefore PROBES 3000 while MAPPING nothing from it -- the
+// bring-up dump answers the question, and until it does, no published reading may come from
+// a range nobody has confirmed this device speaks.
+static void test_the_mic_profile_probes_3000_but_publishes_nothing_from_it() {
     const GrowattProfile* mic = findProfile("mic_tl_x");
     TEST_ASSERT_NOT_NULL(mic);
+
+    bool probesTheOpenRange = false;
     for (size_t i = 0; i < mic->blockCount; ++i) {
-        TEST_ASSERT_TRUE(mic->blocks[i].start < 3000);
+        probesTheOpenRange = probesTheOpenRange || mic->blocks[i].start >= 3000;
     }
+    TEST_ASSERT_TRUE(probesTheOpenRange);
+
     for (size_t i = 0; i < mic->mappingCount; ++i) {
         TEST_ASSERT_TRUE(mic->mappings[i].address < 3000);
+    }
+    // Same rule for the write row: writing into an unconfirmed generation is how you set a
+    // register you did not mean to.
+    for (size_t i = 0; i < mic->writeCount; ++i) {
+        TEST_ASSERT_TRUE(mic->writes[i].address < 3000);
     }
 }
 
@@ -523,7 +535,7 @@ int main(int, char**) {
     RUN_TEST(test_the_profile_registry_finds_sph_and_rejects_unknown_ids);
     RUN_TEST(test_the_profile_option_enumerates_every_compiled_profile);
     RUN_TEST(test_the_mic_profile_describes_a_single_phase_single_tracker_string_inverter);
-    RUN_TEST(test_the_mic_profile_reads_only_the_first_group);
+    RUN_TEST(test_the_mic_profile_probes_3000_but_publishes_nothing_from_it);
     RUN_TEST(test_the_mic_profile_decodes_a_realistic_frame);
     RUN_TEST(test_the_mic_profile_converts_half_seconds_to_hours);
     RUN_TEST(test_the_mic_power_limit_write_row_is_declared_but_dormant);

--- a/tools/gen_profiles.py
+++ b/tools/gen_profiles.py
@@ -529,6 +529,12 @@ def generate(
         f"const GrowattProfile& defaultProfile() {{ return kProfiles[{default_index}]; }}"
     )
     w("")
+    w("size_t profileCount() { return sizeof(kProfiles) / sizeof(kProfiles[0]); }")
+    w("")
+    w("const GrowattProfile& profileAt(size_t index) {")
+    w("    return kProfiles[index < profileCount() ? index : 0];")
+    w("}")
+    w("")
     w("}  // namespace heliograph::growatt")
     w("")
     return "\n".join(lines)


### PR DESCRIPTION
Three Growatt MIC TL-X inverters are going onto one RS485 bus soon, and the existing `sph` profile does not describe them. This adds the profile they need, the bus documentation that goes with it, and closes three gaps that review turned up.

## MIC TL-X is a different register layout

One MPPT, one phase, no battery. The mapped rows follow `INPUT_REGISTERS_120` (input 0-124) in [WouterTuinstra/Homeassistant-Growatt-Local-Modbus](https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus) — a widely deployed integration, so its tables have been run against a great many real inverters. That is the table it uses for a plain Protocol II inverter, which is what a MIC TL-X is. Every mapped row matches it exactly.

**The register generation is not settled, and an earlier revision of this PR wrongly claimed it was.** Review checked the second source and it does not say what I said it said:

- The vendor register CSV agrees only on registers 0-10. From register 11 its "First group" describes an older generation (AC power at 11, frequency at 13, temperature at 34), and the file calls itself "a representative sample".
- That same CSV marks the entire 3000 range `Use for TL-X and TL-XH`. So it is **not** hybrid-only. Splitting it off is the HA integration's implementation choice, not something Growatt states.

So the profile now **probes 40 registers at 3000 and maps nothing from them**, letting the first bring-up dump answer the question directly — the same tactic `sph.toml` already uses for its own open generation question. Step 7 of the bring-up checklist spells out the three possible outcomes and what each one means.

## One profile for the whole range

A profile describes a register layout, not a model number. The 600 W and 3300 W units differ only in rating, which appears nowhere in the map. Holding register 44 reports the real tracker and phase count, so a deviant variant shows up in the dump rather than being silently mis-decoded.

## Deliberately not mapped

- **PV2 (7-10)** — one tracker on this hardware; a permanent zero is not a reading.
- **Pac1 (40-41)** — duplicates `ac.power.total` on one phase, and neither source says whether it is W or VA. On the bench it should track registers 35-36; a persistent offset means VA.
- **IPM/boost temperature, bus voltages, derating and fault codes** — real, but there is one canonical `inverter.temperature`.

All of it stays in the raw TRACE dump, so any row can be promoted from evidence later.

## Curtailment groundwork

**Holding register 3 is the active power limit, 0-100 %, one word, FC06** — confirmed by both sources. The safest write found on any device so far: trivially reversed by writing 100, touching no grid-protection setting, needing no DRM wiring or relay board.

Recorded as a `[[write]]` row and **dormant** behind both existing gates: `verified = false`, and no driver write path (`execute()` returns `Unsupported`, `supportsWrite = false`). Both asserted in tests. The bound stops at 100 rather than 255 — some revisions read 255 as "limit disabled", and a percentage that silently means "off" needs explicit handling.

## Three gaps review found

**`validateDriverOptions` had zero production callers.** It was implemented and then only ever exercised by tests, so enumerating allowed values changed nothing at runtime and the first commit message's claim that a typo gets refused was simply false. The REST config PATCH now calls it before persisting. Boot-time loading is deliberately left alone: refusing a stored config at boot turns a bad option into an unbootable bridge, so there it still warns and falls back.

**Enumerated values activated a web UI path that had never been reachable.** The renderer selects nothing when the stored value is not in the list, so the browser silently selects the first entry — and the untouched-card diffing then writes that fallback into the config on the next unrelated save, quietly changing a setting the user never opened. An unrecognised value now gets its own selected, labelled entry. Every option also gets an explicit `value` attribute, without which the browser submits an option's label rather than its value.

**Two comments claimed more than the sources support.** The temperature register's signedness is a deliberate choice, not a transcription. Pac1 is unmapped because neither source states W or VA, not because revisions are known to disagree.

Plus: the holding block widened to cover register 88, which the identity table listed as read while the block stopped at 44.

## Bus documentation

`docs/rs485-bus.md` — the part that is not Growatt-specific: chain-not-star topology, why ground is not optional, and the 120 Ω rule (two places at the physical ends; three devices each with their own resistor is 40 Ω and kills the bus). Failure symptoms are split the way the bridge actually distinguishes them — timeouts mean nothing came back, checksum errors mean it came back corrupted, and those point at different causes.

The Growatt-specific half sits with the driver: setting the Modbus address via the touch control's `Set Comaddr` menu, or by writing holding register 30 (`Com Address`, 1-254, default 1) with an external tool, one inverter at a time while they all still answer to address 1.

## Verification

- 486 native tests pass (6 new)
- `tools/check_layering.sh` passes, `tools/check_web_js.py` passes
- `waveshare-rs485-can` and `waveshare-relay-6ch` build

Not verified: any of it against a physical MIC TL-X. That is what the bring-up checklist is for, and step 7 is the one that closes the generation question for real.
