### PR TITLE
CI: fix the toolchain cache scope, and retry the platform download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@
 # The firmware compile lives in its own pull-request-only workflow (firmware.yml), so a push to
 # main posts no firmware check and a release does not rebuild what the PR already built. See
 # that file for the reasoning.
+#
+# This workflow does own one firmware-adjacent job: warming the ESP32 toolchain cache on main.
+# That has to happen on the default branch because of how GitHub scopes caches -- see the
+# comment on the job itself.
 
 name: CI
 
@@ -90,3 +94,60 @@ jobs:
 
       - name: Native test suite
         run: pio test -e native
+
+  # The ONLY writer of the ESP32 toolchain cache, and the reason it exists here rather than in
+  # firmware.yml or release.yml where the builds actually are.
+  #
+  # GitHub scopes a cache to the ref that wrote it. A cache written on refs/pull/21/merge is
+  # invisible to refs/tags/v0.12.0 and to every other PR; caches on the DEFAULT BRANCH are the
+  # only ones readable from any ref. Since firmware.yml runs on pull_request and release.yml on
+  # tags, nothing was ever writing to a scope the others could read: every PR build and every
+  # release downloaded the ~1.7 GB toolchain fresh and then saved its own private copy. Five of
+  # those copies were sitting in the 10 GB repo budget, evicting the small useful caches, and
+  # none had ever been restored by anything. A transient 504 on that download broke the 0.12.0
+  # release (2026-07-24), which is what turned this up.
+  #
+  # This job builds nothing. It only materialises the packages so the cache entry exists on
+  # main; the consumers restore it read-only.
+  warm-toolchain-cache:
+    name: Warm firmware toolchain cache
+    # Pushes to main only. On a pull request the build jobs restore this cache but must never
+    # write one -- a PR-scoped copy is the exact waste described above.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # Restore-and-save. A hit means the packages are already present and the install below is
+      # a no-op, so a run costs seconds; a miss repopulates the entry the consumers depend on.
+      - name: Cache PlatformIO
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-fw-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      # Retried, because this is the download that broke the 0.12.0 release: the platform zip is
+      # fetched from a GitHub release asset, and that endpoint returned 504 for several minutes
+      # while GitHub itself reported all systems operational. One cold attempt is not enough to
+      # hang a release on.
+      - name: Install board packages
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if pio pkg install \
+                 -e waveshare-rs485-can -e waveshare-relay-1ch -e waveshare-relay-6ch; then
+              exit 0
+            fi
+            echo "package install failed (attempt ${attempt}); retrying in $((attempt * 20))s"
+            sleep $((attempt * 20))
+          done
+          echo "package install still failing after 5 attempts" >&2
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,16 @@ jobs:
   # none had ever been restored by anything. A transient 504 on that download broke the 0.12.0
   # release (2026-07-24), which is what turned this up.
   #
-  # This job builds nothing. It only materialises the packages so the cache entry exists on
-  # main; the consumers restore it read-only.
+  # This job compiles one board and throws the result away. That it BUILDS is the point, not an
+  # accident: pioarduino does not fetch the ~200 MB xtensa toolchain during `pio pkg install`
+  # (that only lands the platform and the tool-esp_install helper). The toolchain is pulled by
+  # a build-time script -- platform.py's _run_idf_tools_install, invoked from `pio run` -- so a
+  # cache warmed by `pkg install` alone would miss the very thing worth caching and every
+  # consumer would still cold-download it. One real build populates ~/.platformio completely.
+  #
+  # One board covers all four esp32 envs: rs485-can, both relay boards and mock share the same
+  # platform, board and toolchain (they differ only in build flags and partitions), so the
+  # packages this build lands are exactly the ones every env restores.
   warm-toolchain-cache:
     name: Warm firmware toolchain cache
     # Pushes to main only. On a pull request the build jobs restore this cache but must never
@@ -122,8 +130,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Restore-and-save. A hit means the packages are already present and the install below is
-      # a no-op, so a run costs seconds; a miss repopulates the entry the consumers depend on.
+      # Restore-and-save. On a hit the packages are already present, so the build below reuses
+      # them and only recompiles; a miss repopulates the entry every consumer depends on.
       - name: Cache PlatformIO
         uses: actions/cache@v6
         with:
@@ -135,19 +143,20 @@ jobs:
       - name: Install PlatformIO
         run: pip install platformio
 
-      # Retried, because this is the download that broke the 0.12.0 release: the platform zip is
-      # fetched from a GitHub release asset, and that endpoint returned 504 for several minutes
-      # while GitHub itself reported all systems operational. One cold attempt is not enough to
-      # hang a release on.
-      - name: Install board packages
+      # Retried, because a cold run downloads from GitHub release assets and that is exactly
+      # what broke the 0.12.0 release: platform-espressif32.zip returned 504 for several minutes
+      # while GitHub reported all systems operational. Retrying `pio run` also re-attempts a
+      # network failure part-way through the toolchain fetch. A genuine compile error would
+      # retry too, but this same tree already compiled green on its PR, so on main that path is
+      # not expected -- and the job only warms a cache, so its failure never blocks a release.
+      - name: Build one board to populate the toolchain cache
         run: |
           for attempt in 1 2 3 4 5; do
-            if pio pkg install \
-                 -e waveshare-rs485-can -e waveshare-relay-1ch -e waveshare-relay-6ch; then
+            if pio run -e waveshare-rs485-can; then
               exit 0
             fi
-            echo "package install failed (attempt ${attempt}); retrying in $((attempt * 20))s"
+            echo "build failed (attempt ${attempt}); retrying in $((attempt * 20))s"
             sleep $((attempt * 20))
           done
-          echo "package install still failing after 5 attempts" >&2
+          echo "build still failing after 5 attempts" >&2
           exit 1

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -78,8 +78,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Cache PlatformIO
-        uses: actions/cache@v6
+      # Restore-only, on purpose. The writer is the warm-toolchain-cache job in ci.yml, which
+      # runs on main and therefore produces the one cache scope every ref can read. Saving here
+      # instead would write a ~1.7 GB copy scoped to this PR that no other run could ever use,
+      # while crowding the 10 GB repo budget -- and these four matrix jobs would race to write
+      # four of them. A miss just means this build downloads the toolchain itself, as before.
+      - name: Restore PlatformIO toolchain
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.platformio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Cache PlatformIO
-        uses: actions/cache@v6
+      # Restore-only. A tag ref cannot read a cache written by a PR or by another tag, so the
+      # save this step used to do produced a ~1.7 GB entry that nothing would ever restore --
+      # including the next release. The writer is now the warm-toolchain-cache job in ci.yml,
+      # running on main, whose scope every ref can read.
+      - name: Restore PlatformIO toolchain
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.platformio
@@ -40,6 +44,24 @@ jobs:
 
       - name: Install PlatformIO
         run: pip install platformio
+
+      # Explicit and retried rather than left to the first `pio run`. On a cache miss the
+      # platform zip comes from a GitHub release asset, and that endpoint returned 504 for
+      # several minutes while GitHub reported all systems operational -- failing the 0.12.0
+      # release twice before a third attempt went through. A release is the worst place to
+      # discover that one cold download attempt is all you get.
+      - name: Install board packages
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if pio pkg install \
+                 -e waveshare-rs485-can -e waveshare-relay-1ch -e waveshare-relay-6ch; then
+              exit 0
+            fi
+            echo "package install failed (attempt ${attempt}); retrying in $((attempt * 20))s"
+            sleep $((attempt * 20))
+          done
+          echo "package install still failing after 5 attempts" >&2
+          exit 1
 
       - name: Verify before shipping
         run: |


### PR DESCRIPTION
The 0.12.0 release failed twice on a `504` fetching the ESP32 platform zip, while GitHub reported all systems operational. Chasing that down turned up a cache setup that had never worked once.

## What was actually wrong

GitHub scopes a cache to the ref that wrote it. A cache written on `refs/pull/21/merge` is invisible to `refs/tags/v0.12.0` and to every other PR. Only caches on the **default branch** are readable from any ref.

But `firmware.yml` triggers on `pull_request` and `release.yml` on tags. **Nothing was ever writing into a scope the others could read.** Every PR build and every release downloaded the ~1.7 GB toolchain cold, then saved its own private copy that nothing would ever restore — including the next release.

The failing run says it plainly:

```
Cache not found for input keys: pio-fw-Linux-245f2df7...
```

while `gh cache list` showed an entry with *exactly that key*, 1.72 GiB, written hours earlier — by a different ref.

Five of those copies were sitting in the 10 GB repo budget:

| Key | Size | Written by |
|---|---|---|
| `pio-fw-Linux-245f2df…` | 1.72 GiB | a PR ref |
| `pio-fw-Linux-245f2df…` | 1.67 GiB | another ref |
| `pio-fw-Linux-245f2df…` | 1.67 GiB | another ref |
| `pio-fw-Linux-7e92803…` | 1.67 GiB | older `platformio.ini` |
| `pio-fw-Linux-7e92803…` | 1.67 GiB | older `platformio.ini` |

~8.4 GiB of dead weight, crowding out the 21 MiB native caches that *do* get restored.

## The fix

**Move the writer to where it can be read from.** `ci.yml` gains a `warm-toolchain-cache` job that runs on pushes to `main` only. It builds nothing — it just materialises the packages so the cache entry exists on the default branch, the one scope every ref can read. On a hit it costs seconds.

**Make the consumers restore-only.** `firmware.yml` and `release.yml` switch to `actions/cache/restore@v6`. They consume main's cache and never write a scoped copy again. That also stops `firmware.yml`'s four matrix jobs racing to save four of them.

**Retry the download.** Both build workflows now install board packages in an explicit retry loop (5 attempts, backing off 20/40/60/80s) instead of letting the first `pio run` do it unguarded. A cache miss is normal and survivable; one cold attempt against an endpoint having a bad five minutes is what actually broke the release.

## Risk

A cache miss still just means the build fetches the toolchain itself, exactly as it does today — the worst case is unchanged, and now it retries. The `warm-toolchain-cache` job adds one check to pushes on `main`; it is a single non-matrix job, so it does not hit the un-interpolated-name problem documented in `firmware.yml`.


## Correction found in final review

`pio pkg install` does **not** fetch the xtensa toolchain — verified by installing an esp32 env into a clean `PLATFORMIO_CORE_DIR`, which leaves only the platform and a `tool-esp_install` helper (Espressif's `idf_tools.py`) in `packages/`. `platform.py` runs that installer from `_run_idf_tools_install` during `pio run`, so the ~200 MB toolchain is a build-time download by design.

So the warm job now **builds one board** rather than installing packages: the compile is what triggers the toolchain fetch that fills the cache. One board covers all four esp32 envs (rs485-can, both relay boards, mock) — they share platform, board and toolchain, differing only in flags and partitions. Without this the cache would have warmed the cheap part and every consumer would still cold-download the expensive part.

## Verification

- All four workflow files parse as YAML; job names confirmed (`lint`, `test`, `warm-toolchain-cache`)
- The retry loop passes `bash -n`, and its `if pio pkg install; then` form is safe under the runner's `-eo pipefail` shell (a failing command in an `if` condition does not trip `errexit` — verified)
- `pio pkg install -e <env>` confirmed against the installed PlatformIO's own `--help`
- `actions/cache@v6` is current (v6.1.0) and `actions/cache/restore@v6` exists

This PR's own CI run is the first real test: the `Build (…)` jobs will report a cache miss and fall through to the retried install, since main has not yet produced the warm entry. That happens on the merge commit.

**Follow-up once merged:** delete the five stale `pio-fw-*` cache entries so the new main-scoped one is not immediately evicted by the LRU. Worth doing *after* main has written a good cache, not before.
