### PR TITLE
Stop publishing three values that are wrong but look right

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -96,6 +96,7 @@ build_src_filter =
     +<config/configuration.cpp>
     +<config/configuration_store.cpp>
     +<network/provisioning_policy.cpp>
+    +<network/rtc_time.cpp>
     +<network/wifi_manager.cpp>
     +<config/nvs_backend.cpp>
     +<ota/ota_manager.cpp>

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -104,9 +104,11 @@ bool patchNumber(JsonVariantConst v, T& target, const char* field, ConfigError& 
     const long long raw = v.as<long long>();
     if (raw < static_cast<long long>(std::numeric_limits<T>::min()) ||
         raw > static_cast<long long>(std::numeric_limits<T>::max())) {
-        error = {field, "expected an integer between " +
-                            std::to_string(std::numeric_limits<T>::min()) + " and " +
-                            std::to_string(std::numeric_limits<T>::max())};
+        // Deliberately says "out of range for this field" rather than naming numbers: the only
+        // bounds available here are the C type's, and quoting those would be its own plausible
+        // lie -- polling.interval_seconds would advertise 4294967295 where validate() allows
+        // 3600. The narrower rule reports itself one step later, in its own words.
+        error = {field, "value is out of range for this field"};
         return false;
     }
     target = static_cast<T>(raw);

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -7,6 +7,7 @@
 #include <ArduinoJson.h>
 
 #include <algorithm>
+#include <limits>
 #include <cstring>
 #include <string>
 
@@ -95,7 +96,20 @@ bool patchNumber(JsonVariantConst v, T& target, const char* field, ConfigError& 
         error = {field, "expected an integer"};
         return false;
     }
-    target = static_cast<T>(v.as<long long>());
+    // Range-checked BEFORE the narrowing cast. Casting first silently wrapped a value into
+    // something the later validate() was perfectly happy with, so the config that got stored was
+    // not the one that was asked for and nothing said so: port 65537 became 1 -- a privileged
+    // port -- and unit_id 259 became 3. Whether a bad value was caught depended entirely on
+    // where the wrap happened to land (review, 2026-07-25).
+    const long long raw = v.as<long long>();
+    if (raw < static_cast<long long>(std::numeric_limits<T>::min()) ||
+        raw > static_cast<long long>(std::numeric_limits<T>::max())) {
+        error = {field, "expected an integer between " +
+                            std::to_string(std::numeric_limits<T>::min()) + " and " +
+                            std::to_string(std::numeric_limits<T>::max())};
+        return false;
+    }
+    target = static_cast<T>(raw);
     return true;
 }
 

--- a/src/device/device_state.h
+++ b/src/device/device_state.h
@@ -35,6 +35,12 @@ struct DeviceState {
     MeasurementSet       measurements;
 
     uint16_t statusCode = 0;
+    /// The same rule errorCodeSupported already carried, and for the same reason: not every
+    /// driver reads a status word, and 0 is a MEANING in most protocols -- typically "waiting"
+    /// or "standby". Publishing the struct default therefore reports a device at full power as
+    /// idle, with the Modbus validity bit set to say you may believe it. When false, outputs
+    /// publish null (review, 2026-07-25).
+    bool statusCodeSupported = false;
     /// Human-readable status. A driver that cannot map its raw status code to text must say
     /// so ("Unknown (<n>)") rather than guess at a meaning.
     std::string statusText;

--- a/src/drivers/eversolar_legacy/eversolar_driver.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_driver.cpp
@@ -499,7 +499,8 @@ PollResult EversolarDriver::poll(DeviceState& state) {
     m.set(measurement_id::kTemperature, info.temperatureC, ts);
     m.set(measurement_id::kOperatingHours, static_cast<double>(info.operatingHours), ts);
 
-    state.statusCode = info.statusCode;
+    state.statusCode          = info.statusCode;
+    state.statusCodeSupported = true;
     // Observed meanings only (see opModeText for the per-code evidence); anything never
     // seen on hardware stays an honest "Unknown (n)" until the day/night captures grow
     // the map further.

--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -246,7 +246,8 @@ PollResult MockDriver::poll(DeviceState& state) {
     m.set(measurement_id::kEnergyTotal, 24680.0, ts);
     m.set(measurement_id::kTemperature, 25.0 + 20.0 * fraction, ts);
 
-    state.statusCode         = fraction > 0.0 ? 1 : 0;
+    state.statusCode          = fraction > 0.0 ? 1 : 0;
+    state.statusCodeSupported = true;
     state.statusText         = fraction > 0.0 ? "Normal" : "Standby";
     state.errorCode          = 0;
     state.errorCodeSupported = true;  // unlike EverSolar, this device really does report it

--- a/src/drivers/solax_x1/solax_driver.cpp
+++ b/src/drivers/solax_x1/solax_driver.cpp
@@ -477,7 +477,8 @@ PollResult SolaxDriver::poll(DeviceState& state) {
     m.set(measurement_id::kTemperature, report.temperatureC, ts);
     m.set(measurement_id::kOperatingHours, static_cast<double>(report.runtimeHours), ts);
 
-    state.statusCode = report.mode;
+    state.statusCode          = report.mode;
+    state.statusCodeSupported = true;
     // The mode table is documented (0 Wait .. 6 Self Test); a code outside it is reported
     // as unknown rather than named.
     const char* mode = modeText(report.mode);

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -309,7 +309,8 @@ PollResult SunspecDriver::poll(DeviceState& state) {
         m.set(measurement_id::kTemperature, r.temperatureC, ts);
     }
     if (r.hasState) {
-        state.statusCode = r.state;
+        state.statusCode          = r.state;
+        state.statusCodeSupported = true;
     }
     return PollResult::Ok;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -633,7 +633,13 @@ void setup() {
             log::info("rtc: clock restored: %s (awaiting ntp for drift correction)",
                       n > 0 ? buf : "?");
         } else {
-            log::warn("rtc: present but time not set (first boot or empty backup supply)");
+            // Deliberately does not name a cause. readUtc() refuses for five distinct reasons
+            // -- oscillator stopped, a byte that is not valid BCD, a field out of range, a
+            // year outside 2024-2099, or a date that does not exist -- and only the first is
+            // "flat backup cell". Naming that one sent someone to replace a battery over what
+            // was actually a wiring or I2C fault (review, 2026-07-25).
+            log::warn("rtc: present but gave no usable time; running without it until ntp "
+                      "(flat backup cell, or a bad read -- check the I2C wiring if it persists)");
         }
     }
 

--- a/src/network/rtc_pcf85063.cpp
+++ b/src/network/rtc_pcf85063.cpp
@@ -71,8 +71,7 @@ bool writeUtc(time_t t) {
         return false;
     }
     uint8_t r[7];
-    encodeRegisters(t, r);
-    r[4] = static_cast<uint8_t>(((t / 86400) + 4) % 7);  // weekday; 1970-01-01 was a Thursday
+    encodeRegisters(t, r);  // weekday included; see rtc_time.cpp
 
     Wire.beginTransmission(board::kRtcI2cAddress);
     Wire.write(kRegSeconds);

--- a/src/network/rtc_pcf85063.cpp
+++ b/src/network/rtc_pcf85063.cpp
@@ -2,6 +2,8 @@
 
 #include "rtc_pcf85063.h"
 
+#include "rtc_time.h"
+
 #if defined(ESP32)
 
 #include <Wire.h>
@@ -18,32 +20,6 @@ constexpr uint8_t kRegSeconds  = 0x04;  // bit 7 = OS: oscillator stopped, time 
 constexpr uint8_t kOsFlag      = 0x80;
 
 bool    g_present = false;
-
-uint8_t toBcd(int v) { return static_cast<uint8_t>(((v / 10) << 4) | (v % 10)); }
-int     fromBcd(uint8_t v) { return ((v >> 4) * 10) + (v & 0x0F); }
-
-// Civil <-> epoch without mktime: mktime interprets in the process TZ, and newlib has no
-// timegm. Howard Hinnant's days_from_civil algorithm; exact for the Gregorian calendar.
-int64_t daysFromCivil(int y, int m, int d) {
-    y -= m <= 2;
-    const int64_t era = (y >= 0 ? y : y - 399) / 400;
-    const int     yoe = static_cast<int>(y - era * 400);
-    const int     doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
-    const int     doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    return era * 146097 + doe - 719468;
-}
-
-void civilFromDays(int64_t z, int& y, int& m, int& d) {
-    z += 719468;
-    const int64_t era = (z >= 0 ? z : z - 146096) / 146097;
-    const int     doe = static_cast<int>(z - era * 146097);
-    const int     yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    const int     doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    const int     mp  = (5 * doy + 2) / 153;
-    d = doy - (153 * mp + 2) / 5 + 1;
-    m = mp + (mp < 10 ? 3 : -9);
-    y = static_cast<int>(yoe + era * 400) + (m <= 2);
-}
 
 bool readRegs(uint8_t reg, uint8_t* buf, size_t n) {
     Wire.beginTransmission(board::kRtcI2cAddress);
@@ -84,44 +60,25 @@ bool readUtc(time_t& out) {
     if (!readRegs(kRegSeconds, r, sizeof(r))) {
         return false;
     }
-    if ((r[0] & kOsFlag) != 0) {
-        return false;  // oscillator stopped since the last write: time is untrustworthy
-    }
-    const int sec  = fromBcd(r[0] & 0x7F);
-    const int min  = fromBcd(r[1] & 0x7F);
-    const int hour = fromBcd(r[2] & 0x3F);
-    const int day  = fromBcd(r[3] & 0x3F);
-    const int mon  = fromBcd(r[5] & 0x1F);
-    const int year = 2000 + fromBcd(r[6]);
-    if (sec > 59 || min > 59 || hour > 23 || day < 1 || day > 31 || mon < 1 || mon > 12) {
-        return false;  // a garbled BCD read must not become a plausible wrong clock
-    }
-    out = static_cast<time_t>(daysFromCivil(year, mon, day) * 86400 + hour * 3600 +
-                              min * 60 + sec);
-    return true;
+    // Everything past the I2C read is pure and lives in rtc_time.cpp, where it is host-tested:
+    // the OS flag, BCD validation, range and year bounds. A wrong decode here is silent, so it
+    // is the half that must not be untestable.
+    return decodeRegisters(r, out);
 }
 
 bool writeUtc(time_t t) {
     if (!g_present || t <= 0) {
         return false;
     }
-    int           y, m, d;
-    const int64_t days = t / 86400;
-    int           rem  = static_cast<int>(t % 86400);
-    civilFromDays(days, y, m, d);
-    const int hour = rem / 3600;
-    rem %= 3600;
-    const uint8_t weekday = static_cast<uint8_t>((days + 4) % 7);  // 1970-01-01 = Thursday
+    uint8_t r[7];
+    encodeRegisters(t, r);
+    r[4] = static_cast<uint8_t>(((t / 86400) + 4) % 7);  // weekday; 1970-01-01 was a Thursday
 
     Wire.beginTransmission(board::kRtcI2cAddress);
     Wire.write(kRegSeconds);
-    Wire.write(toBcd(rem % 60));  // seconds; writing this register clears the OS flag
-    Wire.write(toBcd(rem / 60));  // minutes
-    Wire.write(toBcd(hour));
-    Wire.write(toBcd(d));
-    Wire.write(weekday);
-    Wire.write(toBcd(m));
-    Wire.write(toBcd(y - 2000));
+    for (uint8_t b : r) {
+        Wire.write(b);
+    }
     return Wire.endTransmission() == 0;
 }
 

--- a/src/network/rtc_time.cpp
+++ b/src/network/rtc_time.cpp
@@ -66,8 +66,17 @@ bool decodeRegisters(const uint8_t regs[7], time_t& out) {
     if (year < kEarliestPlausibleYear || year > kLatestPlausibleYear) {
         return false;
     }
-    out = static_cast<time_t>(daysFromCivil(year, mon, day) * 86400 + hour * 3600 + min * 60 +
-                              sec);
+    // Day against the actual month, not just against 31. February 31st passes every check
+    // above and silently becomes March 3rd -- a plausible date that is not the one on the chip,
+    // which is the exact class of bug this file was split out to close. Round-tripping through
+    // the civil-date conversion is the cheapest way to ask "does this date exist".
+    int ry = 0, rm = 0, rd = 0;
+    const int64_t days = daysFromCivil(year, mon, day);
+    civilFromDays(days, ry, rm, rd);
+    if (ry != year || rm != mon || rd != day) {
+        return false;
+    }
+    out = static_cast<time_t>(days * 86400 + hour * 3600 + min * 60 + sec);
     return true;
 }
 
@@ -83,8 +92,15 @@ void encodeRegisters(time_t utc, uint8_t regs[7]) {
     regs[1] = toBcd(rem / 60);
     regs[2] = toBcd(hour);
     regs[3] = toBcd(d);
-    regs[4] = 0;  // weekday: the chip keeps it, nothing here reads it
+    // The weekday belongs here, not in the caller. Leaving it to the ESP32-only file put the
+    // one bit of arithmetic that is not host-tested back inside the block this unit exists to
+    // get it out of -- and deleting the caller's line as redundant would then store every write
+    // as Sunday with nothing to notice.
+    regs[4] = static_cast<uint8_t>((days + 4) % 7);  // 1970-01-01 was a Thursday
     regs[5] = toBcd(m);
+    // No year guard here on purpose: past 2099 toBcd() emits a non-BCD byte, which the next
+    // boot's decodeRegisters() refuses. The clock is then lost rather than silently wrong, and
+    // that is the direction to fail in.
     regs[6] = toBcd(y - 2000);
 }
 

--- a/src/network/rtc_time.cpp
+++ b/src/network/rtc_time.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+
+#include "rtc_time.h"
+
+namespace heliograph::rtc {
+namespace {
+
+constexpr uint8_t kOsFlag = 0x80;  // seconds bit 7: oscillator stopped, time unreliable
+
+uint8_t toBcd(int v) { return static_cast<uint8_t>(((v / 10) << 4) | (v % 10)); }
+
+/// BCD with the nibbles actually checked. The naive version decodes 0x1A as 20 -- a perfectly
+/// plausible minute out of a byte that is not BCD at all -- so one corrupted I2C bit yields a
+/// wrong time that passes every range check that follows.
+bool fromBcdChecked(uint8_t v, int& out) {
+    const int hi = v >> 4;
+    const int lo = v & 0x0F;
+    if (hi > 9 || lo > 9) {
+        return false;
+    }
+    out = hi * 10 + lo;
+    return true;
+}
+
+}  // namespace
+
+int64_t daysFromCivil(int y, int m, int d) {
+    y -= m <= 2;
+    const int64_t era = (y >= 0 ? y : y - 399) / 400;
+    const int     yoe = static_cast<int>(y - era * 400);
+    const int     doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+    const int     doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    return era * 146097 + doe - 719468;
+}
+
+void civilFromDays(int64_t z, int& y, int& m, int& d) {
+    z += 719468;
+    const int64_t era = (z >= 0 ? z : z - 146096) / 146097;
+    const int     doe = static_cast<int>(z - era * 146097);
+    const int     yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    const int     doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    const int     mp  = (5 * doy + 2) / 153;
+    d = doy - (153 * mp + 2) / 5 + 1;
+    m = mp + (mp < 10 ? 3 : -9);
+    y = static_cast<int>(yoe + era * 400) + (m <= 2);
+}
+
+bool decodeRegisters(const uint8_t regs[7], time_t& out) {
+    if ((regs[0] & kOsFlag) != 0) {
+        return false;  // oscillator stopped since the last write: time is untrustworthy
+    }
+    int sec = 0, min = 0, hour = 0, day = 0, mon = 0, yy = 0;
+    if (!fromBcdChecked(regs[0] & 0x7F, sec) || !fromBcdChecked(regs[1] & 0x7F, min) ||
+        !fromBcdChecked(regs[2] & 0x3F, hour) || !fromBcdChecked(regs[3] & 0x3F, day) ||
+        !fromBcdChecked(regs[5] & 0x1F, mon) || !fromBcdChecked(regs[6], yy)) {
+        return false;  // not valid BCD: the read is garbled, whatever it happens to decode to
+    }
+    if (sec > 59 || min > 59 || hour > 23 || day < 1 || day > 31 || mon < 1 || mon > 12) {
+        return false;
+    }
+    const int year = 2000 + yy;
+    // The year had no bound at all, and it is the field where a wrong value does the most
+    // damage. TimeManager::synced() only guards the LOW side, so an implausibly HIGH year reads
+    // as "the clock is set": it lands in every log line and payload, gets written back into the
+    // chip on the next sync, and on a bridge that never reaches NTP it stays there forever.
+    if (year < kEarliestPlausibleYear || year > kLatestPlausibleYear) {
+        return false;
+    }
+    out = static_cast<time_t>(daysFromCivil(year, mon, day) * 86400 + hour * 3600 + min * 60 +
+                              sec);
+    return true;
+}
+
+void encodeRegisters(time_t utc, uint8_t regs[7]) {
+    const int64_t days = static_cast<int64_t>(utc) / 86400;
+    int32_t       rem  = static_cast<int32_t>(static_cast<int64_t>(utc) - days * 86400);
+    const int     hour = rem / 3600;
+    rem %= 3600;
+    int y = 0, m = 0, d = 0;
+    civilFromDays(days, y, m, d);
+
+    regs[0] = toBcd(rem % 60);  // seconds; writing this register also clears the OS flag
+    regs[1] = toBcd(rem / 60);
+    regs[2] = toBcd(hour);
+    regs[3] = toBcd(d);
+    regs[4] = 0;  // weekday: the chip keeps it, nothing here reads it
+    regs[5] = toBcd(m);
+    regs[6] = toBcd(y - 2000);
+}
+
+}  // namespace heliograph::rtc

--- a/src/network/rtc_time.h
+++ b/src/network/rtc_time.h
@@ -15,9 +15,11 @@
 namespace heliograph::rtc {
 
 /// The RTC counts a two-digit year from 2000, so 2000-2099 is everything it can express. The
-/// lower bound is deliberately "before this firmware existed": a chip that has lost power reads
-/// back something from the last century or from 2000, and that must fail rather than become the
-/// system clock.
+/// lower bound is deliberately "before this firmware existed", and it deliberately matches
+/// TimeManager's kSaneEpoch so the two agree on what counts as a set clock. A chip that lost
+/// power is already caught by its oscillator-stopped flag; this bound is for the cases that are
+/// not -- a corrupted register that still decodes as valid BCD, or a chip written by something
+/// else entirely.
 inline constexpr int kEarliestPlausibleYear = 2024;
 inline constexpr int kLatestPlausibleYear   = 2099;
 

--- a/src/network/rtc_time.h
+++ b/src/network/rtc_time.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+//
+// The pure half of the PCF85063 driver: turning its seven BCD registers into an epoch, and back.
+//
+// Split out of rtc_pcf85063.cpp because that file is `#if defined(ESP32)` around <Wire.h>, so
+// none of this arithmetic could be tested on the host -- and it is the part where a mistake is
+// silent. A wrong I2C address fails loudly; a wrong decode produces a plausible time that
+// propagates into every log line, every payload and back into the chip on the next NTP sync.
+
+#pragma once
+
+#include <cstdint>
+#include <ctime>
+
+namespace heliograph::rtc {
+
+/// The RTC counts a two-digit year from 2000, so 2000-2099 is everything it can express. The
+/// lower bound is deliberately "before this firmware existed": a chip that has lost power reads
+/// back something from the last century or from 2000, and that must fail rather than become the
+/// system clock.
+inline constexpr int kEarliestPlausibleYear = 2024;
+inline constexpr int kLatestPlausibleYear   = 2099;
+
+/// Days since the Unix epoch for a civil date. Howard Hinnant's algorithm, exact for the
+/// Gregorian calendar. Used instead of mktime(), which interprets in the process timezone, and
+/// instead of timegm(), which newlib does not have.
+int64_t daysFromCivil(int y, int m, int d);
+void    civilFromDays(int64_t z, int& y, int& m, int& d);
+
+/// Decodes the seven registers starting at Seconds into a UTC epoch.
+///
+/// Returns false -- meaning "no usable time" -- when the oscillator-stopped flag is set, when
+/// any byte is not valid BCD, or when a field is out of range. Every one of those is a reading
+/// that would otherwise become a confident wrong clock:
+///
+///   - Plain BCD decoding turns 0x1A into 20, a perfectly plausible minute from a byte that is
+///     not BCD at all, so a single flipped I2C bit passes every range check downstream.
+///   - The year had no bound, and 0xFF decodes to 165 -> the year 2165. Because
+///     TimeManager::synced() only guards the low side, that reads as "the clock is set", and on
+///     a bridge that never reaches NTP it stays that way forever.
+bool decodeRegisters(const uint8_t regs[7], time_t& out);
+
+/// The inverse, for the write-back after an NTP sync. Fills seven registers starting at Seconds.
+void encodeRegisters(time_t utc, uint8_t regs[7]);
+
+}  // namespace heliograph::rtc

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -25,6 +25,20 @@ RegisterMap::RegisterMap() {
     for (size_t i = 0; i < kRegisterCount; ++i) {
         registers_[i] = kInvalidU16;
     }
+    // ...except the validity bitmap, where 0xFFFF means the exact opposite: every bit SET, i.e.
+    // "all of this is valid". The fill above therefore announced that a map full of NaN was
+    // trustworthy. publishMeasurement() promises the two signals always agree so a client can
+    // use whichever it can handle, and before the first poll -- at boot, or all night on an
+    // inverter that never answers -- they disagreed completely. A PLC or EVCC that trusts the
+    // bit and cannot represent NaN would record garbage as a real reading, which is precisely
+    // what the sentinel design exists to prevent (review, 2026-07-25).
+    //
+    // Cleared rather than set: unknown-until-proven is the safe direction, and it also zeroes
+    // the reserved bits past the defined ValidityBit range, which setValidity() never touches
+    // and which otherwise read as 1 forever.
+    for (size_t i = 0; i < reg::kValidityBitmapRegisters; ++i) {
+        registers_[reg::kValidityBitmap + i] = 0;
+    }
     writeU32(reg::kSchemaVersionAddr, kSchemaVersion);
 }
 

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -39,6 +39,36 @@ RegisterMap::RegisterMap() {
     for (size_t i = 0; i < reg::kValidityBitmapRegisters; ++i) {
         registers_[reg::kValidityBitmap + i] = 0;
     }
+    // Same inversion, same reasoning, on every other register where all-ones reads as an
+    // assertion rather than as "unknown". A first version of this fix did only the bitmap;
+    // review pointed out that the flags, the capability bitmaps and the identity strings tell
+    // the same lie, and for longer. refresh() only runs once a driver exists and has begun
+    // (main.cpp gates it on g_state), so on a bridge with no driver selected, or one whose
+    // inverter never answered, this is not a boot-time window of a few hundred milliseconds --
+    // it is what a Modbus client reads for the entire uptime: data_valid true, inverter_online
+    // true, and a capability bitmap claiming the driver can write all 64 channels while
+    // driver_read_only reads true in the same breath (review, 2026-07-25).
+    writeU16(reg::kBridgeOnline, 0);
+    writeU16(reg::kInverterOnline, 0);
+    writeU16(reg::kDataValid, 0);
+    writeU16(reg::kDataStale, 1);  // data we do not have is certainly not fresh
+    writeU16(reg::kBatteryPresent, 0);
+    writeU16(reg::kDriverReadOnly, 1);  // claim no write ability until a driver says otherwise
+    writeU16(reg::kPhaseCount, 0);
+    writeU16(reg::kMpptCount, 0);
+    for (uint16_t i = 0; i < 4; ++i) {
+        writeU16(static_cast<uint16_t>(reg::kCapabilitiesRead + i), 0);
+        writeU16(static_cast<uint16_t>(reg::kCapabilitiesWrite + i), 0);
+    }
+    // Identity strings: NUL-padded empty, which writeString() documents as unambiguously
+    // "unknown". 0xFF bytes are neither empty nor printable.
+    writeString(reg::kManufacturer, {}, 16);
+    writeString(reg::kModel, {}, 16);
+    writeString(reg::kSerialNumber, {}, 16);
+    writeString(reg::kFirmwareVersion, {}, 8);
+    writeString(reg::kDriverId, {}, 8);
+    writeString(reg::kBridgeFirmware, {}, 8);
+
     writeU32(reg::kSchemaVersionAddr, kSchemaVersion);
 }
 
@@ -139,9 +169,12 @@ void RegisterMap::update(const DeviceState& state, const BridgeInfo& bridge,
 
     // Status is only meaningful while the data is valid; otherwise it is last night's value.
     const bool statusUsable = state.dataValid && !state.dataStale;
-    writeU16(reg::kStatusCode, statusUsable ? state.statusCode : kInvalidU16);
-    writeU16(reg::kStatusCodeMirror, statusUsable ? state.statusCode : kInvalidU16);
-    setValidity(ValidityBit::StatusCode, statusUsable);
+    // ...and only when the driver actually reads a status word. 0 means "waiting"/"standby" in
+    // most protocols, so the struct default would report a device at full power as idle.
+    const bool statusCodeUsable = state.statusCodeSupported && statusUsable;
+    writeU16(reg::kStatusCode, statusCodeUsable ? state.statusCode : kInvalidU16);
+    writeU16(reg::kStatusCodeMirror, statusCodeUsable ? state.statusCode : kInvalidU16);
+    setValidity(ValidityBit::StatusCode, statusCodeUsable);
 
     // A driver whose protocol has no error code field must not publish 0 here: 0 means
     // "no fault", which is a claim we cannot make.

--- a/src/outputs/modbus_tcp/register_map.h
+++ b/src/outputs/modbus_tcp/register_map.h
@@ -96,6 +96,10 @@ inline constexpr uint16_t kStatusText         = 510;  // 16 regs / 32 chars
 inline constexpr uint16_t kCapabilitiesRead  = 600;  // 4 regs, 64 bits
 inline constexpr uint16_t kCapabilitiesWrite = 604;  // 4 regs, 64 bits
 inline constexpr uint16_t kValidityBitmap    = 610;  // 8 regs, 128 bits
+/// Length of that bitmap, as a constant rather than a number in a comment: the map's
+/// constructor has to clear exactly this range, and a mismatch there silently republishes
+/// "everything is valid" over a map full of NaN.
+inline constexpr uint16_t kValidityBitmapRegisters = 8;
 inline constexpr uint16_t kPhaseCount        = 620;  // uint16
 inline constexpr uint16_t kMpptCount         = 621;  // uint16
 inline constexpr uint16_t kBatteryPresent    = 622;  // uint16

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -86,7 +86,7 @@ bool buildStatePayload(const DeviceState& state, std::string& out, size_t maxByt
     }
 
     const bool statusUsable = state.dataValid && !state.dataStale;
-    if (statusUsable) {
+    if (state.statusCodeSupported && statusUsable) {
         doc["status_code"] = state.statusCode;
         // Absent-as-null, mirroring the REST payload: a driver with no status text for its
         // protocol must not surface as an empty string in Home Assistant.

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -129,7 +129,7 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     }
 
     const bool statusUsable = state.dataValid && !state.dataStale;
-    if (statusUsable) {
+    if (state.statusCodeSupported && statusUsable) {
         doc["status_code"] = state.statusCode;
         // Empty means the driver has no text for this protocol -- same rule as identity
         // fields: absent-as-null, never an empty string the UI would render as a blank tile.

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -220,14 +220,33 @@ static void test_an_empty_status_text_is_null_not_an_empty_string() {
     state.inverterOnline = true;
     state.dataValid      = true;
     state.dataStale      = false;
-    state.statusCode     = 3;
-    state.statusText     = "";
+    state.statusCode          = 3;
+    state.statusCodeSupported = true;
+    state.statusText          = "";
 
     std::string json;
     TEST_ASSERT_TRUE(buildStatePayload(state, json));
     const auto doc = parse(json);
     TEST_ASSERT_TRUE(doc["status_text"].isNull());
     TEST_ASSERT_EQUAL(3, doc["status_code"].as<int>());
+}
+
+// A driver that never reads a status word leaves statusCode at 0 -- and 0 is a MEANING in most
+// protocols ("waiting", "standby"), so publishing the default reports an inverter at full power
+// as idle. Exactly the rule errorCodeSupported already carried, applied to its neighbour
+// (review, 2026-07-25).
+static void test_a_driver_without_a_status_word_publishes_no_status_code() {
+    DeviceState state;
+    state.inverterOnline = true;
+    state.dataValid      = true;
+    state.dataStale      = false;
+    // statusCodeSupported left false, statusCode left at its 0 default.
+
+    std::string json;
+    TEST_ASSERT_TRUE(buildStatePayload(state, json));
+    const auto doc = parse(json);
+    TEST_ASSERT_TRUE(doc["status_code"].isNull());
+    TEST_ASSERT_TRUE(json.find("\"status_code\":0") == std::string::npos);
 }
 
 static void test_stale_measurements_are_published_as_null() {
@@ -834,6 +853,7 @@ int main(int, char**) {
     RUN_TEST(test_error_code_is_null_when_the_protocol_has_none);
     RUN_TEST(test_status_text_is_not_invented);
     RUN_TEST(test_an_empty_status_text_is_null_not_an_empty_string);
+    RUN_TEST(test_a_driver_without_a_status_word_publishes_no_status_code);
     RUN_TEST(test_stale_measurements_are_published_as_null);
     RUN_TEST(test_a_genuine_zero_is_published_as_zero);
     RUN_TEST(test_derived_measurements_are_flagged);

--- a/test/test_register_map/test_main.cpp
+++ b/test/test_register_map/test_main.cpp
@@ -471,6 +471,32 @@ static void test_a_fresh_map_claims_nothing_is_valid() {
     TEST_ASSERT_EQUAL_HEX16(kInvalidU16, map.at(reg::kAcPowerTotal));
 }
 
+// The bitmap was not the only place all-ones reads as an assertion. refresh() only runs once a
+// driver exists and has begun, so on a bridge with no driver selected -- or one whose inverter
+// never answered -- these are what a Modbus client reads for the ENTIRE uptime, not for a boot
+// window. "Everything is online, valid, and writable in 64 ways" is a confident lie.
+static void test_a_fresh_map_asserts_nothing_it_has_not_measured() {
+    RegisterMap map;
+
+    TEST_ASSERT_EQUAL_UINT16(0, map.at(reg::kBridgeOnline));
+    TEST_ASSERT_EQUAL_UINT16(0, map.at(reg::kInverterOnline));
+    TEST_ASSERT_EQUAL_UINT16(0, map.at(reg::kDataValid));
+    TEST_ASSERT_EQUAL_UINT16(1, map.at(reg::kDataStale));  // absent data is not fresh data
+    TEST_ASSERT_EQUAL_UINT16(0, map.at(reg::kBatteryPresent));
+    TEST_ASSERT_EQUAL_UINT16(0, map.at(reg::kPhaseCount));
+    TEST_ASSERT_EQUAL_UINT16(0, map.at(reg::kMpptCount));
+    // No capability may be claimed before a driver has declared one -- least of all a write.
+    for (uint16_t i = 0; i < 4; ++i) {
+        TEST_ASSERT_EQUAL_UINT16(0, map.at(static_cast<uint16_t>(reg::kCapabilitiesRead + i)));
+        TEST_ASSERT_EQUAL_UINT16(0, map.at(static_cast<uint16_t>(reg::kCapabilitiesWrite + i)));
+    }
+    TEST_ASSERT_EQUAL_UINT16(1, map.at(reg::kDriverReadOnly));
+    // Identity strings read as empty, which is what the format documents as unknown.
+    TEST_ASSERT_EQUAL_UINT16(0, map.at(reg::kManufacturer));
+    TEST_ASSERT_EQUAL_UINT16(0, map.at(reg::kSerialNumber));
+    TEST_ASSERT_EQUAL_STRING("", decodeString(map, reg::kModel, 16).c_str());
+}
+
 static void test_validity_bitmap_and_nan_always_agree() {
     // Two ways of saying "unknown" for clients that cannot handle NaN. They must never
     // disagree, or one of them is a trap.
@@ -531,6 +557,7 @@ int main(int, char**) {
     RUN_TEST(test_a_writable_driver_flips_the_read_only_register);
     RUN_TEST(test_a_32bit_error_code_saturates_the_16bit_register);
     RUN_TEST(test_a_fresh_map_claims_nothing_is_valid);
+    RUN_TEST(test_a_fresh_map_asserts_nothing_it_has_not_measured);
     RUN_TEST(test_validity_bitmap_and_nan_always_agree);
     RUN_TEST(test_validity_bits_fit_the_reserved_space);
     RUN_TEST(test_relay_registers_use_the_sentinel_without_hardware);

--- a/test/test_register_map/test_main.cpp
+++ b/test/test_register_map/test_main.cpp
@@ -452,6 +452,25 @@ static void test_a_writable_driver_flips_the_read_only_register() {
     TEST_ASSERT_TRUE(anyWriteBit);
 }
 
+// The agreement below is only tested AFTER a poll. Before one -- at boot, or all night on an
+// inverter that never answers -- the constructor's blanket 0xFFFF fill hit the bitmap too,
+// where every bit set means "all of this is valid". So a map full of NaN announced itself as
+// trustworthy, and a client that trusts the bit and cannot represent NaN would have recorded
+// garbage as a real reading (review, 2026-07-25).
+static void test_a_fresh_map_claims_nothing_is_valid() {
+    RegisterMap map;
+
+    for (size_t i = 0; i < reg::kValidityBitmapRegisters; ++i) {
+        TEST_ASSERT_EQUAL_HEX16(0, map.at(static_cast<uint16_t>(reg::kValidityBitmap + i)));
+    }
+    // Spot-check through the accessor as well, including the reserved bits past the defined
+    // range that setValidity() never touches and that used to read as 1 forever.
+    TEST_ASSERT_FALSE(map.validityBit(ValidityBit::AcPowerTotal));
+    TEST_ASSERT_FALSE(map.validityBit(ValidityBit::EnergyTotal));
+    // ...while the data registers still read as unknown, which was always right.
+    TEST_ASSERT_EQUAL_HEX16(kInvalidU16, map.at(reg::kAcPowerTotal));
+}
+
 static void test_validity_bitmap_and_nan_always_agree() {
     // Two ways of saying "unknown" for clients that cannot handle NaN. They must never
     // disagree, or one of them is a trap.
@@ -511,6 +530,7 @@ int main(int, char**) {
     RUN_TEST(test_the_mock_hybrid_populates_the_same_map_with_no_output_changes);
     RUN_TEST(test_a_writable_driver_flips_the_read_only_register);
     RUN_TEST(test_a_32bit_error_code_saturates_the_16bit_register);
+    RUN_TEST(test_a_fresh_map_claims_nothing_is_valid);
     RUN_TEST(test_validity_bitmap_and_nan_always_agree);
     RUN_TEST(test_validity_bits_fit_the_reserved_space);
     RUN_TEST(test_relay_registers_use_the_sentinel_without_hardware);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -284,6 +284,30 @@ static void test_diagnostics_unit_id_must_differ_from_the_inverter() {
     TEST_ASSERT_FALSE(applyConfigPatch(R"({"modbus":{"diagnostics_unit_id":1}})", c, e));
 }
 
+// A value too large for the field used to be cast first and validated afterwards, so it wrapped
+// into something validate() was perfectly happy with and the stored config was not the one that
+// was asked for -- with no error anywhere. Whether a bad value got caught depended on where the
+// wrap happened to land: 65537 became 1, a privileged port, while 70000 became 4464 and passed
+// too (review, 2026-07-25).
+static void test_a_value_too_large_for_the_field_is_refused_not_wrapped() {
+    Configuration c;
+    ConfigError   e;
+    const uint16_t before = c.mqtt.port;
+
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"mqtt":{"port":65537}})", c, e));
+    TEST_ASSERT_EQUAL_STRING("mqtt.port", e.field.c_str());
+    TEST_ASSERT_EQUAL_UINT16(before, c.mqtt.port);  // and nothing was half-applied
+
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"mqtt":{"port":70000}})", c, e));
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"mqtt":{"port":-1}})", c, e));
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"modbus":{"unit_id":259}})", c, e));
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"polling":{"interval_seconds":4294967306}})", c, e));
+
+    // The boundary itself still works.
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"mqtt":{"port":65535}})", c, e));
+    TEST_ASSERT_EQUAL_UINT16(65535, c.mqtt.port);
+}
+
 static void test_driver_options_are_opaque_to_the_config_model() {
     // The config model must never gain a manufacturer-specific field. Options are a string
     // map here; what the keys mean is the driver's business.
@@ -1039,6 +1063,7 @@ int main(int, char**) {
     RUN_TEST(test_out_of_range_values_are_refused);
     RUN_TEST(test_modbus_write_cannot_be_enabled);
     RUN_TEST(test_diagnostics_unit_id_must_differ_from_the_inverter);
+    RUN_TEST(test_a_value_too_large_for_the_field_is_refused_not_wrapped);
     RUN_TEST(test_driver_options_are_opaque_to_the_config_model);
     RUN_TEST(test_an_option_orphaned_by_a_driver_change_is_dropped);
     RUN_TEST(test_an_existing_orphan_is_dropped_even_without_a_driver_change);

--- a/test/test_rtc_time/test_main.cpp
+++ b/test/test_rtc_time/test_main.cpp
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+//
+// The PCF85063's seven BCD registers, decoded. This arithmetic used to live inside an
+// `#if defined(ESP32)` block around <Wire.h> and so could not be tested at all -- which is how
+// an unbounded year survived: a wrong I2C address fails loudly, a wrong decode does not.
+
+#include <unity.h>
+
+#include "network/rtc_time.h"
+
+using namespace heliograph::rtc;
+
+void setUp() {}
+void tearDown() {}
+
+namespace {
+
+/// Registers in chip order: sec, min, hour, day, weekday, month, year-2000. All BCD.
+void regs(uint8_t out[7], uint8_t s, uint8_t mi, uint8_t h, uint8_t d, uint8_t mo, uint8_t y) {
+    out[0] = s;
+    out[1] = mi;
+    out[2] = h;
+    out[3] = d;
+    out[4] = 0;
+    out[5] = mo;
+    out[6] = y;
+}
+
+}  // namespace
+
+static void test_a_normal_time_decodes() {
+    uint8_t r[7];
+    regs(r, 0x30, 0x45, 0x12, 0x25, 0x07, 0x26);  // 2026-07-25 12:45:30 UTC
+    time_t t = 0;
+    TEST_ASSERT_TRUE(decodeRegisters(r, t));
+    // 2026-07-25T12:45:30Z
+    TEST_ASSERT_EQUAL_INT64(1784983530, static_cast<int64_t>(t));
+}
+
+static void test_a_round_trip_survives() {
+    uint8_t r[7];
+    const time_t original = 1784983530;
+    encodeRegisters(original, r);
+    time_t back = 0;
+    TEST_ASSERT_TRUE(decodeRegisters(r, back));
+    TEST_ASSERT_EQUAL_INT64(original, static_cast<int64_t>(back));
+}
+
+static void test_the_oscillator_stopped_flag_refuses_the_read() {
+    uint8_t r[7];
+    regs(r, 0x30 | 0x80, 0x45, 0x12, 0x25, 0x07, 0x26);  // OS bit set
+    time_t t = 0;
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+}
+
+// The finding this file exists for. fromBcd(0xFF) is 165, so the year came out as 2165 -- and
+// TimeManager::synced() only guards the low side, so that reads as "the clock is set". It then
+// stamps every log line, every payload, and gets written back into the chip on the next sync.
+static void test_a_garbled_year_is_refused_rather_than_becoming_2165() {
+    uint8_t r[7];
+    regs(r, 0x30, 0x45, 0x12, 0x25, 0x07, 0xFF);
+    time_t t = 0;
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+}
+
+// ...and a merely legal-but-implausible year, which is not garbled BCD at all.
+static void test_a_year_outside_the_plausible_range_is_refused() {
+    uint8_t r[7];
+    regs(r, 0x30, 0x45, 0x12, 0x25, 0x07, 0x99);  // 2099 is the chip's ceiling: accepted
+    time_t t = 0;
+    TEST_ASSERT_TRUE(decodeRegisters(r, t));
+
+    regs(r, 0x30, 0x45, 0x12, 0x25, 0x07, 0x00);  // 2000: a chip that lost power
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+    regs(r, 0x30, 0x45, 0x12, 0x25, 0x07, 0x23);  // 2023, before this firmware existed
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+}
+
+// A byte that is not valid BCD can still decode to something in range. 0x1A -> 20 is a
+// perfectly plausible minute, so the range checks alone would wave it through.
+static void test_a_non_bcd_byte_is_refused_even_when_it_decodes_in_range() {
+    uint8_t r[7];
+    regs(r, 0x30, 0x1A, 0x12, 0x25, 0x07, 0x26);  // minutes = 0x1A
+    time_t t = 0;
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+
+    regs(r, 0x30, 0x45, 0x12, 0x25, 0x0A, 0x26);  // month nibble > 9
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+}
+
+static void test_out_of_range_fields_are_refused() {
+    uint8_t r[7];
+    time_t  t = 0;
+    regs(r, 0x60, 0x45, 0x12, 0x25, 0x07, 0x26);  // 60 seconds
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+    regs(r, 0x30, 0x45, 0x24, 0x25, 0x07, 0x26);  // hour 24
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+    regs(r, 0x30, 0x45, 0x12, 0x00, 0x07, 0x26);  // day 0
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+    regs(r, 0x30, 0x45, 0x12, 0x25, 0x13, 0x26);  // month 13
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+}
+
+// A leap day is the classic off-by-one in civil-date arithmetic, and this code deliberately
+// avoids mktime()/timegm() so it owns that correctness itself.
+static void test_a_leap_day_is_handled() {
+    uint8_t r[7];
+    regs(r, 0x00, 0x00, 0x00, 0x29, 0x02, 0x28);  // 2028-02-29T00:00:00Z
+    time_t t = 0;
+    TEST_ASSERT_TRUE(decodeRegisters(r, t));
+    TEST_ASSERT_EQUAL_INT64(1835395200, static_cast<int64_t>(t));
+
+    int y = 0, m = 0, d = 0;
+    civilFromDays(daysFromCivil(2028, 2, 29), y, m, d);
+    TEST_ASSERT_EQUAL_INT(2028, y);
+    TEST_ASSERT_EQUAL_INT(2, m);
+    TEST_ASSERT_EQUAL_INT(29, d);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_a_normal_time_decodes);
+    RUN_TEST(test_a_round_trip_survives);
+    RUN_TEST(test_the_oscillator_stopped_flag_refuses_the_read);
+    RUN_TEST(test_a_garbled_year_is_refused_rather_than_becoming_2165);
+    RUN_TEST(test_a_year_outside_the_plausible_range_is_refused);
+    RUN_TEST(test_a_non_bcd_byte_is_refused_even_when_it_decodes_in_range);
+    RUN_TEST(test_out_of_range_fields_are_refused);
+    RUN_TEST(test_a_leap_day_is_handled);
+    return UNITY_END();
+}

--- a/test/test_rtc_time/test_main.cpp
+++ b/test/test_rtc_time/test_main.cpp
@@ -103,6 +103,33 @@ static void test_out_of_range_fields_are_refused() {
 
 // A leap day is the classic off-by-one in civil-date arithmetic, and this code deliberately
 // avoids mktime()/timegm() so it owns that correctness itself.
+// February 31st passes every field-range check and silently becomes March 3rd. A plausible
+// date that is not the one on the chip is exactly what this file exists to refuse.
+static void test_a_date_that_does_not_exist_is_refused() {
+    uint8_t r[7];
+    time_t  t = 0;
+    regs(r, 0x00, 0x00, 0x12, 0x31, 0x02, 0x26);  // 31 February
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+    regs(r, 0x00, 0x00, 0x12, 0x31, 0x04, 0x26);  // 31 April
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+    regs(r, 0x00, 0x00, 0x12, 0x29, 0x02, 0x26);  // 29 February in a non-leap year
+    TEST_ASSERT_FALSE(decodeRegisters(r, t));
+    // ...and the real ones still pass.
+    regs(r, 0x00, 0x00, 0x12, 0x30, 0x04, 0x26);
+    TEST_ASSERT_TRUE(decodeRegisters(r, t));
+}
+
+// The weekday lives in encodeRegisters so it is covered here. Left to the ESP32-only caller it
+// was the one piece of arithmetic no test could see, in the file split out precisely to stop
+// that -- and deleting the caller's line as redundant would have stored every write as Sunday.
+static void test_the_weekday_register_is_filled() {
+    uint8_t r[7];
+    encodeRegisters(1784983530, r);  // 2026-07-25 was a Saturday
+    TEST_ASSERT_EQUAL_UINT8(6, r[4]);
+    encodeRegisters(1835395200, r);  // 2028-02-29 was a Tuesday
+    TEST_ASSERT_EQUAL_UINT8(2, r[4]);
+}
+
 static void test_a_leap_day_is_handled() {
     uint8_t r[7];
     regs(r, 0x00, 0x00, 0x00, 0x29, 0x02, 0x28);  // 2028-02-29T00:00:00Z
@@ -126,6 +153,8 @@ int main(int, char**) {
     RUN_TEST(test_a_year_outside_the_plausible_range_is_refused);
     RUN_TEST(test_a_non_bcd_byte_is_refused_even_when_it_decodes_in_range);
     RUN_TEST(test_out_of_range_fields_are_refused);
+    RUN_TEST(test_a_date_that_does_not_exist_is_refused);
+    RUN_TEST(test_the_weekday_register_is_filled);
     RUN_TEST(test_a_leap_day_is_handled);
     return UNITY_END();
 }

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -27,6 +27,8 @@ core_paths=(
     src/device
     src/protocols/pmu/pmu_protocol.h
     src/protocols/pmu/pmu_protocol.cpp
+    src/network/rtc_time.h
+    src/network/rtc_time.cpp
     src/drivers/eversolar_legacy/eversolar_parser.h
     src/drivers/eversolar_legacy/eversolar_parser.cpp
     src/drivers/solax_x1/solax_parser.h


### PR DESCRIPTION
The last of the data-integrity findings from the full-codebase review. Unrelated in mechanism, identical in shape: each one reports a value that is **false and entirely plausible** — which is worse than reporting nothing, and is the rule this firmware enforces everywhere else.

## 1. The Modbus validity bitmap claimed everything was valid before the first poll

`RegisterMap`'s constructor fills every register with `0xFFFF` to mean "unknown". Right for data — and exactly backwards for the bitmap, where `0xFFFF` is every bit **set**.

So a map full of NaN announced itself as trustworthy, contradicting the promise `publishMeasurement()` makes two lines away:

> *"Both signals always agree, so a client can use whichever it can handle."*

A PLC or EVCC that trusts the bit and cannot represent NaN records garbage as a real reading — at boot, and all night on an inverter that never answers. Reserved bits past the defined `ValidityBit` range read as 1 forever, too, since `setValidity()` never touches them.

Cleared rather than set: unknown-until-proven is the safe direction. The bitmap length is now a named constant instead of a number in a comment.

**My first version of this fix did only the bitmap, and both reviews caught that independently.** The online/valid/stale flags, both capability bitmaps, battery-present, the phase and MPPT counts and every identity string told the same lie — and for far longer. `refresh()` only runs once a driver exists and has begun, so on a bridge with no driver selected, or one whose inverter never answered, this is not a boot-time window of a few hundred milliseconds: it is what a Modbus client reads **for the entire uptime**. `data_valid` true, `inverter_online` true, and a capability bitmap claiming the driver can write all 64 channels while `driver_read_only` reads true in the same breath.

## 1b. And the same bug sat one function further down the same file

`DeviceState` carries `errorCodeSupported` precisely because 0 would assert *"no fault"* — a claim we cannot make. `statusCode` had no such flag, and 0 is a **meaning** in most protocols: typically "waiting" or "standby".

A driver that never reads a status word therefore reported an inverter at full power as **idle** — on MQTT, on REST, and in the Modbus register with its validity bit set to say you may believe it. The Growatt driver is exactly such a driver, so this was the guaranteed outcome of every successful poll, not an edge case. It would have landed in Home Assistant on all three MIC TL-X from day one.

`statusCodeSupported` now mirrors its neighbour.

## 2. The RTC could put the clock in 2165

The year was the **one field with no bound**, and `fromBcd(0xFF)` is 165. Since `TimeManager::synced()` only guards the low side, that reads as *"the clock is set"* — it then stamps every log line and payload, and gets written back into the chip on the next sync. On a bridge that never reaches NTP it stays there forever.

Worse: the BCD decode never checked its nibbles. `0x1A` decodes to 20 — a perfectly plausible minute out of a byte that is not BCD at all, passing every range check downstream. One flipped I2C bit was enough.

**The arithmetic moved to `src/network/rtc_time.{h,cpp}` so it can be tested.** It could not be before: it sat inside `#if defined(ESP32)` around `<Wire.h>`, and it is precisely the half where a mistake is silent — a wrong I2C address fails loudly, a wrong decode does not. That is how an unbounded year survived in the first place.

Eight tests now cover it, including a leap day, since this code deliberately avoids `mktime()`/`timegm()` and therefore owns that correctness itself. (My first test vector was wrong and the code was right — recomputed independently before trusting either.)

## 3. `patchNumber` narrowed before validating

An out-of-range value was cast into the target type first, wrapped into something `validate()` was perfectly happy with, and stored. No error anywhere:

| PATCH | Stored |
|---|---|
| `mqtt.port: 65537` | **1** — a privileged port |
| `mqtt.port: 70000` | 4464 |
| `modbus.unit_id: 259` | 3 |
| `polling.interval_seconds: 4294967306` | 10 |

Whether a bad value got caught depended entirely on where the wrap happened to land. Now range-checked against the target type before the cast.

The error deliberately does **not** name numbers. My first version quoted the C type's bounds, which is its own plausible lie — `polling.interval_seconds` advertised 4294967295 where `validate()` allows 3600. It now says the value is out of range and leaves the narrower rule to report itself in its own words.

## Three more, all the same genre — introduced or left standing by this branch

- **The boot warning blamed a flat backup cell.** `readUtc()` now refuses for five distinct reasons and only one of them is that. Someone with a garbled I2C read would have replaced a battery over a wiring fault.
- **The weekday register was computed in the ESP32-only caller** while `encodeRegisters` set it to 0 and its header promised to fill all seven. So the round-trip test verified bytes that were *not* the bytes going to the chip, and deleting the caller's line as redundant would have stored every write as Sunday. Moved into the tested unit.
- **February 31st passed every field range** and silently became March 3rd. Now checked against the actual month.

## Verification

- **527 native tests**, 14 new: a fresh register map claiming nothing valid; the garbled year refused rather than becoming 2165; a non-BCD byte refused even when it decodes in range; the oscillator-stopped flag; a leap day; a full encode/decode round trip; and the narrowing cases above including the 65535 boundary still working.
- `tools/check_layering.sh` PASS, `tools/check_web_js.py` OK, all boards build.

**Still open** from the review, in the order I would take them: the checksum counter only moves when *every* block of a poll fails, so a degrading bus stays invisible (documented in `docs/prometheus.md`, needs decoupling the counter from the poll verdict across all four drivers); `security.admin_username` is served unauthenticated; a device discovered on a second serial profile is still polled at the driver's default; and the firmware still polls exactly one device, which matters for three inverters on one bus.
