### PR TITLE
Count bus errors per transaction, not per poll verdict

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -638,7 +638,7 @@ network.
 | `test_register_map` | float32 word order, NaN sentinels, validity bitmap |
 | `test_measurements` | supported/valid/stale matrix, capability filtering |
 | `test_commands` | Read-only rejection per command type, range validation, rate limiting |
-| `test_device_context` | Poll rhythm, and that bus errors reach the metrics per transaction rather than per poll verdict (including across a counter wrap) |
+| `test_device_context` | Bus errors reaching the metrics per transaction rather than per poll verdict, including the construction baseline and a counter wrap |
 
 Fixtures: `test/fixtures/` with frames from the reference, supplemented in Phase 3 with **real
 recordings** from the TL3000-20, plus deliberately corrupted frames and a night scenario.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -638,6 +638,7 @@ network.
 | `test_register_map` | float32 word order, NaN sentinels, validity bitmap |
 | `test_measurements` | supported/valid/stale matrix, capability filtering |
 | `test_commands` | Read-only rejection per command type, range validation, rate limiting |
+| `test_device_context` | Poll rhythm, and that bus errors reach the metrics per transaction rather than per poll verdict (including across a counter wrap) |
 
 Fixtures: `test/fixtures/` with frames from the reference, supplemented in Phase 3 with **real
 recordings** from the TL3000-20, plus deliberately corrupted frames and a night scenario.

--- a/docs/device-profiles/schema.md
+++ b/docs/device-profiles/schema.md
@@ -60,17 +60,34 @@ per block.
 | `space` | string | yes | `"input"` (function 04) or `"holding"` (function 03). |
 | `start` | int | yes | First register, 0–65535. |
 | `count` | int | yes | Registers in the block, 1–125 (the Modbus per-read limit). |
+| `probe` | bool | no (`false`) | This block exists to answer a question, not to feed a measurement. See below. |
 
 Rules enforced by the build:
 
 - at most **8** blocks (the driver's scratch-buffer limit);
 - `start + count` must stay inside the 16-bit register address space;
 - every mapped register must be covered by a block (including the second word of a
-  32-bit value).
+  32-bit value);
+- a mapped register may **not** live only inside a `probe` block.
 
 A block the device refuses with a Modbus exception is skipped at runtime, not fatal —
 deliberately, so a profile may probe ranges that only exist on some firmware generations
 and the TRACE dump shows which ones this unit actually has.
+
+### `probe = true`
+
+Mark a block that maps nothing and exists only so the raw TRACE dump answers a question — most
+often "which register generation does this model speak?". Two things follow:
+
+- its read failures are **excluded from the RS485 bus counters** (`heliograph_rs485_*_total`);
+- mapping a measurement into it becomes a build error, because the exclusion would then hide
+  real bus errors on a range the profile depends on.
+
+The exclusion is the point. A Modbus device *should* answer an unknown range with an exception,
+which was never counted as a bus error — but nothing forces it to, and a unit that answers with
+silence instead would otherwise add a timeout to the metrics on **every poll**, forever, on an
+installation with nothing wrong with it. A probe block's silence is a fact about the register
+map, not about the wire. See [prometheus.md](../prometheus.md).
 
 ## `[[register]]` — 1 or more per file
 

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -49,8 +49,12 @@ integration's implementation choice, not a statement by Growatt.
 **Therefore the profile probes both.** Alongside the mapped 0–124 block it reads 40 registers
 at 3000, mapping nothing from them. The only purpose is that the first bring-up dump answers
 the question directly: does this unit populate 0–124, 3000+, or both? A block the device
-refuses is skipped harmlessly, so probing a range that does not exist costs a timeout and
-nothing else. This is the same tactic `sph.toml` uses for its own open generation question.
+refuses is skipped harmlessly, and the block is declared `probe = true`, which keeps its read
+failures out of the RS485 bus counters — so probing a range that does not exist costs nothing
+at all. That flag is doing real work: a Modbus device *should* answer an unknown range with an
+exception, but it is free to stay silent instead, and an unflagged probe block would then add a
+timeout to the metrics on every poll of a perfectly healthy inverter. This is the same tactic
+`sph.toml` uses for its own open generation question.
 
 The driver stays **Experimental** until someone confirms the map against a physical unit.
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -110,34 +110,61 @@ A quiet night on a solar inverter produces timeouts and no checksum errors, and 
 the inverter powers down after dark. That asymmetry is exactly why the alert below watches
 checksum errors rather than timeouts.
 
-These three count **transactions, not polls**. One poll is several reads — a Modbus poll reads
-each register block separately, and a SunSpec poll walks the model chain before it reads
-anything — so a single poll can add several errors, and on a healthy bus adds none.
+> **Upgrading from a release before per-transaction counting?** `heliograph_rs485_timeouts_total`
+> steps up by roughly 2–3× on the same hardware, with nothing wrong. A dark inverter used to add
+> one timeout per poll; it now adds one per read, which is one per register block on a Modbus
+> profile. On EverSolar and SolaX it is worse: after three consecutive timeouts the recovery
+> probe runs on every poll, so a night goes from ~1 to ~2 timeouts per poll — and a bridge that
+> reboots after dark, which used to report a *cold-start* night as zero timeouts, now reports
+> two per poll. Rescale any threshold you built on the raw counter. The checksum counter climbs
+> too, but only on a bus that was already faulty. Nothing else in this file changed meaning.
 
-That distinction is the whole value of the counter, and it took two fixes to get there:
+These three count **transactions, not polls**. A Growatt poll reads each register block as its
+own Modbus transaction; the PMU drivers may re-register before they query. So one poll can add
+several errors, and on a healthy bus adds none.
+
+That distinction took two fixes to get there:
 
 - Before the release carrying this note, a Modbus driver could not raise the checksum counter
   **at all**: the shared read transaction folded CRC failures into a generic protocol error, so
   on a Growatt or SunSpec install the metric was structurally always zero and the alert could
   never fire. The PMU drivers (EverSolar, SolaX) were unaffected.
 - And on every driver it only counted when a poll failed **outright**, because the counters were
-  derived from the poll's verdict — and a poll succeeds as soon as *one* block decodes. A bus
-  corrupting a third of its frames therefore polled `Ok` nearly every time and left the metric
-  at zero. The counter caught a bus that had already failed and said nothing about one that was
-  degrading, which is backwards for an early warning. Each driver now tallies what the wire did
-  per transaction, and the poll verdict no longer gates it.
+  derived from the poll's verdict — and a poll succeeds as soon as *one* block decodes. Each
+  driver now tallies what the wire did per transaction, and the poll verdict no longer gates it.
 
-> **One under-count remains.** Line noise that damages a length or byte-count field makes the
-> frame un-parseable rather than merely wrong, so it surfaces as a **timeout** rather than a
-> checksum error. A bus with a genuine cabling fault will normally produce both, but a slow rise
-> in timeouts on an inverter that should be awake deserves the same suspicion as a checksum
-> error. The `trace` log is the ground truth either way: a corrupt block says so on the line it
-> happens.
+  Concretely, on a two-block profile polling every 10 s: at a 3% frame-corruption rate the old
+  counter moved about **once every three hours** — never enough for `rate(...[15m]) > 0` to hold
+  for the alert's `for:` window, so it would never have fired. The new counter moves ~22 times
+  an hour and the alert fires reliably. At heavier corruption the old counter did eventually
+  work: at 30% it caught roughly 32 an hour, because both blocks failing at once stops being
+  rare. So this fix does not make a *failing* bus visible sooner; it makes a *degrading* one
+  visible at all, and the crossover is somewhere around 15%.
 
-An exception reply — the device answering "I do not have that register" — is deliberately **not**
-an error in any of the three. It proves the wiring and the addressing are both fine, and a
-bring-up profile that probes a range the inverter does not implement would otherwise put a
-permanent slope on the metric of a perfectly healthy installation.
+> **Two under-counts remain.**
+>
+> - Line noise that damages a length or byte-count field can make the frame un-parseable rather
+>   than merely wrong, and that surfaces as a **timeout** rather than a checksum error. (Not
+>   always: a byte count damaged *downwards* shortens the frame, the CRC is then checked over
+>   the wrong span, and it does land in the checksum counter.)
+> - A poll can fail with all three counters flat. A device that answers every range with an
+>   exception, or a SunSpec device advertising a model this driver cannot decode, is a
+>   configuration fault, not a wire fault — `heliograph_poll_failure_total` and `last_error` are
+>   what carry it.
+>
+> So: treat a non-zero value as a definite problem, and a **zero as "no proof either way"**. The
+> `trace` log is the ground truth: a corrupt block says so on the line it happens.
+
+Two things are deliberately **not** errors in any of the three counters, because both prove the
+wiring and the addressing are fine:
+
+- An **exception reply** — the device answering "I do not have that register".
+- A **probe block** failing in any way. A profile may declare a block that maps nothing and
+  exists only to discover which register generation a model speaks (see
+  [device-profiles/schema.md](device-profiles/schema.md)). A device is allowed to answer an
+  unknown range with silence rather than an exception, and counting that would put a permanent
+  slope on the metric of a perfectly healthy installation — 360 timeouts an hour at the default
+  poll interval.
 
 ### Bridge health
 
@@ -289,13 +316,18 @@ rate(heliograph_rs485_checksum_errors_total[15m]) > 0
 
 Since the counter moves per transaction this fires while the bridge is still delivering data —
 which is the point, but it does mean a *rising* rate on a bus that looks healthy in Home
-Assistant is now the expected shape of an early warning, not a contradiction. The fraction of
-transactions going bad is the more readable version:
+Assistant is now the expected shape of an early warning, not a contradiction. Corrupt
+transactions per poll attempt reads more usefully than a bare rate:
 
 ```promql
 rate(heliograph_rs485_checksum_errors_total[1h])
-  / rate(heliograph_poll_success_total[1h])
+  / (rate(heliograph_poll_success_total[1h]) + rate(heliograph_poll_failure_total[1h]))
 ```
+
+Note this is per **poll**, not per transaction — the number of transactions is not exported, so
+on a three-block profile the value ranges 0–3 rather than 0–1. Dividing by successful polls
+alone would be worse than imprecise: on the failing bus the query exists to describe, that
+denominator stops advancing and the expression goes to `+Inf`.
 
 The bridge rebooted:
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -110,27 +110,34 @@ A quiet night on a solar inverter produces timeouts and no checksum errors, and 
 the inverter powers down after dark. That asymmetry is exactly why the alert below watches
 checksum errors rather than timeouts.
 
-> **A flat zero on the checksum counter is weaker evidence than it looks, on a Modbus device.**
->
-> Before the release carrying this note a Modbus driver could not raise it at all: the shared read transaction folded CRC
-> failures into a generic protocol error, so on a Growatt or SunSpec install the metric was
-> structurally always zero and the alert could never fire. The PMU drivers (EverSolar, SolaX)
-> were unaffected.
->
-> Even after that fix it still under-counts, in two ways worth knowing before you trust it:
->
-> - A Growatt poll reads several register blocks and reports success as soon as **one** of them
->   decodes. So a bus corrupting, say, a third of its frames usually still has a good block per
->   poll, the poll returns Ok, and the checksum error is logged but never counted. The metric
->   therefore catches a bus that is *failing*, not one that is *degrading* — which is the
->   opposite of what an early-warning counter should do. Fixing that means decoupling the
->   counter from the poll verdict; it is tracked and not done yet.
-> - Line noise that damages a length or byte-count field makes the frame un-parseable rather
->   than merely wrong, and that surfaces as a **timeout**, not a checksum error.
->
-> Treat a non-zero value as a definite problem, and a zero as "no proof either way". The log at
-> `trace` level is the reliable source while the above stands: a corrupt block says so on the
-> line it happens.
+These three count **transactions, not polls**. One poll is several reads — a Modbus poll reads
+each register block separately, and a SunSpec poll walks the model chain before it reads
+anything — so a single poll can add several errors, and on a healthy bus adds none.
+
+That distinction is the whole value of the counter, and it took two fixes to get there:
+
+- Before the release carrying this note, a Modbus driver could not raise the checksum counter
+  **at all**: the shared read transaction folded CRC failures into a generic protocol error, so
+  on a Growatt or SunSpec install the metric was structurally always zero and the alert could
+  never fire. The PMU drivers (EverSolar, SolaX) were unaffected.
+- And on every driver it only counted when a poll failed **outright**, because the counters were
+  derived from the poll's verdict — and a poll succeeds as soon as *one* block decodes. A bus
+  corrupting a third of its frames therefore polled `Ok` nearly every time and left the metric
+  at zero. The counter caught a bus that had already failed and said nothing about one that was
+  degrading, which is backwards for an early warning. Each driver now tallies what the wire did
+  per transaction, and the poll verdict no longer gates it.
+
+> **One under-count remains.** Line noise that damages a length or byte-count field makes the
+> frame un-parseable rather than merely wrong, so it surfaces as a **timeout** rather than a
+> checksum error. A bus with a genuine cabling fault will normally produce both, but a slow rise
+> in timeouts on an inverter that should be awake deserves the same suspicion as a checksum
+> error. The `trace` log is the ground truth either way: a corrupt block says so on the line it
+> happens.
+
+An exception reply — the device answering "I do not have that register" — is deliberately **not**
+an error in any of the three. It proves the wiring and the addressing are both fine, and a
+bring-up profile that probes a range the inverter does not implement would otherwise put a
+permanent slope on the metric of a perfectly healthy installation.
 
 ### Bridge health
 
@@ -278,6 +285,16 @@ Line noise rather than a dead link:
 
 ```promql
 rate(heliograph_rs485_checksum_errors_total[15m]) > 0
+```
+
+Since the counter moves per transaction this fires while the bridge is still delivering data —
+which is the point, but it does mean a *rising* rate on a bus that looks healthy in Home
+Assistant is now the expected shape of an early warning, not a contradiction. The fraction of
+transactions going bad is the more readable version:
+
+```promql
+rate(heliograph_rs485_checksum_errors_total[1h])
+  / rate(heliograph_poll_success_total[1h])
 ```
 
 The bridge rebooted:

--- a/docs/rs485-bus.md
+++ b/docs/rs485-bus.md
@@ -153,5 +153,9 @@ One caveat worth knowing before you trust the counters over your own eyes: noise
 bytes — which is what a missing ground most often does — leaves a frame too short to parse, and
 that surfaces as a **timeout**, not a checksum error. So a bus can be electrically bad and still
 show nothing but timeouts. If a "sleeping inverter" is silent at a time it should not be, treat
-the cable as a suspect anyway. See the note in [prometheus.md](prometheus.md) for the other
-place these counters under-report.
+the cable as a suspect anyway.
+
+The counters are per **transaction**, so on a multi-block device they climb while the bridge is
+still publishing perfectly good data. That is deliberate — a bus losing a third of its frames
+should be visible long before it stops working — and it means a slowly rising checksum rate is
+the signal to act on, not a number waiting to jump off zero.

--- a/profiles/growatt/mic_tl_x.toml
+++ b/profiles/growatt/mic_tl_x.toml
@@ -30,7 +30,10 @@
 # Hence the third read block below: the 3000 range is probed during bring-up so the first
 # hardware session settles which range this firmware actually populates, exactly as
 # profiles/growatt/sph.toml does for the same open question. A block the device refuses is
-# skipped harmlessly, so probing a range that does not exist costs nothing but a timeout.
+# skipped harmlessly, and the block is declared `probe = true`, so a range this model does not
+# implement costs nothing at all -- not even a bus-error count. That flag matters: the Modbus
+# spec says an unknown range should be answered with an exception, but a device is free to say
+# nothing instead, and unflagged that silence would read as an RS485 timeout on every poll.
 #
 # Conservative on purpose: only rows the hardware-exercised source states outright are
 # published as measurements. Anything ambiguous is left to the driver's raw-block TRACE
@@ -84,6 +87,10 @@ count = 89
 space = "input"
 start = 3000
 count = 40
+# Marked as a probe: it maps nothing, so its read failures stay out of the RS485 bus counters.
+# See the note above -- with three of these on one bus, a silent range would otherwise show as
+# a steady timeout rate on three healthy bridges.
+probe = true
 
 # --- DC / PV side -------------------------------------------------------------------------
 

--- a/profiles/growatt/sph.toml
+++ b/profiles/growatt/sph.toml
@@ -28,9 +28,9 @@ battery = true
 # 1000-series is the older SPH "second group" (this is where the registers below point); the
 # 3000-series is the newer "TL-X/TL-XH" generation, where the official V1.39 protocol puts
 # battery SOC (3002), power (3005/6) and control (3036-3049). Whichever the device populates
-# tells us the generation. A block the device rejects is skipped (poll() handles it), so
-# probing a range that does not exist on this firmware is harmless — it just does not appear
-# in the raw dump. The whole base block is read, not just mapped registers, so the dump
+# tells us the generation. A block the device rejects is skipped (poll() handles it), and the
+# block is marked `probe`, so a range that does not exist on this firmware costs nothing at all:
+# it does not appear in the raw dump and it does not move the RS485 error counters. The whole base block is read, not just mapped registers, so the dump
 # shows every register for correcting the uncertain rows against the inverter display.
 
 [[block]]
@@ -47,6 +47,11 @@ count = 45
 space = "input"
 start = 3000
 count = 32
+# Marked as a probe: this block answers a question, it does not feed a measurement. Its read
+# failures are therefore kept out of the RS485 bus counters. Without that, a unit that answers
+# an unknown range with silence rather than an exception would add a timeout every poll --
+# roughly 360 an hour, forever, on an installation with nothing wrong with it.
+probe = true
 
 # --- battery (the point of an SPH) ---
 

--- a/src/device/device_context.cpp
+++ b/src/device/device_context.cpp
@@ -14,7 +14,20 @@ DeviceContext::DeviceContext(InverterDriver& driver, StateStore& store, Diagnost
     state_.bridgeOnline = true;
     state_.identity     = driver_.identity();
     state_.capabilities = driver_.capabilities();
+    // Baseline, not zero: discovery probes the bus through the same driver before this context
+    // exists, and those errors belong to the wizard's report rather than to the running
+    // installation's metrics. Anything already counted is water under the bridge.
+    lastBusErrors_ = driver_.busErrors();
     store_.publish(state_);
+}
+
+void DeviceContext::recordBusErrors() {
+    const BusErrorCounts now = driver_.busErrors();
+    // Unsigned differences, so a counter that wraps still yields the right delta.
+    diagnostics_.recordChecksumErrors(now.checksumErrors - lastBusErrors_.checksumErrors);
+    diagnostics_.recordTimeouts(now.timeouts - lastBusErrors_.timeouts);
+    diagnostics_.recordInvalidFrames(now.invalidFrames - lastBusErrors_.invalidFrames);
+    lastBusErrors_ = now;
 }
 
 PollResult DeviceContext::pollOnce() {
@@ -31,6 +44,13 @@ PollResult DeviceContext::pollOnce() {
     DeviceState working = state_;
     const PollResult result = driver_.poll(working);
 
+    // Unconditionally, and before the verdict is even looked at. The bus counters used to be a
+    // switch over `result`, which meant they only ever moved on a poll that failed OUTRIGHT --
+    // and a driver reading several blocks fails outright only when every one of them does. A
+    // bus corrupting a third of its frames kept polling Ok, so the counter that indicts the
+    // cabling stayed at zero for exactly the degrading bus it should have caught first.
+    recordBusErrors();
+
     if (result == PollResult::Ok) {
         state_ = std::move(working);
         state_.recordPollSuccess(now, policy_.staleness);
@@ -38,12 +58,6 @@ PollResult DeviceContext::pollOnce() {
     } else {
         state_.recordPollFailure(now, policy_.staleness);
         diagnostics_.recordPollFailure();
-        switch (result) {
-            case PollResult::ChecksumError: diagnostics_.recordChecksumError(); break;
-            case PollResult::Timeout:       diagnostics_.recordTimeout(); break;
-            case PollResult::InvalidFrame:  diagnostics_.recordInvalidFrame(); break;
-            default: break;
-        }
         // Only the outcome, never payload bytes: this string is published over MQTT and REST.
         diagnostics_.setLastError(std::string("poll failed: ") + pollResultName(result));
     }

--- a/src/device/device_context.cpp
+++ b/src/device/device_context.cpp
@@ -14,9 +14,11 @@ DeviceContext::DeviceContext(InverterDriver& driver, StateStore& store, Diagnost
     state_.bridgeOnline = true;
     state_.identity     = driver_.identity();
     state_.capabilities = driver_.capabilities();
-    // Baseline, not zero: discovery probes the bus through the same driver before this context
-    // exists, and those errors belong to the wizard's report rather than to the running
-    // installation's metrics. Anything already counted is water under the bridge.
+    // Read the driver's tally rather than assuming zero. Today it always IS zero -- main.cpp
+    // builds a fresh driver right before this context, discovery uses its own throwaway
+    // instances, and no begin() touches the bus -- so this is defence, not a fix for anything
+    // observed. It costs one read and it means a driver that arrives pre-used cannot inject its
+    // history into the installation's metrics as one enormous step.
     lastBusErrors_ = driver_.busErrors();
     store_.publish(state_);
 }

--- a/src/device/device_context.h
+++ b/src/device/device_context.h
@@ -48,6 +48,10 @@ public:
     // never worked -- bridgeOnline is simply true while the poll loop runs.
 
 private:
+    /// Feeds the difference in the driver's frame-level tallies into Diagnostics. Called on
+    /// every poll, successful or not.
+    void recordBusErrors();
+
     InverterDriver& driver_;
     StateStore&     store_;
     Diagnostics&    diagnostics_;
@@ -57,6 +61,8 @@ private:
     DeviceState state_;
     uint64_t    lastAttemptMs_ = 0;
     bool        everPolled_    = false;
+    /// The driver's cumulative tallies as of the previous poll.
+    BusErrorCounts lastBusErrors_{};
 };
 
 }  // namespace heliograph

--- a/src/diagnostics/diagnostics.h
+++ b/src/diagnostics/diagnostics.h
@@ -44,9 +44,24 @@ public:
         pollFailureTotal_.fetch_add(1, std::memory_order_relaxed);
         consecutivePollFailures_.fetch_add(1, std::memory_order_relaxed);
     }
-    void recordChecksumError() { checksumErrorTotal_.fetch_add(1, std::memory_order_relaxed); }
-    void recordTimeout() { rs485TimeoutTotal_.fetch_add(1, std::memory_order_relaxed); }
-    void recordInvalidFrame() { invalidFrameTotal_.fetch_add(1, std::memory_order_relaxed); }
+    /// Bus errors arrive in batches: one poll is several transactions, and each can fail on its
+    /// own. Adding a count rather than one at a time is what lets the metric describe a bus
+    /// that is degrading instead of only one that has already stopped working.
+    void recordChecksumErrors(uint32_t n) {
+        if (n != 0) {
+            checksumErrorTotal_.fetch_add(n, std::memory_order_relaxed);
+        }
+    }
+    void recordTimeouts(uint32_t n) {
+        if (n != 0) {
+            rs485TimeoutTotal_.fetch_add(n, std::memory_order_relaxed);
+        }
+    }
+    void recordInvalidFrames(uint32_t n) {
+        if (n != 0) {
+            invalidFrameTotal_.fetch_add(n, std::memory_order_relaxed);
+        }
+    }
     void recordWifiReconnect() { wifiReconnectTotal_.fetch_add(1, std::memory_order_relaxed); }
     void recordMqttReconnect() { mqttReconnectTotal_.fetch_add(1, std::memory_order_relaxed); }
     void recordModbusClient() { modbusClientConnections_.fetch_add(1, std::memory_order_relaxed); }

--- a/src/drivers/eversolar_legacy/eversolar_driver.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_driver.cpp
@@ -173,6 +173,11 @@ EversolarDriver::TransactResult EversolarDriver::transact(CommandCode command,
             }
             if (valid == ParseResult::Ok) {
                 if (frame.dataLength > payloadCapacity) {
+                    // Unreachable today (every caller passes a full-size buffer), but this is
+                    // an InvalidFrame return and every other one tallies. Left untallied it
+                    // would be a return path that silently reports nothing the moment some
+                    // future caller passes a smaller buffer.
+                    ++invalidFrames_;
                     traceOutcome("payload too large");
                     return TransactResult::InvalidFrame;
                 }

--- a/src/drivers/eversolar_legacy/eversolar_driver.h
+++ b/src/drivers/eversolar_legacy/eversolar_driver.h
@@ -108,9 +108,9 @@ private:
     uint32_t timeouts_       = 0;
 
 public:
-    uint32_t checksumErrors() const { return checksumErrors_; }
-    uint32_t invalidFrames() const { return invalidFrames_; }
-    uint32_t timeouts() const { return timeouts_; }
+    BusErrorCounts busErrors() const override {
+        return {checksumErrors_, timeouts_, invalidFrames_};
+    }
 };
 
 }  // namespace heliograph::eversolar

--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -107,6 +107,10 @@ GrowattDriver::ReadResult GrowattDriver::readBlock(RegSpace space, uint16_t star
     const modbus::ReadTiming timing{kTransactionDeadlineMs, kResponseTimeoutMs};
     const auto outcome =
         modbus::readRegisters(*transport_, options_.unitId, fn, start, count, out, count, timing);
+    // Per transaction, not per poll: this driver reads several blocks and reports Ok as soon as
+    // one decodes, so counting from the poll verdict made a bus that corrupted most of its
+    // frames register as healthy.
+    tallyModbusRead(busErrors_, outcome.status);
 
     switch (outcome.status) {
         case modbus::ReadStatus::Ok:

--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -93,7 +93,7 @@ bool GrowattDriver::begin(Transport& transport) {
 }
 
 GrowattDriver::ReadResult GrowattDriver::readBlock(RegSpace space, uint16_t start, uint16_t count,
-                                                   uint16_t* out) {
+                                                   uint16_t* out, bool probe) {
     if (transport_ == nullptr) {
         return ReadResult::TransportError;
     }
@@ -110,7 +110,14 @@ GrowattDriver::ReadResult GrowattDriver::readBlock(RegSpace space, uint16_t star
     // Per transaction, not per poll: this driver reads several blocks and reports Ok as soon as
     // one decodes, so counting from the poll verdict made a bus that corrupted most of its
     // frames register as healthy.
-    tallyModbusRead(busErrors_, outcome.status);
+    //
+    // A probe block is exempt. Asking a model whether it implements a range we are not sure it
+    // has is the firmware's own question, and an inverter is entitled to answer with silence
+    // rather than the exception the Modbus spec prefers. Counting that silence as a bus timeout
+    // would slope the metric of a healthy install for as long as the probe stays in the profile.
+    if (!probe) {
+        tallyModbusRead(busErrors_, outcome.status);
+    }
 
     switch (outcome.status) {
         case modbus::ReadStatus::Ok:
@@ -138,9 +145,9 @@ PollResult GrowattDriver::poll(DeviceState& state) {
     const GrowattProfile& profile = *options_.profile;
 
     size_t validCount  = 0;
-    bool   sawTimeout  = false;
     bool   sawCrcError = false;  // bytes arrived corrupted -> the cable, not the configuration
     bool   sawResponse = false;  // device answered *something* (exception / bad frame) = alive
+    bool   sawBadFrame = false;  // an intact frame that was not ours: addressing, not cabling
 
     // A block the device refuses (exception) or that arrives corrupt is skipped, not fatal:
     // during bring-up the profile deliberately probes ranges that may not exist on this
@@ -153,7 +160,7 @@ PollResult GrowattDriver::poll(DeviceState& state) {
         data.space = b.space;
         data.start = b.start;
         data.count = b.count;
-        const ReadResult r = readBlock(b.space, b.start, b.count, data.values);
+        const ReadResult r = readBlock(b.space, b.start, b.count, data.values, b.probe);
         switch (r) {
             case ReadResult::Ok:
                 ++validCount;
@@ -171,12 +178,12 @@ PollResult GrowattDriver::poll(DeviceState& state) {
                 break;
             case ReadResult::Protocol:
                 sawResponse = true;
+                sawBadFrame = true;
                 log::warn("GROWATT unit %u block %u+%u unreadable (bad frame) -- skipped",
                           options_.unitId, b.start, b.count);
                 break;
             case ReadResult::Timeout:
-                sawTimeout = true;
-                break;
+                break;  // silence on this block; only total silence is a timeout verdict
             case ReadResult::TransportError:
                 return PollResult::TransportError;
         }
@@ -184,13 +191,24 @@ PollResult GrowattDriver::poll(DeviceState& state) {
 
     if (validCount == 0) {
         // Nothing usable. A checksum failure outranks everything else: it is the only outcome
-        // that points at the cable, and it is what the alerting rule watches. Then "silent"
-        // only when the device truly said nothing -- a refused range or a bad frame proves it
-        // is present and addressable, so that outranks a timeout on another block.
+        // that points at the cable, and it is what the alerting rule watches. Then a bad frame,
+        // which proves the device is present and addressable.
         if (sawCrcError) {
             return PollResult::ChecksumError;
         }
-        return (sawTimeout && !sawResponse) ? PollResult::Timeout : PollResult::InvalidFrame;
+        if (sawBadFrame) {
+            return PollResult::InvalidFrame;
+        }
+        // Nothing but exceptions: the device is present, correctly addressed, and refusing
+        // every range this profile asks for -- a wrong profile or unit id, not a wire fault.
+        // This used to report InvalidFrame, which pointed the field diagnosis at the cabling
+        // AND contradicted the bus counters, since an exception rightly moves none of them: the
+        // poll failed every ten seconds while all three RS485 counters read zero. SunSpec has
+        // always called this NotRegistered (failureFor()); the two Modbus drivers now agree.
+        if (sawResponse) {
+            return PollResult::NotRegistered;
+        }
+        return PollResult::Timeout;
     }
 
     // At least one block is good -> safe to touch state.

--- a/src/drivers/growatt_modbus/growatt_driver.h
+++ b/src/drivers/growatt_modbus/growatt_driver.h
@@ -17,6 +17,7 @@
 
 #include "drivers/growatt_modbus/growatt_registers.h"
 #include "drivers/inverter_driver.h"
+#include "drivers/modbus_bus_tally.h"
 
 namespace heliograph::growatt {
 
@@ -48,6 +49,8 @@ public:
     /// on hardware. Battery control is a deliberate later step, not an oversight.
     CommandResult execute(const InverterCommand& command) override;
 
+    BusErrorCounts busErrors() const override { return busErrors_; }
+
 private:
     /// Crc is separate from Protocol for the same reason it is in the codec: it is the only one
     /// that means the wire is bad, and it is what the checksum-error metric and its alert key on.
@@ -60,6 +63,7 @@ private:
     Transport*     transport_ = nullptr;
     GrowattOptions options_;
     uint8_t        lastException_ = 0;
+    BusErrorCounts busErrors_{};
 
     static constexpr size_t kMaxBlocks = 8;
     /// Scratch for poll(): ~2 KB. A member, not a stack array, on purpose. The rs485 task runs

--- a/src/drivers/growatt_modbus/growatt_driver.h
+++ b/src/drivers/growatt_modbus/growatt_driver.h
@@ -57,8 +57,10 @@ private:
     enum class ReadResult { Ok, Timeout, Exception, Crc, Protocol, TransportError };
 
     /// One Modbus read transaction into `out` (at least `count` words). Sets lastException_ on
-    /// an exception reply. TRACE-dumps the raw block for hardware bring-up.
-    ReadResult readBlock(RegSpace space, uint16_t start, uint16_t count, uint16_t* out);
+    /// an exception reply. TRACE-dumps the raw block for hardware bring-up. `probe` marks a
+    /// block read only to answer a bring-up question; its failures never reach the bus counters.
+    ReadResult readBlock(RegSpace space, uint16_t start, uint16_t count, uint16_t* out,
+                         bool probe = false);
 
     Transport*     transport_ = nullptr;
     GrowattOptions options_;

--- a/src/drivers/growatt_modbus/growatt_registers.h
+++ b/src/drivers/growatt_modbus/growatt_registers.h
@@ -43,6 +43,12 @@ struct RegBlock {
     RegSpace space;
     uint16_t start;
     uint16_t count;
+    /// A block read only to answer a bring-up question, mapping nothing. Its silence is a fact
+    /// about the register map, not about the wire, so it must not move the RS485 bus counters:
+    /// otherwise a profile probing a range this model does not implement would put a permanent
+    /// slope on the timeout metric of a perfectly wired installation -- ~360 an hour at the
+    /// default poll interval, forever, on hardware with nothing wrong with it.
+    bool probe = false;
 };
 
 /// A writable numeric setpoint register, declared in a profile's [[write]] section.

--- a/src/drivers/inverter_driver.h
+++ b/src/drivers/inverter_driver.h
@@ -44,6 +44,27 @@ enum class PollResult : uint8_t {
 
 const char* pollResultName(PollResult result);
 
+/// What the wire did, counted per transaction rather than per poll.
+///
+/// The bus counters used to be derived from the PollResult, and a poll is a verdict over
+/// several transactions: any driver that reads more than one block reports Ok as soon as one of
+/// them decodes. A bus corrupting a third of its frames therefore polled Ok almost every time
+/// and moved the checksum counter almost never -- so the one metric that indicts the cabling
+/// caught a bus that had already failed, and stayed flat on a bus that was degrading. That is
+/// backwards for the thing an early warning is for.
+///
+/// Cumulative and monotonic for the driver's lifetime. DeviceContext takes the difference
+/// across each poll, so a driver only has to count; it never has to know what the caller
+/// already saw. Unsigned arithmetic makes the difference correct across a wrap too.
+struct BusErrorCounts {
+    /// Bytes came back corrupted: the wire. See docs/rs485-bus.md.
+    uint32_t checksumErrors = 0;
+    /// A read that got no answer at all.
+    uint32_t timeouts       = 0;
+    /// An intact frame that was not the one asked for: addressing, or a device quirk.
+    uint32_t invalidFrames  = 0;
+};
+
 class InverterDriver {
 public:
     virtual ~InverterDriver() = default;
@@ -60,6 +81,15 @@ public:
     /// Contract: `state` may only be modified when returning Ok. On any failure the caller
     /// keeps the previous state, so a partially decoded frame can never surface as data.
     virtual PollResult poll(DeviceState& state) = 0;
+
+    /// Frame-level tallies for the metrics. Pure virtual on purpose: a default returning zero
+    /// would let a new driver ship with a permanently flat checksum counter and nothing to
+    /// notice, which is the failure mode this whole mechanism exists to remove.
+    ///
+    /// Errors seen during probe() count too -- but discovery runs before a DeviceContext
+    /// exists, and the context takes its baseline at construction, so probe traffic never
+    /// lands in the metric. The wizard reports on its own probes.
+    virtual BusErrorCounts busErrors() const = 0;
 
     virtual DeviceIdentity       identity() const     = 0;
     virtual InverterCapabilities capabilities() const = 0;

--- a/src/drivers/inverter_driver.h
+++ b/src/drivers/inverter_driver.h
@@ -61,7 +61,15 @@ struct BusErrorCounts {
     uint32_t checksumErrors = 0;
     /// A read that got no answer at all.
     uint32_t timeouts       = 0;
-    /// An intact frame that was not the one asked for: addressing, or a device quirk.
+    /// An intact frame that was not usable: a reply from the wrong unit, a structurally
+    /// unreadable one, or a payload this driver cannot decode. Addressing or a device quirk,
+    /// not cabling.
+    ///
+    /// One deliberate asymmetry: the PMU drivers do NOT count a well-formed frame addressed to
+    /// someone else. On a half-duplex bus that branch also catches our own transmission coming
+    /// back, and the two are not distinguishable there, so counting it would put a per-poll
+    /// slope on every installation that echoes. The Modbus drivers have no such ambiguity and
+    /// do count it. Compare installations of the same protocol, not across protocols.
     uint32_t invalidFrames  = 0;
 };
 
@@ -86,9 +94,9 @@ public:
     /// would let a new driver ship with a permanently flat checksum counter and nothing to
     /// notice, which is the failure mode this whole mechanism exists to remove.
     ///
-    /// Errors seen during probe() count too -- but discovery runs before a DeviceContext
-    /// exists, and the context takes its baseline at construction, so probe traffic never
-    /// lands in the metric. The wizard reports on its own probes.
+    /// Errors seen during probe() count too. That is invisible in practice -- DiscoveryEngine
+    /// probes through its own throwaway driver instances, never the polling one -- so a
+    /// discovery sweep across four baud rates does not land in the installation's metrics.
     virtual BusErrorCounts busErrors() const = 0;
 
     virtual DeviceIdentity       identity() const     = 0;

--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -161,9 +161,11 @@ ProbeResult MockDriver::probe() {
 
 PollResult MockDriver::poll(DeviceState& state) {
     if (options_.timeout || options_.offline) {
+        ++busErrors_.timeouts;
         return PollResult::Timeout;
     }
     if (options_.failChecksum) {
+        ++busErrors_.checksumErrors;
         return PollResult::ChecksumError;
     }
 

--- a/src/drivers/mock/mock_driver.h
+++ b/src/drivers/mock/mock_driver.h
@@ -60,6 +60,10 @@ public:
     DeviceIdentity       identity() const override;
     InverterCapabilities capabilities() const override;
     CommandResult        execute(const InverterCommand& command) override;
+    /// The simulation has no bytes, but it does have simulated outcomes: a mock told to fail
+    /// its checksum must move the same counter a real driver would, or the metric path is
+    /// untestable without hardware.
+    BusErrorCounts       busErrors() const override { return busErrors_; }
 
     void setOptions(const MockOptions& options) { options_ = options; }
     const MockOptions& options() const { return options_; }
@@ -76,6 +80,7 @@ private:
     InverterCapabilities capabilities_;
     double               lastAcceptedValue_ = 0.0;
     uint32_t             acceptedCommands_  = 0;
+    BusErrorCounts       busErrors_{};
 };
 
 }  // namespace heliograph::mock

--- a/src/drivers/modbus_bus_tally.h
+++ b/src/drivers/modbus_bus_tally.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+//
+// One mapping from a Modbus read outcome onto the frame-level bus counters, shared by every
+// Modbus-RTU driver.
+//
+// Kept here rather than in protocols/modbus so the codec stays free of anything driver-shaped,
+// and shared rather than written out per driver so the two Modbus drivers cannot drift into
+// describing the same bus condition differently -- which they already did once, when one
+// reported a short reply as an invalid frame and the other as an unregistered device.
+
+#pragma once
+
+#include "drivers/inverter_driver.h"
+#include "protocols/modbus/modbus_client.h"
+
+namespace heliograph {
+
+/// Adds one transaction's outcome to `counts`. Ok and TransportError move nothing (the first
+/// is not an error, the second never reached the wire); nor does an exception reply, which is a
+/// healthy device declining a range -- see docs/prometheus.md on why that must not indict the
+/// cabling.
+inline void tallyModbusRead(BusErrorCounts& counts, modbus::ReadStatus status) {
+    switch (status) {
+        case modbus::ReadStatus::Crc:      ++counts.checksumErrors; break;
+        case modbus::ReadStatus::Timeout:  ++counts.timeouts;       break;
+        case modbus::ReadStatus::Protocol: ++counts.invalidFrames;  break;
+        case modbus::ReadStatus::Ok:
+        case modbus::ReadStatus::Exception:
+        case modbus::ReadStatus::TransportError:
+            break;
+    }
+}
+
+}  // namespace heliograph

--- a/src/drivers/solax_x1/solax_driver.cpp
+++ b/src/drivers/solax_x1/solax_driver.cpp
@@ -154,6 +154,11 @@ SolaxDriver::TransactResult SolaxDriver::transact(Address source, CommandCode co
             }
             if (valid == ParseResult::Ok) {
                 if (frame.dataLength > payloadCapacity) {
+                    // Unreachable today (every caller passes a full-size buffer), but this is
+                    // an InvalidFrame return and every other one tallies. Left untallied it
+                    // would be a return path that silently reports nothing the moment some
+                    // future caller passes a smaller buffer.
+                    ++invalidFrames_;
                     traceOutcome("payload too large");
                     return TransactResult::InvalidFrame;
                 }

--- a/src/drivers/solax_x1/solax_driver.h
+++ b/src/drivers/solax_x1/solax_driver.h
@@ -96,9 +96,9 @@ private:
     uint32_t timeouts_       = 0;
 
 public:
-    uint32_t checksumErrors() const { return checksumErrors_; }
-    uint32_t invalidFrames() const { return invalidFrames_; }
-    uint32_t timeouts() const { return timeouts_; }
+    BusErrorCounts busErrors() const override {
+        return {checksumErrors_, timeouts_, invalidFrames_};
+    }
 };
 
 }  // namespace heliograph::solax

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -29,9 +29,10 @@ modbus::ReadOutcome SunspecDriver::read(uint16_t address, uint16_t count, uint16
     const auto outcome = modbus::readRegisters(*transport_, options_.unitId,
                                                modbus::kReadHoldingRegisters, address, count, out,
                                                capacity, timing);
-    // Every read this driver makes passes through here, so this is the whole tally. It matters
-    // more here than anywhere: a chain walk plus a chunked model read is a dozen transactions
-    // per poll, and only the one that stops the walk ever reached the old poll-verdict counter.
+    // Every read on the wire passes through here. Note that a steady-state poll is ONE
+    // transaction: the chain walk is gated on walked_ and runs once per session, and model 103
+    // fits inside a single chunk. The dozen-transaction case is the walk itself, where only the
+    // read that stopped it ever reached the old poll-verdict counter.
     tallyModbusRead(busErrors_, outcome.status);
     return outcome;
 }
@@ -271,6 +272,12 @@ PollResult SunspecDriver::poll(DeviceState& state) {
 
     InverterReadings r;
     if (!decodeInverter(regs.data(), regs.size(), r)) {
+        // Counted here, not in read(): every read succeeded with a valid CRC, so the tally in
+        // read() saw nothing wrong. The frame is intact and simply not the one this driver can
+        // use -- which is what invalidFrames means, and what the PMU drivers already count on
+        // their own decode failures. Missing it left this path failing every poll with all
+        // three bus counters flat at zero, and walked_ is not reset here, so it stays that way.
+        ++busErrors_.invalidFrames;
         return PollResult::InvalidFrame;
     }
 

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -26,8 +26,14 @@ modbus::ReadOutcome SunspecDriver::read(uint16_t address, uint16_t count, uint16
     const modbus::ReadTiming timing{kTransactionDeadlineMs, kResponseTimeoutMs};
     // Holding registers: SunSpec's own convention, and what every implementation this was
     // checked against uses.
-    return modbus::readRegisters(*transport_, options_.unitId, modbus::kReadHoldingRegisters,
-                                 address, count, out, capacity, timing);
+    const auto outcome = modbus::readRegisters(*transport_, options_.unitId,
+                                               modbus::kReadHoldingRegisters, address, count, out,
+                                               capacity, timing);
+    // Every read this driver makes passes through here, so this is the whole tally. It matters
+    // more here than anywhere: a chain walk plus a chunked model read is a dozen transactions
+    // per poll, and only the one that stops the walk ever reached the old poll-verdict counter.
+    tallyModbusRead(busErrors_, outcome.status);
+    return outcome;
 }
 
 // Translates a failed read into the poll outcome that describes it honestly. Everything used

--- a/src/drivers/sunspec/sunspec_driver.h
+++ b/src/drivers/sunspec/sunspec_driver.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "drivers/inverter_driver.h"
+#include "drivers/modbus_bus_tally.h"
 #include "drivers/sunspec/sunspec_parser.h"
 #include "protocols/modbus/modbus_client.h"
 
@@ -63,6 +64,7 @@ public:
     DeviceIdentity          identity() const override { return identity_; }
     InverterCapabilities    capabilities() const override;
     CommandResult           execute(const InverterCommand& command) override;
+    BusErrorCounts          busErrors() const override { return busErrors_; }
 
     /// Everything the device advertised, in chain order. Empty until a successful walk.
     const std::vector<ChainEntry>& chain() const { return chain_; }
@@ -79,6 +81,7 @@ private:
 
     Transport*     transport_ = nullptr;
     SunspecOptions options_;
+    BusErrorCounts busErrors_{};
 
     std::vector<ChainEntry> chain_;
     const ChainEntry*       inverterEntry_ = nullptr;  ///< into chain_

--- a/test/test_commands/test_main.cpp
+++ b/test/test_commands/test_main.cpp
@@ -319,6 +319,7 @@ public:
     ProbeResult probe() override { return {}; }
     PollResult  poll(DeviceState&) override { return PollResult::Ok; }
     DeviceIdentity identity() const override { return {}; }
+    BusErrorCounts busErrors() const override { return {}; }
     InverterCapabilities capabilities() const override {
         InverterCapabilities c;
         c.addWrite(InverterCapability::SetActivePowerLimit);  // ...and no numeric[] entry

--- a/test/test_device_context/test_main.cpp
+++ b/test/test_device_context/test_main.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// DeviceContext: the poll rhythm, and how the driver's frame-level tallies reach Diagnostics.
+// DeviceContext: how the driver's frame-level tallies reach Diagnostics.
 //
 // The tallies are the reason this suite exists. They used to be a switch over the PollResult,
 // which made the checksum metric a function of the poll VERDICT -- and a driver reading several
@@ -90,9 +90,9 @@ static void test_only_the_new_errors_are_added() {
     TEST_ASSERT_EQUAL_UINT32(5, diagnostics.snapshot().checksumErrorTotal);
 }
 
-// Discovery probes the bus through the same driver before this context exists. Those errors are
-// reported by the wizard; replaying them into the installation's metrics would put a step at
-// every driver switch that no cable fault explains.
+// The baseline is read, not assumed zero. Production never reaches this state -- main.cpp
+// builds a fresh driver right before the context -- so this guards the mechanism rather than an
+// observed bug: a driver that arrived pre-used must not inject its history as one huge step.
 static void test_errors_from_before_the_context_are_not_replayed() {
     ScriptedDriver driver;
     driver.counts.checksumErrors = 9;
@@ -128,14 +128,21 @@ static void test_the_three_counters_do_not_bleed_into_each_other() {
     TEST_ASSERT_EQUAL_UINT32(1, snapshot.pollFailureTotal);
 }
 
-// A failure the wire had nothing to do with -- no driver, or a UART that would not open. Moving
-// a bus counter here would send someone to check the cabling on a fault that never reached it.
-static void test_a_transport_failure_moves_no_bus_counter() {
+// The driver is the authority now, not the verdict. A poll can fail without a single thing
+// having gone wrong on the wire -- a device refusing every register range, or a UART that would
+// not open -- and moving a bus counter there sends someone to check cabling that is fine.
+//
+// This is the direction that would regress silently: under the old code a Timeout verdict
+// incremented the timeout counter by definition, so this test fails if anything reintroduces a
+// switch over the verdict.
+static void test_a_failing_verdict_alone_moves_no_bus_counter() {
     ScriptedDriver driver;
     StateStore     store;
     Diagnostics    diagnostics;
     DeviceContext  context(driver, store, diagnostics, clockFn);
 
+    driver.verdict = PollResult::Timeout;  // ...but the driver tallied nothing
+    context.pollOnce();
     driver.verdict = PollResult::TransportError;
     context.pollOnce();
 
@@ -143,7 +150,22 @@ static void test_a_transport_failure_moves_no_bus_counter() {
     TEST_ASSERT_EQUAL_UINT32(0, snapshot.checksumErrorTotal);
     TEST_ASSERT_EQUAL_UINT32(0, snapshot.rs485TimeoutTotal);
     TEST_ASSERT_EQUAL_UINT32(0, snapshot.invalidFrameTotal);
-    TEST_ASSERT_EQUAL_UINT32(1, snapshot.pollFailureTotal);
+    TEST_ASSERT_EQUAL_UINT32(2, snapshot.pollFailureTotal);
+}
+
+// ...and the converse: a driver that tallied errors is believed even when the verdict is one
+// the old switch ignored entirely.
+static void test_a_driver_tally_counts_under_a_verdict_the_old_switch_ignored() {
+    ScriptedDriver driver;
+    StateStore     store;
+    Diagnostics    diagnostics;
+    DeviceContext  context(driver, store, diagnostics, clockFn);
+
+    driver.verdict               = PollResult::NotRegistered;
+    driver.counts.checksumErrors = 2;
+    context.pollOnce();
+
+    TEST_ASSERT_EQUAL_UINT32(2, diagnostics.snapshot().checksumErrorTotal);
 }
 
 // uint32 counters on a bridge that runs for years: the difference has to survive the wrap, or
@@ -167,7 +189,8 @@ int main(int, char**) {
     RUN_TEST(test_only_the_new_errors_are_added);
     RUN_TEST(test_errors_from_before_the_context_are_not_replayed);
     RUN_TEST(test_the_three_counters_do_not_bleed_into_each_other);
-    RUN_TEST(test_a_transport_failure_moves_no_bus_counter);
+    RUN_TEST(test_a_failing_verdict_alone_moves_no_bus_counter);
+    RUN_TEST(test_a_driver_tally_counts_under_a_verdict_the_old_switch_ignored);
     RUN_TEST(test_the_difference_survives_a_counter_wrap);
     return UNITY_END();
 }

--- a/test/test_device_context/test_main.cpp
+++ b/test/test_device_context/test_main.cpp
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+//
+// DeviceContext: the poll rhythm, and how the driver's frame-level tallies reach Diagnostics.
+//
+// The tallies are the reason this suite exists. They used to be a switch over the PollResult,
+// which made the checksum metric a function of the poll VERDICT -- and a driver reading several
+// blocks returns Ok as soon as one of them decodes. The counter therefore rose only on a bus
+// that had already stopped working, and stayed flat on one that was merely losing a third of
+// its frames. These tests pin the difference-based path so it cannot quietly regress to that.
+
+#include <unity.h>
+
+#include "device/device_context.h"
+#include "diagnostics/diagnostics.h"
+#include "drivers/inverter_driver.h"
+#include "state/state_store.h"
+
+using namespace heliograph;
+
+void setUp() {}
+void tearDown() {}
+
+namespace {
+
+/// A driver whose wire behaviour is dictated per poll: what it reports, and what it counted
+/// while getting there. Those two are deliberately independent -- that is the whole point.
+class ScriptedDriver : public InverterDriver {
+public:
+    PollResult     verdict = PollResult::Ok;
+    BusErrorCounts counts{};
+
+    const DriverDescriptor& descriptor() const override {
+        static const DriverDescriptor d = [] {
+            DriverDescriptor x;
+            x.id = "scripted";
+            return x;
+        }();
+        return d;
+    }
+    bool                 begin(Transport&) override { return true; }
+    ProbeResult          probe() override { return {}; }
+    PollResult           poll(DeviceState&) override { return verdict; }
+    DeviceIdentity       identity() const override { return {}; }
+    InverterCapabilities capabilities() const override { return {}; }
+    CommandResult        execute(const InverterCommand&) override {
+        return CommandResult::Unsupported;
+    }
+    BusErrorCounts busErrors() const override { return counts; }
+};
+
+uint64_t g_now = 0;
+uint64_t clockFn() { return g_now; }
+
+}  // namespace
+
+// The case the old code could not express at all: the poll succeeds, and the bus was still
+// corrupting frames while it did.
+static void test_a_successful_poll_still_reports_the_frames_it_lost() {
+    ScriptedDriver driver;
+    StateStore     store;
+    Diagnostics    diagnostics;
+    DeviceContext  context(driver, store, diagnostics, clockFn);
+
+    driver.verdict = PollResult::Ok;
+    driver.counts.checksumErrors = 3;
+    TEST_ASSERT_EQUAL(PollResult::Ok, context.pollOnce());
+
+    const auto snapshot = diagnostics.snapshot();
+    TEST_ASSERT_EQUAL_UINT32(3, snapshot.checksumErrorTotal);
+    TEST_ASSERT_EQUAL_UINT32(1, snapshot.pollSuccessTotal);
+    TEST_ASSERT_EQUAL_UINT32(0, snapshot.pollFailureTotal);
+}
+
+// The driver's counters are cumulative; the metric must move by the difference, not by the
+// total, or every poll would re-report the entire history.
+static void test_only_the_new_errors_are_added() {
+    ScriptedDriver driver;
+    StateStore     store;
+    Diagnostics    diagnostics;
+    DeviceContext  context(driver, store, diagnostics, clockFn);
+
+    driver.counts.checksumErrors = 2;
+    context.pollOnce();
+    driver.counts.checksumErrors = 5;
+    context.pollOnce();
+    TEST_ASSERT_EQUAL_UINT32(5, diagnostics.snapshot().checksumErrorTotal);
+
+    // A quiet poll adds nothing.
+    context.pollOnce();
+    TEST_ASSERT_EQUAL_UINT32(5, diagnostics.snapshot().checksumErrorTotal);
+}
+
+// Discovery probes the bus through the same driver before this context exists. Those errors are
+// reported by the wizard; replaying them into the installation's metrics would put a step at
+// every driver switch that no cable fault explains.
+static void test_errors_from_before_the_context_are_not_replayed() {
+    ScriptedDriver driver;
+    driver.counts.checksumErrors = 9;
+    driver.counts.timeouts       = 4;
+
+    StateStore    store;
+    Diagnostics   diagnostics;
+    DeviceContext context(driver, store, diagnostics, clockFn);
+
+    context.pollOnce();
+    const auto snapshot = diagnostics.snapshot();
+    TEST_ASSERT_EQUAL_UINT32(0, snapshot.checksumErrorTotal);
+    TEST_ASSERT_EQUAL_UINT32(0, snapshot.rs485TimeoutTotal);
+}
+
+// The three counters stay distinct: they point at three different faults, and docs/prometheus.md
+// tells the reader to act on which one moved.
+static void test_the_three_counters_do_not_bleed_into_each_other() {
+    ScriptedDriver driver;
+    StateStore     store;
+    Diagnostics    diagnostics;
+    DeviceContext  context(driver, store, diagnostics, clockFn);
+
+    driver.verdict               = PollResult::Timeout;
+    driver.counts.timeouts       = 2;
+    driver.counts.invalidFrames  = 1;
+    context.pollOnce();
+
+    const auto snapshot = diagnostics.snapshot();
+    TEST_ASSERT_EQUAL_UINT32(0, snapshot.checksumErrorTotal);
+    TEST_ASSERT_EQUAL_UINT32(2, snapshot.rs485TimeoutTotal);
+    TEST_ASSERT_EQUAL_UINT32(1, snapshot.invalidFrameTotal);
+    TEST_ASSERT_EQUAL_UINT32(1, snapshot.pollFailureTotal);
+}
+
+// A failure the wire had nothing to do with -- no driver, or a UART that would not open. Moving
+// a bus counter here would send someone to check the cabling on a fault that never reached it.
+static void test_a_transport_failure_moves_no_bus_counter() {
+    ScriptedDriver driver;
+    StateStore     store;
+    Diagnostics    diagnostics;
+    DeviceContext  context(driver, store, diagnostics, clockFn);
+
+    driver.verdict = PollResult::TransportError;
+    context.pollOnce();
+
+    const auto snapshot = diagnostics.snapshot();
+    TEST_ASSERT_EQUAL_UINT32(0, snapshot.checksumErrorTotal);
+    TEST_ASSERT_EQUAL_UINT32(0, snapshot.rs485TimeoutTotal);
+    TEST_ASSERT_EQUAL_UINT32(0, snapshot.invalidFrameTotal);
+    TEST_ASSERT_EQUAL_UINT32(1, snapshot.pollFailureTotal);
+}
+
+// uint32 counters on a bridge that runs for years: the difference has to survive the wrap, or
+// the metric would go backwards by four billion once and be useless from then on.
+static void test_the_difference_survives_a_counter_wrap() {
+    ScriptedDriver driver;
+    driver.counts.checksumErrors = 0xFFFFFFFEu;
+
+    StateStore    store;
+    Diagnostics   diagnostics;
+    DeviceContext context(driver, store, diagnostics, clockFn);
+
+    driver.counts.checksumErrors = 1;  // wrapped past 0xFFFFFFFF: three more errors
+    context.pollOnce();
+    TEST_ASSERT_EQUAL_UINT32(3, diagnostics.snapshot().checksumErrorTotal);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_a_successful_poll_still_reports_the_frames_it_lost);
+    RUN_TEST(test_only_the_new_errors_are_added);
+    RUN_TEST(test_errors_from_before_the_context_are_not_replayed);
+    RUN_TEST(test_the_three_counters_do_not_bleed_into_each_other);
+    RUN_TEST(test_a_transport_failure_moves_no_bus_counter);
+    RUN_TEST(test_the_difference_survives_a_counter_wrap);
+    return UNITY_END();
+}

--- a/test/test_discovery/test_main.cpp
+++ b/test/test_discovery/test_main.cpp
@@ -82,6 +82,7 @@ public:
     PollResult           poll(DeviceState&) override { return PollResult::Ok; }
     DeviceIdentity       identity() const override { return {}; }
     InverterCapabilities capabilities() const override { return {}; }
+    BusErrorCounts       busErrors() const override { return {}; }
     CommandResult        execute(const InverterCommand&) override {
         script_->writeAttempted = true;  // discovery must never reach this
         return CommandResult::Ok;

--- a/test/test_eversolar_driver/test_main.cpp
+++ b/test/test_eversolar_driver/test_main.cpp
@@ -309,7 +309,7 @@ static void test_corrupt_reply_does_not_touch_state() {
     // The previous reading survives untouched; a corrupt frame yields no data at all.
     TEST_ASSERT_DOUBLE_WITHIN(1e-6, good,
                               state.measurements.find(measurement_id::kAcPowerTotal)->value);
-    TEST_ASSERT_TRUE(r.driver.checksumErrors() > 0);
+    TEST_ASSERT_TRUE(r.driver.busErrors().checksumErrors > 0);
 }
 
 static void test_reply_of_wrong_length_is_an_invalid_frame() {

--- a/test/test_growatt_driver/test_main.cpp
+++ b/test/test_growatt_driver/test_main.cpp
@@ -283,6 +283,61 @@ static void test_a_corrupt_reply_is_reported_as_a_checksum_error() {
     TEST_ASSERT_EQUAL(PollResult::ChecksumError, driver.poll(state));
 }
 
+// The degrading bus, which is the case the metric exists for and the one it used to miss
+// entirely. One block comes back corrupt, the other decodes; the poll therefore succeeds --
+// correctly, there IS usable data -- and for as long as the counter was derived from that
+// verdict the checksum metric stayed at zero. A third of the frames on the floor and the
+// dashboard said the wire was fine. The tally has to move on the transaction, not the poll.
+static void test_a_corrupt_block_is_counted_even_when_the_poll_succeeds() {
+    MockTransport transport;
+    transport.setResponder([](const std::vector<uint8_t>& req, std::vector<uint8_t>& reply) {
+        if (req.size() < 8) return false;
+        const uint16_t start = static_cast<uint16_t>((req[2] << 8) | req[3]);
+        const uint16_t count = static_cast<uint16_t>((req[4] << 8) | req[5]);
+        reply.push_back(req[0]);
+        reply.push_back(req[1]);
+        reply.push_back(static_cast<uint8_t>(count * 2));
+        for (uint16_t i = 0; i < count * 2; ++i) {
+            reply.push_back(0x00);
+        }
+        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
+        // Only the storage block is wrecked. The base and probe blocks arrive clean, so the
+        // poll has something to publish.
+        const bool wreck = start == 1000;
+        reply.push_back(static_cast<uint8_t>((crc & 0xFF) ^ (wreck ? 0xFF : 0x00)));
+        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        return true;
+    });
+    GrowattDriver driver(transport);
+    DeviceState   state;
+    state.lastPollAttemptMs = 5000;
+
+    TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
+    TEST_ASSERT_EQUAL_UINT32(1, driver.busErrors().checksumErrors);
+    TEST_ASSERT_EQUAL_UINT32(0, driver.busErrors().timeouts);
+
+    // Cumulative, so a bus that keeps corrupting keeps climbing.
+    TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
+    TEST_ASSERT_EQUAL_UINT32(2, driver.busErrors().checksumErrors);
+}
+
+// An exception reply is a healthy device declining a range -- the bring-up probe block does
+// exactly this. Counting it as a bus error would put a permanent slope on the metric of every
+// correctly wired installation.
+static void test_a_refused_block_moves_no_bus_counter() {
+    MockTransport transport;
+    transport.setResponder(alwaysException());
+    GrowattDriver driver(transport);
+
+    DeviceState state;
+    state.lastPollAttemptMs = 5000;
+    driver.poll(state);
+    const auto errors = driver.busErrors();
+    TEST_ASSERT_EQUAL_UINT32(0, errors.checksumErrors);
+    TEST_ASSERT_EQUAL_UINT32(0, errors.timeouts);
+    TEST_ASSERT_EQUAL_UINT32(0, errors.invalidFrames);
+}
+
 // ...while a frame that arrives intact but is not ours stays InvalidFrame. Counting a neighbour
 // on the bus as line corruption would send someone to check a cable that is fine.
 static void test_an_intact_reply_from_another_unit_is_not_a_checksum_error() {
@@ -579,6 +634,8 @@ int main(int, char**) {
     RUN_TEST(test_one_refused_block_does_not_sink_the_poll);
     RUN_TEST(test_a_refused_block_outranks_a_timeout_in_the_outcome);
     RUN_TEST(test_a_corrupt_reply_is_reported_as_a_checksum_error);
+    RUN_TEST(test_a_corrupt_block_is_counted_even_when_the_poll_succeeds);
+    RUN_TEST(test_a_refused_block_moves_no_bus_counter);
     RUN_TEST(test_an_intact_reply_from_another_unit_is_not_a_checksum_error);
     RUN_TEST(test_a_sustained_noise_trickle_hits_the_transaction_deadline);
     RUN_TEST(test_execute_is_unsupported_read_only);

--- a/test/test_growatt_driver/test_main.cpp
+++ b/test/test_growatt_driver/test_main.cpp
@@ -185,14 +185,19 @@ static heliograph::test::Responder alwaysException() {
     };
 }
 
-static void test_all_blocks_refused_is_an_invalid_frame() {
+// Present, correctly addressed, refusing every range this profile asks for: a wrong profile or
+// unit id, not a wire fault. This used to report InvalidFrame, which pointed the field
+// diagnosis at the cabling and contradicted the bus counters -- an exception rightly moves
+// none of them, so the poll failed every ten seconds while all three RS485 counters read zero.
+// SunSpec has always called this NotRegistered; the two Modbus drivers now agree.
+static void test_all_blocks_refused_is_not_registered() {
     MockTransport transport;
     transport.setResponder(alwaysException());
     GrowattDriver driver(transport);
 
     DeviceState state;
     state.lastPollAttemptMs = 5000;
-    TEST_ASSERT_EQUAL(PollResult::InvalidFrame, driver.poll(state));
+    TEST_ASSERT_EQUAL(PollResult::NotRegistered, driver.poll(state));
 }
 
 static void test_one_refused_block_does_not_sink_the_poll() {
@@ -233,7 +238,7 @@ static void test_one_refused_block_does_not_sink_the_poll() {
 
 static void test_a_refused_block_outranks_a_timeout_in_the_outcome() {
     // One block silent, another refused with an exception: the device is demonstrably alive,
-    // so the poll is InvalidFrame (present, nothing usable), not the misleading Timeout.
+    // so the poll says "present, nothing usable" rather than the misleading Timeout.
     MockTransport transport;
     transport.setResponder([](const std::vector<uint8_t>& req, std::vector<uint8_t>& reply) {
         if (req.size() < 8) return false;
@@ -252,7 +257,7 @@ static void test_a_refused_block_outranks_a_timeout_in_the_outcome() {
     GrowattDriver driver(transport);
     DeviceState   state;
     state.lastPollAttemptMs = 5000;
-    TEST_ASSERT_EQUAL(PollResult::InvalidFrame, driver.poll(state));
+    TEST_ASSERT_EQUAL(PollResult::NotRegistered, driver.poll(state));
 }
 
 // A bus with a bad ground or missing termination shows up as CRC failures, and that is the one
@@ -319,6 +324,72 @@ static void test_a_corrupt_block_is_counted_even_when_the_poll_succeeds() {
     // Cumulative, so a bus that keeps corrupting keeps climbing.
     TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
     TEST_ASSERT_EQUAL_UINT32(2, driver.busErrors().checksumErrors);
+}
+
+// The probe block is the one this profile does not know the device has. The Modbus spec says an
+// unknown range should be answered with an exception, but a device may simply say nothing --
+// and unflagged, that silence would add a timeout to the metrics on EVERY poll of a perfectly
+// wired inverter: ~360 an hour, forever. `probe = true` in the profile is what stops it.
+static void test_a_silent_probe_block_moves_no_bus_counter() {
+    MockTransport transport;
+    transport.setResponder([](const std::vector<uint8_t>& req, std::vector<uint8_t>& reply) {
+        if (req.size() < 8) return false;
+        const uint16_t start = static_cast<uint16_t>((req[2] << 8) | req[3]);
+        if (start >= 3000) {
+            return false;  // the probe range: this unit does not implement it, and stays silent
+        }
+        const uint16_t count = static_cast<uint16_t>((req[4] << 8) | req[5]);
+        reply.push_back(req[0]);
+        reply.push_back(req[1]);
+        reply.push_back(static_cast<uint8_t>(count * 2));
+        for (uint16_t i = 0; i < count * 2; ++i) {
+            reply.push_back(0x00);
+        }
+        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
+        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
+        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        return true;
+    });
+    GrowattDriver driver(transport);
+    DeviceState   state;
+    state.lastPollAttemptMs = 5000;
+
+    TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
+    TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
+    const auto errors = driver.busErrors();
+    TEST_ASSERT_EQUAL_UINT32(0, errors.timeouts);
+    TEST_ASSERT_EQUAL_UINT32(0, errors.checksumErrors);
+    TEST_ASSERT_EQUAL_UINT32(0, errors.invalidFrames);
+}
+
+// ...and the flag is on the block the profile actually declares as a probe, not on any block
+// that happens to be silent: a mapped block going quiet is still a real timeout.
+static void test_a_silent_mapped_block_is_still_counted() {
+    MockTransport transport;
+    transport.setResponder([](const std::vector<uint8_t>& req, std::vector<uint8_t>& reply) {
+        if (req.size() < 8) return false;
+        const uint16_t start = static_cast<uint16_t>((req[2] << 8) | req[3]);
+        if (start == 1000) {
+            return false;  // a mapped block, silent
+        }
+        const uint16_t count = static_cast<uint16_t>((req[4] << 8) | req[5]);
+        reply.push_back(req[0]);
+        reply.push_back(req[1]);
+        reply.push_back(static_cast<uint8_t>(count * 2));
+        for (uint16_t i = 0; i < count * 2; ++i) {
+            reply.push_back(0x00);
+        }
+        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
+        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
+        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        return true;
+    });
+    GrowattDriver driver(transport);
+    DeviceState   state;
+    state.lastPollAttemptMs = 5000;
+
+    TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
+    TEST_ASSERT_EQUAL_UINT32(1, driver.busErrors().timeouts);
 }
 
 // An exception reply is a healthy device declining a range -- the bring-up probe block does
@@ -630,11 +701,13 @@ int main(int, char**) {
     RUN_TEST(test_find_register_reports_out_of_range);
     RUN_TEST(test_a_full_poll_decodes_measurements_over_the_bus);
     RUN_TEST(test_silence_is_a_timeout);
-    RUN_TEST(test_all_blocks_refused_is_an_invalid_frame);
+    RUN_TEST(test_all_blocks_refused_is_not_registered);
     RUN_TEST(test_one_refused_block_does_not_sink_the_poll);
     RUN_TEST(test_a_refused_block_outranks_a_timeout_in_the_outcome);
     RUN_TEST(test_a_corrupt_reply_is_reported_as_a_checksum_error);
     RUN_TEST(test_a_corrupt_block_is_counted_even_when_the_poll_succeeds);
+    RUN_TEST(test_a_silent_probe_block_moves_no_bus_counter);
+    RUN_TEST(test_a_silent_mapped_block_is_still_counted);
     RUN_TEST(test_a_refused_block_moves_no_bus_counter);
     RUN_TEST(test_an_intact_reply_from_another_unit_is_not_a_checksum_error);
     RUN_TEST(test_a_sustained_noise_trickle_hits_the_transaction_deadline);

--- a/test/test_sunspec_driver/test_main.cpp
+++ b/test/test_sunspec_driver/test_main.cpp
@@ -338,6 +338,36 @@ static void test_a_marker_with_no_readable_models_is_not_reported_as_a_timeout()
     TEST_ASSERT_EQUAL(PollResult::NotRegistered, d.poll(state));
 }
 
+// A device advertising an inverter model shorter than this driver can decode. Every read
+// succeeds with a valid CRC, so the tally inside read() sees nothing wrong -- the failure is in
+// the decode, and it has to be counted there. It was not, and because walked_ is not reset on
+// this path the driver loops on the same entry forever: every poll fails, and all three RS485
+// counters read zero for the entire uptime. That is the reading an operator is most likely to
+// act on wrongly, since zero bus errors says "the cable is fine" about a bridge that publishes
+// nothing at all.
+static void test_an_undecodable_model_counts_an_invalid_frame() {
+    Rig      r;
+    uint16_t at = r.device.placeMarker();
+    at = r.device.addModel(at, sunspec::kModelCommon,
+                           FakeSunspecDevice::commonPayload("Acme Solar", "AS-5000", "SN12345"));
+    // Declares itself an inverter, then carries far too few registers to be one.
+    at = r.device.addModel(at, sunspec::kModelInverterThreePhase, std::vector<uint16_t>(10, 0));
+    r.device.terminate(at);
+    r.arm();
+    auto d = r.makeDriver();
+
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::InvalidFrame, d.poll(state));
+    TEST_ASSERT_EQUAL_UINT32(1, d.busErrors().invalidFrames);
+    // Not a wire fault: nothing arrived corrupted and nothing went unanswered.
+    TEST_ASSERT_EQUAL_UINT32(0, d.busErrors().checksumErrors);
+    TEST_ASSERT_EQUAL_UINT32(0, d.busErrors().timeouts);
+
+    // ...and it keeps counting, because the driver keeps retrying the same chain entry.
+    TEST_ASSERT_EQUAL(PollResult::InvalidFrame, d.poll(state));
+    TEST_ASSERT_EQUAL_UINT32(2, d.busErrors().invalidFrames);
+}
+
 static void test_a_silent_device_does_not_poll() {
     Rig r;
     buildTypical(r.device);
@@ -378,6 +408,7 @@ int main(int, char**) {
     RUN_TEST(test_a_corrupt_reply_is_reported_as_a_checksum_error);
     RUN_TEST(test_corruption_that_starts_mid_chain_is_still_a_checksum_error);
     RUN_TEST(test_a_marker_with_no_readable_models_is_not_reported_as_a_timeout);
+    RUN_TEST(test_an_undecodable_model_counts_an_invalid_frame);
     RUN_TEST(test_a_silent_device_does_not_poll);
     RUN_TEST(test_the_driver_is_read_only);
     return UNITY_END();

--- a/tools/gen_profiles.py
+++ b/tools/gen_profiles.py
@@ -242,11 +242,18 @@ def parse_profile(
             )
         if start + count > 0x10000:
             raise ProfileError(f"{bw}: start+count exceeds the register address space")
-        parsed_blocks.append({"space": space, "start": start, "count": count})
+        probe = b.get("probe", False)
+        if not isinstance(probe, bool):
+            raise ProfileError(f"{bw}: probe must be true or false")
+        parsed_blocks.append(
+            {"space": space, "start": start, "count": count, "probe": probe}
+        )
 
-    def covered(space: str, address: int) -> bool:
+    def covered(space: str, address: int, exclude_probe: bool = False) -> bool:
         return any(
-            b["space"] == space and b["start"] <= address < b["start"] + b["count"]
+            b["space"] == space
+            and b["start"] <= address < b["start"] + b["count"]
+            and not (exclude_probe and b["probe"])
             for b in parsed_blocks
         )
 
@@ -280,12 +287,20 @@ def parse_profile(
             raise ProfileError(f"{rw}: type must be one of {sorted(TYPES)}")
         words, _signed = TYPES[rtype]
         for a in range(address, address + words):
-            if not covered(space, a):
+            if covered(space, a, exclude_probe=True):
+                continue
+            if covered(space, a):
                 raise ProfileError(
-                    f"{rw}: register {a} ({space}) is not inside any declared [[block]] "
-                    f"-- the driver would never read it (a {rtype} needs {words} "
-                    f"consecutive registers)"
+                    f"{rw}: register {a} ({space}) is only inside a probe block. A probe "
+                    f"block maps nothing and its read failures are kept out of the RS485 bus "
+                    f"counters, so mapping a measurement into one would hide real bus errors "
+                    f"on a range this profile actually depends on"
                 )
+            raise ProfileError(
+                f"{rw}: register {a} ({space}) is not inside any declared [[block]] "
+                f"-- the driver would never read it (a {rtype} needs {words} "
+                f"consecutive registers)"
+            )
         scale = r.get("scale", 1.0)
         if isinstance(scale, bool) or not isinstance(scale, (int, float)):
             raise ProfileError(f"{rw}: scale must be a number")
@@ -456,7 +471,11 @@ def generate(
         w("};")
         w(f"constexpr RegBlock k{sym}Blocks[] = {{")
         for b in p["blocks"]:
-            w(f"    {{RegSpace::{SPACES[b['space']]}, {b['start']}, {b['count']}}},")
+            probe = "true" if b["probe"] else "false"
+            w(
+                f"    {{RegSpace::{SPACES[b['space']]}, {b['start']}, "
+                f"{b['count']}, {probe}}},"
+            )
         w("};")
         if p["writes"]:
             w(f"constexpr WriteMapping k{sym}Writes[] = {{")


### PR DESCRIPTION
The last of the review findings that I had **shipped a promise about**: `docs/prometheus.md` told the reader the checksum counter only moves when a poll fails outright, and that fixing it "is tracked and not done yet".

## What was wrong

`heliograph_rs485_checksum_errors_total` is the metric that indicts the *cabling* — the alerting example in the docs keys on it precisely because timeouts are normal every night. It was derived from the `PollResult`.

But a poll is a verdict over several transactions. The Growatt driver reads three register blocks and returns `Ok` as soon as **one** decodes. So a degrading bus kept polling `Ok` and the counter that should have caught it stayed near zero.

Worth being precise about the size of that, because my first version of this description was flattering rather than accurate. On a two-block profile polling every 10 s: at **3%** frame corruption the old counter moved about once every three hours — never enough for `rate(...[15m]) > 0` to hold, so the alert would never have fired, while the new counter moves ~22 times an hour. At **30%** the old counter already caught ~32 an hour, because both blocks failing together stops being rare. This does not make a *failing* bus visible sooner; it makes a *degrading* one visible at all. Crossover is around 15%.

## What changed

Drivers report cumulative frame-level tallies through a new `busErrors()`; `DeviceContext` takes the difference each poll and feeds `Diagnostics`. The `poll()` contract is untouched — this is an accessor, not a new outcome.

- **`busErrors()` is pure virtual.** A default returning zero would let a new driver ship with a permanently flat checksum counter and nothing to notice, which is the exact failure this exists to remove.
- **The PMU drivers already counted this** — `checksumErrors_`, `timeouts_`, `invalidFrames_` have been in EverSolar and SolaX for a while, with accessors used by one test and by nothing in production.
- **Both Modbus drivers tally through one shared mapping** (`drivers/modbus_bus_tally.h`). They already drifted once.
- **An exception reply moves nothing.** It proves wiring *and* addressing are fine.

## Probe blocks — a regression this PR created, found in review

Both Growatt profiles declare a block that maps nothing and exists only so the first bring-up dump answers "which register generation does this model speak?". Both profiles, and `docs/growatt-mic-tl-x-protocol.md`, said in writing that probing a range the model lacks "costs a timeout and nothing else".

Per-transaction counting made that false. Modbus prefers an exception for an unknown range, but a device may answer with silence — and that would have added a timeout **every poll**: ~360 an hour, forever, on hardware with nothing wrong with it, on three bridges at once once three MIC TL-X are on the bus.

So `[[block]]` gained `probe = true`. Probe failures stay out of the bus counters, and mapping a measurement into a probe block is now a **build error** — otherwise the exclusion would hide real bus errors on a range the profile actually depends on.

## Two more places the counter still lied

- **SunSpec decode failures** were the one `InvalidFrame` return left untallied. Every read succeeds with a valid CRC, so the tally in `read()` sees nothing, and `walked_` is not reset on that path — so the driver retries the same chain entry forever. Every poll fails with all three RS485 counters flat at zero, which is the reading an operator is most likely to act on wrongly.
- **Growatt's all-exception poll** returned `InvalidFrame` while the counters (rightly) stayed at zero: the verdict blamed the cabling and the metrics contradicted it. SunSpec has always called this `NotRegistered`. My first commit message claimed the shared tally stopped the two Modbus drivers describing the same condition differently — that was only ever true of the counters, not the verdicts. Now it is true of both.

## Semantics change, with numbers this time

The three counters now count **transactions, not polls**, which is what the metric table always claimed. `heliograph_rs485_timeouts_total` steps up **2–3×** on the same hardware: one per register block instead of one per poll, and on the PMU drivers the recovery probe doubles it again after three consecutive timeouts. A bridge that reboots after dark used to report a cold-start night as *zero* timeouts and now reports two per poll. `docs/prometheus.md` now says so under an upgrade note — the first version of this PR changed the magnitude and warned about the direction only.

I also had to fix a query I added in the same breath: it divided transactions by *successful* polls, so it went to `+Inf` exactly when the bus it describes starts failing.

## Corrections to my own claims

- The construction baseline comment said discovery probes the bus through the polling driver. It does not — `DiscoveryEngine` uses throwaway instances and `main.cpp` builds a fresh driver, so the baseline is always zero in practice. It is defence, not a fix for anything observed, and now says that.
- I deleted "treat a zero as no proof either way" while making it *more* necessary. Restored, with the two failure modes that now produce a failing poll and three flat counters.
- "A SunSpec poll walks the model chain before it reads anything" — `walked_` is sticky, so a steady-state poll is one transaction, not a dozen. Growatt was always the real multi-transaction case.
- `test_a_transport_failure_moves_no_bus_counter` asserted a tautology: it left the driver's tallies at zero, so it passed with the mechanism deleted. Replaced by one that fails if anything reintroduces a switch over the verdict.

## Tests

New `test_device_context` suite — there was none on the class that owns the poll rhythm. Plus probe-block coverage (silent probe moves nothing; a silent *mapped* block still counts), the Growatt case the docs describe (one block corrupt, two clean, poll `Ok`, counter moves), and the SunSpec undecodable-model case.

**539 tests pass** (was 527 on main), `check_layering.sh` PASS, all four boards build.

## Still open

In the order I would take them: `security.admin_username` is served unauthenticated; a device discovered on a second serial profile is still polled at the driver's default baud; and the firmware still polls exactly one device (`kMaxActiveDevices = 1`), which is the blocking one for three inverters on one bus.
