### PR TITLE
Close five defects found in the full-codebase review

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ it with your phone or laptop; the setup page opens by itself. Choose your networ
 admin password, and save. The board reboots and tells you the address to visit, something
 like `http://heliograph-a1b2c3.local`.
 
+**Write that admin password down.** The same setup network comes back on its own if the board
+later loses WiFi for a few minutes — a router reboot is enough — so that you can point it at a
+new network without digging the board out. Because that network is open and anyone in range
+could otherwise reconfigure your bridge, changing anything through it asks for the admin
+password once one is set.
+
+If you lose the password, the way back in is a **factory reset**: hold the board's **BOOT**
+button for about 5 seconds while it is running. That erases the stored configuration — WiFi,
+password, everything — and returns the board to first-boot setup. Failing that, re-flash a
+`-factory.bin` over USB, which wipes the same settings. Details and the download-mode caveat:
+[docs/hardware.md](docs/hardware.md#recovery--hold-boot-to-factory-reset).
+
 ### 4. Wire it to the inverter
 
 With the inverter's manual in front of you, connect:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,13 @@ password once one is set.
 If you lose the password, the way back in is a **factory reset**: hold the board's **BOOT**
 button for about 5 seconds while it is running. That erases the stored configuration — WiFi,
 password, everything — and returns the board to first-boot setup. Failing that, re-flash a
-`-factory.bin` over USB, which wipes the same settings. Details and the download-mode caveat:
+`-factory.bin` over USB, which wipes the same settings.
+
+Two things worth knowing before you rely on it. On the Relay-6CH the countdown blinks the LED
+and the buzzer confirms the wipe; **on the RS485-CAN there is no LED and no buzzer, so the hold
+gives no feedback at all** — the board simply reboots into setup when it worked. And the reset
+itself is only hardware-verified on the Relay-6CH; on the other two boards the pin comes from
+the schematic and nobody has run it. Details and the download-mode caveat:
 [docs/hardware.md](docs/hardware.md#recovery--hold-boot-to-factory-reset).
 
 ### 4. Wire it to the inverter

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -79,10 +79,28 @@ source — a deliberate decision for later, not an accident waiting in a header 
 ## Recovery — hold BOOT to factory-reset
 
 Holding **BOOT for ~5 seconds while the firmware is running** erases the stored
-configuration and reboots into the setup portal. It is the only recovery path on a headless
-board: a config wrong enough to lock you out of the web UI (a bad hostname, a wrong static
-setup) is otherwise unreachable without USB. The hold is deliberately long so it is never one
-accidental brush.
+configuration and reboots into the setup portal. It is the only on-device recovery path on a
+headless board: a config wrong enough to lock you out of the web UI (a bad hostname, a wrong
+static setup) is otherwise unreachable without USB. The hold is deliberately long so it is
+never one accidental brush.
+
+**This carries more weight than it used to.** Provisioning through the setup portal is now
+gated on the admin password once one exists, because that portal also returns on an
+already-configured board after a few minutes without WiFi and its AP is open (see
+[docs/security.md](security.md)). So for a forgotten password this reset — or a USB
+`-factory.bin` flash, which wipes the same NVS — is the way back in.
+
+**Verification status differs per board, and this is worth knowing before you rely on it:**
+
+| Board | BOOT pin | Factory reset measured? |
+|---|---|---|
+| ESP32-S3-Relay-6CH | GPIO0 | **Yes** — hold, LED countdown and release confirmed on hardware 2026-07-23 |
+| ESP32-S3-RS485-CAN | GPIO0 | Schematic only — the pin is confirmed, the 5 s reset has not been run on this board |
+| ESP32-S3-Relay-1CH | GPIO0 | Schematic only — nobody on the project owns one |
+
+The pin is the same GPIO0 on all three and the code path is shared, so there is no reason to
+expect a difference — but "no reason to expect" is not a measurement. If you own an RS485-CAN
+or a 1CH, running it once and reporting the result is a genuinely useful contribution.
 
 **Not to be confused with download mode.** BOOT is GPIO0, the SoC's download strapping pin,
 so holding it *at power-on or during RESET* drops the board into the USB firmware-download

--- a/docs/security.md
+++ b/docs/security.md
@@ -34,9 +34,20 @@ plain text. Anyone who can read the flash over USB can read them. Flash encrypti
 this but makes OTA and recovery considerably more complex; given the threat model (LAN, no
 physical access) this has not been done. Be aware of it.
 
-**The setup AP is open.** The window is small (until
-the first successful connection) but it is a window: anyone within wifi range at that
-moment can configure the bridge.
+**The setup AP is open**, and it is not limited to first boot: the bridge raises it again on
+an already-configured device after repeated WiFi failures (a router reboot reaches that in
+about two minutes), because without a reset button that portal is the only way back in.
+
+Provisioning over it is therefore gated on whether a credential exists yet, not on whether
+the portal happens to be up. On a factory-fresh device `/api/v1/provision` is open — there is
+nothing to protect and no password to present. Once an admin password is set, the same
+endpoint requires it even while the portal is running. It was previously open in both cases,
+which meant anyone in radio range of a bridge whose WiFi had dropped could overwrite its
+configuration, including the admin password and the relay gates.
+
+`/api/v1/wifi/scan` carries the same gate. What the open AP still exposes on a configured
+device is the setup page itself and the fact that the bridge exists; joining it grants no
+control and no data.
 
 **No brute-force protection on HTTP Basic.** Rate limiting is on `/actions/*`, not on the
 auth itself.

--- a/docs/security.md
+++ b/docs/security.md
@@ -45,9 +45,21 @@ endpoint requires it even while the portal is running. It was previously open in
 which meant anyone in radio range of a bridge whose WiFi had dropped could overwrite its
 configuration, including the admin password and the relay gates.
 
-`/api/v1/wifi/scan` carries the same gate. What the open AP still exposes on a configured
-device is the setup page itself and the fact that the bridge exists; joining it grants no
-control and no data.
+`/api/v1/wifi/scan` carries the same gate, and the setup page asks for the admin password when
+the bridge already has one.
+
+**What the open AP still exposes is read access, and that is not nothing.** The web server
+listens on every interface, so anyone joining the failure-portal AP reaches the same
+unauthenticated read endpoints a LAN user does: `/api/v1/status`, `/devices`, `/diagnostics`,
+`/discovery`, `/drivers`, `/config` (GET) and `/metrics`. Between them that is live production
+data, the inverter's model and serial number, your WiFi SSID and hostname, the MQTT host, port
+and base topic, the relay roles, and `security.admin_username`. The Modbus TCP server on port
+502 is reachable from that AP too, and Modbus has no authentication at all.
+
+None of it is a secret — no password is served anywhere (see the table above) — and none of it
+grants control. But "an open AP that appears for a few minutes when your WiFi drops" is a
+disclosure surface worth knowing about, and `admin_username` in particular hands out half of a
+login that has no brute-force protection. Closing that one is tracked separately.
 
 **No brute-force protection on HTTP Basic.** Rate limiting is on `/actions/*`, not on the
 auth itself.

--- a/docs/security.md
+++ b/docs/security.md
@@ -61,6 +61,13 @@ grants control. But "an open AP that appears for a few minutes when your WiFi dr
 disclosure surface worth knowing about, and `admin_username` in particular hands out half of a
 login that has no brute-force protection. Closing that one is tracked separately.
 
+**The gate has a cost of its own: authenticating over that AP puts the admin password on the
+air.** HTTP Basic is base64, not encryption, so a passive listener in radio range of the open
+setup AP can read it — and then use it on your LAN. The same is true of the normal web UI over
+plain HTTP, but the setup AP is the case where the network itself is open by design. If that
+matters to you, do the recovery with the board on a cable-fed network, or factory-reset and
+re-provision instead of authenticating over the air.
+
 **No brute-force protection on HTTP Basic.** Rate limiting is on `/actions/*`, not on the
 auth itself.
 

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -397,8 +397,21 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
     }
 
     if (JsonObjectConst driver = doc["driver"]; !driver.isNull()) {
+        const std::string previousDriverId = merged.driver.id;
         if (!patchString(driver["id"], merged.driver.id, "driver.id", error)) return false;
         if (!patchBool(driver["auto_detect"], merged.driver.autoDetect, "driver.auto_detect", error)) return false;
+        // Options are scoped to the driver that declares them: `layout` means something to one
+        // driver and nothing to the next. The merge below has no way to remove a key, so a
+        // stale option used to survive a driver change -- harmless until the REST layer began
+        // validating options against the descriptor, at which point the orphan made every
+        // subsequent PATCH fail with "unknown option for driver X" and switching drivers became
+        // impossible without a factory reset (which also wipes WiFi and the admin password).
+        // Dropping them on the transition is the narrow fix: within one driver, partial patches
+        // still merge exactly as before (regression shipped in 0.12.0, found in review
+        // 2026-07-25).
+        if (merged.driver.id != previousDriverId) {
+            merged.driver.options.clear();
+        }
         if (JsonObjectConst options = driver["options"]; !options.isNull()) {
             for (JsonPairConst kv : options) {
                 if (!kv.value().is<const char*>()) {

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -417,39 +417,60 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
             }
         }
     }
-    // Drop orphans: options the resulting driver does not declare and that this patch did not
-    // itself supply. They can only be left over from a previous driver, and because the merge
-    // has no delete they used to survive forever -- harmless until the REST layer started
-    // validating options against the descriptor, after which an orphan failed every later PATCH
-    // with "unknown option for driver X" and switching drivers became impossible short of a
-    // factory reset (regression shipped in 0.12.0).
+    // Heal driver options the resulting driver cannot accept, so that a stored value can never
+    // make the configuration permanently unsaveable. Two shapes of that:
+    //   - a key the driver does not declare at all -- an orphan from a previous driver, which
+    //     the merge has no way to delete;
+    //   - a declared key holding a value outside the driver's allowed set, which happens without
+    //     anyone editing it when a firmware update renames or drops a choice. Not theoretical:
+    //     a driver whose option values are generated from the shipped device profiles narrows
+    //     that list whenever a profile is renamed or removed.
+    // Either one makes the REST layer's validateDriverOptions refuse EVERY later PATCH, including
+    // ones that touch nothing driver-related -- the lockout this batch exists to remove, which
+    // shipped in 0.12.0 as the orphan case.
     //
-    // Runs on every patch, not only one that touches `driver`: a bridge already carrying an
-    // orphan must heal on the next save it makes, otherwise it stays locked out forever.
+    // Runs on every patch, not only one that touches `driver`: a bridge already carrying a bad
+    // value must heal on the next save it makes, otherwise it stays stuck forever.
     //
-    // Two exclusions keep this from destroying data. A key this patch supplied is never dropped,
-    // so a typo'd option is still reported by the REST layer rather than silently swallowed
-    // here. And nothing happens when the id resolves to no driver, which would otherwise orphan
-    // every option at once -- a typo'd DRIVER id must stay recoverable by correcting it, and an
-    // empty id ("let the firmware pick") carries no descriptor to judge against. An earlier
-    // attempt simply cleared the map whenever the id changed; review showed that silently wiped
-    // a working setup on a discovery-wizard click, on a typo, and on an empty id, and never
-    // repaired an already-stuck config (2026-07-25).
+    // Only values this request did NOT assert are touched. "Asserted" means the patch supplied
+    // the key AND changed it -- a caller echoing back what it just read (the obvious
+    // read-modify-write script) is asking for nothing and must not thereby pin a broken value,
+    // while a genuine new value is left alone so the REST layer reports the mistake instead of
+    // this code silently swallowing it. And nothing at all happens when the id resolves to no
+    // driver: that would orphan every option at once, and a typo'd DRIVER id has to stay
+    // recoverable by correcting it.
+    //
+    // An earlier attempt simply cleared the map whenever the id changed. Review showed that
+    // silently wiped a working setup on a discovery-wizard click, on a typo, and on an empty id,
+    // and never repaired an already-stuck config (2026-07-25).
     if (const DriverDescriptor* target = lookupDriver ? lookupDriver(merged.driver.id) : nullptr) {
-        const auto declares = [target](const std::string& key) {
-            for (const auto& o : target->options) {
-                if (o.key == key) return true;
-            }
-            return false;
-        };
         for (auto it = merged.driver.options.begin(); it != merged.driver.options.end();) {
             const bool supplied = std::find(suppliedOptionKeys.begin(), suppliedOptionKeys.end(),
                                             it->first) != suppliedOptionKeys.end();
-            if (!supplied && !declares(it->first)) {
-                it = merged.driver.options.erase(it);
-            } else {
+            const auto stored   = config.driver.options.find(it->first);
+            const bool asserted = supplied && (stored == config.driver.options.end() ||
+                                               stored->second != it->second);
+            if (asserted) {
                 ++it;
+                continue;
             }
+            const DriverOption* declared = nullptr;
+            for (const auto& o : target->options) {
+                if (o.key == it->first) {
+                    declared = &o;
+                    break;
+                }
+            }
+            if (declared == nullptr) {
+                it = merged.driver.options.erase(it);
+                continue;
+            }
+            if (!declared->allowedValues.empty() &&
+                std::find(declared->allowedValues.begin(), declared->allowedValues.end(),
+                          it->second) == declared->allowedValues.end()) {
+                it->second = declared->defaultValue;
+            }
+            ++it;
         }
     }
 

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -6,6 +6,7 @@
 
 #include <ArduinoJson.h>
 
+#include <algorithm>
 #include <cstring>
 #include <string>
 
@@ -349,7 +350,8 @@ bool configChangeRequiresReboot(const Configuration& a, const Configuration& b) 
            a.ntp.server != b.ntp.server || a.ntp.timezone != b.ntp.timezone;
 }
 
-bool applyConfigPatch(const std::string& json, Configuration& config, ConfigError& error) {
+bool applyConfigPatch(const std::string& json, Configuration& config, ConfigError& error,
+                      const DriverLookupFn& lookupDriver) {
     JsonDocument doc;
     if (deserializeJson(doc, json) != DeserializationError::Ok) {
         error = {"", "body is not valid JSON"};
@@ -359,6 +361,10 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
         error = {"", "body must be a JSON object"};
         return false;
     }
+
+    // Driver option keys this request itself supplied. Collected during the merge and consulted
+    // by the orphan cleanup below, which must never drop what the caller just asked for.
+    std::vector<std::string> suppliedOptionKeys;
 
     // Merge into a copy: validation runs on the result, so a rejected patch never leaves a
     // half-applied configuration behind.
@@ -397,21 +403,8 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
     }
 
     if (JsonObjectConst driver = doc["driver"]; !driver.isNull()) {
-        const std::string previousDriverId = merged.driver.id;
         if (!patchString(driver["id"], merged.driver.id, "driver.id", error)) return false;
         if (!patchBool(driver["auto_detect"], merged.driver.autoDetect, "driver.auto_detect", error)) return false;
-        // Options are scoped to the driver that declares them: `layout` means something to one
-        // driver and nothing to the next. The merge below has no way to remove a key, so a
-        // stale option used to survive a driver change -- harmless until the REST layer began
-        // validating options against the descriptor, at which point the orphan made every
-        // subsequent PATCH fail with "unknown option for driver X" and switching drivers became
-        // impossible without a factory reset (which also wipes WiFi and the admin password).
-        // Dropping them on the transition is the narrow fix: within one driver, partial patches
-        // still merge exactly as before (regression shipped in 0.12.0, found in review
-        // 2026-07-25).
-        if (merged.driver.id != previousDriverId) {
-            merged.driver.options.clear();
-        }
         if (JsonObjectConst options = driver["options"]; !options.isNull()) {
             for (JsonPairConst kv : options) {
                 if (!kv.value().is<const char*>()) {
@@ -420,6 +413,42 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
                     return false;
                 }
                 merged.driver.options[kv.key().c_str()] = kv.value().as<const char*>();
+                suppliedOptionKeys.emplace_back(kv.key().c_str());
+            }
+        }
+    }
+    // Drop orphans: options the resulting driver does not declare and that this patch did not
+    // itself supply. They can only be left over from a previous driver, and because the merge
+    // has no delete they used to survive forever -- harmless until the REST layer started
+    // validating options against the descriptor, after which an orphan failed every later PATCH
+    // with "unknown option for driver X" and switching drivers became impossible short of a
+    // factory reset (regression shipped in 0.12.0).
+    //
+    // Runs on every patch, not only one that touches `driver`: a bridge already carrying an
+    // orphan must heal on the next save it makes, otherwise it stays locked out forever.
+    //
+    // Two exclusions keep this from destroying data. A key this patch supplied is never dropped,
+    // so a typo'd option is still reported by the REST layer rather than silently swallowed
+    // here. And nothing happens when the id resolves to no driver, which would otherwise orphan
+    // every option at once -- a typo'd DRIVER id must stay recoverable by correcting it, and an
+    // empty id ("let the firmware pick") carries no descriptor to judge against. An earlier
+    // attempt simply cleared the map whenever the id changed; review showed that silently wiped
+    // a working setup on a discovery-wizard click, on a typo, and on an empty id, and never
+    // repaired an already-stuck config (2026-07-25).
+    if (const DriverDescriptor* target = lookupDriver ? lookupDriver(merged.driver.id) : nullptr) {
+        const auto declares = [target](const std::string& key) {
+            for (const auto& o : target->options) {
+                if (o.key == key) return true;
+            }
+            return false;
+        };
+        for (auto it = merged.driver.options.begin(); it != merged.driver.options.end();) {
+            const bool supplied = std::find(suppliedOptionKeys.begin(), suppliedOptionKeys.end(),
+                                            it->first) != suppliedOptionKeys.end();
+            if (!supplied && !declares(it->first)) {
+                it = merged.driver.options.erase(it);
+            } else {
+                ++it;
             }
         }
     }

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -158,11 +159,29 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
 /// with the RESTART_NEEDED map in the web UI.
 bool configChangeRequiresReboot(const Configuration& before, const Configuration& after);
 
+/// Resolves a driver id to its descriptor, or nullptr when the id names no compiled-in driver.
+/// The config layer has no registry of its own, so it asks; the returned pointer is only read
+/// for the option keys the driver declares.
+using DriverLookupFn = std::function<const DriverDescriptor*(const std::string& driverId)>;
+
 /// Applies a `PATCH /api/v1/config` body.
 ///
 /// Absent fields are left alone. A password field set to a string sets it; set to null clears
 /// it. Validation runs on the merged result, so a patch can never leave a half-applied
 /// configuration behind.
-bool applyConfigPatch(const std::string& json, Configuration& config, ConfigError& error);
+///
+/// `lookupDriver` is optional. When supplied, a stored driver option that the *resulting* driver
+/// does not declare and that this patch did not itself supply is dropped, because it can only be
+/// an orphan left behind by a previous driver. Options are scoped to the driver that declares
+/// them, and the merge has no other way to remove a key -- an orphan otherwise fails every later
+/// PATCH once the REST layer validates options against the descriptor, which is what made
+/// switching drivers impossible in 0.12.0.
+///
+/// Deliberately narrow: a key this patch DID supply is never dropped, so a typo'd option is
+/// still reported rather than silently swallowed, and nothing is dropped when lookupDriver
+/// returns nullptr, so a typo'd *driver* id destroys nothing and stays recoverable by correcting
+/// it.
+bool applyConfigPatch(const std::string& json, Configuration& config, ConfigError& error,
+                      const DriverLookupFn& lookupDriver = {});
 
 }  // namespace heliograph

--- a/src/drivers/growatt_modbus/growatt_driver.h
+++ b/src/drivers/growatt_modbus/growatt_driver.h
@@ -65,7 +65,10 @@ private:
     /// binary, poll()'s frame with this array on the stack plus the TRACE logging chain peaked
     /// at ~5.2 KB (64%) -- too close to a second stack-canary boot loop. The driver lives on
     /// the heap and rs485Task owns the bus exclusively, so a member is safe.
-    BlockData blocks_[kMaxBlocks];
+    /// Value-initialised on purpose: readBlock() fills only what the device actually returned,
+    /// so anything it does not reach must be a defined 0 rather than indeterminate memory that
+    /// could be decoded and published as a reading.
+    BlockData blocks_[kMaxBlocks]{};
 };
 
 }  // namespace heliograph::growatt

--- a/src/drivers/growatt_modbus/growatt_driver.h
+++ b/src/drivers/growatt_modbus/growatt_driver.h
@@ -65,9 +65,12 @@ private:
     /// binary, poll()'s frame with this array on the stack plus the TRACE logging chain peaked
     /// at ~5.2 KB (64%) -- too close to a second stack-canary boot loop. The driver lives on
     /// the heap and rs485Task owns the bus exclusively, so a member is safe.
-    /// Value-initialised on purpose: readBlock() fills only what the device actually returned,
-    /// so anything it does not reach must be a defined 0 rather than indeterminate memory that
-    /// could be decoded and published as a reading.
+    /// Value-initialised so the FIRST poll cannot decode indeterminate memory. It is only that:
+    /// from the second poll on these slots hold whatever the previous poll left, and because a
+    /// slot is claimed by index as blocks_[validCount] a skipped block can leave a neighbour's
+    /// data behind it. What actually keeps stale words out of a reading is readRegisters()
+    /// refusing a reply shorter than requested, plus applyProfile() only walking [0, validCount).
+    /// This initialiser is a floor under the first poll, not the guarantee.
     BlockData blocks_[kMaxBlocks]{};
 };
 

--- a/src/network/provisioning_policy.h
+++ b/src/network/provisioning_policy.h
@@ -2,10 +2,12 @@
 //
 // When to start the setup portal, and when to stop trying.
 //
-// Pure policy, no WiFi calls, so the state machine is host-tested. This board has no
-// confirmed reset button (the BOOT GPIO could not be established from the schematic -- see
-// docs/hardware.md), which makes this logic the ONLY way out of a bad WiFi configuration
-// short of reflashing. It had better be right.
+// Pure policy, no WiFi calls, so the state machine is host-tested. It is also the only way out
+// of a bad WiFi configuration that does not destroy the rest of the settings: the BOOT-hold
+// factory reset exists on every board (see docs/hardware.md) but wipes everything, and on the
+// RS485-CAN it gives no LED or buzzer feedback while it counts down. So this logic had better
+// be right -- it is what turns "the router changed" into a recoverable afternoon rather than a
+// re-provisioning from scratch.
 
 #pragma once
 

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -194,8 +194,12 @@ bool RestApi::begin() {
     // seconds and briefly takes the radio off-channel -- fine for a deliberate button press.
     g_server->on("/api/v1/wifi/scan", HTTP_GET,
                  [this, authorised](AsyncWebServerRequest* request) {
-        const bool portal = context_.portalActive && context_.portalActive();
-        if (!portal && !authorised(request)) {
+        // Same gate as /provision, and for the same reason: the portal also returns on an
+        // already-configured device after repeated WiFi failures, so "the portal is up" does
+        // not imply "there is nothing to protect". Open only while no password exists yet.
+        const bool portal   = context_.portalActive && context_.portalActive();
+        const bool unsealed = context_.config->security.adminPassword.empty();
+        if (!(portal && unsealed) && !authorised(request)) {
             return;  // authorised() answered with 401
         }
         request->send(200, kJson, context_.scanNetworks().c_str());
@@ -203,7 +207,7 @@ bool RestApi::begin() {
 
     g_server->on(
         "/api/v1/provision", HTTP_POST,
-        [this](AsyncWebServerRequest* request) {
+        [this, authorised](AsyncWebServerRequest* request) {
             // The request handler forms the response; the body handler only collects. If the
             // body never completed, nothing was queued and this is a genuinely empty POST.
             if (bodyOwner_ != request) {
@@ -214,6 +218,21 @@ bool RestApi::begin() {
                 releaseBody();
                 sendError(request, {403, "portal_only", "only available during setup"});
                 return;
+            }
+            // Skipping auth here is safe only while there is nothing to protect. The portal is
+            // NOT exclusive to first boot: WifiManager raises it again on an already-provisioned
+            // device after ProvisioningPolicy::failuresBeforePortal failed attempts, which a
+            // router reboot reaches in about two minutes -- and that AP is open (softAP with no
+            // password). Gated on portalActive() alone, anyone in radio range could then POST a
+            // full config patch over a configured bridge: admin password, broker, relays.enabled,
+            // read_only_mode. On a relay board that is remote control of the DRM contacts.
+            //
+            // So the gate is "does a credential exist yet", not "is the portal up". On first boot
+            // the password is empty and setup proceeds unauthenticated as before; afterwards the
+            // user knows the password they set (review, 2026-07-25).
+            if (!context_.config->security.adminPassword.empty() && !authorised(request)) {
+                releaseBody();
+                return;  // authorised() stored the 401
             }
 
             Configuration updated = *context_.config;
@@ -635,9 +654,19 @@ bool RestApi::begin() {
     // that a definitive error response was already stored.
     g_server->on(
         "/api/v1/ota", HTTP_POST,
-        [this](AsyncWebServerRequest* request) {
+        [this, authorised](AsyncWebServerRequest* request) {
             if (request->_tempObject != nullptr) {
                 return;  // the upload callback already stored the specific error response
+            }
+            // Gated here as well as in the upload callback, because the two run on different
+            // conditions. handleUpload is reached ONLY from the multipart parser (verified in
+            // ESPAsyncWebServer 3.11.2: WebRequest.cpp guards it behind _isMultipart), so a POST
+            // with an empty or non-multipart body never runs the upload callback -- and therefore
+            // never ran authorised() -- yet still lands here. Unguarded, that let anyone on the
+            // LAN call end() on an admin's in-flight image: a failed verify destroys the update,
+            // and a complete one flips the boot partition and reboots (review, 2026-07-25).
+            if (!authorised(request)) {
+                return;  // authorised() stored the 401
             }
             const auto result = g_ota.end();
             if (result != ota::OtaResult::Ok) {

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -484,12 +484,18 @@ bool RestApi::begin() {
                                             optionError.message});
                     return;
                 }
-            } else if (!updated.driver.id.empty()) {
-                // An id naming no compiled-in driver is refused rather than stored. Storing it
-                // left the bridge pointed at nothing until someone noticed, and it also blinded
-                // the orphan cleanup above (which cannot judge options for a driver it cannot
-                // resolve), so a single typo used to be a quiet dead end. Empty stays legal --
-                // it means "let the firmware pick the highest-priority driver".
+            } else if (!updated.driver.id.empty() && updated.driver.id != before.driver.id) {
+                // An id naming no compiled-in driver is refused rather than stored: it leaves the
+                // bridge pointed at nothing, and it blinds the orphan cleanup above, which cannot
+                // judge options for a driver it cannot resolve. Empty stays legal -- it means
+                // "let the firmware pick the highest-priority driver".
+                //
+                // Only when THIS patch changes it. A stored id can become unresolvable without
+                // anyone touching it -- flashing a build that compiles that driver out is enough,
+                // which the mock env does to every real driver -- and refusing on the stored value
+                // would make every unrelated setting unsaveable, recoverable only by a factory
+                // reset. That is the same lockout this batch exists to remove; found reviewing
+                // my own fix (2026-07-25).
                 sendError(request, {400, "invalid_config",
                                     "driver.id: unknown driver '" + updated.driver.id + "'"});
                 return;

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -451,7 +451,12 @@ bool RestApi::begin() {
             const Configuration before  = *context_.config;
             Configuration       updated = before;
             ConfigError         error;
-            const bool          parsed  = applyConfigPatch(bodyBuffer_, updated, error);
+            // The lookup lets the config layer drop options orphaned by a previous driver
+            // without itself knowing what a driver is; see applyConfigPatch's contract.
+            const auto lookupDriver = [this](const std::string& id) -> const DriverDescriptor* {
+                return context_.registry != nullptr ? context_.registry->find(id) : nullptr;
+            };
+            const bool parsed = applyConfigPatch(bodyBuffer_, updated, error, lookupDriver);
             releaseBody();
             if (!parsed) {
                 sendError(request, {400, "invalid_config",
@@ -471,7 +476,7 @@ bool RestApi::begin() {
             // Only the PATCH path is gated. A config already in flash is deliberately still
             // loaded with the warn-and-fall-back behaviour: refusing it at boot would turn a
             // bad option into an unbootable bridge.
-            if (const DriverDescriptor* d = context_.registry->find(updated.driver.id)) {
+            if (const DriverDescriptor* d = lookupDriver(updated.driver.id)) {
                 DriverOptionError optionError;
                 if (!validateDriverOptions(*d, updated.driver.options, optionError)) {
                     sendError(request, {400, "invalid_config",
@@ -479,6 +484,15 @@ bool RestApi::begin() {
                                             optionError.message});
                     return;
                 }
+            } else if (!updated.driver.id.empty()) {
+                // An id naming no compiled-in driver is refused rather than stored. Storing it
+                // left the bridge pointed at nothing until someone noticed, and it also blinded
+                // the orphan cleanup above (which cannot judge options for a driver it cannot
+                // resolve), so a single typo used to be a quiet dead end. Empty stays legal --
+                // it means "let the firmware pick the highest-priority driver".
+                sendError(request, {400, "invalid_config",
+                                    "driver.id: unknown driver '" + updated.driver.id + "'"});
+                return;
             }
 
             if (!context_.saveConfig(updated)) {

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -63,7 +63,8 @@ struct RestContext {
     /// Current discovery report, for the wizard to poll.
     std::function<DiscoveryReport()> discoveryReport;
     /// Wipes stored configuration including credentials, then reboots into the setup portal.
-    /// With no reset button on this board, this is a user's main way back from a bad config.
+    /// The same wipe the BOOT-hold performs, reached over the network instead of the button --
+    /// which is what a user without physical access has when a config locks them out.
     std::function<bool()> requestFactoryReset;
     /// True while the setup portal is up: the API then serves the setup page and /provision.
     std::function<bool()> portalActive;

--- a/src/protocols/modbus/modbus_client.cpp
+++ b/src/protocols/modbus/modbus_client.cpp
@@ -41,6 +41,19 @@ ReadOutcome readRegisters(Transport& transport, uint8_t unitId, uint8_t function
         ReadResponse resp;
         switch (parseReadResponse(rx, have, unitId, functionCode, out, count, resp)) {
             case ParseResult::Ok:
+                // A reply that decodes cleanly but carries FEWER registers than were asked for
+                // is not success. The codec only checks the byte count against the caller's
+                // buffer capacity, so a short frame leaves the tail of `out` untouched -- while
+                // callers record the block as covering the full count they requested. Whatever
+                // that tail happens to hold is then decoded and published as genuine readings
+                // on a poll reporting Ok: uninitialised scratch in one driver, zeros in another
+                // (and a zero scale factor is legal, so zeros read as a real 0 W). Either way
+                // it defeats the never-fabricate-a-reading rule one layer below where that rule
+                // is enforced (review, 2026-07-25).
+                if (resp.registerCount != count) {
+                    outcome.status = ReadStatus::Protocol;
+                    return outcome;
+                }
                 outcome.status = ReadStatus::Ok;
                 return outcome;
             case ParseResult::Exception:

--- a/src/protocols/modbus/modbus_rtu.cpp
+++ b/src/protocols/modbus/modbus_rtu.cpp
@@ -148,7 +148,10 @@ ParseResult parseReadResponse(const uint8_t* buf, size_t len, uint8_t expectedUn
     if (buf[1] != expectedFunction) {
         return ParseResult::WrongFunction;
     }
-    // Byte count must be even (whole registers) and match the caller's buffer.
+    // Byte count must be even (whole registers) and fit the caller's buffer. This is a
+    // CAPACITY check only -- the codec is not told how many registers were requested, so a
+    // reply carrying fewer than that still parses as Ok with a smaller registerCount. Callers
+    // must compare registerCount against what they asked for; readRegisters() does.
     if ((byteCount & 1) != 0) {
         return ParseResult::Malformed;
     }

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -149,7 +149,11 @@ async function askAuth(){
     p.value='';d.returnValue='';
     d.onclose=()=>{
       const ok=d.returnValue==='ok'&&p.value!=='';
-      if(ok)sessionStorage.setItem('sb_auth',btoa(u+':'+p.value));
+      // UTF-8, not btoa()'s default. btoa() only throws above U+00FF, so it would silently emit
+      // Latin-1 for é/ë/ü/ö/ç -- and the firmware compares against the UTF-8 bytes it stored,
+      // so such a password could never authenticate here (review, 2026-07-25).
+      if(ok)sessionStorage.setItem('sb_auth',
+        btoa(String.fromCharCode(...new TextEncoder().encode(u+':'+p.value))));
       p.value='';
       resolve(ok);
     };

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -629,7 +629,16 @@ async function renderConfig(){
     fallback is used when the network offers none.</div></div>
   <div class="card"><b>Driver</b> <span class="tag" style="font-weight:400">needs restart</span>
     <label for="c_drv">Active driver</label>
-    <select id="c_drv" onchange="reloadDriverOpts()">${(cfgDrivers.drivers||[]).map(d=>
+    <select id="c_drv" onchange="reloadDriverOpts()">${
+      // A stored id that matches no option selects nothing, so the browser silently shows the
+      // first driver -- and the save path then diffs that against the stored value, sees a
+      // change and PATCHes it. The DEFAULT state hits this: a freshly provisioned bridge stores
+      // "" meaning "let the firmware pick the highest-priority driver", so saving any unrelated
+      // setting would quietly pin the driver to whichever one happens to sort first. Same class
+      // as the driver-option select below; fixed here too (review, 2026-07-25).
+      (((cfgDrivers.drivers||[]).some(d=>d.id===c.driver.id))?'':
+        `<option value="${esc(c.driver.id)}" selected>${c.driver.id?esc(c.driver.id)+' — not recognised':'(firmware picks automatically)'}</option>`)+
+      (cfgDrivers.drivers||[]).map(d=>
       `<option value="${esc(d.id)}" ${d.id===c.driver.id?'selected':''}>${esc(d.display_name)} (${esc(d.support_level)})</option>`).join('')}</select>
     ${driverOpts}
   </div>

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -48,6 +48,8 @@ button:disabled{opacity:.5;cursor:default}
 
   <label for="pw">WiFi password</label>
   <input id="pw" type="password" autocomplete="new-password">
+  <div class="hint" id="pwhint" style="display:none">Leave empty to keep the password already
+  stored for this network.</div>
 
   <label for="admin">Admin password</label>
   <input id="admin" type="password" autocomplete="new-password">
@@ -87,12 +89,14 @@ const msg=(t,ok)=>{const m=$('m');m.textContent=t;m.className='msg '+(ok?'ok':'e
 // enough), a password already exists, and provisioning demands it -- so the form authenticates
 // and changes only the network. Detected up front rather than on a failed submit, because a 401
 // from requestAuthentication() has an empty body and the old code parsed it as JSON.
-let reauth=false, adminUser='admin';
+let reauth=false, adminUser='admin', modeKnown=false;
 const setupReady=fetch('/api/v1/config').then(r=>r.json()).then(c=>{
   const sec=(c&&c.security)||{};
   adminUser=sec.admin_username||'admin';
   reauth=!!sec.password_set;
+  modeKnown=true;
   if(reauth){
+    $('pwhint').style.display='block';
     $('reauth').style.display='block';
     // The existing password stays as it is; this flow only moves the bridge to a new network.
     for(const id of ['admin','admin2']){const el=$(id);el.style.display='none';
@@ -101,7 +105,13 @@ const setupReady=fetch('/api/v1/config').then(r=>r.json()).then(c=>{
         el.nextElementSibling.style.display='none';}
     $('b').textContent='Save network and restart';
   }
-}).catch(()=>{});
+}).catch(()=>{
+  // Which mode we are in decides whether the form must carry a new admin password or an
+  // existing one. Guessing wrong means submitting a body the firmware refuses and then blaming
+  // the user's password for it, so the form stays shut until this is actually known.
+  msg('Could not read this bridge’s state. Reload the page to try again.');
+  $('b').disabled=true;
+});
 
 fetch('/api/v1/wifi/scan').then(r=>r.json()).then(d=>{
   const s=$('ssid');s.innerHTML='';
@@ -129,41 +139,65 @@ $('ssid').onchange=e=>{
 
 $('f').onsubmit=async e=>{
   e.preventDefault();
-  await setupReady;   // which mode we are in decides what the form must contain
+  // Disabled first, before any await: two quick taps while the mode lookup is still in flight
+  // would otherwise fire two provisions.
+  $('b').disabled=true;
+  // Which mode we are in decides what the form must contain. Bounded, because a web task busy
+  // with a WiFi scan can leave this pending for seconds and a dead-looking button with no
+  // message is worse than an honest one.
+  await Promise.race([setupReady, new Promise(r=>setTimeout(r,3000))]);
+  if(!modeKnown){
+    $('b').disabled=false;
+    msg('Could not read this bridge’s state. Reload the page to try again.');
+    return;
+  }
+  // Every rejection has to hand the button back, or the form is dead until a reload.
+  const refuse=t=>{$('b').disabled=false;msg(t)};
   const ssid=$('ssid').value==='__other__'?$('ssid2').value.trim():$('ssid').value;
-  if(!ssid){msg('Pick or type a network name.');return}
+  if(!ssid){refuse('Pick or type a network name.');return}
   if(reauth){
-    if(!$('cur').value){msg('Enter the admin password for this bridge.');return}
+    if(!$('cur').value){refuse('Enter the admin password for this bridge.');return}
   }else{
-    if(!$('admin').value){msg('An admin password is required.');return}
+    if(!$('admin').value){refuse('An admin password is required.');return}
     // A typo'd admin password costs a factory reset, so it is the one field worth the
     // friction of typing twice.
-    if($('admin').value!==$('admin2').value){msg('The admin passwords do not match.');return}
+    if($('admin').value!==$('admin2').value){refuse('The admin passwords do not match.');return}
   }
-  $('b').disabled=true;msg('Saving…',true);
+  msg('Saving…',true);
   try{
     const headers={'Content-Type':'application/json'};
-    const body={wifi:{ssid,password:$('pw').value}};
+    const body={wifi:{ssid}};
+    // An absent password leaves the stored one alone; an empty string SETS it to empty. In
+    // reconfigure mode the field starts blank while a password is already stored, so sending it
+    // unconditionally wiped the credential of anyone reconnecting to the same network -- after
+    // which the bridge could never join anything again and sat in the portal forever. On first
+    // boot there is nothing to preserve, so an open network still sends the empty value.
+    if(!reauth||$('pw').value!=='')body.wifi.password=$('pw').value;
     if(reauth){
       // Basic auth by hand: fetch() will not surface the browser's credential dialog reliably,
       // least of all in the captive-portal mini-browser this page is usually opened in.
-      // btoa() only handles Latin-1, so a password with other characters is encoded first.
+      //
+      // Always UTF-8. btoa() takes a string of code units and only throws above U+00FF, so a
+      // plain btoa() silently emits LATIN-1 for exactly the range that matters here -- é, ë, ü,
+      // ö, ç. The firmware compares against the bytes it stored from the setup POST, which are
+      // UTF-8, so those passwords would never match and the owner would be locked out of their
+      // own recovery with "password not accepted" (review, 2026-07-25).
       const raw=adminUser+':'+$('cur').value;
-      let enc;try{enc=btoa(raw)}catch(_){enc=btoa(unescape(encodeURIComponent(raw)))}
-      headers['Authorization']='Basic '+enc;
+      headers['Authorization']='Basic '+btoa(String.fromCharCode(...new TextEncoder().encode(raw)));
     }else{
       body.security={admin_password:$('admin').value};
     }
     const r=await fetch('/api/v1/provision',{method:'POST',headers,body:JSON.stringify(body)});
     if(r.status===401){
-      $('b').disabled=false;
-      msg('That admin password was not accepted. Forgotten it? Hold BOOT for ~5 seconds while '+
-          'the board is running to factory-reset it.');
+      refuse('That admin password was not accepted. Forgotten it? Hold BOOT for ~5 seconds '+
+             'while the board is running to factory-reset it.');
       return;
     }
-    // Only parse once a 401 is ruled out: requestAuthentication() answers with an empty body,
-    // and json() on that throws "Unexpected end of JSON input" instead of anything useful.
-    const d=await r.json();
+    // Tolerate a missing or non-JSON body on ANY status, not just 401. requestAuthentication()
+    // answers empty, and a captive-portal interceptor or a truncated response can do the same
+    // on other codes -- json() then throws "Unexpected end of JSON input", which is exactly the
+    // useless message this rewrite set out to remove rather than relocate.
+    const d=await r.json().catch(()=>({}));
     if(!r.ok)throw new Error(d.error?d.error.message:('HTTP '+r.status));
     // The concrete next step, not "find it via your router": this AP is about to vanish
     // and the user needs an address to type on the network they are returning to.

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -55,8 +55,19 @@ button:disabled{opacity:.5;cursor:default}
 
   <label for="admin2">Admin password (again)</label>
   <input id="admin2" type="password" autocomplete="new-password">
-  <div class="hint">The board has no reset button — a typo here means recovery over USB.
-  Type it twice.</div>
+  <div class="hint">Type it twice — a typo here means holding BOOT for 5 seconds to factory-reset,
+  or re-flashing over USB.</div>
+
+  <!-- Shown only when this bridge already has an admin password, i.e. the setup network came
+       back after a WiFi outage rather than on first boot. Then the new-password fields above are
+       hidden and this one authenticates the change instead. -->
+  <div id="reauth" style="display:none">
+    <label for="cur">Admin password</label>
+    <input id="cur" type="password" autocomplete="current-password">
+    <div class="hint">This bridge is already set up, so changing its network needs the admin
+    password you chose. Forgotten it? Hold <b>BOOT</b> for ~5 seconds while the board is running
+    to erase the configuration and start over.</div>
+  </div>
 
   <button id="b" type="submit">Save and restart</button>
   <div id="m" class="msg"></div>
@@ -71,6 +82,27 @@ button:disabled{opacity:.5;cursor:default}
 const $=s=>document.getElementById(s);
 const msg=(t,ok)=>{const m=$('m');m.textContent=t;m.className='msg '+(ok?'ok':'err')};
 
+// Two modes. First boot: no admin password exists, provisioning is open, and the form sets one.
+// Reconfigure: this setup network came back because the bridge lost WiFi (a router reboot is
+// enough), a password already exists, and provisioning demands it -- so the form authenticates
+// and changes only the network. Detected up front rather than on a failed submit, because a 401
+// from requestAuthentication() has an empty body and the old code parsed it as JSON.
+let reauth=false, adminUser='admin';
+const setupReady=fetch('/api/v1/config').then(r=>r.json()).then(c=>{
+  const sec=(c&&c.security)||{};
+  adminUser=sec.admin_username||'admin';
+  reauth=!!sec.password_set;
+  if(reauth){
+    $('reauth').style.display='block';
+    // The existing password stays as it is; this flow only moves the bridge to a new network.
+    for(const id of ['admin','admin2']){const el=$(id);el.style.display='none';
+      const lab=document.querySelector('label[for="'+id+'"]');if(lab)lab.style.display='none';
+      if(el.nextElementSibling&&el.nextElementSibling.className==='hint')
+        el.nextElementSibling.style.display='none';}
+    $('b').textContent='Save network and restart';
+  }
+}).catch(()=>{});
+
 fetch('/api/v1/wifi/scan').then(r=>r.json()).then(d=>{
   const s=$('ssid');s.innerHTML='';
   // Strongest first: the network the user wants is almost always the loudest one.
@@ -82,8 +114,11 @@ fetch('/api/v1/wifi/scan').then(r=>r.json()).then(d=>{
   const o=document.createElement('option');o.value='__other__';o.textContent='Other…';
   s.appendChild(o);
 }).catch(()=>{
-  // A failed scan must not block setup: the field falls back to free text.
+  // A failed scan must not block setup: the field falls back to free text, and the text box is
+  // revealed straight away rather than hidden behind discovering the "Other…" entry. This is the
+  // normal path in reconfigure mode, where the scan is admin-gated like provisioning itself.
   $('ssid').innerHTML='<option value="__other__">Other…</option>';
+  $('ssid2').style.display='block';$('ssid2l').style.display='block';
 });
 
 $('ssid').onchange=e=>{
@@ -94,17 +129,40 @@ $('ssid').onchange=e=>{
 
 $('f').onsubmit=async e=>{
   e.preventDefault();
+  await setupReady;   // which mode we are in decides what the form must contain
   const ssid=$('ssid').value==='__other__'?$('ssid2').value.trim():$('ssid').value;
   if(!ssid){msg('Pick or type a network name.');return}
-  if(!$('admin').value){msg('An admin password is required.');return}
-  // A typo'd admin password can only be recovered over USB (no reset button), so it is
-  // the one field worth the friction of typing twice.
-  if($('admin').value!==$('admin2').value){msg('The admin passwords do not match.');return}
+  if(reauth){
+    if(!$('cur').value){msg('Enter the admin password for this bridge.');return}
+  }else{
+    if(!$('admin').value){msg('An admin password is required.');return}
+    // A typo'd admin password costs a factory reset, so it is the one field worth the
+    // friction of typing twice.
+    if($('admin').value!==$('admin2').value){msg('The admin passwords do not match.');return}
+  }
   $('b').disabled=true;msg('Saving…',true);
   try{
-    const r=await fetch('/api/v1/provision',{method:'POST',headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({wifi:{ssid,password:$('pw').value},
-                           security:{admin_password:$('admin').value}})});
+    const headers={'Content-Type':'application/json'};
+    const body={wifi:{ssid,password:$('pw').value}};
+    if(reauth){
+      // Basic auth by hand: fetch() will not surface the browser's credential dialog reliably,
+      // least of all in the captive-portal mini-browser this page is usually opened in.
+      // btoa() only handles Latin-1, so a password with other characters is encoded first.
+      const raw=adminUser+':'+$('cur').value;
+      let enc;try{enc=btoa(raw)}catch(_){enc=btoa(unescape(encodeURIComponent(raw)))}
+      headers['Authorization']='Basic '+enc;
+    }else{
+      body.security={admin_password:$('admin').value};
+    }
+    const r=await fetch('/api/v1/provision',{method:'POST',headers,body:JSON.stringify(body)});
+    if(r.status===401){
+      $('b').disabled=false;
+      msg('That admin password was not accepted. Forgotten it? Hold BOOT for ~5 seconds while '+
+          'the board is running to factory-reset it.');
+      return;
+    }
+    // Only parse once a 401 is ruled out: requestAuthentication() answers with an empty body,
+    // and json() on that throws "Unexpected end of JSON input" instead of anything useful.
     const d=await r.json();
     if(!r.ok)throw new Error(d.error?d.error.message:('HTTP '+r.status));
     // The concrete next step, not "find it via your router": this AP is about to vanish

--- a/test/test_modbus_client/test_main.cpp
+++ b/test/test_modbus_client/test_main.cpp
@@ -145,6 +145,38 @@ static void test_a_request_larger_than_the_buffer_is_refused_before_the_bus() {
     TEST_ASSERT_TRUE(t.writes.empty());  // nothing was ever put on the bus
 }
 
+// A CRC-valid reply that simply carries FEWER registers than were asked for is not success.
+// The codec only bounds the byte count against the caller's capacity, so a short frame leaves
+// the tail of the buffer untouched -- while the driver's block descriptor already claims the
+// full count. Growatt's scratch is a member array (indeterminate on the first poll before it
+// was value-initialised) and SunSpec zero-fills, where a zero scale factor is legal; either
+// way the untouched tail would be decoded and published as genuine readings on a poll that
+// reports Ok. Found in review 2026-07-25.
+static void test_a_reply_with_too_few_registers_is_refused() {
+    MockTransport t;
+    t.replyWith(goodReply(kUnit, kReadHoldingRegisters, {0x1111, 0x2222}));  // 2, not 4
+
+    uint16_t   regs[4] = {0xDEAD, 0xDEAD, 0xDEAD, 0xDEAD};
+    const auto r = readRegisters(t, kUnit, kReadHoldingRegisters, kFrom, 4, regs, 4);
+
+    TEST_ASSERT_EQUAL(ReadStatus::Protocol, r.status);
+    // Whatever the caller had there stays there, and the caller is told not to trust it.
+    TEST_ASSERT_EQUAL_UINT16(0xDEAD, regs[2]);
+    TEST_ASSERT_EQUAL_UINT16(0xDEAD, regs[3]);
+}
+
+// The exact-length reply must still be Ok -- the guard above must not cost a legitimate read.
+static void test_a_reply_with_exactly_the_requested_count_is_ok() {
+    MockTransport t;
+    t.replyWith(goodReply(kUnit, kReadInputRegisters, {1, 2, 3, 4}));
+
+    uint16_t   regs[4] = {};
+    const auto r = readRegisters(t, kUnit, kReadInputRegisters, kFrom, 4, regs, 4);
+
+    TEST_ASSERT_EQUAL(ReadStatus::Ok, r.status);
+    TEST_ASSERT_EQUAL_UINT16(4, regs[3]);
+}
+
 static void test_a_zero_length_read_is_refused() {
     MockTransport t;
     uint16_t      regs[1] = {};
@@ -163,6 +195,8 @@ int main(int, char**) {
     RUN_TEST(test_a_reply_from_another_unit_is_refused);
     RUN_TEST(test_an_endless_trickle_still_hits_the_deadline);
     RUN_TEST(test_a_request_larger_than_the_buffer_is_refused_before_the_bus);
+    RUN_TEST(test_a_reply_with_too_few_registers_is_refused);
+    RUN_TEST(test_a_reply_with_exactly_the_requested_count_is_ok);
     RUN_TEST(test_a_zero_length_read_is_refused);
     return UNITY_END();
 }

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -303,8 +303,12 @@ static void test_driver_options_are_opaque_to_the_config_model() {
 static const DriverDescriptor* fakeLookup(const std::string& id) {
     static const DriverDescriptor alpha = [] {
         DriverDescriptor d;
-        d.id      = "alpha";
-        d.options = {DriverOption{"layout", "Layout", "", "", {}}};
+        d.id = "alpha";
+        // Two options, one of them an enum with a default: a single-option driver could not tell
+        // "keeps the others" from "replaces the map", and the enum is what the value-healing
+        // rule below is judged against.
+        d.options = {DriverOption{"layout", "Layout", "", "auto", {"auto", "single", "dual"}},
+                     DriverOption{"note", "Note", "", "", {}}};
         return d;
     }();
     static const DriverDescriptor beta = [] {
@@ -381,6 +385,49 @@ static void test_a_typo_d_driver_id_destroys_no_options() {
     TEST_ASSERT_EQUAL_STRING("dual", c.driver.options["layout"].c_str());
 }
 
+// A declared key can hold a value the driver no longer accepts without anyone editing it -- a
+// firmware update that renames or drops a choice is enough, and the growatt `profile` option
+// takes its allowed values from the generated profile list. validateDriverOptions then refuses
+// every later PATCH, including ones touching nothing driver-related: the same lockout as an
+// orphan, so it heals the same way, back to the declared default.
+static void test_a_value_the_driver_no_longer_accepts_is_healed_to_the_default() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id                = "alpha";
+    c.driver.options["layout"] = "triple";  // no longer in allowedValues
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"bridge_name":"iets anders"})", c, e, fakeLookup));
+    TEST_ASSERT_EQUAL_STRING("auto", c.driver.options["layout"].c_str());
+}
+
+// A value this patch genuinely asserts is left alone, so the REST layer reports the mistake
+// rather than this code silently correcting it.
+static void test_a_bad_value_supplied_by_the_patch_is_left_for_the_validator() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id = "alpha";
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"options":{"layout":"triple"}}})", c, e,
+                                      fakeLookup));
+    TEST_ASSERT_EQUAL_STRING("triple", c.driver.options["layout"].c_str());
+}
+
+// Echoing back what was just read is the obvious read-modify-write script, and it asserts
+// nothing. Treating it as an assertion would let a broken stored value pin itself forever.
+static void test_echoing_a_stored_bad_value_still_heals() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id                = "alpha";
+    c.driver.options["layout"] = "triple";
+    c.driver.options["stale"]  = "x";  // orphan, echoed back too
+
+    TEST_ASSERT_TRUE(applyConfigPatch(
+        R"({"driver":{"options":{"layout":"triple","stale":"x"}}})", c, e, fakeLookup));
+
+    TEST_ASSERT_EQUAL_STRING("auto", c.driver.options["layout"].c_str());
+    TEST_ASSERT_TRUE(c.driver.options.find("stale") == c.driver.options.end());
+}
+
 // An empty id means "let the firmware pick", so there is no descriptor to judge against and
 // nothing may be dropped.
 static void test_an_empty_driver_id_keeps_the_options() {
@@ -400,10 +447,12 @@ static void test_patching_one_option_keeps_the_others_on_the_same_driver() {
     ConfigError   e;
     c.driver.id                = "alpha";
     c.driver.options["layout"] = "dual";
+    c.driver.options["note"]   = "keep me";
 
     TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"options":{"layout":"single"}}})", c, e,
                                       fakeLookup));
     TEST_ASSERT_EQUAL_STRING("single", c.driver.options["layout"].c_str());
+    TEST_ASSERT_EQUAL_STRING("keep me", c.driver.options["note"].c_str());
 
     // Without a lookup nothing is ever dropped -- the pre-existing behaviour is untouched.
     Configuration d;
@@ -994,6 +1043,9 @@ int main(int, char**) {
     RUN_TEST(test_an_option_orphaned_by_a_driver_change_is_dropped);
     RUN_TEST(test_an_existing_orphan_is_dropped_even_without_a_driver_change);
     RUN_TEST(test_an_unknown_option_supplied_by_the_patch_survives_to_be_reported);
+    RUN_TEST(test_a_value_the_driver_no_longer_accepts_is_healed_to_the_default);
+    RUN_TEST(test_a_bad_value_supplied_by_the_patch_is_left_for_the_validator);
+    RUN_TEST(test_echoing_a_stored_bad_value_still_heals);
     RUN_TEST(test_a_typo_d_driver_id_destroys_no_options);
     RUN_TEST(test_an_empty_driver_id_keeps_the_options);
     RUN_TEST(test_patching_one_option_keeps_the_others_on_the_same_driver);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -297,44 +297,121 @@ static void test_driver_options_are_opaque_to_the_config_model() {
     TEST_ASSERT_EQUAL_STRING("dual", parse(json)["driver"]["options"]["layout"]);
 }
 
-// Options belong to the driver that declares them, so switching drivers must not carry them
-// over. The merge has no delete, so a stale key used to survive forever -- and once the REST
-// layer started validating options against the descriptor (0.12.0), that orphan failed every
-// later PATCH with "unknown option" and made switching drivers impossible short of a factory
-// reset. Regression found in review 2026-07-25.
-static void test_changing_the_driver_drops_the_previous_driver_s_options() {
+// A stand-in registry: driver "alpha" declares {layout}, "beta" declares {address}. Returning
+// nullptr for anything else models a typo'd driver id, which is the case the orphan cleanup
+// must refuse to act on.
+static const DriverDescriptor* fakeLookup(const std::string& id) {
+    static const DriverDescriptor alpha = [] {
+        DriverDescriptor d;
+        d.id      = "alpha";
+        d.options = {DriverOption{"layout", "Layout", "", "", {}}};
+        return d;
+    }();
+    static const DriverDescriptor beta = [] {
+        DriverDescriptor d;
+        d.id      = "beta";
+        d.options = {DriverOption{"address", "Address", "", "", {}}};
+        return d;
+    }();
+    if (id == "alpha") return &alpha;
+    if (id == "beta") return &beta;
+    return nullptr;
+}
+
+// Options are scoped to the driver that declares them, and the merge has no delete, so an
+// option left by a previous driver used to survive forever. Harmless until the REST layer
+// started validating options against the descriptor (0.12.0), after which the orphan failed
+// every later PATCH with "unknown option" and switching drivers became impossible short of a
+// factory reset. Regression found in review 2026-07-25.
+static void test_an_option_orphaned_by_a_driver_change_is_dropped() {
     Configuration c;
     ConfigError   e;
-    c.driver.id                = "eversolar_legacy";
+    c.driver.id                = "alpha";
     c.driver.options["layout"] = "dual";
 
     TEST_ASSERT_TRUE(applyConfigPatch(
-        R"({"driver":{"id":"solax_x1","options":{"address":"10"}}})", c, e));
+        R"({"driver":{"id":"beta","options":{"address":"10"}}})", c, e, fakeLookup));
 
-    TEST_ASSERT_EQUAL_STRING("solax_x1", c.driver.id.c_str());
+    TEST_ASSERT_EQUAL_STRING("beta", c.driver.id.c_str());
     TEST_ASSERT_EQUAL_STRING("10", c.driver.options["address"].c_str());
-    // The orphan is gone -- this is what unblocks validateDriverOptions on the new driver.
     TEST_ASSERT_TRUE(c.driver.options.find("layout") == c.driver.options.end());
-    TEST_ASSERT_EQUAL_UINT32(1, c.driver.options.size());
 }
 
-// The flip side: within one driver a partial patch must still MERGE, or setting one option
-// would silently erase the others.
+// An already-stuck config must heal on any patch, not only on a driver change -- otherwise
+// every bridge orphaned by 0.12.0 stays locked out.
+static void test_an_existing_orphan_is_dropped_even_without_a_driver_change() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id                 = "beta";
+    c.driver.options["address"] = "10";
+    c.driver.options["layout"]  = "dual";  // orphan from a previous driver
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"bridge_name":"iets anders"})", c, e, fakeLookup));
+
+    TEST_ASSERT_EQUAL_STRING("10", c.driver.options["address"].c_str());
+    TEST_ASSERT_TRUE(c.driver.options.find("layout") == c.driver.options.end());
+}
+
+// A key THIS patch supplied is never dropped, even when the driver does not declare it: a
+// typo'd option must be reported by validateDriverOptions, not silently swallowed here.
+static void test_an_unknown_option_supplied_by_the_patch_survives_to_be_reported() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id = "beta";
+
+    TEST_ASSERT_TRUE(applyConfigPatch(
+        R"({"driver":{"options":{"addres":"10"}}})", c, e, fakeLookup));  // typo
+    TEST_ASSERT_EQUAL_STRING("10", c.driver.options["addres"].c_str());
+}
+
+// Nothing is dropped for a driver id that resolves to nothing. A typo'd DRIVER id would
+// otherwise orphan every option at once and make the mistake unrecoverable; correcting the id
+// must bring the configuration back.
+static void test_a_typo_d_driver_id_destroys_no_options() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id                = "alpha";
+    c.driver.options["layout"] = "dual";
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"id":"alfa"}})", c, e, fakeLookup));
+    TEST_ASSERT_EQUAL_STRING("dual", c.driver.options["layout"].c_str());
+
+    // ...and correcting it restores a working configuration.
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"id":"alpha"}})", c, e, fakeLookup));
+    TEST_ASSERT_EQUAL_STRING("dual", c.driver.options["layout"].c_str());
+}
+
+// An empty id means "let the firmware pick", so there is no descriptor to judge against and
+// nothing may be dropped.
+static void test_an_empty_driver_id_keeps_the_options() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id                = "alpha";
+    c.driver.options["layout"] = "dual";
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"id":""}})", c, e, fakeLookup));
+    TEST_ASSERT_EQUAL_STRING("dual", c.driver.options["layout"].c_str());
+}
+
+// Within one driver a partial patch must still MERGE, or setting one option would erase the
+// others.
 static void test_patching_one_option_keeps_the_others_on_the_same_driver() {
     Configuration c;
     ConfigError   e;
-    c.driver.id                 = "growatt_modbus";
-    c.driver.options["profile"] = "mic_tl_x";
+    c.driver.id                = "alpha";
+    c.driver.options["layout"] = "dual";
 
-    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"options":{"unit_id":"3"}}})", c, e));
-    TEST_ASSERT_EQUAL_STRING("mic_tl_x", c.driver.options["profile"].c_str());
-    TEST_ASSERT_EQUAL_STRING("3", c.driver.options["unit_id"].c_str());
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"options":{"layout":"single"}}})", c, e,
+                                      fakeLookup));
+    TEST_ASSERT_EQUAL_STRING("single", c.driver.options["layout"].c_str());
 
-    // Re-stating the same id is not a change either.
-    TEST_ASSERT_TRUE(applyConfigPatch(
-        R"({"driver":{"id":"growatt_modbus","options":{"unit_id":"4"}}})", c, e));
-    TEST_ASSERT_EQUAL_STRING("mic_tl_x", c.driver.options["profile"].c_str());
-    TEST_ASSERT_EQUAL_STRING("4", c.driver.options["unit_id"].c_str());
+    // Without a lookup nothing is ever dropped -- the pre-existing behaviour is untouched.
+    Configuration d;
+    ConfigError   e2;
+    d.driver.id                = "alpha";
+    d.driver.options["stale"]  = "x";
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"id":"beta"}})", d, e2));
+    TEST_ASSERT_EQUAL_STRING("x", d.driver.options["stale"].c_str());
 }
 
 static void test_driver_options_are_validated_against_the_driver() {
@@ -914,7 +991,11 @@ int main(int, char**) {
     RUN_TEST(test_modbus_write_cannot_be_enabled);
     RUN_TEST(test_diagnostics_unit_id_must_differ_from_the_inverter);
     RUN_TEST(test_driver_options_are_opaque_to_the_config_model);
-    RUN_TEST(test_changing_the_driver_drops_the_previous_driver_s_options);
+    RUN_TEST(test_an_option_orphaned_by_a_driver_change_is_dropped);
+    RUN_TEST(test_an_existing_orphan_is_dropped_even_without_a_driver_change);
+    RUN_TEST(test_an_unknown_option_supplied_by_the_patch_survives_to_be_reported);
+    RUN_TEST(test_a_typo_d_driver_id_destroys_no_options);
+    RUN_TEST(test_an_empty_driver_id_keeps_the_options);
     RUN_TEST(test_patching_one_option_keeps_the_others_on_the_same_driver);
     RUN_TEST(test_driver_options_are_validated_against_the_driver);
     RUN_TEST(test_an_unset_option_falls_back_to_the_declared_default);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -297,6 +297,46 @@ static void test_driver_options_are_opaque_to_the_config_model() {
     TEST_ASSERT_EQUAL_STRING("dual", parse(json)["driver"]["options"]["layout"]);
 }
 
+// Options belong to the driver that declares them, so switching drivers must not carry them
+// over. The merge has no delete, so a stale key used to survive forever -- and once the REST
+// layer started validating options against the descriptor (0.12.0), that orphan failed every
+// later PATCH with "unknown option" and made switching drivers impossible short of a factory
+// reset. Regression found in review 2026-07-25.
+static void test_changing_the_driver_drops_the_previous_driver_s_options() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id                = "eversolar_legacy";
+    c.driver.options["layout"] = "dual";
+
+    TEST_ASSERT_TRUE(applyConfigPatch(
+        R"({"driver":{"id":"solax_x1","options":{"address":"10"}}})", c, e));
+
+    TEST_ASSERT_EQUAL_STRING("solax_x1", c.driver.id.c_str());
+    TEST_ASSERT_EQUAL_STRING("10", c.driver.options["address"].c_str());
+    // The orphan is gone -- this is what unblocks validateDriverOptions on the new driver.
+    TEST_ASSERT_TRUE(c.driver.options.find("layout") == c.driver.options.end());
+    TEST_ASSERT_EQUAL_UINT32(1, c.driver.options.size());
+}
+
+// The flip side: within one driver a partial patch must still MERGE, or setting one option
+// would silently erase the others.
+static void test_patching_one_option_keeps_the_others_on_the_same_driver() {
+    Configuration c;
+    ConfigError   e;
+    c.driver.id                 = "growatt_modbus";
+    c.driver.options["profile"] = "mic_tl_x";
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"options":{"unit_id":"3"}}})", c, e));
+    TEST_ASSERT_EQUAL_STRING("mic_tl_x", c.driver.options["profile"].c_str());
+    TEST_ASSERT_EQUAL_STRING("3", c.driver.options["unit_id"].c_str());
+
+    // Re-stating the same id is not a change either.
+    TEST_ASSERT_TRUE(applyConfigPatch(
+        R"({"driver":{"id":"growatt_modbus","options":{"unit_id":"4"}}})", c, e));
+    TEST_ASSERT_EQUAL_STRING("mic_tl_x", c.driver.options["profile"].c_str());
+    TEST_ASSERT_EQUAL_STRING("4", c.driver.options["unit_id"].c_str());
+}
+
 static void test_driver_options_are_validated_against_the_driver() {
     // Validation lives with the driver that declares the option, not in the config validator
     // -- which has no way to know what a "layout" is.
@@ -874,6 +914,8 @@ int main(int, char**) {
     RUN_TEST(test_modbus_write_cannot_be_enabled);
     RUN_TEST(test_diagnostics_unit_id_must_differ_from_the_inverter);
     RUN_TEST(test_driver_options_are_opaque_to_the_config_model);
+    RUN_TEST(test_changing_the_driver_drops_the_previous_driver_s_options);
+    RUN_TEST(test_patching_one_option_keeps_the_others_on_the_same_driver);
     RUN_TEST(test_driver_options_are_validated_against_the_driver);
     RUN_TEST(test_an_unset_option_falls_back_to_the_declared_default);
     RUN_TEST(test_driver_options_reach_the_driver);


### PR DESCRIPTION
The five critical findings from the full-codebase review, plus the fixes from two review passes over this branch itself. Two of the original defects were mine, and one of those shipped in 0.12.0.

## 1. Open setup AP allowed unauthenticated reconfiguration of a configured bridge

`WifiManager` raises the setup portal again on an **already-provisioned** device once 5 WiFi attempts fail — a router reboot reaches that in about two minutes — and `WiFi.softAP()` is called with no password. `/api/v1/provision` was gated on `portalActive()` alone, so anyone in radio range could POST a full config patch: admin password, MQTT broker, `relays.enabled`, `read_only_mode`. On a relay board that is remote control of the DRM contacts.

The gate is now **"does a credential exist yet"**, not "is the portal up". `/api/v1/wifi/scan` carries the same gate.

**That closed a takeover and broke the recovery it depends on** — caught by the adversarial review, not by me. The setup page had no field for an existing password and no way to send one, and `requestAuthentication()` answers 401 with an **empty body**, so `await r.json()` threw `Unexpected end of JSON input`. The owner of a bridge whose router rebooted got a parse error and no way forward.

The page now detects which mode it is in up front (`security.password_set` from the unauthenticated config GET) rather than on a failed submit. On first boot: unchanged. On a configured bridge: it asks for the admin password, sends Basic auth by hand (`fetch` does not reliably surface the browser dialog, least of all in a captive-portal mini-browser), and changes **only** the network.

**A second review round found that rewrite shipped two permanent lockouts of its own:**

- `btoa()` only throws above U+00FF, so it did not fail on é/ë/ü/ö/ç — it silently emitted **Latin-1** while the firmware compares against the UTF-8 bytes it stored. Any accented character in an admin password meant it could never authenticate, and since that password now also guards recovery, such a user was shut out of both the dashboard and the way back in. My fallback was backwards: it only triggered for the range that already worked. Now always UTF-8, here and in the dashboard, which had the same bug with no fallback at all.
- An absent WiFi password leaves the stored one alone; an **empty string sets it to empty**. The field starts blank while a password is already stored, so anyone reconnecting to the same network and filling in only their admin password erased the credential and left the bridge unable to join anything. It is now omitted when left blank in that mode, and the field says so.

Also from that round: a failed mode lookup no longer guesses (it used to show the first-boot form on a configured bridge, then blame a password nobody asked for), the button is disabled before the first `await` so a double tap cannot fire two provisions, every rejection hands it back, the mode lookup is bounded so a busy web task cannot leave the form silently dead, and the body is parsed defensively on **every** status — the `Unexpected end of JSON input` this rewrite removed from the 401 path was still reachable on the others.

Recovery is documented where a locked-out user looks — README, not just `docs/hardware.md` — and the BOOT-hold verification status is now stated per board: measured end to end on the Relay-6CH, schematic-only on the RS485-CAN and the 1CH.

## 2. Short Modbus replies published as genuine readings

`parseReadResponse` bounds the byte count against the caller's **capacity**, never against the quantity requested. Callers record the block as covering everything they asked for, so the untouched tail of the buffer was decoded and published — on a poll reporting `Ok`.

Proven on the bench before fixing:

```
gevraagd = 125 registers,  registerCount = 3,  parse = Ok
regs[40]  Pac = 0xDEDE  (NOOIT geschreven)
regs[116] PV  = 0xDEDE  (NOOIT geschreven)
```

`readRegisters` now refuses a short reply as `Protocol`.

**Behaviour change worth knowing:** a device that answers fewer registers than requested previously had its short tail published (zeros, or worse). It now fails the read. That is correct under the never-fabricate rule — FC3/FC4 mandate `byte count = 2 × quantity requested` — but a non-conforming device that used to "work" will now report failures instead. Belongs in the release notes.

## 3. OTA completion handler ran unauthenticated

`authorised()` lived only in the upload callback, and `handleUpload` is reached **only** from the multipart parser (verified in ESPAsyncWebServer 3.11.2 — `WebRequest.cpp` guards it behind `_isMultipart`). A POST with an empty body never ran it, yet still landed in the handler that calls `g_ota.end()`. Against an in-flight image that either destroys the update or commits it and reboots. Now gated in both places.

## 4. Switching drivers was impossible once an option was stored — regression from 0.12.0

`applyConfigPatch` merges `driver.options` and has no delete, so a stale option survived a driver change. Harmless until I wired `validateDriverOptions` into the config PATCH in 0.12.0 — after which the orphan failed **every** later PATCH with `unknown option for driver X`, and only a factory reset recovered.

**My first fix for this was wrong and the adversarial review took it apart.** Clearing the options whenever the id changed was destructive in three unannounced ways: the discovery wizard PATCHes `{"driver":{"id":…}}` with no options, so accepting a detected driver silently wiped a working profile and unit id; a typo'd id counted as a change, so one mistyped character destroyed the options irrecoverably; and an empty id — which legitimately means "let the firmware pick" — wiped them too. It also never repaired a config already stuck, since a patch leaving the id alone never triggered the clear.

Replaced with an **orphan rule**. `applyConfigPatch` takes an optional driver lookup — the config layer still knows nothing about drivers, it asks. An option is dropped only when the resulting driver does not declare it **and** this patch did not supply it. So a key the caller just sent is still reported by `validateDriverOptions` rather than swallowed, and a driver id resolving to nothing drops nothing, keeping a typo recoverable. It runs on every patch, which is what heals an already-orphaned config on its next save.

The REST layer now also **refuses an id naming no compiled-in driver — but only when the patch changes it**. Testing the merged value instead was a lockout of exactly the kind this batch removes: a stored id stops resolving the moment you flash a build without that driver (the `mock` env does this to every real driver), and every unrelated setting then became unsaveable.

A later review round found the rule only covered unknown *keys*. A declared key holding a value the driver no longer accepts is the same lockout and needs no user action to occur — a driver whose option values are generated from the shipped device profiles narrows that list whenever a profile is renamed. Such a value now heals to the declared default under the same exemption. And "supplied by this patch" now means supplied **and changed**, so a read-modify-write client echoing back what it just read cannot pin a broken value forever.

## 5. Driver `<select>` silently pinned the active driver

The same silent-fallback bug I fixed for driver *options* earlier that day, one line above, missed. A stored id matching no option selects nothing, the browser shows the first driver, and the save path writes it. The **default state** hits this: a fresh bridge stores `""`, so saving any unrelated setting would pin the driver to whichever sorted first. An unrecognised value now gets its own visible entry; `""` renders as *(firmware picks automatically)*.

## Also corrected: two things I had overstated

- `docs/security.md` — my first version replaced one false claim with another. Joining the open AP grants no *control*, but it certainly grants *data*: every unauthenticated read endpoint, the inverter serial, the MQTT host, `security.admin_username`, and Modbus TCP on 502. It now says so, and flags `admin_username` as separately tracked.
- The value-initialiser on the Growatt scratch array only protects the **first** poll; from the second on those slots hold the previous poll's words. The real guarantee is the short-reply refusal. Comment corrected.

## Verification

- **497 native tests**, 15 new. The orphan rule is pinned in both directions: dropped on a driver change, dropped on an unrelated patch so a stuck config heals, a supplied key kept so a typo is still reported, a typo'd driver id destroying nothing and then recovering, an empty id keeping everything, and no lookup meaning no drops at all. Plus the short reply refused with the tail provably untouched, and the exact-length reply still `Ok`. Value-healing is pinned three ways: a stale value healed to the default, a bad value *supplied by the patch* left for the validator to report, and an echoed stored value still healing.
- A reviewer verified empirically that two of the original four tests fail when the guards are reverted (the other two are anti-over-correction guards, as their comments say).
- `tools/check_layering.sh` PASS, `tools/check_web_js.py` OK, all four boards build.

**Not covered:** the auth fixes, the unknown-driver-id refusal, the setup-page rewrite and the `<select>` fallback have no automated coverage — `RestApi::begin()` is inside `#if defined(ESP32)`, and no REST route's authorisation is pinned by any test at all. That is how #3 survived in the first place. It needs a host-testable route-policy table and gets its own PR.

**Deferred from the same review, for the next PR:** the command dispatcher skips its range check when a driver declares the write bit without `NumericCapability`, and it throttles OFF commands — both must be closed before the MIC TL-X write path lands. Plus `security.admin_username` served unauthenticated, and SunSpec reporting a short read as `Timeout` rather than as corruption.

**Known trade-offs, stated rather than hidden** (the previous version of this fix was rejected on exactly this kind of silence): accepting a driver in the discovery wizard still drops options the new driver does not declare — `unit_id` and `address` are the same quantity under different names, so switching loses it, with no warning in the wizard. And authenticating over the open setup AP puts the admin password on the air as base64; `docs/security.md` now says so and suggests factory-resetting instead if that matters to you.
