### PR TITLE
Make a Modbus bus diagnosable, and discoverable at its actual baud rate

### DIFF
--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -112,7 +112,7 @@ checksum errors rather than timeouts.
 
 > **A flat zero on the checksum counter is weaker evidence than it looks, on a Modbus device.**
 >
-> Until 0.13.0 a Modbus driver could not raise it at all: the shared read transaction folded CRC
+> Before the release carrying this note a Modbus driver could not raise it at all: the shared read transaction folded CRC
 > failures into a generic protocol error, so on a Growatt or SunSpec install the metric was
 > structurally always zero and the alert could never fire. The PMU drivers (EverSolar, SolaX)
 > were unaffected.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -110,11 +110,27 @@ A quiet night on a solar inverter produces timeouts and no checksum errors, and 
 the inverter powers down after dark. That asymmetry is exactly why the alert below watches
 checksum errors rather than timeouts.
 
-> Until 0.13.0 a Modbus driver could not raise the checksum counter at all: the shared read
-> transaction folded CRC failures into a generic protocol error, so on a Growatt or SunSpec
-> install this metric was structurally always zero and the alert could never fire. The PMU
-> drivers (EverSolar, SolaX) were unaffected. If you have been running a Modbus device on an
-> earlier version, a flat zero there was not evidence of a clean bus.
+> **A flat zero on the checksum counter is weaker evidence than it looks, on a Modbus device.**
+>
+> Until 0.13.0 a Modbus driver could not raise it at all: the shared read transaction folded CRC
+> failures into a generic protocol error, so on a Growatt or SunSpec install the metric was
+> structurally always zero and the alert could never fire. The PMU drivers (EverSolar, SolaX)
+> were unaffected.
+>
+> Even after that fix it still under-counts, in two ways worth knowing before you trust it:
+>
+> - A Growatt poll reads several register blocks and reports success as soon as **one** of them
+>   decodes. So a bus corrupting, say, a third of its frames usually still has a good block per
+>   poll, the poll returns Ok, and the checksum error is logged but never counted. The metric
+>   therefore catches a bus that is *failing*, not one that is *degrading* — which is the
+>   opposite of what an early-warning counter should do. Fixing that means decoupling the
+>   counter from the poll verdict; it is tracked and not done yet.
+> - Line noise that damages a length or byte-count field makes the frame un-parseable rather
+>   than merely wrong, and that surfaces as a **timeout**, not a checksum error.
+>
+> Treat a non-zero value as a definite problem, and a zero as "no proof either way". The log at
+> `trace` level is the reliable source while the above stands: a corrupt block says so on the
+> line it happens.
 
 ### Bridge health
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -96,11 +96,25 @@ temperature sensor has no temperature series. That is not a fault.
 | `heliograph_modbus_client_connections_total` | counter | Modbus TCP connections accepted |
 | `heliograph_modbus_clients` | gauge | Modbus TCP clients connected right now |
 
-The distinction matters when something is wrong. **Timeouts** mean nothing came back — wiring,
-a swapped A/B, or an inverter that is asleep. **Checksum errors and invalid frames** mean bytes
-did come back but were corrupted — usually electrical: a missing ground, no termination, or a
-cable run alongside something noisy. A quiet night on a solar inverter produces timeouts and no
-checksum errors, and that is normal: the inverter powers down after dark.
+The distinction matters when something is wrong, and it is three-way rather than two:
+
+- **Timeouts** — nothing came back at all. Wiring, a swapped A/B, a wrong address, or an
+  inverter that is simply asleep.
+- **Checksum errors** — bytes came back corrupted. This is the one that indicts the *wire*: a
+  missing ground, no termination (or termination in three places instead of two), a long stub,
+  a run alongside the inverter's own output cabling. See [rs485-bus.md](rs485-bus.md).
+- **Invalid frames** — an intact frame that was not what we asked for: a neighbour on a
+  multidrop bus answering, or a device quirk. Addressing, not cabling.
+
+A quiet night on a solar inverter produces timeouts and no checksum errors, and that is normal:
+the inverter powers down after dark. That asymmetry is exactly why the alert below watches
+checksum errors rather than timeouts.
+
+> Until 0.13.0 a Modbus driver could not raise the checksum counter at all: the shared read
+> transaction folded CRC failures into a generic protocol error, so on a Growatt or SunSpec
+> install this metric was structurally always zero and the alert could never fire. The PMU
+> drivers (EverSolar, SolaX) were unaffected. If you have been running a Modbus device on an
+> earlier version, a flat zero there was not evidence of a clean bus.
 
 ### Bridge health
 

--- a/docs/rs485-bus.md
+++ b/docs/rs485-bus.md
@@ -117,7 +117,7 @@ How you set it is per manufacturer. For Growatt (including the MIC TL-X), see
 
 ## When it does not work
 
-The bridge distinguishes two failure modes, and they point at different causes. Both are
+The bridge distinguishes three failure modes, and they point at different causes. All are
 visible in the logs at `trace` level, in `/api/v1/diagnostics`, and as Prometheus counters
 (see [prometheus.md](prometheus.md)).
 
@@ -132,6 +132,10 @@ visible in the logs at `trace` level, in `/api/v1/diagnostics`, and as Prometheu
 - A break in the chain: every device past the break goes silent, which is a useful clue about
   where to look
 
+**Invalid frames — an intact frame arrived that was not an answer to us.** Usually addressing:
+another device on the bus replied, or this one answered with fewer registers than asked for.
+Look at the addresses before you look at the cable.
+
 **Checksum errors — bytes came back, corrupted.** This is an electrical problem, not a
 configuration one:
 
@@ -144,3 +148,10 @@ configuration one:
 A night of timeouts is normal and expected: the inverter powers down when the sun does. That
 is why the alerting examples in [prometheus.md](prometheus.md) watch checksum errors rather
 than timeouts.
+
+One caveat worth knowing before you trust the counters over your own eyes: noise that *drops*
+bytes — which is what a missing ground most often does — leaves a frame too short to parse, and
+that surfaces as a **timeout**, not a checksum error. So a bus can be electrically bad and still
+show nothing but timeouts. If a "sleeping inverter" is silent at a time it should not be, treat
+the cable as a suspect anyway. See the note in [prometheus.md](prometheus.md) for the other
+place these counters under-report.

--- a/src/drivers/discovery_engine.cpp
+++ b/src/drivers/discovery_engine.cpp
@@ -70,8 +70,9 @@ DiscoveryOutcome DiscoveryEngine::run(DiscoveryMode mode, const DiscoveryConfig&
             }
 
             DiscoveryCandidate candidate;
-            candidate.descriptor = descriptor;
-            candidate.probe      = first;
+            candidate.descriptor    = descriptor;
+            candidate.probe         = first;
+            candidate.matchedProfile = profile;
 
             if (config.requireConsistentProbes) {
                 const ProbeResult second = driver->probe();

--- a/src/drivers/discovery_engine.cpp
+++ b/src/drivers/discovery_engine.cpp
@@ -55,6 +55,14 @@ DiscoveryOutcome DiscoveryEngine::run(DiscoveryMode mode, const DiscoveryConfig&
             if (!driver->begin(transport_)) {
                 continue;
             }
+            // Re-applied, because begin() configures the line to the driver's OWN first choice.
+            // That is correct at boot -- a driver started straight from config must not depend
+            // on a discovery run having configured the UART, which was a real bug -- but here it
+            // silently undid the sweep: every iteration probed at the driver's default, so the
+            // second and later profiles were never actually tried. A device shipped at the
+            // family's other baud rate could not be found, and the failure looked exactly like
+            // bad wiring (review, 2026-07-25).
+            transport_.configure(profile);
 
             ProbeResult first = driver->probe();
             if (!first.responded) {

--- a/src/drivers/discovery_engine.h
+++ b/src/drivers/discovery_engine.h
@@ -37,6 +37,11 @@ struct DiscoveryConfig {
 struct DiscoveryCandidate {
     DriverDescriptor descriptor;
     ProbeResult      probe;
+    /// The line settings this candidate actually answered at -- not the driver's first
+    /// recommendation. Those were the same thing only because begin() used to undo the sweep,
+    /// so every probe really did happen at the driver default. Now that the sweep works, the
+    /// two can differ, and reporting the recommendation would be an active lie in the wizard.
+    SerialProfile matchedProfile{};
     /// False when a repeat probe contradicted the first; the score is halved in that case.
     bool consistent = true;
 };

--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -23,7 +23,8 @@ constexpr uint32_t kTransactionDeadlineMs = 3000;
 /// register number. This is the bring-up tool: with the map still unconfirmed, reading these
 /// against the inverter display is how the correct addresses and scaling are found. TRACE-only,
 /// so it costs nothing in normal operation.
-void traceBlock(RegSpace space, uint16_t start, uint16_t count, const uint16_t* values) {
+void traceBlock(uint8_t unitId, RegSpace space, uint16_t start, uint16_t count,
+                const uint16_t* values) {
     if (!log::enabled(LogLevel::Trace)) {
         return;
     }
@@ -31,7 +32,8 @@ void traceBlock(RegSpace space, uint16_t start, uint16_t count, const uint16_t* 
     constexpr uint16_t perLine = 8;
     for (uint16_t i = 0; i < count; i += perLine) {
         char line[128];
-        int  pos = snprintf(line, sizeof(line), "GROWATT %s %u:", spaceName,
+        int  pos = snprintf(line, sizeof(line), "GROWATT unit %u %s %u:",
+                            static_cast<unsigned>(unitId), spaceName,
                             static_cast<unsigned>(start + i));
         for (uint16_t j = 0; j < perLine && i + j < count; ++j) {
             pos += snprintf(line + pos, sizeof(line) - pos, " %04X", values[i + j]);
@@ -108,7 +110,7 @@ GrowattDriver::ReadResult GrowattDriver::readBlock(RegSpace space, uint16_t star
 
     switch (outcome.status) {
         case modbus::ReadStatus::Ok:
-            traceBlock(space, start, count, out);
+            traceBlock(options_.unitId, space, start, count, out);
             return ReadResult::Ok;
         case modbus::ReadStatus::Exception:
             lastException_ = outcome.exceptionCode;
@@ -154,19 +156,19 @@ PollResult GrowattDriver::poll(DeviceState& state) {
                 break;
             case ReadResult::Exception:
                 sawResponse = true;
-                log::warn("GROWATT block %u+%u refused (exception 0x%02X) -- skipped", b.start,
-                          b.count, lastException_);
+                log::warn("GROWATT unit %u block %u+%u refused (exception 0x%02X) -- skipped",
+                          options_.unitId, b.start, b.count, lastException_);
                 break;
             case ReadResult::Crc:
                 sawResponse = true;
                 sawCrcError = true;
-                log::warn("GROWATT block %u+%u failed checksum -- check ground, termination "
-                          "and cable routing", b.start, b.count);
+                log::warn("GROWATT unit %u block %u+%u failed checksum -- check ground, termination "
+                          "and cable routing", options_.unitId, b.start, b.count);
                 break;
             case ReadResult::Protocol:
                 sawResponse = true;
-                log::warn("GROWATT block %u+%u unreadable (bad frame) -- skipped", b.start,
-                          b.count);
+                log::warn("GROWATT unit %u block %u+%u unreadable (bad frame) -- skipped",
+                          options_.unitId, b.start, b.count);
                 break;
             case ReadResult::Timeout:
                 sawTimeout = true;

--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -233,6 +233,16 @@ ProbeResult GrowattDriver::probe() {
         result.responded = true;
         result.confidenceScore += 20;
         result.evidence.push_back("Modbus device answered with an exception (wrong register?)");
+    } else if (r == ReadResult::Crc) {
+        // Bytes DID come back, they just did not survive the CRC. Deliberately still
+        // responded=false: the discovery engine stops sweeping the remaining serial profiles as
+        // soon as a candidate responds, and garbage that happens to frame up as a bad-CRC reply
+        // is entirely normal at the wrong line speed -- claiming a device here would abort the
+        // sweep before the right baud rate is ever tried. Only the wording changes, and that
+        // wording is shown to the user verbatim in the wizard.
+        result.evidence.push_back(
+            "replies arrived but failed their checksum: wrong line speed, or a noisy bus "
+            "(check ground, termination and cable routing)");
     } else {
         result.evidence.push_back("no Modbus reply at this unit id and line speed");
     }

--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -117,6 +117,8 @@ GrowattDriver::ReadResult GrowattDriver::readBlock(RegSpace space, uint16_t star
             return ReadResult::Timeout;
         case modbus::ReadStatus::TransportError:
             return ReadResult::TransportError;
+        case modbus::ReadStatus::Crc:
+            return ReadResult::Crc;
         case modbus::ReadStatus::Protocol:
             break;
     }
@@ -131,6 +133,7 @@ PollResult GrowattDriver::poll(DeviceState& state) {
 
     size_t validCount  = 0;
     bool   sawTimeout  = false;
+    bool   sawCrcError = false;  // bytes arrived corrupted -> the cable, not the configuration
     bool   sawResponse = false;  // device answered *something* (exception / bad frame) = alive
 
     // A block the device refuses (exception) or that arrives corrupt is skipped, not fatal:
@@ -154,6 +157,12 @@ PollResult GrowattDriver::poll(DeviceState& state) {
                 log::warn("GROWATT block %u+%u refused (exception 0x%02X) -- skipped", b.start,
                           b.count, lastException_);
                 break;
+            case ReadResult::Crc:
+                sawResponse = true;
+                sawCrcError = true;
+                log::warn("GROWATT block %u+%u failed checksum -- check ground, termination "
+                          "and cable routing", b.start, b.count);
+                break;
             case ReadResult::Protocol:
                 sawResponse = true;
                 log::warn("GROWATT block %u+%u unreadable (bad frame) -- skipped", b.start,
@@ -168,9 +177,13 @@ PollResult GrowattDriver::poll(DeviceState& state) {
     }
 
     if (validCount == 0) {
-        // Nothing usable. Report "silent" only when the device truly said nothing: a refused
-        // range or a bad frame proves it is present and addressable, so that outranks a
-        // timeout on another block -- InvalidFrame, not the misleading Timeout.
+        // Nothing usable. A checksum failure outranks everything else: it is the only outcome
+        // that points at the cable, and it is what the alerting rule watches. Then "silent"
+        // only when the device truly said nothing -- a refused range or a bad frame proves it
+        // is present and addressable, so that outranks a timeout on another block.
+        if (sawCrcError) {
+            return PollResult::ChecksumError;
+        }
         return (sawTimeout && !sawResponse) ? PollResult::Timeout : PollResult::InvalidFrame;
     }
 

--- a/src/drivers/growatt_modbus/growatt_driver.h
+++ b/src/drivers/growatt_modbus/growatt_driver.h
@@ -49,7 +49,9 @@ public:
     CommandResult execute(const InverterCommand& command) override;
 
 private:
-    enum class ReadResult { Ok, Timeout, Exception, Protocol, TransportError };
+    /// Crc is separate from Protocol for the same reason it is in the codec: it is the only one
+    /// that means the wire is bad, and it is what the checksum-error metric and its alert key on.
+    enum class ReadResult { Ok, Timeout, Exception, Crc, Protocol, TransportError };
 
     /// One Modbus read transaction into `out` (at least `count` words). Sets lastException_ on
     /// an exception reply. TRACE-dumps the raw block for hardware bring-up.

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -30,19 +30,45 @@ modbus::ReadOutcome SunspecDriver::read(uint16_t address, uint16_t count, uint16
                                  address, count, out, capacity, timing);
 }
 
-bool SunspecDriver::walkChain() {
+// Translates a failed read into the poll outcome that describes it honestly. Everything used
+// to become Timeout, which meant a bus with a bad ground -- CRC failures -- was invisible in the
+// one counter the alerting rules key on, and pointed the field diagnosis at the wrong thing.
+static PollResult failureFor(modbus::ReadStatus status) {
+    switch (status) {
+        case modbus::ReadStatus::Crc:
+            return PollResult::ChecksumError;
+        case modbus::ReadStatus::Timeout:
+            return PollResult::Timeout;
+        case modbus::ReadStatus::TransportError:
+            return PollResult::TransportError;
+        case modbus::ReadStatus::Exception:
+        case modbus::ReadStatus::Protocol:
+        case modbus::ReadStatus::Ok:
+            break;
+    }
+    // An exception or a malformed reply both mean the device is present and talking, just not
+    // giving us this range. Not InvalidFrame: nothing is wrong with the wire.
+    return PollResult::NotRegistered;
+}
+
+bool SunspecDriver::walkChain(PollResult& outFailure) {
     chain_.clear();
     inverterEntry_ = nullptr;
     commonEntry_   = nullptr;
     walked_        = false;
 
-    uint16_t marker[2] = {};
-    if (read(options_.baseAddress, 2, marker, 2).status != modbus::ReadStatus::Ok) {
+    uint16_t   marker[2] = {};
+    const auto markerRead = read(options_.baseAddress, 2, marker, 2);
+    if (markerRead.status != modbus::ReadStatus::Ok) {
+        outFailure = failureFor(markerRead.status);
         return false;
     }
     if (marker[0] != kMarkerHigh || marker[1] != kMarkerLow) {
         log::debug("SUNSPEC no marker at %u (read %04X %04X)", options_.baseAddress, marker[0],
                    marker[1]);
+        // A healthy device that simply is not SunSpec. Saying Timeout here accused the wiring
+        // of a fault that does not exist.
+        outFailure = PollResult::NotRegistered;
         return false;
     }
 
@@ -93,7 +119,9 @@ bool SunspecDriver::walkChain() {
     if (commonEntry_ != nullptr) {
         std::vector<uint16_t> regs;
         CommonIdentity        id;
-        if (readModel(*commonEntry_, regs) && decodeCommon(regs.data(), regs.size(), id)) {
+        PollResult            ignored = PollResult::Timeout;  // identity is best-effort here
+        if (readModel(*commonEntry_, regs, ignored) &&
+            decodeCommon(regs.data(), regs.size(), id)) {
             identity_.manufacturer    = id.manufacturer;
             identity_.model           = id.model;
             identity_.serialNumber    = id.serial;
@@ -116,7 +144,8 @@ bool SunspecDriver::walkChain() {
     return true;
 }
 
-bool SunspecDriver::readModel(const ChainEntry& entry, std::vector<uint16_t>& out) {
+bool SunspecDriver::readModel(const ChainEntry& entry, std::vector<uint16_t>& out,
+                              PollResult& outFailure) {
     const uint16_t total = static_cast<uint16_t>(kHeaderRegisters + entry.length);
     out.assign(total, 0);
     uint16_t done = 0;
@@ -125,6 +154,7 @@ bool SunspecDriver::readModel(const ChainEntry& entry, std::vector<uint16_t>& ou
         const auto     r    = read(static_cast<uint16_t>(entry.address + done), want,
                                    out.data() + done, want);
         if (r.status != modbus::ReadStatus::Ok) {
+            outFailure = failureFor(r.status);
             return false;
         }
         done = static_cast<uint16_t>(done + want);
@@ -154,7 +184,8 @@ bool SunspecDriver::begin(Transport& transport) {
 
 ProbeResult SunspecDriver::probe() {
     ProbeResult result;
-    if (transport_ == nullptr || !walkChain()) {
+    PollResult  ignored = PollResult::Timeout;  // probing only cares whether it worked
+    if (transport_ == nullptr || !walkChain(ignored)) {
         return result;
     }
     result.responded     = true;
@@ -194,8 +225,9 @@ PollResult SunspecDriver::poll(DeviceState& state) {
     if (transport_ == nullptr) {
         return PollResult::TransportError;
     }
-    if (!walked_ && !walkChain()) {
-        return PollResult::Timeout;
+    PollResult failure = PollResult::Timeout;
+    if (!walked_ && !walkChain(failure)) {
+        return failure;
     }
     if (inverterEntry_ == nullptr) {
         // Mapped fine, but carries no model this driver reads -- a battery-only device, say.
@@ -206,11 +238,11 @@ PollResult SunspecDriver::poll(DeviceState& state) {
     }
 
     std::vector<uint16_t> regs;
-    if (!readModel(*inverterEntry_, regs)) {
+    if (!readModel(*inverterEntry_, regs, failure)) {
         // Force a fresh walk next time: a device that stopped answering mid-chain may have
         // rebooted into a different layout.
         walked_ = false;
-        return PollResult::Timeout;
+        return failure;
     }
 
     InverterReadings r;

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -41,13 +41,20 @@ static PollResult failureFor(modbus::ReadStatus status) {
             return PollResult::Timeout;
         case modbus::ReadStatus::TransportError:
             return PollResult::TransportError;
-        case modbus::ReadStatus::Exception:
         case modbus::ReadStatus::Protocol:
+            // An intact frame that was not ours: a neighbour on the multidrop bus answering, or
+            // a short reply. Addressing or a device quirk -- which is exactly what
+            // docs/prometheus.md defines invalid frames as, and what the Growatt driver already
+            // reports for the same status. Reporting NotRegistered here instead left the two
+            // Modbus drivers describing identical bus conditions differently.
+            return PollResult::InvalidFrame;
+        case modbus::ReadStatus::Exception:
         case modbus::ReadStatus::Ok:
             break;
     }
-    // An exception or a malformed reply both mean the device is present and talking, just not
-    // giving us this range. Not InvalidFrame: nothing is wrong with the wire.
+    // An exception means the device is present, addressed correctly, and refusing this range.
+    // Nothing is wrong with the wire and no frame was malformed, so neither error counter
+    // should move.
     return PollResult::NotRegistered;
 }
 
@@ -73,11 +80,19 @@ bool SunspecDriver::walkChain(PollResult& outFailure) {
     }
 
     uint16_t cursor = static_cast<uint16_t>(options_.baseAddress + 2);
+    // Why the walk stopped, for the case where it stopped before mapping anything at all.
+    // Silence there is a device that answered the marker and then went quiet; a CRC failure is
+    // a bad wire; an exception is a device refusing the range. Left unset, the caller's default
+    // reported all three as Timeout -- the exact mislabel this change exists to remove.
+    modbus::ReadStatus stoppedBecause = modbus::ReadStatus::Timeout;
     for (size_t i = 0; i < kMaxChainEntries; ++i) {
-        uint16_t header[2] = {};
-        if (read(cursor, kHeaderRegisters, header, 2).status != modbus::ReadStatus::Ok) {
+        uint16_t   header[2]  = {};
+        const auto headerRead = read(cursor, kHeaderRegisters, header, 2);
+        if (headerRead.status != modbus::ReadStatus::Ok) {
             // A chain that stops answering is not a broken device: several vendors simply do
-            // not serve the terminator. Keep whatever was mapped so far.
+            // not serve the terminator. Keep whatever was mapped so far -- but remember why,
+            // because if nothing was mapped this is the only clue we will have.
+            stoppedBecause = headerRead.status;
             break;
         }
         if (header[0] == kEndOfChain) {
@@ -101,6 +116,9 @@ bool SunspecDriver::walkChain(PollResult& outFailure) {
     }
 
     if (chain_.empty()) {
+        // The marker was there, so something SunSpec-shaped is on the bus, but not one model
+        // could be read. Report the reason the walk stopped rather than a blanket Timeout.
+        outFailure = failureFor(stoppedBecause);
         return false;
     }
     // Resolved now that the vector is final and cannot reallocate under these pointers.

--- a/src/drivers/sunspec/sunspec_driver.h
+++ b/src/drivers/sunspec/sunspec_driver.h
@@ -69,9 +69,12 @@ public:
 
 private:
     /// Reads the marker and walks the chain. Fills chain_, inverterEntry_ and commonEntry_.
-    bool walkChain();
+    /// Maps the model chain. On failure `outFailure` says WHY, so poll() can report a corrupt
+    /// wire differently from a silent one -- collapsing both into Timeout hid CRC errors from
+    /// the one counter the alerting rules watch.
+    bool walkChain(PollResult& outFailure);
     /// Reads one model's payload into `out`, chunked to respect the Modbus read ceiling.
-    bool readModel(const ChainEntry& entry, std::vector<uint16_t>& out);
+    bool readModel(const ChainEntry& entry, std::vector<uint16_t>& out, PollResult& outFailure);
     modbus::ReadOutcome read(uint16_t address, uint16_t count, uint16_t* out, uint16_t capacity);
 
     Transport*     transport_ = nullptr;

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -335,8 +335,10 @@ bool buildDiscoveryPayload(const DiscoveryReport& report, uint64_t nowMs, std::s
             addOptional(e, "detected_model", c.probe.detectedModel);
             addOptional(e, "serial_number", c.probe.serialNumber);
             addOptional(e, "firmware_version", c.probe.firmwareVersion);
-            if (!c.descriptor.recommendedSerialProfiles.empty()) {
-                const auto& p        = c.descriptor.recommendedSerialProfiles.front();
+            {
+                // What it answered at, not what the driver recommends first -- with a working
+                // profile sweep those are no longer the same thing.
+                const auto& p        = c.matchedProfile;
                 JsonObject  profile  = e["serial_profile"].to<JsonObject>();
                 profile["baud_rate"] = p.baudRate;
                 profile["parity"]    = parityName(p.parity);

--- a/src/protocols/modbus/modbus_client.cpp
+++ b/src/protocols/modbus/modbus_client.cpp
@@ -62,8 +62,14 @@ ReadOutcome readRegisters(Transport& transport, uint8_t unitId, uint8_t function
                 return outcome;
             case ParseResult::Incomplete:
                 break;  // fall through and read more
+            case ParseResult::BadCrc:
+                // The one outcome that indicts the cable rather than the configuration. The
+                // codec has always kept it separate; fusing it here is what made a Modbus
+                // driver unable to ever report a checksum error.
+                outcome.status = ReadStatus::Crc;
+                return outcome;
             default:
-                // BadCrc / WrongUnit / WrongFunction / Malformed.
+                // WrongUnit / WrongFunction / Malformed.
                 outcome.status = ReadStatus::Protocol;
                 return outcome;
         }

--- a/src/protocols/modbus/modbus_client.h
+++ b/src/protocols/modbus/modbus_client.h
@@ -25,10 +25,20 @@
 namespace heliograph::modbus {
 
 enum class ReadStatus : uint8_t {
-    Ok,              ///< `count` registers decoded into the caller's buffer
-    Exception,       ///< the device answered, refusing: see ReadOutcome::exceptionCode
-    Timeout,         ///< nothing, or not a whole frame, arrived in time
-    Protocol,        ///< bad CRC, wrong unit, wrong function code, or malformed
+    Ok,         ///< `count` registers decoded into the caller's buffer
+    Exception,  ///< the device answered, refusing: see ReadOutcome::exceptionCode
+    Timeout,    ///< nothing, or not a whole frame, arrived in time
+    /// Bytes arrived and failed the CRC. Kept apart from Protocol on purpose: this is the one
+    /// outcome that means the WIRE is bad -- a missing ground, no termination, a stub, noise
+    /// coupled from the inverter's own output. Drivers map it to PollResult::ChecksumError,
+    /// which is what the alerting rules key on, precisely because every night legitimately
+    /// produces timeouts and would drown a rule built on those. Fusing it into Protocol made
+    /// that counter structurally unreachable on a Modbus bus (review, 2026-07-25).
+    Crc,
+    /// The frame was intact but not what we asked for: wrong unit, wrong function code,
+    /// malformed, or fewer registers than requested. Points at addressing or a device quirk,
+    /// not at the cable.
+    Protocol,
     TransportError,  ///< the request could not be written at all
 };
 

--- a/test/support/fake_sunspec_device.h
+++ b/test/support/fake_sunspec_device.h
@@ -137,10 +137,17 @@ public:
     /// send an installer to look at completely different things.
     bool corruptCrc = false;
 
+    /// Leave the first N replies intact before `corruptCrc` starts biting. Without this a test
+    /// wrecks the very first read too, so the driver never gets past its opening exchange and
+    /// everything downstream stays unexercised -- which is exactly how a swallowed status in the
+    /// SunSpec chain walk survived its own test (review, 2026-07-25).
+    uint32_t intactReplies = 0;
+
 private:
     void appendCrc(std::vector<uint8_t>& frame) const {
-        const uint16_t crc = modbus::crc16(frame.data(), frame.size());
-        frame.push_back(static_cast<uint8_t>((crc & 0xFF) ^ (corruptCrc ? 0xFF : 0x00)));
+        const uint16_t crc     = modbus::crc16(frame.data(), frame.size());
+        const bool     corrupt = corruptCrc && reads > intactReplies;
+        frame.push_back(static_cast<uint8_t>((crc & 0xFF) ^ (corrupt ? 0xFF : 0x00)));
         frame.push_back(static_cast<uint8_t>(crc >> 8));
     }
 

--- a/test/support/fake_sunspec_device.h
+++ b/test/support/fake_sunspec_device.h
@@ -132,10 +132,15 @@ public:
     bool     asleep = false;
     uint32_t reads  = 0;  ///< how many requests were answered, for round-trip assertions
 
+    /// Answer with a wrecked checksum, as a bus with a missing ground or no termination does.
+    /// Distinct from `asleep`: the device is talking, the wire is mangling it -- and those two
+    /// send an installer to look at completely different things.
+    bool corruptCrc = false;
+
 private:
-    static void appendCrc(std::vector<uint8_t>& frame) {
+    void appendCrc(std::vector<uint8_t>& frame) const {
         const uint16_t crc = modbus::crc16(frame.data(), frame.size());
-        frame.push_back(static_cast<uint8_t>(crc & 0xFF));
+        frame.push_back(static_cast<uint8_t>((crc & 0xFF) ^ (corruptCrc ? 0xFF : 0x00)));
         frame.push_back(static_cast<uint8_t>(crc >> 8));
     }
 

--- a/test/test_discovery/test_main.cpp
+++ b/test/test_discovery/test_main.cpp
@@ -32,16 +32,42 @@ public:
         /// Second and later probes report this serial instead, simulating an unstable match.
         std::string serialOnRepeat;
         bool        writeAttempted = false;
+        /// Non-zero: begin() reconfigures the line to this, as every real driver does.
+        uint32_t    begunAtBaud = 0;
+        /// Non-zero: probe() only answers when `bus` is actually at this rate. `bus` is the
+        /// test's own MockTransport -- the base Transport exposes no way to read back the
+        /// configured line settings, and adding one just for a test would be the tail wagging
+        /// the dog.
+        uint32_t             respondsOnlyAtBaud = 0;
+        const MockTransport* bus                = nullptr;
     };
 
     FakeDriver(DriverDescriptor d, Script* script) : descriptor_(std::move(d)), script_(script) {}
 
     const DriverDescriptor& descriptor() const override { return descriptor_; }
-    bool begin(Transport&) override { return true; }
+
+    // Real drivers configure the UART here, from their own first recommended profile, because a
+    // driver started straight from config must not depend on a discovery run having done it.
+    // Modelled so the profile sweep is tested against the behaviour it actually has to survive.
+    bool begin(Transport& t) override {
+        if (script_->begunAtBaud != 0) {
+            SerialProfile own;
+            own.baudRate = script_->begunAtBaud;
+            t.configure(own);
+        }
+        return true;
+    }
 
     ProbeResult probe() override {
         ++probeCount_;
         ProbeResult r;
+        // A device only answers at the line rate it actually runs at.
+        if (script_->respondsOnlyAtBaud != 0 && script_->bus != nullptr &&
+            script_->bus->profile().baudRate != script_->respondsOnlyAtBaud) {
+            r.responded = false;
+            r.evidence.push_back("wrong baud");
+            return r;
+        }
         r.responded      = script_->responded;
         r.checksumValid  = script_->checksumValid;
         r.confidenceScore = script_->score;
@@ -286,6 +312,33 @@ static void test_drivers_are_skipped_on_an_unsupported_transport() {
     TEST_ASSERT_EQUAL_size_t(0, e.run(DiscoveryMode::Quick).candidates.size());
 }
 
+// The sweep has to survive begin() reconfiguring the line. Every real driver does that, on
+// purpose: a driver started straight from config must not depend on a discovery run having set
+// up the UART, which was a real bug once. But it silently undid the sweep -- the engine set the
+// profile, begin() put it straight back to the driver's own default, and every iteration probed
+// at the same rate. A device shipped at the family's other baud rate simply could not be found,
+// and the failure looked exactly like bad wiring (review, 2026-07-25).
+static void test_a_device_on_the_second_profile_is_still_found() {
+    DriverRegistry     reg;
+    MockTransport      t;
+    FakeDriver::Script s;
+    s.score              = 97;
+    s.begunAtBaud        = 9600;    // what begin() forces, like a real driver
+    s.respondsOnlyAtBaud = 115200;  // where the device actually is
+    s.bus                = &t;
+
+    auto d = desc("two_rates", 10);
+    d.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3},
+                                   SerialProfile{115200, SerialParity::None, 8, 1, 1000, 3}};
+    addDriver(reg, d, &s);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_TRUE(out.autoSelected);
+    TEST_ASSERT_EQUAL_STRING("two_rates", out.selectedDriverId.c_str());
+}
+
 static void test_only_profiles_the_driver_recommends_are_tried() {
     // No brute-forcing baud rates on a live bus.
     DriverRegistry     reg;
@@ -450,6 +503,7 @@ int main(int, char**) {
     RUN_TEST(test_discovery_never_executes_a_command);
     RUN_TEST(test_drivers_opting_out_of_auto_detection_are_skipped);
     RUN_TEST(test_drivers_are_skipped_on_an_unsupported_transport);
+    RUN_TEST(test_a_device_on_the_second_profile_is_still_found);
     RUN_TEST(test_only_profiles_the_driver_recommends_are_tried);
     return UNITY_END();
 }

--- a/test/test_growatt_driver/test_main.cpp
+++ b/test/test_growatt_driver/test_main.cpp
@@ -255,6 +255,56 @@ static void test_a_refused_block_outranks_a_timeout_in_the_outcome() {
     TEST_ASSERT_EQUAL(PollResult::InvalidFrame, driver.poll(state));
 }
 
+// A bus with a bad ground or missing termination shows up as CRC failures, and that is the one
+// symptom the alerting rules watch -- every night legitimately produces timeouts, so a rule
+// built on those would drown. Until this was fixed the codec folded CRC into a generic protocol
+// error and the driver reported InvalidFrame, making PollResult::ChecksumError structurally
+// unreachable on a Modbus bus: the counter existed, the metric existed, the alert existed, and
+// nothing could ever raise it (review, 2026-07-25).
+static void test_a_corrupt_reply_is_reported_as_a_checksum_error() {
+    MockTransport transport;
+    transport.setResponder([](const std::vector<uint8_t>& req, std::vector<uint8_t>& reply) {
+        if (req.size() < 8) return false;
+        const uint16_t count = static_cast<uint16_t>((req[4] << 8) | req[5]);
+        reply.push_back(req[0]);
+        reply.push_back(req[1]);
+        reply.push_back(static_cast<uint8_t>(count * 2));
+        for (uint16_t i = 0; i < count * 2; ++i) {
+            reply.push_back(0x11);
+        }
+        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
+        reply.push_back(static_cast<uint8_t>((crc & 0xFF) ^ 0xFF));  // wrecked
+        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        return true;
+    });
+    GrowattDriver driver(transport);
+    DeviceState   state;
+    state.lastPollAttemptMs = 5000;
+    TEST_ASSERT_EQUAL(PollResult::ChecksumError, driver.poll(state));
+}
+
+// ...while a frame that arrives intact but is not ours stays InvalidFrame. Counting a neighbour
+// on the bus as line corruption would send someone to check a cable that is fine.
+static void test_an_intact_reply_from_another_unit_is_not_a_checksum_error() {
+    MockTransport transport;
+    transport.setResponder([](const std::vector<uint8_t>& req, std::vector<uint8_t>& reply) {
+        if (req.size() < 8) return false;
+        reply.push_back(static_cast<uint8_t>(req[0] + 1));  // someone else's address
+        reply.push_back(req[1]);
+        reply.push_back(2);
+        reply.push_back(0x00);
+        reply.push_back(0x2A);
+        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
+        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
+        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        return true;
+    });
+    GrowattDriver driver(transport);
+    DeviceState   state;
+    state.lastPollAttemptMs = 5000;
+    TEST_ASSERT_EQUAL(PollResult::InvalidFrame, driver.poll(state));
+}
+
 static void test_a_sustained_noise_trickle_hits_the_transaction_deadline() {
     // Same bound as the eversolar driver: a line that never completes a frame must not hold
     // the bus indefinitely (review, 2026-07-20).
@@ -528,6 +578,8 @@ int main(int, char**) {
     RUN_TEST(test_all_blocks_refused_is_an_invalid_frame);
     RUN_TEST(test_one_refused_block_does_not_sink_the_poll);
     RUN_TEST(test_a_refused_block_outranks_a_timeout_in_the_outcome);
+    RUN_TEST(test_a_corrupt_reply_is_reported_as_a_checksum_error);
+    RUN_TEST(test_an_intact_reply_from_another_unit_is_not_a_checksum_error);
     RUN_TEST(test_a_sustained_noise_trickle_hits_the_transaction_deadline);
     RUN_TEST(test_execute_is_unsupported_read_only);
     RUN_TEST(test_begin_configures_the_serial_line);

--- a/test/test_modbus_client/test_main.cpp
+++ b/test/test_modbus_client/test_main.cpp
@@ -83,7 +83,7 @@ static void test_silence_is_a_timeout() {
     TEST_ASSERT_EQUAL(ReadStatus::Timeout, r.status);
 }
 
-static void test_a_corrupt_frame_is_protocol_not_timeout() {
+static void test_a_corrupt_frame_is_crc_not_timeout_and_not_protocol() {
     MockTransport t;
     auto bad = goodReply(kUnit, kReadHoldingRegisters, {0x1234});
     bad.back() ^= 0xFF;  // wreck the CRC
@@ -92,18 +92,26 @@ static void test_a_corrupt_frame_is_protocol_not_timeout() {
     uint16_t   regs[1] = {};
     const auto r = readRegisters(t, kUnit, kReadHoldingRegisters, kFrom, 1, regs, 1);
 
-    // The distinction matters in the field: Timeout means nothing came back (wiring, a
-    // sleeping device), Protocol means bytes came back corrupted (electrical noise).
-    TEST_ASSERT_EQUAL(ReadStatus::Protocol, r.status);
+    // Three outcomes, three different things to go check in the field. Timeout: nothing came
+    // back at all -- wiring, address, a sleeping device. Crc: bytes came back corrupted, which
+    // indicts the wire itself (ground, termination, a stub, noise from the inverter). Protocol:
+    // an intact frame that was not what we asked for -- addressing or a device quirk.
+    //
+    // Crc used to be folded into Protocol, and the drivers mapped Protocol to InvalidFrame, so
+    // PollResult::ChecksumError was structurally unreachable on a Modbus bus and the alert rule
+    // built on that counter could never fire (review, 2026-07-25).
+    TEST_ASSERT_EQUAL(ReadStatus::Crc, r.status);
 }
 
-static void test_a_reply_from_another_unit_is_refused() {
+static void test_a_reply_from_another_unit_is_protocol_not_crc() {
     MockTransport t;
-    t.replyWith(goodReply(kUnit + 1, kReadHoldingRegisters, {0x1111}));
+    t.replyWith(goodReply(kUnit + 1, kReadHoldingRegisters, {0x1111}));  // valid CRC, wrong unit
 
     uint16_t   regs[1] = {};
     const auto r = readRegisters(t, kUnit, kReadHoldingRegisters, kFrom, 1, regs, 1);
 
+    // Protocol, deliberately not Crc: the frame arrived intact, a neighbour on the multidrop
+    // bus simply answered. Nothing wrong with the cable, so it must not be counted against it.
     TEST_ASSERT_EQUAL(ReadStatus::Protocol, r.status);
 }
 
@@ -191,8 +199,8 @@ int main(int, char**) {
     RUN_TEST(test_a_good_reply_decodes);
     RUN_TEST(test_an_exception_reports_its_code);
     RUN_TEST(test_silence_is_a_timeout);
-    RUN_TEST(test_a_corrupt_frame_is_protocol_not_timeout);
-    RUN_TEST(test_a_reply_from_another_unit_is_refused);
+    RUN_TEST(test_a_corrupt_frame_is_crc_not_timeout_and_not_protocol);
+    RUN_TEST(test_a_reply_from_another_unit_is_protocol_not_crc);
     RUN_TEST(test_an_endless_trickle_still_hits_the_deadline);
     RUN_TEST(test_a_request_larger_than_the_buffer_is_refused_before_the_bus);
     RUN_TEST(test_a_reply_with_too_few_registers_is_refused);

--- a/test/test_sunspec_driver/test_main.cpp
+++ b/test/test_sunspec_driver/test_main.cpp
@@ -305,6 +305,20 @@ static void test_a_corrupt_reply_is_reported_as_a_checksum_error() {
     TEST_ASSERT_EQUAL(PollResult::ChecksumError, d.poll(state));
 }
 
+// The marker is there, so something SunSpec-shaped is on the bus, but the very first model
+// header is refused. Nothing gets mapped. The reason the walk stopped used to be discarded
+// here, so the caller's default won and this reported Timeout -- accusing the wiring of a
+// fault on a device that is demonstrably answering (review, 2026-07-25).
+static void test_a_marker_with_no_readable_models_is_not_reported_as_a_timeout() {
+    Rig r;
+    r.device.placeMarker();  // marker only; every later register earns an exception
+    r.arm();
+
+    auto        d = r.makeDriver();
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::NotRegistered, d.poll(state));
+}
+
 static void test_a_silent_device_does_not_poll() {
     Rig r;
     buildTypical(r.device);
@@ -343,6 +357,7 @@ int main(int, char**) {
     RUN_TEST(test_an_unreadable_device_is_not_reported_as_line_corruption);
     RUN_TEST(test_a_device_without_the_marker_is_not_reported_as_a_timeout);
     RUN_TEST(test_a_corrupt_reply_is_reported_as_a_checksum_error);
+    RUN_TEST(test_a_marker_with_no_readable_models_is_not_reported_as_a_timeout);
     RUN_TEST(test_a_silent_device_does_not_poll);
     RUN_TEST(test_the_driver_is_read_only);
     return UNITY_END();

--- a/test/test_sunspec_driver/test_main.cpp
+++ b/test/test_sunspec_driver/test_main.cpp
@@ -305,6 +305,25 @@ static void test_a_corrupt_reply_is_reported_as_a_checksum_error() {
     TEST_ASSERT_EQUAL(PollResult::ChecksumError, d.poll(state));
 }
 
+// The same symptom, but appearing only once the chain is already mapped -- so the failure has
+// to travel back out of readModel rather than out of the opening marker read. Corrupting
+// everything from the first byte, as the test above does, never exercises that path.
+static void test_corruption_that_starts_mid_chain_is_still_a_checksum_error() {
+    Rig r;
+    buildTypical(r.device);
+    r.device.corruptCrc    = true;
+    r.device.intactReplies = 5;  // marker, chain headers and the identity read survive
+    r.arm();
+
+    auto        d = r.makeDriver();
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::ChecksumError, d.poll(state));
+    // Self-evidencing: a fully mapped chain proves the walk completed, so the failure can only
+    // have come out of readModel. Without this the test would silently pass while exercising
+    // the marker read, which is what the sibling test above already covers.
+    TEST_ASSERT_EQUAL_UINT32(2, d.chain().size());
+}
+
 // The marker is there, so something SunSpec-shaped is on the bus, but the very first model
 // header is refused. Nothing gets mapped. The reason the walk stopped used to be discarded
 // here, so the caller's default won and this reported Timeout -- accusing the wiring of a
@@ -357,6 +376,7 @@ int main(int, char**) {
     RUN_TEST(test_an_unreadable_device_is_not_reported_as_line_corruption);
     RUN_TEST(test_a_device_without_the_marker_is_not_reported_as_a_timeout);
     RUN_TEST(test_a_corrupt_reply_is_reported_as_a_checksum_error);
+    RUN_TEST(test_corruption_that_starts_mid_chain_is_still_a_checksum_error);
     RUN_TEST(test_a_marker_with_no_readable_models_is_not_reported_as_a_timeout);
     RUN_TEST(test_a_silent_device_does_not_poll);
     RUN_TEST(test_the_driver_is_read_only);

--- a/test/test_sunspec_driver/test_main.cpp
+++ b/test/test_sunspec_driver/test_main.cpp
@@ -275,6 +275,36 @@ static void test_an_unreadable_device_is_not_reported_as_line_corruption() {
     TEST_ASSERT_NOT_EQUAL(PollResult::ChecksumError, result);
 }
 
+// A perfectly healthy Modbus device that simply is not SunSpec used to be reported as Timeout,
+// which accused the wiring of a fault that does not exist. It answers promptly; the marker is
+// just not there.
+static void test_a_device_without_the_marker_is_not_reported_as_a_timeout() {
+    Rig r;
+    r.device.registers[r.device.baseAddress]     = 0x1234;  // something, but not "SunS"
+    r.device.registers[r.device.baseAddress + 1] = 0x5678;
+    r.arm();
+
+    auto        d = r.makeDriver();
+    DeviceState state;
+    const auto  result = d.poll(state);
+
+    TEST_ASSERT_EQUAL(PollResult::NotRegistered, result);
+}
+
+// The one symptom that indicts the cable. Everything used to collapse into Timeout, so a bus
+// with a bad ground was invisible in the counter the alerting rules key on -- and pointed the
+// field diagnosis at "the inverter is asleep" instead (review, 2026-07-25).
+static void test_a_corrupt_reply_is_reported_as_a_checksum_error() {
+    Rig r;
+    buildTypical(r.device);
+    r.device.corruptCrc = true;
+    r.arm();
+
+    auto        d = r.makeDriver();
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::ChecksumError, d.poll(state));
+}
+
 static void test_a_silent_device_does_not_poll() {
     Rig r;
     buildTypical(r.device);
@@ -311,6 +341,8 @@ int main(int, char**) {
     RUN_TEST(test_begin_configures_the_serial_line);
     RUN_TEST(test_identity_is_available_without_probing);
     RUN_TEST(test_an_unreadable_device_is_not_reported_as_line_corruption);
+    RUN_TEST(test_a_device_without_the_marker_is_not_reported_as_a_timeout);
+    RUN_TEST(test_a_corrupt_reply_is_reported_as_a_checksum_error);
     RUN_TEST(test_a_silent_device_does_not_poll);
     RUN_TEST(test_the_driver_is_read_only);
     return UNITY_END();


### PR DESCRIPTION
Two defects from the full-codebase review. Both bite precisely when three inverters go onto one shared RS485 bus — which is what happens next.

## A Modbus driver could not report a checksum error at all

The shared read transaction folded `ParseResult::BadCrc` into a generic `Protocol` status, and both Modbus drivers mapped that to `InvalidFrame`. So `PollResult::ChecksumError` was **structurally unreachable** on a Modbus install: the counter existed, the Prometheus metric existed, the alert rule in `docs/prometheus.md` existed, and nothing could ever raise any of them.

That alert watches checksum errors rather than timeouts for a good reason — every night legitimately produces timeouts, so a rule built on those would drown in false positives. On a Growatt or SunSpec bridge it was watching a number that could only ever be zero. The PMU drivers (EverSolar, SolaX) were unaffected, which is why this never showed up in the soak.

`ReadStatus` now separates the two, and the distinction is the one that actually sends someone somewhere:

| Outcome | Means | Go check |
|---|---|---|
| `Timeout` | nothing came back | wiring, address, a sleeping inverter |
| `Crc` | bytes came back corrupted | **the wire** — ground, termination, a stub, noise from the inverter's own output |
| `Protocol` | intact frame, not ours | addressing — a neighbour on the multidrop bus answered |

Growatt reports a corrupt block as `ChecksumError` and names the likely cause in the log; a neighbour's reply stays `InvalidFrame`.

**SunSpec was worse.** A CRC failure, a device refusing a range, and a perfectly healthy *non-SunSpec* device all came back as `Timeout` — accusing the wiring of a fault that in two of those three cases does not exist. `walkChain()` and `readModel()` now report *why* they failed and `poll()` maps that honestly.

## Discovery never actually tried a driver's second serial profile

The engine configures the line, then `begin()` configures it again to the driver's own first choice. That call in `begin()` is correct and was added deliberately — a driver started straight from config must not depend on a discovery run having set up the UART, which was a real bug once — but the two were never reconciled. Every iteration of the sweep probed at the same rate.

A device shipped at the family's other baud rate (Growatt declares 9600 **and** 115200; SunSpec 9600 and 19200) simply could not be found, and the failure looked exactly like bad wiring. The engine now re-applies the profile after `begin()` returns.

**This one needed a fixture change to catch.** The fake driver's `begin()` did nothing, so no existing test could see the bug — the sweep worked fine against a driver that does not behave like a real one. It now reconfigures the way real drivers do, and the new test is verified to fail when the fix is reverted:

```
--- without fix ---
test_a_device_on_the_second_profile_is_still_found: Expected TRUE Was FALSE  [FAILED]
--- with fix ---
22 test cases: 22 succeeded
```

## What this does NOT fix — two reviews' worth of honesty

**The checksum metric still catches a failing bus, not a degrading one.** A Growatt poll reads several blocks and returns `Ok` as soon as **one** decodes, so a bus corrupting a fraction of its frames almost always still has a good block per poll — the error is logged and never counted. Rough shape: if per-block corruption is `q`, the counter moves at about `q²`, so you need roughly a third of frames corrupt before the alert fires. That is backwards for an early-warning counter. Fixing it means decoupling the counter from the poll verdict, which touches all four drivers and the `poll()` contract, so it is its own change. `docs/prometheus.md` now says this plainly instead of implying the metric is now trustworthy.

**Noise that drops bytes still reports as a timeout.** A frame too short to parse never reaches the CRC check. On RS-485 a missing ground often does exactly that, so a bus can be electrically bad and show nothing but timeouts. Both docs now warn about it.

**A device found on the second serial profile is still polled at the driver's default.** No baud rate is persisted anywhere — `Configuration` has no serial section, and every driver's `begin()` uses its first recommended profile. For the MIC TL-X the profile's own `[serial]` block makes this certain. Finding it beats not finding it, but this is half a feature, and the wizard now at least reports the rate that actually answered instead of the one it will use.

## Also fixed, from reviewing this branch

- SunSpec discarded **why** its chain walk stopped and left the failure reason unset when nothing got mapped — so the caller's default won and it reported `Timeout` for a device that had just answered the marker. My own commit message claimed to have removed exactly that mislabel.
- SunSpec mapped `Protocol` to `NotRegistered`, which increments **no** counter, while Growatt maps the same status to `InvalidFrame`. Two Modbus drivers described one wire condition differently, and the SunSpec side contradicted the definition this PR writes into the docs.
- The Growatt probe said "no Modbus reply" when replies had arrived and failed their CRC. Wording only — it deliberately still reports `responded=false`, because the engine stops sweeping once something responds and garbage framing up as a bad-CRC reply is normal at the wrong baud rate.
- **Growatt log lines never named the unit.** With three inverters on one bus that is the difference between "device 2 is dead" and "the bus is bad". Now in all three warnings and the TRACE dump — the cheapest change here and probably the most useful for the bring-up.
- The wizard reported the wrong serial profile. It was accidentally correct before, because the sweep never worked; fixing the sweep turned it into a lie. `DiscoveryCandidate` now carries the profile that answered.
- `docs/prometheus.md` cited a version that does not exist, and `docs/rs485-bus.md` still described two failure modes where the other page now describes three.
- My own CRC test wrecked every reply including the first, so `readModel` was never exercised — which is exactly how the swallowed chain-walk status survived its own test. The fixture can now leave the first N replies intact, and the new test asserts a fully mapped chain so it cannot pass while testing the wrong path.

## Verification

- **513 native tests**. New: a corrupt reply reported as `ChecksumError` and an intact reply from another unit deliberately *not*; a non-SunSpec device reported as `NotRegistered` rather than `Timeout`; a device found on the second serial profile.
- The `FakeSunspecDevice` fixture gained a `corruptCrc` flag — modelling a noisy bus, distinct from `asleep`, because those two send an installer to look at completely different things.
- `tools/check_layering.sh` PASS, all boards build.

`docs/prometheus.md` gains the three-way distinction and an explicit note that a flat zero on the checksum counter was **not** evidence of a clean bus before this.

**Still open** from the same review, roughly in order: the Modbus validity bitmap reads all-ones before the first poll (so a PLC sees NaN flagged as valid), an unvalidated RTC year can put the clock in 2165, `patchNumber` narrows before validating (`port: 65537` is stored as `1`), and `security.admin_username` is served unauthenticated.
