### PR TITLE
Stop serving the admin username to unauthenticated readers

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -93,10 +93,14 @@ Never an HTTP 200 with an error message in the body.
 ## Secrets
 
 `GET /api/v1/config` **never** returns credential material. Not masked-but-present, but
-omitted, with a boolean indicator. This covers every password **and the MQTT username** —
-the username is half of a login pair, so it is treated like the password it accompanies.
+omitted, with a boolean indicator. This covers every password **and both usernames** — a
+username is half of a login pair, so it is treated like the password it accompanies.
 Non-credential config (SSID, broker host, topics) stays readable; the UI needs it and it is
 not a secret.
+
+`security.admin_username` has no `*_set` companion because it can never be unset: validation
+requires it to be non-empty, so the flag would be a constant `true`. Clients that need to
+authenticate must ask the user for it rather than read it back; the factory value is `admin`.
 
 ```json
 {
@@ -104,6 +108,7 @@ not a secret.
   "mqtt":  { "host": "10.0.0.5", "port": 1883, "username_set": true, "password_set": true },
   "modbus": { "enabled": true, "port": 502, "unit_id": 1, "write_enabled": false },
   "polling": { "interval_seconds": 10 },
+  "security": { "password_set": true, "read_only_mode": false },
   "driver": { "id": "eversolar_legacy", "auto_detect": false },
   "logging": { "level": "info" }
 }

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -114,9 +114,15 @@ authenticate must ask the user for it rather than read it back; the factory valu
 }
 ```
 
-`PATCH` accepts `"password": "..."` / `"username": "..."` to set either, and `null` to clear
-it. An omitted field stays unchanged. Passwords and the username never appear in logs, in
-SSE, in MQTT, or in Prometheus.
+`PATCH` accepts `"password": "..."` / `"username": "..."` to set either. An omitted field stays
+unchanged. Credentials never appear in logs, in SSE, in MQTT, or in Prometheus.
+
+**`null` clears a password, but not a username.** Passwords go through `patchSecret`, which
+distinguishes an absent key from an explicit `null` and clears on the latter. Usernames go
+through `patchString`, where `null` is indistinguishable from absent and therefore does
+nothing — `PATCH {"mqtt":{"username":null}}` returns `200` and leaves the stored value in place.
+Send `""` to clear the MQTT username. `security.admin_username` cannot be cleared at all:
+`validate()` refuses an empty one.
 
 ## Applying changes: `reboot_required`
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,13 +53,24 @@ listens on every interface, so anyone joining the failure-portal AP reaches the 
 unauthenticated read endpoints a LAN user does: `/api/v1/status`, `/devices`, `/diagnostics`,
 `/discovery`, `/drivers`, `/config` (GET) and `/metrics`. Between them that is live production
 data, the inverter's model and serial number, your WiFi SSID and hostname, the MQTT host, port
-and base topic, the relay roles, and `security.admin_username`. The Modbus TCP server on port
-502 is reachable from that AP too, and Modbus has no authentication at all.
+and base topic, and the relay roles. The Modbus TCP server on port 502 is reachable from that AP
+too, and Modbus has no authentication at all.
 
 None of it is a secret — no password is served anywhere (see the table above) — and none of it
 grants control. But "an open AP that appears for a few minutes when your WiFi drops" is a
-disclosure surface worth knowing about, and `admin_username` in particular hands out half of a
-login that has no brute-force protection. Closing that one is tracked separately.
+disclosure surface worth knowing about.
+
+**`security.admin_username` used to be in that list and no longer is.** It is half of a login
+that has no brute-force protection, and serving it turned guessing the credentials into guessing
+only the password. It is now omitted from `GET /api/v1/config` exactly as `mqtt.username` always
+was. The practical consequence: the web UI can no longer pre-fill it, so the sign-in dialog asks
+for a username (defaulting to `admin`, remembered for the tab) and the settings field behaves
+like the other credential fields — blank means keep. If you renamed the admin account, you now
+type that name once per browser session.
+
+This is defence in depth, not a fix for a hole: HTTP Basic over plain HTTP already puts the
+password itself on the wire, so anyone positioned to sniff had both halves regardless. What it
+removes is the far lower bar of a single unauthenticated GET.
 
 **The gate has a cost of its own: authenticating over that AP puts the admin password on the
 air.** HTTP Basic is base64, not encryption, so a passive listener in radio range of the open

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,7 +14,7 @@ the same LAN", not "someone holding the PCB in their hands".
 | REST PATCH/POST | HTTP Basic required; **rejected** without a configured password, not left open |
 | OTA | Same auth + firmware magic check (0xE9) before the first byte hits flash |
 | Completing setup | Refuses without an admin password |
-| Secrets in logs/REST/MQTT/Prometheus | Never. `serializeConfig()` omits every password **and the MQTT username** (not masked, absent); `serializeConfigForStorage()` is the only one that writes them |
+| Secrets in logs/REST/MQTT/Prometheus | Never. `serializeConfig()` omits every password **and both usernames** — the MQTT one and `security.admin_username` (not masked, absent); `serializeConfigForStorage()` is the only one that writes them |
 | Rate limiting | 1 req/s on `/actions/*` |
 | Request size | 4096 bytes, rejected with 413 |
 | String lengths | Bounded in `validate()`; SSID 32 and PSK 64 are the 802.11/WPA2 limits |
@@ -52,9 +52,13 @@ the bridge already has one.
 listens on every interface, so anyone joining the failure-portal AP reaches the same
 unauthenticated read endpoints a LAN user does: `/api/v1/status`, `/devices`, `/diagnostics`,
 `/discovery`, `/drivers`, `/config` (GET) and `/metrics`. Between them that is live production
-data, the inverter's model and serial number, your WiFi SSID and hostname, the MQTT host, port
-and base topic, and the relay roles. The Modbus TCP server on port 502 is reachable from that AP
-too, and Modbus has no authentication at all.
+data and the inverter's model and serial number, plus everything `GET /config` carries: your
+WiFi SSID and hostname, the MQTT host, port, base topic, discovery prefix and QoS, the Modbus
+port and unit ids, the bridge name, the poll interval, the NTP server and timezone, the log
+level, the driver id **and its options**, the relay roles, the `*_set` booleans saying which
+credentials exist — and `security.read_only_mode`, which tells a stranger whether the relay/DRM
+write gate is currently open. The Modbus TCP server on port 502 is reachable from that AP too,
+and Modbus has no authentication at all.
 
 None of it is a secret — no password is served anywhere (see the table above) — and none of it
 grants control. But "an open AP that appears for a few minutes when your WiFi drops" is a
@@ -63,14 +67,31 @@ disclosure surface worth knowing about.
 **`security.admin_username` used to be in that list and no longer is.** It is half of a login
 that has no brute-force protection, and serving it turned guessing the credentials into guessing
 only the password. It is now omitted from `GET /api/v1/config` exactly as `mqtt.username` always
-was. The practical consequence: the web UI can no longer pre-fill it, so the sign-in dialog asks
-for a username (defaulting to `admin`, remembered for the tab) and the settings field behaves
-like the other credential fields — blank means keep. If you renamed the admin account, you now
-type that name once per browser session.
+was.
 
-This is defence in depth, not a fix for a hole: HTTP Basic over plain HTTP already puts the
-password itself on the wire, so anyone positioned to sniff had both halves regardless. What it
-removes is the far lower bar of a single unauthenticated GET.
+Be clear-eyed about the size of this. Almost every install keeps the factory `admin`, and for
+those an attacker guesses right on the first try either way — the search space only shrinks for
+someone who renamed the account. That is also exactly who pays the cost below. The change is
+consistency with how the broker credential is already treated, not a meaningful second factor,
+and on a device whose Modbus port has no authentication at all it would be silly to claim more.
+
+It is defence in depth rather than a hole closed: HTTP Basic over plain HTTP puts the password
+itself on the wire, so a listener who catches someone signing in has had both halves all along.
+What goes away is the much lower bar of one unauthenticated GET — no timing, no waiting for an
+admin to appear, and on a bridge nobody ever signs into, that GET was the *only* way to get the
+username.
+
+> **If you change the admin username, write it down.** There is no way to read it back — that
+> is the whole point of the change — and it is not in the logs, the API, MQTT or Prometheus. A
+> forgotten username costs a factory reset (BOOT held ~5 s), which erases WiFi, MQTT, the driver
+> selection, relay roles and the timezone along with it. Forgetting the *password* always cost
+> that; forgetting the username now does too.
+
+The everyday cost is smaller: the sign-in dialog has a username field defaulting to `admin`, and
+the settings field behaves like the other credential fields — blank means keep. The dialog
+remembers the last username the bridge actually accepted, but only for that tab and that origin,
+so `http://heliograph.local` and `http://192.168.1.50` each ask once, and a second tab asks
+again.
 
 **The gate has a cost of its own: authenticating over that AP puts the admin password on the
 air.** HTTP Basic is base64, not encryption, so a passive listener in radio range of the open

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -325,10 +325,14 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     ntp["timezone"]      = config.ntp.timezone;
     ntp["timezone_name"] = config.ntp.timezoneName;
 
-    JsonObject security         = doc["security"].to<JsonObject>();
-    security["admin_username"]  = config.security.adminUsername;
-    security["password_set"]    = !config.security.adminPassword.empty();
-    security["read_only_mode"]  = config.security.readOnlyMode;
+    JsonObject security = doc["security"].to<JsonObject>();
+    // The admin username is omitted for the same reason mqtt.username is, twelve lines up: it
+    // is half of a credential pair, this endpoint is unauthenticated, and HTTP Basic here has no
+    // brute-force protection. Serving it turned guessing the login into guessing only the
+    // password. Unlike the MQTT one it needs no *_set flag -- validate() requires it to be
+    // non-empty, so "is one set" is always yes and would say nothing.
+    security["password_set"]   = !config.security.adminPassword.empty();
+    security["read_only_mode"] = config.security.readOnlyMode;
 
     doc["logging"]["level"] = logLevelName(config.logLevel);
 

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -326,7 +326,8 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     ntp["timezone_name"] = config.ntp.timezoneName;
 
     JsonObject security = doc["security"].to<JsonObject>();
-    // The admin username is omitted for the same reason mqtt.username is, twelve lines up: it
+    // The admin username is omitted for the same reason mqtt.username is, in the mqtt block
+    // above: it
     // is half of a credential pair, this endpoint is unauthenticated, and HTTP Basic here has no
     // brute-force protection. Serving it turned guessing the login into guessing only the
     // password. Unlike the MQTT one it needs no *_set flag -- validate() requires it to be

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -139,12 +139,20 @@ bool validate(const Configuration& config, ConfigError& error);
 
 /// Serialises for `GET /api/v1/config` and the `PATCH` response.
 ///
-/// Credential material is NOT included -- not masked, omitted. Passwords and the MQTT
-/// username each get a `*_set` boolean saying whether one exists. Masking with "***" still
-/// tells an attacker the length class and invites a client to round-trip the mask back in as
-/// a literal secret. The MQTT username is half of a credential pair, so it is treated like
-/// the password it accompanies; non-credential config (SSID, broker host, topics) stays
-/// readable because the UI needs it and it is not a secret.
+/// Credential material is NOT included -- not masked, omitted. Masking with "***" still tells
+/// an attacker the length class and invites a client to round-trip the mask back in as a
+/// literal secret. Passwords get a `*_set` boolean saying whether one exists, and so does the
+/// MQTT username: a username is half of a credential pair, so it is treated like the password
+/// it accompanies.
+///
+/// `security.admin_username` is omitted on the same grounds but has NO `*_set` companion --
+/// validate() refuses an empty one, so the flag could only ever be true. This endpoint is
+/// unauthenticated, so serving that name reduced guessing an admin login with no brute-force
+/// protection to guessing only the password. Nothing else in the firmware can read it back
+/// either; that is deliberate, and docs/security.md tells the owner to write it down.
+///
+/// Non-credential config (SSID, broker host, topics) stays readable because the UI needs it
+/// and it is not a secret.
 ///
 /// When `rebootRequired` is non-null its value is emitted as a top-level `reboot_required`
 /// boolean -- the PATCH handler passes the result of configChangeRequiresReboot(); GET passes

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -86,8 +86,9 @@ dialog::backdrop{background:#000a}
 </main>
 <dialog id="authdlg">
 <form method="dialog">
-<b>Admin password</b>
-<div class="dim" style="font-size:13px;margin-top:4px">Signing in as <span id="authu">admin</span></div>
+<b>Admin sign-in</b>
+<label for="authu">Username</label>
+<input id="authu" autocomplete="username" required value="admin">
 <label for="authpw">Password</label>
 <input id="authpw" type="password" autocomplete="current-password" required autofocus>
 <div style="display:flex;gap:10px">
@@ -133,27 +134,32 @@ function authHeader(){
   return c?{'Authorization':'Basic '+c}:{};
 }
 // A real modal with a masked input, not window.prompt(): prompt() shows the password in
-// plain text on screen. And the device has exactly one admin account, whose name is in the
-// config (readable without auth precisely so the UI can render) -- so only the password is
-// asked; typing a username nobody chose was noise. Fetched fresh on every prompt, so a
-// just-renamed admin user is picked up without a reload.
+// plain text on screen.
+//
+// The username is typed, not fetched. This dialog used to read it from GET /config, which is
+// unauthenticated -- so the config endpoint was handing every LAN reader half of a login that
+// has no brute-force protection, purely so this field could be filled in for them. The field
+// defaults to 'admin' (the factory value, and what almost every install keeps) and the last
+// one that worked is remembered for the tab, so anyone who renamed the account types it once.
 async function askAuth(){
-  let u='admin';
-  try{
-    const r=await fetch('/api/v1/config');
-    if(r.ok){const j=await r.json();u=(j.security&&j.security.admin_username)||'admin'}
-  }catch(e){}
-  $('#authu').textContent=u;
+  const remembered=sessionStorage.getItem('sb_user');
   return new Promise(resolve=>{
-    const d=$('#authdlg'),p=$('#authpw');
+    const d=$('#authdlg'),p=$('#authpw'),un=$('#authu');
+    un.value=remembered||'admin';
     p.value='';d.returnValue='';
     d.onclose=()=>{
+      const u=un.value||'admin';
       const ok=d.returnValue==='ok'&&p.value!=='';
       // UTF-8, not btoa()'s default. btoa() only throws above U+00FF, so it would silently emit
       // Latin-1 for é/ë/ü/ö/ç -- and the firmware compares against the UTF-8 bytes it stored,
       // so such a password could never authenticate here (review, 2026-07-25).
-      if(ok)sessionStorage.setItem('sb_auth',
-        btoa(String.fromCharCode(...new TextEncoder().encode(u+':'+p.value))));
+      if(ok){
+        sessionStorage.setItem('sb_auth',
+          btoa(String.fromCharCode(...new TextEncoder().encode(u+':'+p.value))));
+        // Remembered separately from the credential so a wrong PASSWORD does not also make the
+        // user retype a username that was right: clearAuth() drops the credential, not this.
+        sessionStorage.setItem('sb_user',u);
+      }
       p.value='';
       resolve(ok);
     };
@@ -665,7 +671,7 @@ async function renderConfig(){
     Disabling releases every relay. Roles name the switches in Home Assistant and build
     the DRM Mode select; see docs/drm.md for the wiring rules (failsafe: a dead bridge
     must leave the inverter running).</div></div>`:''}
-  <div class="card"><b>Security</b> <span class="tag" style="font-weight:400">applied immediately</span>${txt('c_au','Admin username',c.security.admin_username)}
+  <div class="card"><b>Security</b> <span class="tag" style="font-weight:400">applied immediately</span>${credtxt('c_au','Admin username',true,'Leave blank to keep. Not shown here — it is half of the login and this page is readable without one.')}
     ${pw('c_ap','Admin password',c.security.password_set)}
     <!-- !==false, not a plain truthiness test: a missing field must render as ON. If GET ever
          stops carrying read_only_mode (a serialiser regression, an older firmware behind a
@@ -745,7 +751,8 @@ async function saveConfig(){
     driver:{id:v('c_drv'),options:{}},
     // read_only_mode is rendered from the stored value, so the generic per-key diff below is
     // enough: no rendered default to mistake for a change (unlike driver options / relay roles).
-    security:{admin_username:v('c_au'),read_only_mode:b('c_ro')},
+    // admin_username is added below only when typed, like the other credential fields.
+    security:{read_only_mode:b('c_ro')},
     logging:{level:v('c_lg')}};
   // A blank password field means "keep": sending "" would clear it, which is never what an
   // untouched field means.
@@ -753,6 +760,9 @@ async function saveConfig(){
   // The MQTT username is credential-like (never returned by GET), so like the passwords it
   // travels only when typed -- a blank field means keep.
   if(v('c_mqu'))body.mqtt.username=v('c_mqu');
+  // Same rule for the admin username, and the same reason: GET no longer returns it, so there
+  // is nothing to pre-fill and a blank field can only mean keep.
+  if(v('c_au'))body.security.admin_username=v('c_au');
   if(v('c_mqpw'))body.mqtt.password=v('c_mqpw');
   if(v('c_ap'))body.security.admin_password=v('c_ap');
   document.querySelectorAll('[data-opt]').forEach(e=>body.driver.options[e.dataset.opt]=e.value);
@@ -787,11 +797,11 @@ async function saveConfig(){
   for(const sect of Object.keys(body)){
     if(typeof body[sect]!=='object')continue;
     for(const k of Object.keys(body[sect])){
-      // Credential-like keys (passwords, the MQTT username) and driver options are only in
-      // the body when the user acted; GET never returns them, so there is nothing to diff
-      // against and they must not be dropped. Exact match on 'username' so 'admin_username'
-      // -- which IS returned and must be diffed -- is not caught.
-      if(k.includes('password')||k==='username'||k==='options')continue;
+      // Credential-like keys (passwords, both usernames) and driver options are only in the
+      // body when the user acted; GET never returns them, so there is nothing to diff against
+      // and they must not be dropped. admin_username used to be the exception here because it
+      // WAS returned -- that is exactly what this release stopped doing.
+      if(k.includes('password')||k.endsWith('username')||k==='options')continue;
       if(same(body[sect][k],(cfgBefore[sect]||{})[k]))delete body[sect][k];
     }
     if(!Object.keys(body[sect]).length)delete body[sect];

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -87,8 +87,13 @@ dialog::backdrop{background:#000a}
 <dialog id="authdlg">
 <form method="dialog">
 <b>Admin sign-in</b>
+<!-- Shown only after a 401. Both fields can be the reason now, and they fail identically, so
+     a silent re-prompt would read as "wrong password" and send the user round in circles. -->
+<div id="autherr" class="msg err" style="display:none">Not accepted. Check the username too — it
+is only <b>admin</b> if you never changed it.</div>
 <label for="authu">Username</label>
-<input id="authu" autocomplete="username" required value="admin">
+<input id="authu" autocomplete="username" autocapitalize="none" autocorrect="off"
+       spellcheck="false" required value="admin">
 <label for="authpw">Password</label>
 <input id="authpw" type="password" autocomplete="current-password" required autofocus>
 <div style="display:flex;gap:10px">
@@ -139,16 +144,23 @@ function authHeader(){
 // The username is typed, not fetched. This dialog used to read it from GET /config, which is
 // unauthenticated -- so the config endpoint was handing every LAN reader half of a login that
 // has no brute-force protection, purely so this field could be filled in for them. The field
-// defaults to 'admin' (the factory value, and what almost every install keeps) and the last
-// one that worked is remembered for the tab, so anyone who renamed the account types it once.
-async function askAuth(){
+// defaults to 'admin', the factory value and what almost every install keeps.
+//
+// `retry` is true when this prompt follows a 401. That case has to say so: a wrong USERNAME and
+// a wrong PASSWORD are now both possible and they fail identically, so an unexplained second
+// dialog reads as "bad password" and the user retypes the password forever.
+async function askAuth(retry){
   const remembered=sessionStorage.getItem('sb_user');
   return new Promise(resolve=>{
-    const d=$('#authdlg'),p=$('#authpw'),un=$('#authu');
+    const d=$('#authdlg'),p=$('#authpw'),un=$('#authu'),err=$('#autherr');
     un.value=remembered||'admin';
+    err.style.display=retry?'block':'none';
     p.value='';d.returnValue='';
     d.onclose=()=>{
-      const u=un.value||'admin';
+      // Trimmed, and typed lowercase by the input's autocapitalize=none: HTTP Basic compares
+      // bytes, so a phone keyboard capitalising the first letter or autocorrect adding a
+      // trailing space is a login that fails with nothing on screen to show why.
+      const u=un.value.trim()||'admin';
       const ok=d.returnValue==='ok'&&p.value!=='';
       // UTF-8, not btoa()'s default. btoa() only throws above U+00FF, so it would silently emit
       // Latin-1 for é/ë/ü/ö/ç -- and the firmware compares against the UTF-8 bytes it stored,
@@ -156,15 +168,23 @@ async function askAuth(){
       if(ok){
         sessionStorage.setItem('sb_auth',
           btoa(String.fromCharCode(...new TextEncoder().encode(u+':'+p.value))));
-        // Remembered separately from the credential so a wrong PASSWORD does not also make the
-        // user retype a username that was right: clearAuth() drops the credential, not this.
-        sessionStorage.setItem('sb_user',u);
+        // Held apart from sb_auth, and NOT written here: rememberUser() is called only once a
+        // request with these credentials has actually come back non-401. Storing it on submit
+        // meant a typo'd username was cached and then helpfully re-filled on every retry, so
+        // the user was handed their own mistake back and could never converge (review).
+        sessionStorage.setItem('sb_pending',u);
       }
       p.value='';
       resolve(ok);
     };
     d.showModal();
   });
+}
+// Promotes the username that was just proven to work. Anything else stays pending, so the next
+// prompt offers the last name the device actually accepted rather than the last one typed.
+function rememberUser(){
+  const u=sessionStorage.getItem('sb_pending');
+  if(u)sessionStorage.setItem('sb_user',u);
 }
 function clearAuth(){sessionStorage.removeItem('sb_auth')}
 
@@ -180,13 +200,15 @@ const authCancelled=()=>({ok:false,status:0,cancelled:true,
 // as the baffling "HTTP 0" (status is 0 on the cancellation object above).
 const httpWhy=r=>r.cancelled?'cancelled (admin password required)':'HTTP '+r.status;
 async function authFetch(url,opts={}){
-  if(!sessionStorage.getItem('sb_auth')&&!await askAuth())return authCancelled();
+  if(!sessionStorage.getItem('sb_auth')&&!await askAuth(false))return authCancelled();
   let r=await fetch(url,{...opts,headers:{...(opts.headers||{}),...authHeader()}});
   if(r.status===401){
     clearAuth();
-    if(!await askAuth())return authCancelled();
+    // retry=true: the dialog explains that the username is a candidate too.
+    if(!await askAuth(true))return authCancelled();
     r=await fetch(url,{...opts,headers:{...(opts.headers||{}),...authHeader()}});
   }
+  if(r.status!==401)rememberUser();
   return r;
 }
 
@@ -297,10 +319,16 @@ let logsAuthStop=false;
 async function loadLogs(){
   if(logsAuthStop||$('#logpause').checked)return;
   const r=await authFetch('/api/v1/logs?limit=64');
-  if(r.cancelled){
+  // A 401 latches too, not just a cancel. authFetch has already prompted twice and failed, and
+  // this runs on a 5 s timer: without the latch the dialog reappears every five seconds and
+  // cannot be escaped except by leaving the tab. That was survivable while a wrong password was
+  // the only way to get here; a mistyped username is now a second way, and a far quieter one.
+  if(r.cancelled||r.status===401){
     logsAuthStop=true;
-    $('#logbox').innerHTML='<span class="dim">Admin password required. '+
-      '<a href="#" onclick="logsAuthStop=false;loadLogs();return false">Try again</a></span>';
+    $('#logbox').innerHTML='<span class="dim">'+
+      (r.cancelled?'Admin sign-in required.':'Admin sign-in was not accepted — check the '+
+       'username as well as the password.')+
+      ' <a href="#" onclick="logsAuthStop=false;loadLogs();return false">Try again</a></span>';
     return;
   }
   if(!r.ok){$('#loginfo').textContent=httpWhy(r);return}
@@ -552,8 +580,14 @@ async function renderConfig(){
   // pre-filled -- blank means keep, typing changes it, exactly like the password fields.
   // Visible text, not dots (a username is not secret to its owner), autocomplete=off for the
   // same login-form reason as the other settings fields.
+  // readonly-until-focus like pw() above, and for the same reason: a text field sitting on top
+  // of a password field is a login form to a password manager, and autocomplete="off" is widely
+  // ignored for that pair. An autofilled username here would PATCH security.admin_username on
+  // every unrelated save. autocapitalize/autocorrect off because HTTP Basic compares bytes: a
+  // phone that capitalises the first letter stores a name its owner cannot see is different.
   const credtxt=(id,label,isSet,hint)=>`<label for="${id}">${label}</label>
-    <input id="${id}" autocomplete="off" placeholder="${isSet?'(unchanged)':'(not set)'}">
+    <input id="${id}" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false"
+      placeholder="${isSet?'(unchanged)':'(not set)'}" readonly onfocus="this.removeAttribute('readonly')">
     <div class="dim" style="font-size:12px">${hint}</div>`;
   const num=(id,label,val)=>`<label for="${id}">${label}</label><input id="${id}" type="number" value="${val}">`;
   const chk=(id,label,val)=>`<label style="display:flex;gap:8px;align-items:center;margin-top:12px">
@@ -617,7 +651,7 @@ async function renderConfig(){
     ${pw('c_wpw','Password',c.wifi.password_set)}</div>
   <div class="card"><b>MQTT</b> <span class="tag" style="font-weight:400">needs restart</span>${chk('c_mqe','Enabled',c.mqtt.enabled)}
     ${txt('c_mqh','Broker host',c.mqtt.host)}${num('c_mqp','Port',c.mqtt.port)}
-    ${credtxt('c_mqu','Username',c.mqtt.username_set,'Leave blank to keep. Not shown here; the API accepts null to clear it.')}${pw('c_mqpw','Password',c.mqtt.password_set)}
+    ${credtxt('c_mqu','Username',c.mqtt.username_set,'Leave blank to keep. Not shown here; send an empty string via the API to clear it (null is a no-op for usernames).')}${pw('c_mqpw','Password',c.mqtt.password_set)}
     ${txt('c_mqt','Base topic',c.mqtt.base_topic)}
     ${chk('c_mqd','Home Assistant discovery',c.mqtt.discovery_enabled)}</div>
   <div class="card"><b>Modbus TCP</b> <span class="tag" style="font-weight:400">needs restart</span>${chk('c_mbe','Enabled',c.modbus.enabled)}
@@ -671,7 +705,7 @@ async function renderConfig(){
     Disabling releases every relay. Roles name the switches in Home Assistant and build
     the DRM Mode select; see docs/drm.md for the wiring rules (failsafe: a dead bridge
     must leave the inverter running).</div></div>`:''}
-  <div class="card"><b>Security</b> <span class="tag" style="font-weight:400">applied immediately</span>${credtxt('c_au','Admin username',true,'Leave blank to keep. Not shown here — it is half of the login and this page is readable without one.')}
+  <div class="card"><b>Security</b> <span class="tag" style="font-weight:400">applied immediately</span>${credtxt('c_au','Admin username',true,'Leave blank to keep. Not shown here — it is half of the login and this page is readable without one. <b>Write down anything other than “admin”: it cannot be read back, and a forgotten username needs a factory reset.</b>')}
     ${pw('c_ap','Admin password',c.security.password_set)}
     <!-- !==false, not a plain truthiness test: a missing field must render as ON. If GET ever
          stops carrying read_only_mode (a serialiser regression, an older firmware behind a
@@ -759,10 +793,12 @@ async function saveConfig(){
   if(v('c_wpw'))body.wifi.password=v('c_wpw');
   // The MQTT username is credential-like (never returned by GET), so like the passwords it
   // travels only when typed -- a blank field means keep.
-  if(v('c_mqu'))body.mqtt.username=v('c_mqu');
+  if(v('c_mqu'))body.mqtt.username=v('c_mqu').trim();
   // Same rule for the admin username, and the same reason: GET no longer returns it, so there
-  // is nothing to pre-fill and a blank field can only mean keep.
-  if(v('c_au'))body.security.admin_username=v('c_au');
+  // is nothing to pre-fill and a blank field can only mean keep. Trimmed, because validate()
+  // only rejects an empty one -- "beheerder " would be stored and then never match again, with
+  // no way to see the difference and no way to read the stored value back.
+  if(v('c_au').trim())body.security.admin_username=v('c_au').trim();
   if(v('c_mqpw'))body.mqtt.password=v('c_mqpw');
   if(v('c_ap'))body.security.admin_password=v('c_ap');
   document.querySelectorAll('[data-opt]').forEach(e=>body.driver.options[e.dataset.opt]=e.value);
@@ -817,6 +853,21 @@ async function saveConfig(){
       headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
   }catch(e){m.className='msg err';m.textContent='Cancelled.';m.style.display='block';return}
   const d=await r.json().catch(()=>({}));
+  // Renaming the admin account invalidates the credential we just authenticated with. Before
+  // this release the sign-in dialog re-fetched the name from GET /config, so a rename healed
+  // itself; now nothing would, and the very next admin action would 401 straight after a
+  // successful rename -- the most confusing possible moment for it. Re-key on the new name,
+  // reusing the password half of the credential that just worked.
+  if(r.ok&&body.security&&body.security.admin_username){
+    const cur=atob(sessionStorage.getItem('sb_auth')||'');
+    const pw=cur.slice(cur.indexOf(':')+1);
+    if(cur){
+      const raw=body.security.admin_username+':'+pw;
+      sessionStorage.setItem('sb_auth',
+        btoa(String.fromCharCode(...new TextEncoder().encode(raw))));
+      sessionStorage.setItem('sb_user',body.security.admin_username);
+    }
+  }
   if(!r.ok){
     m.className='msg err';
     m.textContent=(d.error&&d.error.message)||('HTTP '+r.status);

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -64,6 +64,11 @@ button:disabled{opacity:.5;cursor:default}
        back after a WiFi outage rather than on first boot. Then the new-password fields above are
        hidden and this one authenticates the change instead. -->
   <div id="reauth" style="display:none">
+    <!-- Typed, not fetched. The username used to come from GET /api/v1/config, which is
+         unauthenticated -- so this page's convenience was the reason every LAN reader was
+         handed half of the bridge's login. Defaults to the factory value. -->
+    <label for="curuser">Admin username</label>
+    <input id="curuser" autocomplete="username" value="admin">
     <label for="cur">Admin password</label>
     <input id="cur" type="password" autocomplete="current-password">
     <div class="hint">This bridge is already set up, so changing its network needs the admin
@@ -89,10 +94,9 @@ const msg=(t,ok)=>{const m=$('m');m.textContent=t;m.className='msg '+(ok?'ok':'e
 // enough), a password already exists, and provisioning demands it -- so the form authenticates
 // and changes only the network. Detected up front rather than on a failed submit, because a 401
 // from requestAuthentication() has an empty body and the old code parsed it as JSON.
-let reauth=false, adminUser='admin', modeKnown=false;
+let reauth=false, modeKnown=false;
 const setupReady=fetch('/api/v1/config').then(r=>r.json()).then(c=>{
   const sec=(c&&c.security)||{};
-  adminUser=sec.admin_username||'admin';
   reauth=!!sec.password_set;
   modeKnown=true;
   if(reauth){
@@ -182,15 +186,16 @@ $('f').onsubmit=async e=>{
       // ö, ç. The firmware compares against the bytes it stored from the setup POST, which are
       // UTF-8, so those passwords would never match and the owner would be locked out of their
       // own recovery with "password not accepted" (review, 2026-07-25).
-      const raw=adminUser+':'+$('cur').value;
+      const raw=($('curuser').value||'admin')+':'+$('cur').value;
       headers['Authorization']='Basic '+btoa(String.fromCharCode(...new TextEncoder().encode(raw)));
     }else{
       body.security={admin_password:$('admin').value};
     }
     const r=await fetch('/api/v1/provision',{method:'POST',headers,body:JSON.stringify(body)});
     if(r.status===401){
-      refuse('That admin password was not accepted. Forgotten it? Hold BOOT for ~5 seconds '+
-             'while the board is running to factory-reset it.');
+      refuse('Those admin credentials were not accepted — check the username too if you ever '+
+             'changed it. Forgotten them? Hold BOOT for ~5 seconds while the board is running '+
+             'to factory-reset it.');
       return;
     }
     // Tolerate a missing or non-JSON body on ANY status, not just 401. requestAuthentication()

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -68,7 +68,8 @@ button:disabled{opacity:.5;cursor:default}
          unauthenticated -- so this page's convenience was the reason every LAN reader was
          handed half of the bridge's login. Defaults to the factory value. -->
     <label for="curuser">Admin username</label>
-    <input id="curuser" autocomplete="username" value="admin">
+    <input id="curuser" autocomplete="username" autocapitalize="none" autocorrect="off"
+           spellcheck="false" value="admin">
     <label for="cur">Admin password</label>
     <input id="cur" type="password" autocomplete="current-password">
     <div class="hint">This bridge is already set up, so changing its network needs the admin
@@ -186,7 +187,9 @@ $('f').onsubmit=async e=>{
       // ö, ç. The firmware compares against the bytes it stored from the setup POST, which are
       // UTF-8, so those passwords would never match and the owner would be locked out of their
       // own recovery with "password not accepted" (review, 2026-07-25).
-      const raw=($('curuser').value||'admin')+':'+$('cur').value;
+      // Trimmed: Basic auth compares bytes, and this page is most often opened in a phone's
+      // captive-portal browser, where a stray autocorrect space is easy and invisible.
+      const raw=($('curuser').value.trim()||'admin')+':'+$('cur').value;
       headers['Authorization']='Basic '+btoa(String.fromCharCode(...new TextEncoder().encode(raw)));
     }else{
       body.security={admin_password:$('admin').value};

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -30,8 +30,10 @@ static Configuration provisionedConfig() {
     return c;
 }
 
-/// Exactly the body the settings form sends when only the Modbus checkbox is cleared: every
-/// section present, passwords omitted (blank field means "keep").
+/// A full-section PATCH of the shape the settings form used to send when only the Modbus
+/// checkbox was cleared. Kept verbatim as a back-compat case rather than updated: the current
+/// form no longer sends admin_username unless it is typed, and always sends read_only_mode, so
+/// this body is now an OLD client's -- which is exactly what makes it worth still accepting.
 static void test_turning_modbus_off_leaves_mqtt_running_after_a_restart() {
     MemoryBackend      backend;
     ConfigurationStore store(backend);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -99,7 +99,7 @@ static void test_config_response_contains_no_secret_anywhere() {
     TEST_ASSERT_TRUE(json.find("SuperSecretAdminPassword789") == std::string::npos);
     // The admin username is half of the login, and this endpoint needs no credentials at all.
     // Serving it reduced guessing a login with no brute-force protection to guessing only the
-    // password -- while mqtt.username, twelve lines up in the same serialiser, was already
+    // password -- while mqtt.username, in the same serialiser, was already
     // omitted for exactly that reason.
     TEST_ASSERT_TRUE(json.find("beheerder") == std::string::npos);
     // And no masked placeholder either: a client could round-trip "***" back in as a literal.
@@ -119,9 +119,12 @@ static void test_config_reports_whether_a_secret_is_set() {
     TEST_ASSERT_TRUE(doc["mqtt"]["username_set"].as<bool>());
     TEST_ASSERT_TRUE(doc["mqtt"]["username"].isNull());
     TEST_ASSERT_TRUE(json.find("solar") == std::string::npos);
-    // No admin_username, and no *_set flag for it either: validate() refuses an empty one, so
-    // the flag could only ever be true and would tell a reader nothing.
+    // No admin_username. This one is the actual regression guard: it fails against the old
+    // serialiser.
     TEST_ASSERT_TRUE(doc["security"]["admin_username"].isNull());
+    // And no *_set flag for it either, because validate() refuses an empty one so the flag
+    // could only ever be true. Note this asserts nothing about the change -- the flag never
+    // existed on either side. It is a forward guard against someone adding one later.
     TEST_ASSERT_TRUE(doc["security"]["username_set"].isNull());
     // Non-secret fields are readable, which is what makes the UI usable.
     TEST_ASSERT_EQUAL_STRING("thuisnetwerk", doc["wifi"]["ssid"]);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -79,6 +79,9 @@ static Configuration configWithSecrets() {
     c.mqtt.username            = "solar";
     c.mqtt.password            = "SuperSecretMqttPassword456";
     c.security.adminPassword   = "SuperSecretAdminPassword789";
+    // Deliberately not the factory "admin": a leak of the default would be invisible in a body
+    // that legitimately contains the word "admin" in prose or in a driver id.
+    c.security.adminUsername   = "beheerder";
     return c;
 }
 
@@ -94,6 +97,11 @@ static void test_config_response_contains_no_secret_anywhere() {
     TEST_ASSERT_TRUE(json.find("SuperSecretWifiPassword123") == std::string::npos);
     TEST_ASSERT_TRUE(json.find("SuperSecretMqttPassword456") == std::string::npos);
     TEST_ASSERT_TRUE(json.find("SuperSecretAdminPassword789") == std::string::npos);
+    // The admin username is half of the login, and this endpoint needs no credentials at all.
+    // Serving it reduced guessing a login with no brute-force protection to guessing only the
+    // password -- while mqtt.username, twelve lines up in the same serialiser, was already
+    // omitted for exactly that reason.
+    TEST_ASSERT_TRUE(json.find("beheerder") == std::string::npos);
     // And no masked placeholder either: a client could round-trip "***" back in as a literal.
     TEST_ASSERT_TRUE(json.find("***") == std::string::npos);
 }
@@ -111,6 +119,10 @@ static void test_config_reports_whether_a_secret_is_set() {
     TEST_ASSERT_TRUE(doc["mqtt"]["username_set"].as<bool>());
     TEST_ASSERT_TRUE(doc["mqtt"]["username"].isNull());
     TEST_ASSERT_TRUE(json.find("solar") == std::string::npos);
+    // No admin_username, and no *_set flag for it either: validate() refuses an empty one, so
+    // the flag could only ever be true and would tell a reader nothing.
+    TEST_ASSERT_TRUE(doc["security"]["admin_username"].isNull());
+    TEST_ASSERT_TRUE(doc["security"]["username_set"].isNull());
     // Non-secret fields are readable, which is what makes the UI usable.
     TEST_ASSERT_EQUAL_STRING("thuisnetwerk", doc["wifi"]["ssid"]);
     TEST_ASSERT_EQUAL_STRING("10.0.0.5", doc["mqtt"]["host"]);


### PR DESCRIPTION
`docs/security.md` listed this leak and said *"Closing that one is tracked separately."* This is that.

## The inconsistency

`GET /api/v1/config` needs no credentials — deliberately, the UI renders from it — and it returned `security.admin_username` in full. That is half of a login with **no brute-force protection**, so guessing the credentials was reduced to guessing only the password. `mqtt.username` in the same serialiser was already omitted, with a comment spelling out exactly that reasoning. The admin credential was the exception to a rule already written down for the broker credential.

The username is now omitted the same way. No `*_set` companion: `validate()` requires it non-empty, so the flag could only ever be `true`.

## How big is this, honestly

Small, and the second commit says so in the docs rather than in a PR nobody will read later.

The firmware ships `adminUsername = "admin"`, the setup page never asks for one, and changing it is a single field in Settings. So for almost every install an attacker guesses right on the first try either way — **the search space only shrinks for someone who renamed the account, and that is the only person who pays for this.** On a device whose Modbus port has no authentication at all, claiming more would be silly.

It is also not "a hole closed": Basic over plain HTTP puts the password on the wire, so a listener who catches a sign-in has had both halves all along. What goes away is the much lower bar of one unauthenticated GET — no timing, no waiting for an admin to appear. On a bridge nobody ever signs into, that GET was the *only* source.

## The second commit is where the real work is

The review found that the serialiser change was complete and everything built on top of it was not.

**I claimed something false.** My first commit said the dialog "remembers an accepted name" — inside a paragraph headed *Verified against the real page*. It did not: `sb_user` was written the moment the dialog was submitted, before anything had spoken to the device. A typo'd username was cached and then helpfully re-filled on the retry, with no message. The user was handed their own mistake back and could never converge. The name is now held pending and promoted only after a request with it returns non-401.

**A lockout risk I introduced.** A wrong username and a wrong password now fail identically, and only the setup page said so — the dashboard re-prompted in silence. The dialog gained an error line on the retry pass. The Logs tab made it worse: it latched on cancel but not on 401, and runs on a 5 s timer, so a mistyped username re-summoned the modal every five seconds forever. It latches on 401 too now.

**Nothing was trimmed.** Three new credential inputs, no `autocapitalize` suppression, no `.trim()`. A phone capitalising the first letter stores a name the owner cannot see is different and — this is the part that matters — cannot read back. That is a factory reset. Fixed at all three sites, and the settings field got the readonly-until-focus treatment the password fields already have, because a text field above a password field is a login form to a password manager. This file documents that biting for real on 2026-07-21.

**Renaming used to self-heal**, because the dialog re-fetched the name — the comment saying so is one I deleted. A rename now re-keys the stored credential, so a 401 does not land immediately after a successful rename.

**And the thing nobody was told:** there is now no way to read the username back. `docs/security.md` and the settings hint say plainly that anything other than `admin` must be written down, and that forgetting it costs a factory reset. My first version described the entire cost as "type it once per browser session" — which is also wrong: it is per tab *and* per origin.

## Other corrections to my own claims

- *"Twelve lines up in the same serialiser"* — 39. Asserted in three places without counting.
- `docs/security.md`'s enforcement table and the `serializeConfig` contract comment still said "and the MQTT username". That is the row a maintainer greps; I rewrote the prose that argued for the change and left the reference behind.
- The widened "both usernames" prose pulled `admin_username` under a documented `null`-clears contract that **neither** username has — `patchString` cannot tell `null` from absent. Pre-existing and wrong for MQTT too, including in a UI hint shown to users.
- *"A sniffer had both halves regardless"* — only if they caught someone signing in.
- The exposure list omitted driver options and `security.read_only_mode`, which tells a stranger on the open recovery AP whether the relay/DRM write gate is open.
- One of my three new assertions passes identically on both sides of the change. Kept, relabelled as the forward guard it actually is.

## Verification

Against the real page served from a stub whose admin was renamed away from `admin`:

- prompt 1 offers `admin`, no error banner;
- a wrong username returns 401 → prompt 2 shows the error **and still offers `admin`**, not the typo;
- the accepted name is what ends up remembered;
- `"  Nieuw  "` is stored trimmed and re-keys the session credential to `Nieuw:geheim`;
- the Logs tab prompts twice and then stops.

**539 tests pass**, `check_layering.sh` PASS, all four boards build.

## Not taken

One reviewer suggested serving the username only on an *authenticated* GET, to keep a readback path. It does not work: you can only make an authenticated request if you already know the username, so it does nothing for the case that matters. Warning the owner is the honest fix.

## Still open

A device discovered on a second serial profile is still polled at the driver's default baud; and the firmware still polls exactly one device (`kMaxActiveDevices = 1`), the blocking one for three inverters on one bus.
