### PR TITLE
Harden the command dispatcher before anything can write

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -437,15 +437,36 @@ MQTT / REST / Modbus / HA
           │
           ▼
    CommandDispatcher
-     1. global read-only mode?          → Rejected(ReadOnlyMode)
-     2. capabilities.write[type]?        → Rejected(NotSupported)
-     3. range/step validation            → Rejected(OutOfRange)
-     4. rate limit (1/s, burst 3)        → Rejected(RateLimited)
+     1. global read-only mode?           → ReadOnlyMode
+     2. capabilities.write[type]?        → Unsupported
+     3. range/step validation            → OutOfRange / Unsupported
+     4. rate limit                       → RateLimited
      5. driver->execute(command)
           │
           ▼
-       Driver → Unsupported (EverSolar)
+       Driver → Unsupported (every driver today)
 ```
+
+Two details of that chain are easy to get wrong and are worth stating.
+
+**Gate 3 asks the command, not the driver.** Whether a value is required follows from the
+command type (`commandTakesNumericValue`), so a driver that declares a write capability but
+publishes no `NumericCapability` is *refused*, not waved through. That check used to live inside
+`if (nc.supported && nc.writable)`, which made a missing bound a bypass — the failure mode being
+that the first driver to grow a write path gets no range checking at all.
+
+**Gate 4 is not one queue.** Commands that change whether the inverter runs at all — `Start` and
+`Stop` — ride a separate track: never blocked by a burst of restricting traffic, but still spaced
+so a loop cannot saturate the bus with them. Everything that carries a value uses the normal
+burst allowance. The reason is that `RateLimited` is a *drop*, not a defer — nothing queues or
+retries — and losing "run" or "stop" is worse than losing "run at 60%", which an automation
+resends on its next tick. A limit set to its own maximum is deliberately **not** exempt: deriving
+"unrestricted" from a bound the driver may not have thought about reintroduces exactly the trust
+gate 3 removes.
+
+The dispatcher locks only its rate-limiter bookkeeping; `execute()` runs outside that lock,
+because a real write is a multi-second RS485 transaction and bus exclusivity is already the
+transport's job.
 
 ```cpp
 enum class CommandResult { Ok, Unsupported, Rejected, ReadOnlyMode,

--- a/docs/growatt-sph-protocol.md
+++ b/docs/growatt-sph-protocol.md
@@ -100,9 +100,10 @@ Battery *mode* (Battery First / Grid First / Load First) is driven by time-slot 
 (3038-3056), not a single mode write — a later, more involved mapping. The percentage/SoC
 writes above are the useful, low-risk first control surface.
 
-Every write goes through the existing CommandDispatcher (kill switch on by default, rate limit,
-range check) and must be write-verified (write → read back → confirm) before being reported
-as applied.
+Every write goes through the existing CommandDispatcher (kill switch on by default, capability
+check, range check, rate limit) and must be write-verified (write → read back → confirm) before
+being reported as applied. Note the rate limit is not uniform: `Start` and `Stop` ride a separate
+track so a burst of setpoint traffic can never swallow them. See docs/architecture.md for why.
 
 ## Sources
 

--- a/src/commands/command_dispatcher.cpp
+++ b/src/commands/command_dispatcher.cpp
@@ -21,7 +21,13 @@ CommandDispatcher::CommandDispatcher(ClockFn clock, RateLimitPolicy rateLimit)
     : clock_(std::move(clock)), rateLimit_(rateLimit) {}
 
 bool CommandDispatcher::allowedByRateLimit(uint64_t nowMs) {
-    if (everAccepted_ && nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+    // Clamped rather than wrapped. On unsigned types a clock that goes backwards turns the
+    // subtraction into a huge number, which reads as "ages ago" and refills the whole allowance
+    // -- the throttle fails OPEN. Not reachable with the esp_timer-backed monotonic clock this
+    // ships with, but the clock is injectable and the failure direction is the permissive one,
+    // so it is clamped here the way DeviceContext::due() and updateStaleness() already do.
+    const uint64_t since = nowMs > lastAcceptedMs_ ? nowMs - lastAcceptedMs_ : 0;
+    if (everAccepted_ && since >= rateLimit_.minIntervalMs) {
         burstUsed_ = 0;  // quiet long enough, the allowance refills
     }
     if (burstUsed_ < rateLimit_.burst) {
@@ -30,7 +36,7 @@ bool CommandDispatcher::allowedByRateLimit(uint64_t nowMs) {
         lastAcceptedMs_ = nowMs;
         return true;
     }
-    if (!everAccepted_ || nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+    if (!everAccepted_ || since >= rateLimit_.minIntervalMs) {
         everAccepted_   = true;
         lastAcceptedMs_ = nowMs;
         return true;
@@ -38,9 +44,50 @@ bool CommandDispatcher::allowedByRateLimit(uint64_t nowMs) {
     return false;
 }
 
+namespace {
+
+/// Whether this command lifts a restriction rather than imposing one.
+///
+/// The rate limiter exists to spare the bus, but it must never be the reason a curtailed
+/// inverter stays curtailed. Which direction counts as safe is not obvious and is worth
+/// stating: under a grid-protection reading you would exempt Stop, because being unable to shut
+/// an inverter down is the hazard. This project takes the opposite stance throughout -- the
+/// failsafe in docs/drm.md is "bridge dead, inverter keeps producing", and RelayController
+/// exempts OFF for exactly that reason -- so here the protected direction is the one that gives
+/// production back.
+///
+/// Deliberately narrow. Start is unambiguous. A limit command counts only when it is set to the
+/// driver's own declared maximum, i.e. explicitly no limit; anything below that is still a
+/// restriction and pays for its token. SoC floors and ceilings are not included: "maximum" does
+/// not mean "unrestricted" for those, and inventing a direction for a command no driver
+/// implements yet would be guessing.
+bool liftsRestriction(const InverterCommand& command, const NumericCapability& nc) {
+    if (command.type == InverterCommandType::Start) {
+        return true;
+    }
+    const bool isLimit = command.type == InverterCommandType::SetActivePowerLimitPercent ||
+                         command.type == InverterCommandType::SetActivePowerLimitWatts ||
+                         command.type == InverterCommandType::SetExportLimitWatts;
+    return isLimit && nc.supported && nc.writable && command.numericValue.has_value() &&
+           *command.numericValue >= nc.maximum;
+}
+
+}  // namespace
+
+void CommandDispatcher::setReadOnlyMode(bool readOnly) {
+    std::lock_guard<std::mutex> lock(m_);
+    readOnly_ = readOnly;
+}
+
+bool CommandDispatcher::readOnlyMode() const {
+    std::lock_guard<std::mutex> lock(m_);
+    return readOnly_;
+}
+
 DispatchOutcome CommandDispatcher::dispatch(const InverterCommand& command,
                                             InverterDriver&        driver) {
-    const uint64_t now = clock_ ? clock_() : 0;
+    std::lock_guard<std::mutex> lock(m_);
+    const uint64_t              now = clock_ ? clock_() : 0;
 
     // 1. Global read-only mode. Checked first and independently of the driver, so that
     //    turning it on is sufficient on its own -- it cannot be defeated by a driver that
@@ -60,9 +107,19 @@ DispatchOutcome CommandDispatcher::dispatch(const InverterCommand& command,
                 "the active driver does not support '" + cname + "'"};
     }
 
-    // 3. Range and step, from the driver's own declared bounds.
+    // 3. Range and step. Whether a value is required comes from the COMMAND TYPE, not from what
+    //    the driver declared. This check used to sit inside `if (nc.supported && nc.writable)`,
+    //    so a driver that set the write bit and left its NumericCapability at the defaults
+    //    skipped range checking altogether and an unbounded value went straight to execute() --
+    //    a bypass dressed as a check. A declared write with no published bounds is now a
+    //    refusal: the driver is telling us it can move something without telling us how far.
     const NumericCapability& nc = caps.numeric[static_cast<size_t>(command.type)];
-    if (nc.supported && nc.writable) {
+    if (commandTakesNumericValue(command.type)) {
+        if (!nc.supported || !nc.writable) {
+            return {CommandResult::Unsupported,
+                    "the active driver declares '" + cname +
+                        "' writable but publishes no range for it"};
+        }
         if (!command.numericValue.has_value()) {
             return {CommandResult::OutOfRange, "'" + cname + "' requires a numeric value"};
         }
@@ -75,10 +132,16 @@ DispatchOutcome CommandDispatcher::dispatch(const InverterCommand& command,
             return {CommandResult::OutOfRange,
                     "value for '" + cname + "' is not a multiple of the step size"};
         }
+    } else if (commandTakesEnumValue(command.type) && !command.enumValue.has_value()) {
+        // There is no EnumCapability to range-check against yet, so this only pins presence.
+        // The first driver implementing a mode write has to bring its own validation, and this
+        // is the reminder that the dispatcher is not doing it for it.
+        return {CommandResult::OutOfRange, "'" + cname + "' requires a mode selection"};
     }
 
-    // 4. Rate limit, last: a rejected command should not consume the allowance.
-    if (!allowedByRateLimit(now)) {
+    // 4. Rate limit, last: a rejected command should not consume the allowance. Commands that
+    //    lift a restriction skip it entirely and spend no token -- see liftsRestriction().
+    if (!liftsRestriction(command, nc) && !allowedByRateLimit(now)) {
         return {CommandResult::RateLimited, "too many commands; try again shortly"};
     }
 

--- a/src/commands/command_dispatcher.cpp
+++ b/src/commands/command_dispatcher.cpp
@@ -46,48 +46,55 @@ bool CommandDispatcher::allowedByRateLimit(uint64_t nowMs) {
 
 namespace {
 
-/// Whether this command lifts a restriction rather than imposing one.
+/// Whether this command changes whether the inverter runs at all, rather than by how much.
 ///
-/// The rate limiter exists to spare the bus, but it must never be the reason a curtailed
-/// inverter stays curtailed. Which direction counts as safe is not obvious and is worth
-/// stating: under a grid-protection reading you would exempt Stop, because being unable to shut
-/// an inverter down is the hazard. This project takes the opposite stance throughout -- the
-/// failsafe in docs/drm.md is "bridge dead, inverter keeps producing", and RelayController
-/// exempts OFF for exactly that reason -- so here the protected direction is the one that gives
-/// production back.
+/// These get their own rate-limit track: never blocked by a burst of restricting traffic, but
+/// still spaced, so they cannot be dropped when they matter and cannot be looped to saturate the
+/// bus either.
 ///
-/// Deliberately narrow. Start is unambiguous. A limit command counts only when it is set to the
-/// driver's own declared maximum, i.e. explicitly no limit; anything below that is still a
-/// restriction and pays for its token. SoC floors and ceilings are not included: "maximum" does
-/// not mean "unrestricted" for those, and inventing a direction for a command no driver
-/// implements yet would be guessing.
-bool liftsRestriction(const InverterCommand& command, const NumericCapability& nc) {
-    if (command.type == InverterCommandType::Start) {
-        return true;
-    }
-    const bool isLimit = command.type == InverterCommandType::SetActivePowerLimitPercent ||
-                         command.type == InverterCommandType::SetActivePowerLimitWatts ||
-                         command.type == InverterCommandType::SetExportLimitWatts;
-    return isLimit && nc.supported && nc.writable && command.numericValue.has_value() &&
-           *command.numericValue >= nc.maximum;
+/// Why they are special at all, stated carefully because an earlier version of this comment got
+/// it wrong. It is tempting to borrow the relay failsafe from docs/drm.md -- "bridge dead,
+/// inverter keeps producing" -- and conclude that releasing is the protected direction. That
+/// argument does NOT transfer. A relay failsafe works because a de-energised coil physically
+/// falls back with no firmware involved. A curtailment written to a holding register does the
+/// opposite: it SURVIVES a dead bridge, and undoing it needs a living one.
+///
+/// That is the actual reason to protect these. Because there is no passive fallback for a
+/// register write, the only way out of any commanded state is another command -- so the throttle
+/// must never be the reason one cannot be issued. And RateLimited here is a drop, not a defer:
+/// nothing queues or retries, so a refused command is simply lost. Losing "run" or "stop" is
+/// worse than losing "run at 60%", which an automation will send again on its next tick.
+///
+/// Both directions, deliberately. Whether stopping or starting is the safer failure depends on
+/// whose hazard you are reasoning about -- grid protection wants a guaranteed stop, an
+/// availability argument wants a guaranteed start -- and there is no need to pick: both carry no
+/// value that could be wrong, and both are a single small frame.
+///
+/// Value-carrying commands are NOT included, including a limit set to its maximum. An earlier
+/// version exempted that as "explicitly no limit", which a driver declaring minimum == maximum
+/// (or leaving both at 0) turned inside out: full curtailment then satisfied "value >= maximum"
+/// and skipped the limiter entirely. Deriving intent from bounds a driver may not have thought
+/// about is exactly the trust this batch removed from gate 3.
+bool changesRunState(const InverterCommand& command) {
+    return command.type == InverterCommandType::Start ||
+           command.type == InverterCommandType::Stop;
 }
 
 }  // namespace
 
-void CommandDispatcher::setReadOnlyMode(bool readOnly) {
-    std::lock_guard<std::mutex> lock(m_);
-    readOnly_ = readOnly;
-}
-
-bool CommandDispatcher::readOnlyMode() const {
-    std::lock_guard<std::mutex> lock(m_);
-    return readOnly_;
+bool CommandDispatcher::allowedAsRelease(uint64_t nowMs) {
+    const uint64_t since = nowMs > lastReleaseMs_ ? nowMs - lastReleaseMs_ : 0;
+    if (everReleased_ && since < rateLimit_.minIntervalMs) {
+        return false;
+    }
+    everReleased_  = true;
+    lastReleaseMs_ = nowMs;
+    return true;
 }
 
 DispatchOutcome CommandDispatcher::dispatch(const InverterCommand& command,
                                             InverterDriver&        driver) {
-    std::lock_guard<std::mutex> lock(m_);
-    const uint64_t              now = clock_ ? clock_() : 0;
+    const uint64_t now = clock_ ? clock_() : 0;
 
     // 1. Global read-only mode. Checked first and independently of the driver, so that
     //    turning it on is sufficient on its own -- it cannot be defeated by a driver that
@@ -139,10 +146,24 @@ DispatchOutcome CommandDispatcher::dispatch(const InverterCommand& command,
         return {CommandResult::OutOfRange, "'" + cname + "' requires a mode selection"};
     }
 
-    // 4. Rate limit, last: a rejected command should not consume the allowance. Commands that
-    //    lift a restriction skip it entirely and spend no token -- see liftsRestriction().
-    if (!liftsRestriction(command, nc) && !allowedByRateLimit(now)) {
-        return {CommandResult::RateLimited, "too many commands; try again shortly"};
+    // 4. Rate limit, last: a rejected command should not consume the allowance. Run/stop
+    //    commands use a separate track so a burst of restricting traffic cannot swallow them --
+    //    see changesRunState(). Only this bookkeeping is locked; the driver runs outside it.
+    {
+        std::lock_guard<std::mutex> lock(m_);
+        const bool allowed = changesRunState(command) ? allowedAsRelease(now)
+                                                      : allowedByRateLimit(now);
+        if (!allowed) {
+            return {CommandResult::RateLimited, "too many commands; try again shortly"};
+        }
+    }
+
+    // Re-read the kill switch as late as possible: it is not held across the gates, so it can
+    // have been thrown while this command was being checked. Narrows the window to the call
+    // itself -- a command already on the bus cannot be recalled either way.
+    if (readOnly_) {
+        return {CommandResult::ReadOnlyMode,
+                "bridge is in read-only mode; no write commands are accepted"};
     }
 
     const auto result = driver.execute(command);

--- a/src/commands/command_dispatcher.h
+++ b/src/commands/command_dispatcher.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -39,28 +40,43 @@ public:
     explicit CommandDispatcher(ClockFn clock, RateLimitPolicy rateLimit = {});
 
     /// Global kill switch, independent of driver capabilities. On in the MVP.
-    void setReadOnlyMode(bool readOnly);
-    bool readOnlyMode() const;
+    ///
+    /// Atomic rather than mutex-guarded: it is one bool, and the whole point of a kill switch is
+    /// that reaching it never waits. Guarding it with the same mutex as the rate limiter would
+    /// have made turning it ON block behind whatever is currently dispatching.
+    void setReadOnlyMode(bool readOnly) { readOnly_ = readOnly; }
+    bool readOnlyMode() const { return readOnly_; }
 
     /// Checks, in order: read-only mode, capability, value range, rate limit. Only then does
     /// the command reach the driver.
     ///
-    /// Thread-safe. CommandSource already names Mqtt, Rest, ModbusTcp and Web -- three different
-    /// tasks -- and the burst counter is read-modify-write, so two concurrent commands could
-    /// each see the last free slot and both take it, quietly exceeding the burst. Locked
-    /// internally rather than left to every call site: RelayController gets away with being
-    /// lock-free only because main.cpp wraps every one of its callers in the same mutex, and
-    /// that is an easy contract to break from a new call site. Note the driver's execute() runs
-    /// under this lock, which also serialises the bus access a write implies.
+    /// Thread-safe for its own state. CommandSource names Mqtt, Rest, ModbusTcp and Web, and the
+    /// burst counter is read-modify-write, so two concurrent commands could each see the last
+    /// free slot and both take it. (Nothing constructs a dispatcher yet -- there is no write
+    /// path. This is what the contract must be when there is one.)
+    ///
+    /// The lock covers ONLY the rate-limiter bookkeeping and is released before the driver runs.
+    /// execute() on a real driver is an RS485 transaction that waits up to 2 s for the bus lock
+    /// and then up to 3 s for the reply, and holding a mutex across that would stall every other
+    /// caller for seconds -- the same mistake main.cpp:492 documents finding live in Phase 3,
+    /// where a seconds-long bus transaction ran inside an AsyncTCP callback. Bus exclusivity is
+    /// already the transport's job (Transport::lock), so this mutex does not need to provide it.
+    ///
+    /// Consequence worth knowing: the kill switch is re-read immediately before execute() to
+    /// narrow the window, but a command already on the bus cannot be recalled by switching to
+    /// read-only, exactly as a poll in flight cannot be.
     DispatchOutcome dispatch(const InverterCommand& command, InverterDriver& driver);
 
 private:
     bool allowedByRateLimit(uint64_t nowMs);
+    bool allowedAsRelease(uint64_t nowMs);
 
-    mutable std::mutex m_;
-    ClockFn            clock_;
-    RateLimitPolicy    rateLimit_;
-    bool               readOnly_ = true;
+    ClockFn           clock_;
+    RateLimitPolicy   rateLimit_;
+    std::atomic<bool> readOnly_{true};
+
+    /// Guards the rate-limiter fields below, and nothing else.
+    std::mutex m_;
 
     // Explicit flag, not a "0 means never" sentinel: millis() at boot IS near zero, and
     // the sentinel collision let the first post-boot window bypass the throttle (found by
@@ -68,6 +84,12 @@ private:
     bool     everAccepted_   = false;
     uint64_t lastAcceptedMs_ = 0;
     uint32_t burstUsed_      = 0;
+
+    // Releases run on their own track: they are never blocked by restricting traffic, but they
+    // still keep a minimum spacing so a loop cannot saturate the bus with them. See
+    // releasesRestriction() for why they are treated apart at all.
+    bool     everReleased_  = false;
+    uint64_t lastReleaseMs_ = 0;
 };
 
 }  // namespace heliograph

--- a/src/commands/command_dispatcher.h
+++ b/src/commands/command_dispatcher.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <functional>
+#include <mutex>
 #include <string>
 
 #include "device/capability.h"
@@ -38,19 +39,28 @@ public:
     explicit CommandDispatcher(ClockFn clock, RateLimitPolicy rateLimit = {});
 
     /// Global kill switch, independent of driver capabilities. On in the MVP.
-    void setReadOnlyMode(bool readOnly) { readOnly_ = readOnly; }
-    bool readOnlyMode() const { return readOnly_; }
+    void setReadOnlyMode(bool readOnly);
+    bool readOnlyMode() const;
 
     /// Checks, in order: read-only mode, capability, value range, rate limit. Only then does
     /// the command reach the driver.
+    ///
+    /// Thread-safe. CommandSource already names Mqtt, Rest, ModbusTcp and Web -- three different
+    /// tasks -- and the burst counter is read-modify-write, so two concurrent commands could
+    /// each see the last free slot and both take it, quietly exceeding the burst. Locked
+    /// internally rather than left to every call site: RelayController gets away with being
+    /// lock-free only because main.cpp wraps every one of its callers in the same mutex, and
+    /// that is an easy contract to break from a new call site. Note the driver's execute() runs
+    /// under this lock, which also serialises the bus access a write implies.
     DispatchOutcome dispatch(const InverterCommand& command, InverterDriver& driver);
 
 private:
     bool allowedByRateLimit(uint64_t nowMs);
 
-    ClockFn         clock_;
-    RateLimitPolicy rateLimit_;
-    bool            readOnly_ = true;
+    mutable std::mutex m_;
+    ClockFn            clock_;
+    RateLimitPolicy    rateLimit_;
+    bool               readOnly_ = true;
 
     // Explicit flag, not a "0 means never" sentinel: millis() at boot IS near zero, and
     // the sentinel collision let the first post-boot window bypass the throttle (found by

--- a/src/device/command.cpp
+++ b/src/device/command.cpp
@@ -67,4 +67,31 @@ InverterCapability requiredCapability(InverterCommandType type) {
     return InverterCapability::_Count;
 }
 
+bool commandTakesNumericValue(InverterCommandType type) {
+    switch (type) {
+        case InverterCommandType::SetActivePowerLimitPercent:
+        case InverterCommandType::SetActivePowerLimitWatts:
+        case InverterCommandType::SetExportLimitWatts:
+        case InverterCommandType::SetReactivePower:
+        case InverterCommandType::SetBatteryChargeLimitWatts:
+        case InverterCommandType::SetBatteryDischargeLimitWatts:
+        case InverterCommandType::SetMinimumSoc:
+        case InverterCommandType::SetMaximumSoc:
+            return true;
+        // Start/Stop and SynchronizeTime carry nothing; SetBatteryOperatingMode carries an
+        // enum. Listed rather than defaulted so a new command type has to make the choice.
+        case InverterCommandType::Start:
+        case InverterCommandType::Stop:
+        case InverterCommandType::SetBatteryOperatingMode:
+        case InverterCommandType::SynchronizeTime:
+        case InverterCommandType::_Count:
+            return false;
+    }
+    return false;
+}
+
+bool commandTakesEnumValue(InverterCommandType type) {
+    return type == InverterCommandType::SetBatteryOperatingMode;
+}
+
 }  // namespace heliograph

--- a/src/device/command.h
+++ b/src/device/command.h
@@ -50,4 +50,16 @@ const char* commandTypeName(InverterCommandType type);
 /// against the active driver's capabilities without knowing which driver it is.
 InverterCapability requiredCapability(InverterCommandType type);
 
+/// Whether this command type carries a number at all.
+///
+/// A property of the COMMAND, not of what a driver happened to declare. The dispatcher's range
+/// check used to be conditional on the driver publishing a NumericCapability, so a driver that
+/// set the write bit and left the bounds at their defaults skipped the check entirely and an
+/// unbounded value reached execute(). Asking the command type instead means a missing bound is
+/// a refusal rather than a bypass.
+bool commandTakesNumericValue(InverterCommandType type);
+
+/// Whether this command type carries an enum selection instead of a number.
+bool commandTakesEnumValue(InverterCommandType type);
+
 }  // namespace heliograph

--- a/src/relays/relay_controller.cpp
+++ b/src/relays/relay_controller.cpp
@@ -22,14 +22,16 @@ void RelayController::allOff() {
     }
 }
 
-// Same refill logic as CommandDispatcher::allowedByRateLimit, with one fix: "has ever
-// accepted" is an explicit flag instead of the lastAcceptedMs_ == 0 sentinel. millis() at
-// boot is near zero, so the sentinel collides exactly when the device just started -- and
-// the first seconds after a boot are when unthrottled relay chatter is least welcome.
+// Same refill logic as CommandDispatcher::allowedByRateLimit. This copy found two problems
+// first and the dispatcher has since adopted both: "has ever accepted" as an explicit flag
+// rather than a lastAcceptedMs_ == 0 sentinel (millis() at boot IS near zero, so the sentinel
+// collides exactly when the device just started), and a clamped elapsed time so a clock that
+// moves backwards cannot wrap the subtraction into "ages ago" and refill the whole allowance.
 // Duplicated rather than shared through a base class by intent: two small, independently
 // testable copies beat a coupling between the inverter write path and the bridge actuator.
 bool RelayController::allowedByRateLimit(uint64_t nowMs) {
-    if (everAccepted_ && nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+    const uint64_t since = nowMs > lastAcceptedMs_ ? nowMs - lastAcceptedMs_ : 0;
+    if (everAccepted_ && since >= rateLimit_.minIntervalMs) {
         burstUsed_ = 0;
     }
     if (burstUsed_ < rateLimit_.burst) {

--- a/src/relays/relay_controller.cpp
+++ b/src/relays/relay_controller.cpp
@@ -40,7 +40,7 @@ bool RelayController::allowedByRateLimit(uint64_t nowMs) {
         lastAcceptedMs_ = nowMs;
         return true;
     }
-    if (!everAccepted_ || nowMs - lastAcceptedMs_ >= rateLimit_.minIntervalMs) {
+    if (!everAccepted_ || since >= rateLimit_.minIntervalMs) {
         everAccepted_   = true;
         lastAcceptedMs_ = nowMs;
         return true;

--- a/src/relays/relay_controller.h
+++ b/src/relays/relay_controller.h
@@ -79,9 +79,9 @@ private:
     bool            enabled_  = false;
     bool            state_[kMaxRelays] = {};
 
-    // An explicit flag, not the "0 means never" sentinel the dispatcher uses: millis() at
-    // boot IS near zero, and a sentinel collision there let the first post-boot burst
-    // bypass the throttle (caught by test_rate_limit_throttles_on_but_never_off).
+    // An explicit flag, not a "0 means never" sentinel: millis() at boot IS near zero, and a
+    // sentinel collision there let the first post-boot burst bypass the throttle (caught by
+    // test_rate_limit_throttles_on_but_never_off). CommandDispatcher carries the same flag.
     bool     everAccepted_   = false;
     uint64_t lastAcceptedMs_ = 0;
     uint32_t burstUsed_      = 0;

--- a/test/test_commands/test_main.cpp
+++ b/test/test_commands/test_main.cpp
@@ -358,21 +358,47 @@ static void test_a_value_less_command_on_a_boundless_driver_is_also_refused() {
     TEST_ASSERT_EQUAL_UINT32(0, driver.executed);
 }
 
+// Reaching gate 3's enum branch needs a driver that actually declares the mode write -- the
+// mock does not, so it stops at gate 2. An earlier version of this test used the mock and
+// accepted either result, which meant it passed with the enum branch deleted entirely.
+namespace {
+class ModeDriver : public BoundlessDriver {
+public:
+    InverterCapabilities capabilities() const override {
+        InverterCapabilities c;
+        c.addWrite(InverterCapability::SetBatteryOperatingMode);
+        return c;
+    }
+};
+}  // namespace
+
 static void test_a_mode_command_without_a_selection_is_refused() {
-    mock::MockOptions o;
-    o.writable = true;
-    mock::MockDriver  driver(clockFn, o);
+    ModeDriver        driver;
     CommandDispatcher d(clockFn);
     d.setReadOnlyMode(false);
 
     InverterCommand c;
     c.type = InverterCommandType::SetBatteryOperatingMode;  // no enumValue
-    // The mock does not declare this capability, so it stops at gate 2 -- which is the point:
-    // an undeclared mode write is refused either way, and the presence check below only bites
-    // once a driver does declare it.
     const auto out = d.dispatch(c, driver);
-    TEST_ASSERT_TRUE(out.result == CommandResult::Unsupported ||
-                     out.result == CommandResult::OutOfRange);
+
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, out.result);
+    TEST_ASSERT_EQUAL_UINT32(0, driver.executed);
+}
+
+static void test_a_mode_command_with_a_selection_reaches_the_driver() {
+    ModeDriver        driver;
+    CommandDispatcher d(clockFn);
+    d.setReadOnlyMode(false);
+
+    InverterCommand c;
+    c.type      = InverterCommandType::SetBatteryOperatingMode;
+    c.enumValue = 2;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, d.dispatch(c, driver).result);
+    TEST_ASSERT_EQUAL_UINT32(1, driver.executed);
+    // No EnumCapability exists to range-check against, so the value is passed through
+    // unvalidated. The first driver implementing a mode write brings its own validation --
+    // this pins that the dispatcher is not silently pretending to do it.
+    TEST_ASSERT_EQUAL_INT32(2, *driver.last.enumValue);
 }
 
 // --- lifting a restriction is never throttled -----------------------------------------------
@@ -401,7 +427,12 @@ static void test_start_is_never_throttled() {
     TEST_ASSERT_EQUAL(CommandResult::Ok, d.dispatch(start, driver).result);
 }
 
-static void test_a_limit_set_to_its_maximum_is_never_throttled() {
+// A limit at its maximum is NOT exempt, deliberately. An earlier version treated "value >=
+// declared maximum" as "explicitly no limit" -- which a driver declaring minimum == maximum, or
+// leaving both at their 0 defaults, turned inside out: full curtailment then satisfied the test
+// and skipped the limiter entirely. Deriving intent from bounds the driver may not have thought
+// about is the same trust gate 3 just removed.
+static void test_a_limit_at_its_maximum_still_pays_for_a_token() {
     mock::MockOptions o;
     o.writable = true;
     mock::MockDriver  driver(clockFn, o);
@@ -411,19 +442,14 @@ static void test_a_limit_set_to_its_maximum_is_never_throttled() {
     TEST_ASSERT_EQUAL(CommandResult::Ok,
                       d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 20.0),
                                  driver).result);
-    // 100 % is the declared maximum: explicitly no limit, so it goes through.
-    TEST_ASSERT_EQUAL(CommandResult::Ok,
-                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 100.0),
-                                 driver).result);
-    // ...while anything still restricting keeps paying for a token.
     TEST_ASSERT_EQUAL(CommandResult::RateLimited,
-                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 99.0),
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 100.0),
                                  driver).result);
 }
 
-// Lifting a restriction must not spend a token either, or a flood of releases would starve the
-// next genuine command.
-static void test_lifting_a_restriction_spends_no_token() {
+// Run/stop commands ride their own track, so a burst of restricting traffic can never swallow
+// them -- but they are still spaced, so a loop cannot saturate the bus with them either.
+static void test_run_state_commands_are_spaced_but_never_starved() {
     mock::MockOptions o;
     o.writable = true;
     mock::MockDriver  driver(clockFn, o);
@@ -432,10 +458,13 @@ static void test_lifting_a_restriction_spends_no_token() {
 
     InverterCommand start;
     start.type = InverterCommandType::Start;
-    for (int i = 0; i < 5; ++i) {
-        TEST_ASSERT_EQUAL(CommandResult::Ok, d.dispatch(start, driver).result);
-    }
-    // Both burst slots are still available.
+    TEST_ASSERT_EQUAL(CommandResult::Ok, d.dispatch(start, driver).result);
+    // Immediately again: spaced, not starved.
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited, d.dispatch(start, driver).result);
+    g_now += 1000;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, d.dispatch(start, driver).result);
+
+    // ...and none of that touched the restricting allowance: both burst slots are intact.
     TEST_ASSERT_EQUAL(CommandResult::Ok,
                       d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 10.0),
                                  driver).result);
@@ -445,6 +474,29 @@ static void test_lifting_a_restriction_spends_no_token() {
     TEST_ASSERT_EQUAL(CommandResult::RateLimited,
                       d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 12.0),
                                  driver).result);
+}
+
+// Both directions ride that track. Which of stopping or starting is the safer failure depends on
+// whose hazard you reason about, and there is no need to choose: neither carries a value that
+// could be wrong, and RateLimited here is a DROP -- nothing queues or retries -- so losing
+// either is worse than losing "run at 60%", which an automation resends on its next tick.
+static void test_stop_is_not_starved_by_restricting_traffic() {
+    mock::MockOptions o;
+    o.writable = true;
+    mock::MockDriver  driver(clockFn, o);
+    CommandDispatcher d(clockFn, RateLimitPolicy{1000, 1});
+    d.setReadOnlyMode(false);
+
+    TEST_ASSERT_EQUAL(CommandResult::Ok,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 20.0),
+                                 driver).result);
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 30.0),
+                                 driver).result);
+
+    InverterCommand stop;
+    stop.type = InverterCommandType::Stop;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, d.dispatch(stop, driver).result);
 }
 
 // A clock that jumps backwards must not refill the allowance. On unsigned types the naive
@@ -490,9 +542,11 @@ int main(int, char**) {
     RUN_TEST(test_a_declared_write_without_published_bounds_is_refused_not_waved_through);
     RUN_TEST(test_a_value_less_command_on_a_boundless_driver_is_also_refused);
     RUN_TEST(test_a_mode_command_without_a_selection_is_refused);
-    RUN_TEST(test_start_is_never_throttled);
-    RUN_TEST(test_a_limit_set_to_its_maximum_is_never_throttled);
-    RUN_TEST(test_lifting_a_restriction_spends_no_token);
+    RUN_TEST(test_a_mode_command_with_a_selection_reaches_the_driver);
+
+    RUN_TEST(test_a_limit_at_its_maximum_still_pays_for_a_token);
+    RUN_TEST(test_run_state_commands_are_spaced_but_never_starved);
+    RUN_TEST(test_stop_is_not_starved_by_restricting_traffic);
     RUN_TEST(test_a_backwards_clock_does_not_refill_the_allowance);
     return UNITY_END();
 }

--- a/test/test_commands/test_main.cpp
+++ b/test/test_commands/test_main.cpp
@@ -299,6 +299,174 @@ static void test_every_rejection_explains_itself() {
     TEST_ASSERT_TRUE(out.reason.find("range") != std::string::npos);
 }
 
+// --- gate 3 must not be skippable ----------------------------------------------------------
+
+// A driver that stands in for the realistic mistake: it claims a capability it can write but
+// never fills in the matching NumericCapability. That combination used to skip range checking
+// entirely, because the check lived inside `if (nc.supported && nc.writable)`.
+namespace {
+class BoundlessDriver : public InverterDriver {
+public:
+    const DriverDescriptor& descriptor() const override {
+        static const DriverDescriptor d = [] {
+            DriverDescriptor x;
+            x.id = "boundless";
+            return x;
+        }();
+        return d;
+    }
+    bool       begin(Transport&) override { return true; }
+    ProbeResult probe() override { return {}; }
+    PollResult  poll(DeviceState&) override { return PollResult::Ok; }
+    DeviceIdentity identity() const override { return {}; }
+    InverterCapabilities capabilities() const override {
+        InverterCapabilities c;
+        c.addWrite(InverterCapability::SetActivePowerLimit);  // ...and no numeric[] entry
+        return c;
+    }
+    CommandResult execute(const InverterCommand& command) override {
+        last = command;
+        ++executed;
+        return CommandResult::Ok;
+    }
+    InverterCommand last{};
+    uint32_t        executed = 0;
+};
+}  // namespace
+
+static void test_a_declared_write_without_published_bounds_is_refused_not_waved_through() {
+    BoundlessDriver   driver;
+    CommandDispatcher d(clockFn);
+    d.setReadOnlyMode(false);
+
+    const auto out = d.dispatch(cmd(InverterCommandType::SetActivePowerLimitWatts, 1e9), driver);
+
+    TEST_ASSERT_EQUAL(CommandResult::Unsupported, out.result);
+    TEST_ASSERT_EQUAL_UINT32(0, driver.executed);  // 1e9 W never reached the driver
+}
+
+static void test_a_value_less_command_on_a_boundless_driver_is_also_refused() {
+    BoundlessDriver   driver;
+    CommandDispatcher d(clockFn);
+    d.setReadOnlyMode(false);
+
+    InverterCommand c;
+    c.type = InverterCommandType::SetActivePowerLimitPercent;  // no numericValue at all
+    const auto out = d.dispatch(c, driver);
+
+    TEST_ASSERT_EQUAL(CommandResult::Unsupported, out.result);
+    TEST_ASSERT_EQUAL_UINT32(0, driver.executed);
+}
+
+static void test_a_mode_command_without_a_selection_is_refused() {
+    mock::MockOptions o;
+    o.writable = true;
+    mock::MockDriver  driver(clockFn, o);
+    CommandDispatcher d(clockFn);
+    d.setReadOnlyMode(false);
+
+    InverterCommand c;
+    c.type = InverterCommandType::SetBatteryOperatingMode;  // no enumValue
+    // The mock does not declare this capability, so it stops at gate 2 -- which is the point:
+    // an undeclared mode write is refused either way, and the presence check below only bites
+    // once a driver does declare it.
+    const auto out = d.dispatch(c, driver);
+    TEST_ASSERT_TRUE(out.result == CommandResult::Unsupported ||
+                     out.result == CommandResult::OutOfRange);
+}
+
+// --- lifting a restriction is never throttled -----------------------------------------------
+
+// The rate limiter must never be the reason a curtailed inverter stays curtailed. Which way is
+// "safe" is a deliberate choice: this project's failsafe is "bridge dead, inverter keeps
+// producing" (docs/drm.md), so the protected direction is the one that gives production back --
+// the opposite of what a grid-protection stance would pick.
+static void test_start_is_never_throttled() {
+    mock::MockOptions o;
+    o.writable = true;
+    mock::MockDriver  driver(clockFn, o);
+    CommandDispatcher d(clockFn, RateLimitPolicy{1000, 1});
+    d.setReadOnlyMode(false);
+
+    // Burn the whole allowance on a restricting command.
+    TEST_ASSERT_EQUAL(CommandResult::Ok,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 20.0),
+                                 driver).result);
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 30.0),
+                                 driver).result);
+
+    InverterCommand start;
+    start.type = InverterCommandType::Start;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, d.dispatch(start, driver).result);
+}
+
+static void test_a_limit_set_to_its_maximum_is_never_throttled() {
+    mock::MockOptions o;
+    o.writable = true;
+    mock::MockDriver  driver(clockFn, o);
+    CommandDispatcher d(clockFn, RateLimitPolicy{1000, 1});
+    d.setReadOnlyMode(false);
+
+    TEST_ASSERT_EQUAL(CommandResult::Ok,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 20.0),
+                                 driver).result);
+    // 100 % is the declared maximum: explicitly no limit, so it goes through.
+    TEST_ASSERT_EQUAL(CommandResult::Ok,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 100.0),
+                                 driver).result);
+    // ...while anything still restricting keeps paying for a token.
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 99.0),
+                                 driver).result);
+}
+
+// Lifting a restriction must not spend a token either, or a flood of releases would starve the
+// next genuine command.
+static void test_lifting_a_restriction_spends_no_token() {
+    mock::MockOptions o;
+    o.writable = true;
+    mock::MockDriver  driver(clockFn, o);
+    CommandDispatcher d(clockFn, RateLimitPolicy{1000, 2});
+    d.setReadOnlyMode(false);
+
+    InverterCommand start;
+    start.type = InverterCommandType::Start;
+    for (int i = 0; i < 5; ++i) {
+        TEST_ASSERT_EQUAL(CommandResult::Ok, d.dispatch(start, driver).result);
+    }
+    // Both burst slots are still available.
+    TEST_ASSERT_EQUAL(CommandResult::Ok,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 10.0),
+                                 driver).result);
+    TEST_ASSERT_EQUAL(CommandResult::Ok,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 11.0),
+                                 driver).result);
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 12.0),
+                                 driver).result);
+}
+
+// A clock that jumps backwards must not refill the allowance. On unsigned types the naive
+// subtraction wraps to an enormous value, which reads as "ages ago" -- the throttle would fail
+// open, which is the wrong direction for a gate.
+static void test_a_backwards_clock_does_not_refill_the_allowance() {
+    mock::MockOptions o;
+    o.writable = true;
+    mock::MockDriver  driver(clockFn, o);
+    CommandDispatcher d(clockFn, RateLimitPolicy{1000, 1});
+    d.setReadOnlyMode(false);
+
+    g_now = 100000;
+    TEST_ASSERT_EQUAL(CommandResult::Ok,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 20.0),
+                                 driver).result);
+    g_now = 50;  // clock went backwards
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited,
+                      d.dispatch(cmd(InverterCommandType::SetActivePowerLimitPercent, 30.0),
+                                 driver).result);
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_read_only_mode_rejects_every_command_type);
@@ -319,5 +487,12 @@ int main(int, char**) {
     RUN_TEST(test_the_allowance_refills_after_a_quiet_period);
     RUN_TEST(test_a_rejected_command_does_not_consume_the_allowance);
     RUN_TEST(test_every_rejection_explains_itself);
+    RUN_TEST(test_a_declared_write_without_published_bounds_is_refused_not_waved_through);
+    RUN_TEST(test_a_value_less_command_on_a_boundless_driver_is_also_refused);
+    RUN_TEST(test_a_mode_command_without_a_selection_is_refused);
+    RUN_TEST(test_start_is_never_throttled);
+    RUN_TEST(test_a_limit_set_to_its_maximum_is_never_throttled);
+    RUN_TEST(test_lifting_a_restriction_spends_no_token);
+    RUN_TEST(test_a_backwards_clock_does_not_refill_the_allowance);
     return UNITY_END();
 }

--- a/test/test_relays/test_main.cpp
+++ b/test/test_relays/test_main.cpp
@@ -113,6 +113,30 @@ static void test_rate_limit_throttles_on_but_never_off() {
     TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(0, true));
 }
 
+// A clock that jumps backwards must not refill the allowance. On unsigned types the naive
+// subtraction wraps into an enormous value that reads as "ages ago", so the throttle fails OPEN
+// -- and this controller is the one that already drives real contacts on hardware. No relay test
+// moved the clock at all before this one, which is how a half-applied clamp went unnoticed
+// (found in review, 2026-07-25).
+static void test_a_backwards_clock_does_not_refill_the_allowance() {
+    RateLimitPolicy policy;
+    policy.minIntervalMs = 1000;
+    policy.burst         = 1;
+    RelayController c(&fakeClock, policy);
+    c.begin(1, [](uint8_t i, bool on) { g_writes.push_back({i, on}); });
+    c.setReadOnlyMode(false);
+    c.setEnabled(true);
+
+    g_now = 100000;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(0, true));
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited, c.set(0, true));
+
+    g_now = 50;  // backwards
+    TEST_ASSERT_EQUAL(CommandResult::RateLimited, c.set(0, true));
+    // Releasing is still never throttled, whatever the clock does.
+    TEST_ASSERT_EQUAL(CommandResult::Ok, c.set(0, false));
+}
+
 static void test_pattern_wider_than_burst_asserts_in_one_command() {
     // The bug this guards against: charging the rate limiter per relay made a role spanning
     // more relays than the burst (default 3) impossible to assert -- the 4th ON was always
@@ -214,6 +238,7 @@ int main(int, char**) {
     RUN_TEST(test_switching_works_when_both_gates_open);
     RUN_TEST(test_out_of_range_index_is_refused);
     RUN_TEST(test_rate_limit_throttles_on_but_never_off);
+    RUN_TEST(test_a_backwards_clock_does_not_refill_the_allowance);
     RUN_TEST(test_pattern_wider_than_burst_asserts_in_one_command);
     RUN_TEST(test_pattern_charges_one_token_and_throttles_as_a_whole);
     RUN_TEST(test_pattern_honours_gates_and_size);


### PR DESCRIPTION
The MIC TL-X write path lands on holding register 3 next. This is the gate it will run through, so these get closed first — three defects from the full-codebase review, all latent today because nothing writes yet.

## Gate 3 was skippable

The range and step check sat inside `if (nc.supported && nc.writable)`. A driver that sets the write bit and leaves its `NumericCapability` at the defaults therefore skipped range checking **entirely**, and an unbounded value went straight to `execute()` — a bypass dressed as a check, and exactly the mistake waiting for whoever adds a write path first.

Whether a command carries a number is a property of the **command**, not of what a driver happened to declare, so `commandTakesNumericValue()` decides now. A declared write with no published bounds is a refusal: the driver is telling us it can move something without telling us how far.

```
before:  addWrite(SetActivePowerLimit), numeric[] untouched, value 1e9  ->  ok, driver executed
after:                                                                  ->  Unsupported, never reached
```

Mode commands get a presence check on `enumValue`, with a note that there is no `EnumCapability` to range-check against — so the first driver implementing a mode write brings its own validation and the dispatcher does not silently pretend to.

## The rate limiter could refuse to release

`RelayController` exempts OFF; the dispatcher exempted nothing. A ramp-down that exhausted the burst could leave the next command waiting.

**My first justification for this did not survive review.** I argued from the relay failsafe in `docs/drm.md` — *"bridge dead, inverter keeps producing"* — and that does not transfer. A relay failsafe works because a de-energised coil falls back **physically**, with no firmware involved. A curtailment written to a holding register does the opposite: it **survives** a dead bridge, and undoing it needs a living one.

The conclusion still holds, but for the opposite reason: precisely *because* there is no passive fallback for a register write, the only way out of any commanded state is another command — so the throttle must never be why one cannot be issued.

That also settles the direction question I had picked a side on. `RateLimited` is a **drop, not a defer** — nothing queues or retries — so a refused command is simply lost. Both `Start` and `Stop` now ride a separate track: never blocked by a burst of restricting traffic, but still spaced so a loop cannot saturate the bus with them. There is no need to choose which of the two is the safer failure, and no good reason to let either be silently dropped.

**The limit-at-maximum exemption is gone.** A driver declaring `minimum == maximum`, or leaving both at their defaults, made `value >= maximum` true for *full curtailment* — so the most restrictive action there is would have skipped the limiter entirely. The bypass had moved from gate 3 to gate 4 rather than closing. Deriving intent from bounds a driver may not have thought about is the same trust gate 3 exists to remove.

## The limiter failed open on a backwards clock

`nowMs - lastAcceptedMs_` on `uint64_t` wraps to an enormous number when the clock moves backwards, which reads as "ages ago" and refills the whole allowance. Not reachable with the `esp_timer` clock this ships with, but the clock is injectable and a gate should never fail permissive.

**The mirror of this into `RelayController` was half-applied, and the first version of this PR claimed otherwise.** One of its two branches got the clamp; the other — the only one a throttled assert ever reaches — kept the raw subtraction, so the change altered no observable behaviour at all while the commit message said the fix had been applied and a comment claimed the dispatcher had "adopted both". That is the controller already driving real contacts on hardware, so it was the worse half to get wrong. Now genuinely fixed, and covered: no relay test moved the clock at all before this one, which is exactly how it went unnoticed.

## The dispatcher is now internally locked

`CommandSource` already names `Mqtt`, `Rest`, `ModbusTcp` and `Web`, and the burst counter is read-modify-write, so two concurrent commands could each see the last free slot and both take it.

**The first version locked too much.** `execute()` ran under the mutex, and on a real driver that is an RS485 transaction waiting up to 2 s for the bus and 3 s for the reply — so a concurrent `readOnlyMode()` from the web task would have stalled for seconds. That is the mistake `main.cpp:492` already documents finding live in Phase 3, where a seconds-long bus transaction ran inside an AsyncTCP callback.

Now the mutex covers only the rate-limiter bookkeeping, `readOnly_` is a `std::atomic` (a kill switch must never wait behind anything), and the switch is re-read immediately before `execute()` to narrow the window that opens up. Bus exclusivity was never this lock's job — `Transport::lock` does it.

## Verification

- **506 native tests**. A boundless driver refused instead of waved through (and its value-less variant); `Start` and `Stop` surviving a spent allowance while a limit *at its maximum* now correctly pays for a token; run-state commands spaced but never starved; a backwards clock not refilling — in the dispatcher **and** in `RelayController`, which had no clock-moving test at all.
- One of the original seven tests was worthless and both reviewers caught it independently by reverting the fix and watching it pass anyway: it used a driver that does not declare the mode capability, so gate 2 answered and the enum branch was never reached, and the assertion accepted either result. Replaced with a driver that declares it, plus a positive counterpart.
- `tools/check_layering.sh` PASS, all boards build.

`docs/architecture.md` still drew gate 4 as one unconditional queue and used result names that are not in the enum; it now describes both tracks and why gate 3 asks the command rather than the driver.

**Still deferred** from the same review, not blockers for the write path: `security.admin_username` served unauthenticated, SunSpec reporting a short read as `Timeout` rather than corruption, and no host-testable coverage of REST route authorisation.
