### PR TITLE
Keep the line settings discovery found

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,8 +247,17 @@ EverSolar:
 }
 ```
 
-Only **one** serial profile: 9600 8N1 is hardcoded in the reference. We do not try other
-combinations — that would be blind brute-forcing.
+Only **one** serial profile for this driver: 9600 8N1 is hardcoded in the reference. We do not
+try other combinations — that would be blind brute-forcing. Drivers whose protocol genuinely
+allows more list them, and extended discovery tries each in turn (quick discovery only tries the
+first).
+
+The driver's list is not the last word at runtime. `config.serial` stores an optional line
+override: off by default, and set by the discovery wizard when a device answers at a profile the
+driver does not lead with, since otherwise the next boot would reconfigure the line to the
+driver's own first choice and the identified device would go silent. It is applied after every
+`begin()` — at boot and again after a discovery run — and it is dropped when the driver is
+switched by a request that does not itself carry new line settings. See `docs/rest-api.md`.
 
 ### DriverRegistry
 

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -184,7 +184,9 @@ address in turn and confirm exactly one answers, at the address you expect.
 1. **Give each inverter a unique Modbus address**, as above, before wiring anything to a
    shared bus.
 2. Wire A/B/GND to the RS485 port — see [rs485-bus.md](rs485-bus.md) for topology, ground and
-   the 120 Ω termination rule. 9600 8N1 is what the profile declares.
+   the 120 Ω termination rule. 9600 8N1 is what the profile declares — if your units are set to
+   something else, run **extended** discovery (quick only tries the first profile) and the
+   wizard stores the line settings that answered.
 3. Configure the driver: `growatt_modbus`, profile `mic_tl_x`, `unit_id` as set in step 1.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -108,6 +108,8 @@ authenticate must ask the user for it rather than read it back; the factory valu
   "mqtt":  { "host": "10.0.0.5", "port": 1883, "username_set": true, "password_set": true },
   "modbus": { "enabled": true, "port": 502, "unit_id": 1, "write_enabled": false },
   "polling": { "interval_seconds": 10 },
+  "serial": { "override": false, "baud_rate": 9600, "parity": "none",
+              "data_bits": 8, "stop_bits": 1, "response_timeout_ms": 1000 },
   "security": { "password_set": true, "read_only_mode": false },
   "driver": { "id": "eversolar_legacy", "auto_detect": false },
   "logging": { "level": "info" }
@@ -124,10 +126,28 @@ nothing — `PATCH {"mqtt":{"username":null}}` returns `200` and leaves the stor
 Send `""` to clear the MQTT username. `security.admin_username` cannot be cleared at all:
 `validate()` refuses an empty one.
 
+## `serial` — overriding the line the driver picks
+
+Every driver advertises the serial profiles plausible for its protocol and configures the first
+one in `begin()`. `serial.override` replaces that choice, and it exists for one case: discovery
+sweeps *all* of a driver's profiles, so a device can be found at a profile the driver does not
+lead with. Saving the driver alone then meant the next boot went back to the driver's default
+and the identified inverter fell silent.
+
+`override: false` (the default) means the driver decides — leave it there unless something is
+actually wrong. When it is on, the settings are applied immediately after `begin()`, so they win
+over both the driver's default and a device profile's own `[serial]` block.
+
+Bounds when the override is on: `baud_rate` 1200–115200, `data_bits` 7 or 8, `stop_bits` 1 or 2,
+`response_timeout_ms` 50–10000, `parity` one of `none` / `even` / `odd`. An unrecognised parity
+is a `400`, not a silent fall back to `none`. While the override is off these fields are stored
+but not validated — they configure nothing.
+
 ## Applying changes: `reboot_required`
 
-Most settings — WiFi, MQTT, Modbus, the polling interval, the driver, NTP — are read once at
-boot, so a `PATCH` stores them but they take effect only after a restart. A few
+Most settings — WiFi, MQTT, Modbus, the polling interval, the driver, NTP, the RS485 line
+override — are read once at boot, so a `PATCH` stores them but they take effect only after a
+restart. A few
 (`bridge_name`, `relays.*`, `security.*`, `logging.level`) are applied live.
 
 The `PATCH /api/v1/config` response therefore carries a top-level `reboot_required` boolean so

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -109,7 +109,7 @@ authenticate must ask the user for it rather than read it back; the factory valu
   "modbus": { "enabled": true, "port": 502, "unit_id": 1, "write_enabled": false },
   "polling": { "interval_seconds": 10 },
   "serial": { "override": false, "baud_rate": 9600, "parity": "none",
-              "data_bits": 8, "stop_bits": 1, "response_timeout_ms": 1000 },
+              "data_bits": 8, "stop_bits": 1 },
   "security": { "password_set": true, "read_only_mode": false },
   "driver": { "id": "eversolar_legacy", "auto_detect": false },
   "logging": { "level": "info" }
@@ -129,19 +129,32 @@ Send `""` to clear the MQTT username. `security.admin_username` cannot be cleare
 ## `serial` — overriding the line the driver picks
 
 Every driver advertises the serial profiles plausible for its protocol and configures the first
-one in `begin()`. `serial.override` replaces that choice, and it exists for one case: discovery
-sweeps *all* of a driver's profiles, so a device can be found at a profile the driver does not
-lead with. Saving the driver alone then meant the next boot went back to the driver's default
-and the identified inverter fell silent.
+one in `begin()`. `serial.override` replaces that choice, and it exists for one case:
+**extended** discovery tries all of a driver's profiles (quick mode only tries the first), so a
+device can be found at a profile the driver does not lead with. Saving the driver alone then
+meant the next boot went back to the driver's default and the identified inverter fell silent.
 
 `override: false` (the default) means the driver decides — leave it there unless something is
-actually wrong. When it is on, the settings are applied immediately after `begin()`, so they win
-over both the driver's default and a device profile's own `[serial]` block.
+actually wrong. When it is on, the settings are applied immediately after `begin()` — at boot
+and again after any discovery run, since discovery reconfigures the line per candidate and
+`begin()` then puts it back on the driver's own choice. So the override wins over both the
+driver's default and a device profile's own `[serial]` block.
 
-Bounds when the override is on: `baud_rate` 1200–115200, `data_bits` 7 or 8, `stop_bits` 1 or 2,
-`response_timeout_ms` 50–10000, `parity` one of `none` / `even` / `odd`. An unrecognised parity
-is a `400`, not a silent fall back to `none`. While the override is off these fields are stored
-but not validated — they configure nothing.
+Switching `driver.id` in a request that does **not** itself carry a `serial` block turns the
+override off. It was derived from one driver's profile sweep; carried across to another it
+forces line settings that were never measured against it. The numbers are kept, so turning it
+back on does not mean retyping them.
+
+Bounds when the override is on: `baud_rate` 1200–115200, `data_bits` **8 only**, `stop_bits` 1
+or 2, `parity` one of `none` / `even` / `odd`. An unrecognised parity is a `400`, not a silent
+fall back to `none`. 7-bit framing is refused rather than accepted: the transport maps a profile
+onto the ESP32's `SERIAL_*` constants and handles only the 8-bit ones, so a 7 would land on
+`SERIAL_8N1` — losing the parity too — while still reporting success.
+
+There is no `response_timeout_ms` here. Read deadlines are per-driver compile-time constants;
+a field on this object would have been a knob that changed nothing.
+
+While the override is off these fields are stored but not validated — they configure nothing.
 
 ## Applying changes: `reboot_required`
 

--- a/docs/rs485-bus.md
+++ b/docs/rs485-bus.md
@@ -126,12 +126,14 @@ visible in the logs at `trace` level, in `/api/v1/diagnostics`, and as Prometheu
 - A and B swapped (try swapping them; it costs nothing)
 - Wrong address, or the device is still on its factory default while you are asking for
   another
-- Wrong baud rate or framing. The driver configures the line itself, and discovery sweeps every
-  profile that driver advertises — so if the wizard *found* the device, the working settings are
-  known. Selecting the driver from the wizard saves them when they differ from the driver's own
-  first choice; **Settings → RS485 line** is where to check or change them by hand. Before the
-  release carrying this note the wizard displayed the profile that answered and then discarded
-  it, so a device found at a non-default profile went silent again on the next boot
+- Wrong baud rate or framing. The driver configures the line itself, and **extended** discovery
+  tries every profile that driver advertises — quick mode only tries the first, so a device on a
+  non-default line will not be found by the quick run at all. If the extended run *did* find it,
+  the working settings are known: selecting the driver from the wizard saves them when they
+  differ from the driver's own first choice, and **Settings → RS485 line** is where to check or
+  change them by hand. Before the release carrying this note the wizard displayed the profile
+  that answered and then discarded it, so a device found at a non-default profile went silent
+  again on the next boot
 - Wrong port on the inverter — some units have several RJ45 sockets and only one is RS485
 - The port is occupied by the manufacturer's own WiFi dongle
 - A break in the chain: every device past the break goes silent, which is a useful clue about

--- a/docs/rs485-bus.md
+++ b/docs/rs485-bus.md
@@ -126,7 +126,12 @@ visible in the logs at `trace` level, in `/api/v1/diagnostics`, and as Prometheu
 - A and B swapped (try swapping them; it costs nothing)
 - Wrong address, or the device is still on its factory default while you are asking for
   another
-- Wrong baud rate or framing
+- Wrong baud rate or framing. The driver configures the line itself, and discovery sweeps every
+  profile that driver advertises — so if the wizard *found* the device, the working settings are
+  known. Selecting the driver from the wizard saves them when they differ from the driver's own
+  first choice; **Settings → RS485 line** is where to check or change them by hand. Before the
+  release carrying this note the wizard displayed the profile that answered and then discarded
+  it, so a device found at a non-default profile went silent again on the next boot
 - Wrong port on the inverter — some units have several RJ45 sockets and only one is RS485
 - The port is occupied by the manufacturer's own WiFi dongle
 - A break in the chain: every device past the break goes silent, which is a useful clue about

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -261,16 +261,19 @@ bool validate(const Configuration& config, ConfigError& error) {
             error = {"serial.baud_rate", "must be between 1200 and 115200"};
             return false;
         }
-        if (p.dataBits < 7 || p.dataBits > 8) {
-            error = {"serial.data_bits", "must be 7 or 8"};
+        // 8 only. The transport maps a SerialProfile onto the ESP32's SERIAL_* constants and
+        // handles the 8-bit combinations; anything else falls through to SERIAL_8N1, which
+        // loses the data bits AND the parity while configure() still reports success. That
+        // fallthrough was harmless while only drivers picked the line -- every driver ships
+        // 8 bits -- and this override is what made it reachable from the API and the settings
+        // form. Refused here rather than coerced silently, because the symptom of the coercion
+        // is a dead bus and a log line stating the setting that was NOT applied.
+        if (p.dataBits != 8) {
+            error = {"serial.data_bits", "must be 8; 7-bit framing is not supported"};
             return false;
         }
         if (p.stopBits < 1 || p.stopBits > 2) {
             error = {"serial.stop_bits", "must be 1 or 2"};
-            return false;
-        }
-        if (p.responseTimeoutMs < 50 || p.responseTimeoutMs > 10000) {
-            error = {"serial.response_timeout_ms", "must be between 50 and 10000"};
             return false;
         }
     }
@@ -355,7 +358,6 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     serial["parity"]    = parityName(config.serial.profile.parity);
     serial["data_bits"] = config.serial.profile.dataBits;
     serial["stop_bits"] = config.serial.profile.stopBits;
-    serial["response_timeout_ms"] = config.serial.profile.responseTimeoutMs;
 
     JsonObject security = doc["security"].to<JsonObject>();
     // The admin username is omitted for the same reason mqtt.username is, in the mqtt block
@@ -405,9 +407,7 @@ bool configChangeRequiresReboot(const Configuration& a, const Configuration& b) 
            // next boot -- and saying otherwise would leave someone watching a bus that is still
            // running at the old rate while the page claims the new one is in force.
            a.serial.enabled != b.serial.enabled ||
-           (b.serial.enabled && !(a.serial.profile == b.serial.profile)) ||
-           (b.serial.enabled &&
-            a.serial.profile.responseTimeoutMs != b.serial.profile.responseTimeoutMs);
+           (b.serial.enabled && !(a.serial.profile == b.serial.profile));
 }
 
 bool applyConfigPatch(const std::string& json, Configuration& config, ConfigError& error,
@@ -549,6 +549,7 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
         }
     }
 
+    const bool serialSupplied = !doc["serial"].isNull();
     if (JsonObjectConst serial = doc["serial"]; !serial.isNull()) {
         if (!patchBool(serial["override"], merged.serial.enabled, "serial.override", error))
             return false;
@@ -560,9 +561,6 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
             return false;
         if (!patchNumber(serial["stop_bits"], merged.serial.profile.stopBits, "serial.stop_bits",
                          error))
-            return false;
-        if (!patchNumber(serial["response_timeout_ms"], merged.serial.profile.responseTimeoutMs,
-                         "serial.response_timeout_ms", error))
             return false;
         if (JsonVariantConst parity = serial["parity"]; !parity.isNull()) {
             std::string name;
@@ -577,6 +575,23 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
             }
         }
     }
+
+    // A line override belongs to the driver it was derived from. The wizard pins one only when
+    // the device answered at a profile that driver does not lead with, so carrying it across to
+    // a DIFFERENT driver forces line settings that were never measured against it -- and every
+    // driver in this build leads with 9600 8N1, so the carried value is wrong by construction.
+    // The symptom is a silent bus right after a restart the Driver card asked for, with the
+    // cause sitting in a different card further up the page.
+    //
+    // Only when this patch did not supply `serial` itself. The wizard sends driver AND serial
+    // together, and clearing what the caller just asked for is the mistake the driver-option
+    // rule above already had to be redesigned to avoid. Clearing degrades to "the driver
+    // decides", which is where every healthy install already is, is visible in Settings, and
+    // is re-derived by running discovery again -- so the recovery does not need a factory reset.
+    if (!serialSupplied && merged.driver.id != config.driver.id && merged.serial.enabled) {
+        merged.serial.enabled = false;
+    }
+
 
     if (JsonObjectConst ntp = doc["ntp"]; !ntp.isNull()) {
         if (!patchBool(ntp["enabled"], merged.ntp.enabled, "ntp.enabled", error)) return false;

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -252,6 +252,28 @@ bool validate(const Configuration& config, ConfigError& error) {
     if (!checkLength(config.ntp.server, 64, "ntp.server", error)) return false;
     if (!checkLength(config.ntp.timezone, 48, "ntp.timezone", error)) return false;
     if (!checkLength(config.ntp.timezoneName, 48, "ntp.timezone_name", error)) return false;
+    if (config.serial.enabled) {
+        // Bounds, not a whitelist of "known good" rates. RS485 devices in the field run at
+        // 1200 and at 115200, and refusing an odd-but-real rate would be the firmware deciding
+        // it knows the installation better than the installer does.
+        const auto& p = config.serial.profile;
+        if (p.baudRate < 1200 || p.baudRate > 115200) {
+            error = {"serial.baud_rate", "must be between 1200 and 115200"};
+            return false;
+        }
+        if (p.dataBits < 7 || p.dataBits > 8) {
+            error = {"serial.data_bits", "must be 7 or 8"};
+            return false;
+        }
+        if (p.stopBits < 1 || p.stopBits > 2) {
+            error = {"serial.stop_bits", "must be 1 or 2"};
+            return false;
+        }
+        if (p.responseTimeoutMs < 50 || p.responseTimeoutMs > 10000) {
+            error = {"serial.response_timeout_ms", "must be between 50 and 10000"};
+            return false;
+        }
+    }
     // A POSIX TZ is always needed to stamp logs in local time; a default is provided, so empty
     // is a mistake rather than a choice.
     if (config.ntp.timezone.empty()) {
@@ -325,10 +347,19 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     ntp["timezone"]      = config.ntp.timezone;
     ntp["timezone_name"] = config.ntp.timezoneName;
 
+    // Always emitted, enabled or not, so the settings page can show what the bridge will
+    // actually do to the line rather than leaving the reader to infer it from an absent key.
+    JsonObject serial   = doc["serial"].to<JsonObject>();
+    serial["override"]  = config.serial.enabled;
+    serial["baud_rate"] = config.serial.profile.baudRate;
+    serial["parity"]    = parityName(config.serial.profile.parity);
+    serial["data_bits"] = config.serial.profile.dataBits;
+    serial["stop_bits"] = config.serial.profile.stopBits;
+    serial["response_timeout_ms"] = config.serial.profile.responseTimeoutMs;
+
     JsonObject security = doc["security"].to<JsonObject>();
     // The admin username is omitted for the same reason mqtt.username is, in the mqtt block
-    // above: it
-    // is half of a credential pair, this endpoint is unauthenticated, and HTTP Basic here has no
+    // above: it is half of a credential pair, this endpoint is unauthenticated, and Basic has no
     // brute-force protection. Serving it turned guessing the login into guessing only the
     // password. Unlike the MQTT one it needs no *_set flag -- validate() requires it to be
     // non-empty, so "is one set" is always yes and would say nothing.
@@ -368,7 +399,15 @@ bool configChangeRequiresReboot(const Configuration& a, const Configuration& b) 
            a.polling.intervalSeconds != b.polling.intervalSeconds ||
            a.driver.id != b.driver.id || a.driver.options != b.driver.options ||
            a.ntp.enabled != b.ntp.enabled || a.ntp.useDhcp != b.ntp.useDhcp ||
-           a.ntp.server != b.ntp.server || a.ntp.timezone != b.ntp.timezone;
+           a.ntp.server != b.ntp.server || a.ntp.timezone != b.ntp.timezone ||
+           // The line is configured once, in setup(), right after the driver's begin(). Nothing
+           // reconfigures a live UART mid-poll, so a changed override only takes effect on the
+           // next boot -- and saying otherwise would leave someone watching a bus that is still
+           // running at the old rate while the page claims the new one is in force.
+           a.serial.enabled != b.serial.enabled ||
+           (b.serial.enabled && !(a.serial.profile == b.serial.profile)) ||
+           (b.serial.enabled &&
+            a.serial.profile.responseTimeoutMs != b.serial.profile.responseTimeoutMs);
 }
 
 bool applyConfigPatch(const std::string& json, Configuration& config, ConfigError& error,
@@ -506,6 +545,35 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
                     return false;
                 }
                 merged.relays.roles.emplace_back(v.as<const char*>());
+            }
+        }
+    }
+
+    if (JsonObjectConst serial = doc["serial"]; !serial.isNull()) {
+        if (!patchBool(serial["override"], merged.serial.enabled, "serial.override", error))
+            return false;
+        if (!patchNumber(serial["baud_rate"], merged.serial.profile.baudRate, "serial.baud_rate",
+                         error))
+            return false;
+        if (!patchNumber(serial["data_bits"], merged.serial.profile.dataBits, "serial.data_bits",
+                         error))
+            return false;
+        if (!patchNumber(serial["stop_bits"], merged.serial.profile.stopBits, "serial.stop_bits",
+                         error))
+            return false;
+        if (!patchNumber(serial["response_timeout_ms"], merged.serial.profile.responseTimeoutMs,
+                         "serial.response_timeout_ms", error))
+            return false;
+        if (JsonVariantConst parity = serial["parity"]; !parity.isNull()) {
+            std::string name;
+            if (!patchString(parity, name, "serial.parity", error)) {
+                return false;
+            }
+            // Refused rather than defaulted: a typo'd parity that silently became "none" would
+            // configure a line the user did not ask for and then blame the cable.
+            if (!parseParity(name, merged.serial.profile.parity)) {
+                error = {"serial.parity", "must be \"none\", \"even\" or \"odd\""};
+                return false;
             }
         }
     }

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -116,14 +116,21 @@ struct SecuritySettings {
 /// A line-settings override that survives a reboot.
 ///
 /// Normally the driver picks the line: every driver advertises the profiles plausible for its
-/// protocol and configures the first one in begin(). That is right until discovery finds the
-/// device at one of the OTHER profiles it swept -- an inverter set to 4800 8N1 when the driver
-/// leads with 9600, say. The wizard showed which profile answered and then threw it away, so
-/// the selection was saved, the bridge rebooted onto the driver's default, and the device it
-/// had just positively identified went silent with nothing on screen to explain it.
+/// protocol and configures the first one in begin(). That is right until EXTENDED discovery
+/// finds the device at one of the other profiles it tried -- a Modbus inverter answering at
+/// 115200 when its driver leads with 9600, say. (Quick discovery only tries the first profile,
+/// so it cannot find such a device at all.) The wizard showed which profile answered and then
+/// threw it away, so the selection was saved, the bridge rebooted onto the driver's default,
+/// and the device it had just positively identified went silent with nothing to explain it.
 ///
 /// Off unless something set it, so a healthy install keeps following its driver and a device
-/// profile that declares its own [serial] block still wins by default.
+/// profile that declares its own [serial] block still wins by default. Applied after every
+/// begin(), which means at boot AND after a discovery run -- missing the second one silently
+/// undid the override on a running bridge.
+///
+/// responseTimeoutMs and retries within `profile` are carried but unused: read deadlines are
+/// per-driver compile-time constants, and Rs485Transport::read() takes its timeout from the
+/// caller. Exposing them would have been a control that changes nothing.
 struct SerialOverride {
     bool          enabled = false;
     SerialProfile profile{};

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "drivers/driver_descriptor.h"
+#include "transport/serial_profile.h"
 
 namespace heliograph {
 
@@ -112,6 +113,22 @@ struct SecuritySettings {
     bool readOnlyMode = true;
 };
 
+/// A line-settings override that survives a reboot.
+///
+/// Normally the driver picks the line: every driver advertises the profiles plausible for its
+/// protocol and configures the first one in begin(). That is right until discovery finds the
+/// device at one of the OTHER profiles it swept -- an inverter set to 4800 8N1 when the driver
+/// leads with 9600, say. The wizard showed which profile answered and then threw it away, so
+/// the selection was saved, the bridge rebooted onto the driver's default, and the device it
+/// had just positively identified went silent with nothing on screen to explain it.
+///
+/// Off unless something set it, so a healthy install keeps following its driver and a device
+/// profile that declares its own [serial] block still wins by default.
+struct SerialOverride {
+    bool          enabled = false;
+    SerialProfile profile{};
+};
+
 struct Configuration {
     uint16_t         version = kConfigVersion;
     std::string      bridgeName = "Heliograph";
@@ -122,6 +139,7 @@ struct Configuration {
     DriverSettings   driver;
     RelaySettings    relays;
     NtpSettings      ntp;
+    SerialOverride   serial;
     SecuritySettings security;
     LogLevel         logLevel = LogLevel::Info;
 

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -127,7 +127,6 @@ bool serializeConfigForStorage(const Configuration& config, std::string& out) {
     serial["parity"]    = parityName(config.serial.profile.parity);
     serial["data_bits"] = config.serial.profile.dataBits;
     serial["stop_bits"] = config.serial.profile.stopBits;
-    serial["response_timeout_ms"] = config.serial.profile.responseTimeoutMs;
 
     JsonObject security        = doc["security"].to<JsonObject>();
     security["admin_username"] = config.security.adminUsername;
@@ -268,7 +267,6 @@ LoadResult deserializeConfigFromStorage(const std::string& json, Configuration& 
         if (serial["baud_rate"].is<uint32_t>()) parsed.serial.profile.baudRate = serial["baud_rate"].as<uint32_t>();
         if (serial["data_bits"].is<uint8_t>()) parsed.serial.profile.dataBits = serial["data_bits"].as<uint8_t>();
         if (serial["stop_bits"].is<uint8_t>()) parsed.serial.profile.stopBits = serial["stop_bits"].as<uint8_t>();
-        if (serial["response_timeout_ms"].is<uint32_t>()) parsed.serial.profile.responseTimeoutMs = serial["response_timeout_ms"].as<uint32_t>();
         // An unparseable parity leaves the default rather than guessing. The value came out of
         // our own NVS, so this only fires on a corrupted or hand-edited blob -- and silently
         // becoming "none" there would configure a line nobody chose.

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -121,6 +121,14 @@ bool serializeConfigForStorage(const Configuration& config, std::string& out) {
     ntp["timezone"]      = config.ntp.timezone;
     ntp["timezone_name"] = config.ntp.timezoneName;
 
+    JsonObject serial   = doc["serial"].to<JsonObject>();
+    serial["override"]  = config.serial.enabled;
+    serial["baud_rate"] = config.serial.profile.baudRate;
+    serial["parity"]    = parityName(config.serial.profile.parity);
+    serial["data_bits"] = config.serial.profile.dataBits;
+    serial["stop_bits"] = config.serial.profile.stopBits;
+    serial["response_timeout_ms"] = config.serial.profile.responseTimeoutMs;
+
     JsonObject security        = doc["security"].to<JsonObject>();
     security["admin_username"] = config.security.adminUsername;
     security["admin_password"] = config.security.adminPassword;
@@ -254,6 +262,20 @@ LoadResult deserializeConfigFromStorage(const std::string& json, Configuration& 
         if (ntp["server"].is<const char*>())   parsed.ntp.server   = ntp["server"].as<const char*>();
         if (ntp["timezone"].is<const char*>()) parsed.ntp.timezone = ntp["timezone"].as<const char*>();
         if (ntp["timezone_name"].is<const char*>()) parsed.ntp.timezoneName = ntp["timezone_name"].as<const char*>();
+    }
+    if (JsonObjectConst serial = doc["serial"]; !serial.isNull()) {
+        if (serial["override"].is<bool>()) parsed.serial.enabled = serial["override"].as<bool>();
+        if (serial["baud_rate"].is<uint32_t>()) parsed.serial.profile.baudRate = serial["baud_rate"].as<uint32_t>();
+        if (serial["data_bits"].is<uint8_t>()) parsed.serial.profile.dataBits = serial["data_bits"].as<uint8_t>();
+        if (serial["stop_bits"].is<uint8_t>()) parsed.serial.profile.stopBits = serial["stop_bits"].as<uint8_t>();
+        if (serial["response_timeout_ms"].is<uint32_t>()) parsed.serial.profile.responseTimeoutMs = serial["response_timeout_ms"].as<uint32_t>();
+        // An unparseable parity leaves the default rather than guessing. The value came out of
+        // our own NVS, so this only fires on a corrupted or hand-edited blob -- and silently
+        // becoming "none" there would configure a line nobody chose.
+        if (serial["parity"].is<const char*>()) {
+            SerialParity p{};
+            if (parseParity(serial["parity"].as<const char*>(), p)) parsed.serial.profile.parity = p;
+        }
     }
     if (JsonObjectConst security = doc["security"]; !security.isNull()) {
         if (security["admin_username"].is<const char*>()) parsed.security.adminUsername = security["admin_username"].as<const char*>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -701,6 +701,24 @@ void setup() {
     if (g_driver && g_driver->begin(g_transport)) {
         Serial.printf("[driver] %s (%s)\n", g_driver->descriptor().id.c_str(),
                       supportLevelName(g_driver->descriptor().supportLevel));
+        // AFTER begin(), never before: begin() configures the line to the driver's own first
+        // choice, so anything applied earlier is undone by the very next statement. That is
+        // also why discovery finding a device at a non-default profile used to be worthless --
+        // the wizard displayed the profile that answered and the next boot went back to the
+        // driver's default, leaving a positively identified inverter silent.
+        if (g_config.serial.enabled) {
+            const auto& p = g_config.serial.profile;
+            if (g_transport.configure(p)) {
+                Serial.printf("[serial] override %u baud, %u data bits, %s parity, %u stop, "
+                              "timeout %u ms\n", p.baudRate, p.dataBits, parityName(p.parity),
+                              p.stopBits, p.responseTimeoutMs);
+            } else {
+                // Loud, because the fallback is the driver's default and the symptom of that
+                // is silence on the bus -- indistinguishable from a dead inverter.
+                Serial.printf("[serial] override REFUSED (%u baud); the line is still at the "
+                              "driver's own setting\n", p.baudRate);
+            }
+        }
         const DeviceId id = g_driver->identity().deviceId();
         g_state           = g_devices.add(id);
         if (g_state) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,38 @@ std::string selectedDriverId() {
     return available.empty() ? std::string{} : available.front().id;
 }
 
+/// Puts the stored line-settings override back on the UART, and says what the line is either
+/// way.
+///
+/// Called after EVERY begin(): at boot, and again after a discovery run, because begin()
+/// unconditionally configures the driver's own first profile. Missing the second call meant
+/// running discovery from the web UI on a healthy bridge silently reset the line and the
+/// inverter went quiet until the next power cycle -- the same failure the override exists to
+/// prevent, on the one path that reconfigures the line at runtime (review, 2026-07-25).
+void applySerialOverride() {
+    if (!g_config.serial.enabled) {
+        // Logged even when nothing is overridden. Most bridges follow their driver, and without
+        // this line an owner has no way to learn what the bus is actually running at -- which
+        // matters the day a firmware update changes a driver's recommendation under them.
+        if (g_driver) {
+            Serial.println("[serial] line follows the driver's own profile");
+        }
+        return;
+    }
+    const auto& p = g_config.serial.profile;
+    if (g_transport.configure(p)) {
+        Serial.printf("[serial] override: %u baud, %u data bits, %s parity, %u stop\n",
+                      p.baudRate, p.dataBits, parityName(p.parity), p.stopBits);
+    } else {
+        // configure() opens the UART before the direction-pin setup that is the only thing
+        // that can fail, so on this path the line IS at the override's speed and framing --
+        // what is missing is half-duplex direction control. Saying "the line is still at the
+        // driver's setting" would have sent the reader to the wrong hypothesis entirely.
+        Serial.printf("[serial] override applied at %u baud, but RS485 direction control "
+                      "failed to configure; transmissions may collide\n", p.baudRate);
+    }
+}
+
 BridgeInfo bridgeInfo() {
     BridgeInfo info;
     info.boardName        = board::kName;
@@ -549,6 +581,12 @@ void rs485Task(void* /*arg*/) {
             // poll a stale address.
             if (g_driver) {
                 g_driver->begin(g_transport);
+                // ...and begin() has just put the line back on the driver's own first profile,
+                // exactly as it does at boot. Without this, running discovery from the web UI
+                // on a healthy bridge silently undid the override and the inverter went quiet
+                // until the next power cycle -- the same failure this override exists to
+                // prevent, on the one path that reconfigures the line at runtime.
+                applySerialOverride();
             }
             vTaskDelay(pdMS_TO_TICKS(250));
             continue;
@@ -701,24 +739,7 @@ void setup() {
     if (g_driver && g_driver->begin(g_transport)) {
         Serial.printf("[driver] %s (%s)\n", g_driver->descriptor().id.c_str(),
                       supportLevelName(g_driver->descriptor().supportLevel));
-        // AFTER begin(), never before: begin() configures the line to the driver's own first
-        // choice, so anything applied earlier is undone by the very next statement. That is
-        // also why discovery finding a device at a non-default profile used to be worthless --
-        // the wizard displayed the profile that answered and the next boot went back to the
-        // driver's default, leaving a positively identified inverter silent.
-        if (g_config.serial.enabled) {
-            const auto& p = g_config.serial.profile;
-            if (g_transport.configure(p)) {
-                Serial.printf("[serial] override %u baud, %u data bits, %s parity, %u stop, "
-                              "timeout %u ms\n", p.baudRate, p.dataBits, parityName(p.parity),
-                              p.stopBits, p.responseTimeoutMs);
-            } else {
-                // Loud, because the fallback is the driver's default and the symptom of that
-                // is silence on the bus -- indistinguishable from a dead inverter.
-                Serial.printf("[serial] override REFUSED (%u baud); the line is still at the "
-                              "driver's own setting\n", p.baudRate);
-            }
-        }
+        applySerialOverride();
         const DeviceId id = g_driver->identity().deviceId();
         g_state           = g_devices.add(id);
         if (g_state) {

--- a/src/transport/rs485_transport.cpp
+++ b/src/transport/rs485_transport.cpp
@@ -14,8 +14,11 @@ namespace heliograph {
 namespace {
 
 uint32_t toSerialConfig(const SerialProfile& p) {
-    // Only the combinations a driver can actually ask for. Anything else is a bug, not a
-    // configuration to accommodate.
+    // 8-bit framing only. That used to be safe to assume because only driver descriptors
+    // reached here, and every driver ships 8 bits; the stored line override made it reachable
+    // from the REST API and the settings form, so config validation now refuses anything else
+    // outright rather than letting it land on the fallthrough below -- which silently drops
+    // both the data bits and the parity while configure() still reports success.
     if (p.dataBits == 8 && p.stopBits == 1) {
         switch (p.parity) {
             case SerialParity::None: return SERIAL_8N1;

--- a/src/transport/serial_profile.h
+++ b/src/transport/serial_profile.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace heliograph {
 
@@ -26,5 +27,8 @@ struct SerialProfile {
 };
 
 const char* parityName(SerialParity parity);
+/// Inverse of parityName(). False on anything else, so a stored or patched value that does not
+/// name a parity is refused rather than quietly becoming None.
+bool        parseParity(const std::string& name, SerialParity& out);
 
 }  // namespace heliograph

--- a/src/transport/transport.cpp
+++ b/src/transport/transport.cpp
@@ -24,4 +24,11 @@ const char* parityName(SerialParity parity) {
     return "unknown";
 }
 
+bool parseParity(const std::string& name, SerialParity& out) {
+    if (name == "none") { out = SerialParity::None; return true; }
+    if (name == "even") { out = SerialParity::Even; return true; }
+    if (name == "odd")  { out = SerialParity::Odd;  return true; }
+    return false;
+}
+
 }  // namespace heliograph

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -414,10 +414,16 @@ function renderWizard(){
     <p class="dim">The driver is stored. It takes effect after a restart.</p>`+
     // Said out loud, because it is a setting the user never asked for and would otherwise
     // find in Settings with no idea where it came from.
-    (wizSavedSerial?`<p class="dim">This device answered at
+    (wizSavedSerial&&wizSavedSerial.override?`<p class="dim">This device answered at
       <b>${wizSavedSerial.baud_rate} ${wizSavedSerial.data_bits}${esc(wizSavedSerial.parity[0].toUpperCase())}${wizSavedSerial.stop_bits}</b>,
       which is not this driver's default, so those line settings were saved with it. You can
       change or clear that under <b>Settings → RS485 line</b>.</p>`:'')+
+    // Worth saying in the other direction too, and phrased so it is true whether or not an
+    // override existed before: this run cleared one if there was one. cfgBefore is only
+    // populated once the Settings tab has been opened, so it cannot be relied on here.
+    (wizSavedSerial&&wizSavedSerial.override===false?`<p class="dim">This device answered at
+      this driver's own default, so no <b>RS485 line</b> override is stored — the driver
+      decides. Any override left over from an earlier run has been switched off.</p>`:'')+
     `
     <button onclick="wizReboot()">Restart now</button>
     <div id="wizmsg" class="msg" style="display:none"></div></div>`;
@@ -471,15 +477,22 @@ async function testPoll(){
   },3000);
 }
 
-// The serial profile a candidate answered at, but only when it is NOT the one the chosen driver
-// would configure by itself. Discovery sweeps every profile a driver advertises; if the device
-// replied at the second or third one, saving the driver alone means the next boot configures
-// the first and the bus goes quiet. Returns null when the driver's own default already matches,
-// so the common case stores no override at all and keeps following the driver.
+// What to store for the line, given the candidate that answered.
+//
+// Extended discovery tries every profile a driver advertises (quick mode only tries the
+// first), so a device can reply at one the driver does not lead with. Saving the driver alone
+// then means the next boot configures the driver's own first profile and the bus goes quiet.
+//
+// Returns an override when the match differs from what this driver would configure by itself,
+// and {override:false} when it does not -- NOT null. Omitting the key entirely made the wizard
+// a one-way ratchet: a PATCH without `serial` leaves the stored value alone, so once anything
+// had pinned 115200, re-running the wizard on a device that answers at the driver's default
+// could never undo it and step 7 would not even mention the setting that was about to silence
+// the bus. Null is reserved for "this run learned nothing", where leaving it alone is right.
 async function discoveredSerialOverride(id){
   const cand=((wizReport&&wizReport.candidates)||[]).find(c=>c.driver_id===id);
   const found=cand&&cand.serial_profile;
-  if(!found||!cand.responded)return null;
+  if(!found)return null;
   // cfgDrivers is only populated once the Settings tab has been opened, and the wizard is
   // reachable without ever going there. Fetch rather than assume: with no default to compare
   // against, every discovery would pin an override, including the overwhelming majority where
@@ -489,11 +502,13 @@ async function discoveredSerialOverride(id){
   }
   const drv=((cfgDrivers&&cfgDrivers.drivers)||[]).find(d=>d.id===id);
   const def=drv&&(drv.serial_profiles||[])[0];
-  if(def&&def.baud_rate===found.baud_rate&&def.parity===found.parity&&
-     def.data_bits===found.data_bits&&def.stop_bits===found.stop_bits)return null;
+  if(!def)return null;  // nothing to compare against; do not guess
+  if(def.baud_rate===found.baud_rate&&def.parity===found.parity&&
+     def.data_bits===found.data_bits&&def.stop_bits===found.stop_bits){
+    return {override:false};
+  }
   return {override:true,baud_rate:found.baud_rate,parity:found.parity,
-          data_bits:found.data_bits,stop_bits:found.stop_bits,
-          response_timeout_ms:found.response_timeout_ms};
+          data_bits:found.data_bits,stop_bits:found.stop_bits};
 }
 
 async function saveDriver(){
@@ -575,6 +590,9 @@ const RESTART_NEEDED={
   'driver.id':'Active driver','driver.options':'Driver options',
   'ntp.enabled':'NTP on/off','ntp.use_dhcp':'NTP via DHCP','ntp.server':'NTP server',
   'ntp.timezone':'Timezone',
+  'serial.override':'RS485 line override','serial.baud_rate':'RS485 baud rate',
+  'serial.parity':'RS485 parity','serial.data_bits':'RS485 data bits',
+  'serial.stop_bits':'RS485 stop bits',
 };
 // Applied immediately, no restart:
 //   bridge_name          - read fresh on every status response
@@ -721,9 +739,7 @@ async function renderConfig(){
     <label for="c_serdb">Data bits</label>
     <input id="c_serdb" type="number" value="${c.serial.data_bits}">
     <label for="c_sersb">Stop bits</label>
-    <input id="c_sersb" type="number" value="${c.serial.stop_bits}">
-    <label for="c_serto">Response timeout (ms)</label>
-    <input id="c_serto" type="number" value="${c.serial.response_timeout_ms}"></div>
+    <input id="c_sersb" type="number" value="${c.serial.stop_bits}"></div>
   <div class="card"><b>Driver</b> <span class="tag" style="font-weight:400">needs restart</span>
     <label for="c_drv">Active driver</label>
     <select id="c_drv" onchange="reloadDriverOpts()">${
@@ -840,8 +856,7 @@ async function saveConfig(){
     // enough: no rendered default to mistake for a change (unlike driver options / relay roles).
     // admin_username is added below only when typed, like the other credential fields.
     serial:{override:b('c_ser'),baud_rate:n('c_serbaud'),parity:v('c_serpar'),
-            data_bits:n('c_serdb'),stop_bits:n('c_sersb'),
-            response_timeout_ms:n('c_serto')},
+            data_bits:n('c_serdb'),stop_bits:n('c_sersb')},
     security:{read_only_mode:b('c_ro')},
     logging:{level:v('c_lg')}};
   // A blank password field means "keep": sending "" would clear it, which is never what an

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -346,7 +346,7 @@ async function loadLogs(){
 }
 
 // ---------------- Discovery wizard (§28: 7 steps) ----------------
-let wizStep=1, wizPoll=null, wizChosen=null, wizReport=null;
+let wizStep=1, wizPoll=null, wizChosen=null, wizReport=null, wizSavedSerial=null;
 const STEPS=['Interface','Mode','Probing','Candidates','Confirm','Test poll','Save'];
 
 function stepBar(){
@@ -411,7 +411,14 @@ function renderWizard(){
     h+=`<div class="card"><b>Step 6 — Test poll</b><div id="tp" class="dim">Polling…</div></div>`;
   } else if(wizStep===7){
     h+=`<div class="card"><b>Step 7 — Saved</b>
-    <p class="dim">The driver is stored. It takes effect after a restart.</p>
+    <p class="dim">The driver is stored. It takes effect after a restart.</p>`+
+    // Said out loud, because it is a setting the user never asked for and would otherwise
+    // find in Settings with no idea where it came from.
+    (wizSavedSerial?`<p class="dim">This device answered at
+      <b>${wizSavedSerial.baud_rate} ${wizSavedSerial.data_bits}${esc(wizSavedSerial.parity[0].toUpperCase())}${wizSavedSerial.stop_bits}</b>,
+      which is not this driver's default, so those line settings were saved with it. You can
+      change or clear that under <b>Settings → RS485 line</b>.</p>`:'')+
+    `
     <button onclick="wizReboot()">Restart now</button>
     <div id="wizmsg" class="msg" style="display:none"></div></div>`;
   }
@@ -464,6 +471,31 @@ async function testPoll(){
   },3000);
 }
 
+// The serial profile a candidate answered at, but only when it is NOT the one the chosen driver
+// would configure by itself. Discovery sweeps every profile a driver advertises; if the device
+// replied at the second or third one, saving the driver alone means the next boot configures
+// the first and the bus goes quiet. Returns null when the driver's own default already matches,
+// so the common case stores no override at all and keeps following the driver.
+async function discoveredSerialOverride(id){
+  const cand=((wizReport&&wizReport.candidates)||[]).find(c=>c.driver_id===id);
+  const found=cand&&cand.serial_profile;
+  if(!found||!cand.responded)return null;
+  // cfgDrivers is only populated once the Settings tab has been opened, and the wizard is
+  // reachable without ever going there. Fetch rather than assume: with no default to compare
+  // against, every discovery would pin an override, including the overwhelming majority where
+  // the driver's own first choice is already right.
+  if(!cfgDrivers){
+    try{cfgDrivers=await (await fetch('/api/v1/drivers')).json()}catch(e){return null}
+  }
+  const drv=((cfgDrivers&&cfgDrivers.drivers)||[]).find(d=>d.id===id);
+  const def=drv&&(drv.serial_profiles||[])[0];
+  if(def&&def.baud_rate===found.baud_rate&&def.parity===found.parity&&
+     def.data_bits===found.data_bits&&def.stop_bits===found.stop_bits)return null;
+  return {override:true,baud_rate:found.baud_rate,parity:found.parity,
+          data_bits:found.data_bits,stop_bits:found.stop_bits,
+          response_timeout_ms:found.response_timeout_ms};
+}
+
 async function saveDriver(){
   // wizChosen is captured when leaving step 5 -- the #wd select no longer exists here (step 6
   // re-rendered the wizard). Before that capture existed, the manual path saved
@@ -471,9 +503,13 @@ async function saveDriver(){
   // nothing had been saved at all.
   const id=wizChosen;
   if(!id){alert('No driver selected.');wizStep=5;renderWizard();return}
+  const body={driver:{id}};
+  const serial=await discoveredSerialOverride(id);
+  if(serial)body.serial=serial;
   const r=await authFetch('/api/v1/config',{method:'PATCH',
-    headers:{'Content-Type':'application/json'},body:JSON.stringify({driver:{id}})});
+    headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
   if(!r.ok){alert('Save failed: '+httpWhy(r));return}
+  wizSavedSerial=serial;
   wizStep=7;renderWizard();
 }
 
@@ -671,6 +707,23 @@ async function renderConfig(){
     </span>
     <div class="dim" style="font-size:12px;margin-top:8px">A DHCP-provided server wins; the
     fallback is used when the network offers none.</div></div>
+  <div class="card"><b>RS485 line</b> <span class="tag" style="font-weight:400">needs restart</span>
+    ${chk('c_ser','Override the line settings the driver chooses',c.serial.override)}
+    <div class="dim" style="font-size:12px;margin-top:6px">Off, the driver configures the line
+    itself — right for almost every install. The discovery wizard turns this on by itself when
+    it finds a device at a profile the driver does not lead with, because the driver would
+    otherwise go back to its own default on the next boot and the bus would fall silent.</div>
+    <label for="c_serbaud">Baud rate</label>
+    <input id="c_serbaud" type="number" value="${c.serial.baud_rate}">
+    <label for="c_serpar">Parity</label>
+    <select id="c_serpar">${['none','even','odd'].map(x=>
+      `<option value="${x}" ${c.serial.parity===x?'selected':''}>${x}</option>`).join('')}</select>
+    <label for="c_serdb">Data bits</label>
+    <input id="c_serdb" type="number" value="${c.serial.data_bits}">
+    <label for="c_sersb">Stop bits</label>
+    <input id="c_sersb" type="number" value="${c.serial.stop_bits}">
+    <label for="c_serto">Response timeout (ms)</label>
+    <input id="c_serto" type="number" value="${c.serial.response_timeout_ms}"></div>
   <div class="card"><b>Driver</b> <span class="tag" style="font-weight:400">needs restart</span>
     <label for="c_drv">Active driver</label>
     <select id="c_drv" onchange="reloadDriverOpts()">${
@@ -786,6 +839,9 @@ async function saveConfig(){
     // read_only_mode is rendered from the stored value, so the generic per-key diff below is
     // enough: no rendered default to mistake for a change (unlike driver options / relay roles).
     // admin_username is added below only when typed, like the other credential fields.
+    serial:{override:b('c_ser'),baud_rate:n('c_serbaud'),parity:v('c_serpar'),
+            data_bits:n('c_serdb'),stop_bits:n('c_sersb'),
+            response_timeout_ms:n('c_serto')},
     security:{read_only_mode:b('c_ro')},
     logging:{level:v('c_lg')}};
   // A blank password field means "keep": sending "" would clear it, which is never what an

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -535,6 +535,51 @@ static void test_non_firmware_is_rejected() {
     TEST_ASSERT_FALSE(looksLikeFirmware(html, 0));
 }
 
+// The whole point of the override: it has to survive the restart. Discovery runs, reports the
+// profile the device answered at, the wizard saves it -- and then the bridge reboots. If NVS
+// does not carry it, setup() configures the driver's own first profile and the inverter that
+// was just positively identified goes quiet, with the wizard's own screenshot showing the
+// right numbers.
+static void test_a_serial_override_survives_a_restart() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    auto               c = provisionedConfig();
+    c.serial.enabled                  = true;
+    c.serial.profile.baudRate         = 4800;
+    c.serial.profile.parity           = SerialParity::Even;
+    c.serial.profile.stopBits         = 2;
+    c.serial.profile.responseTimeoutMs = 1500;
+    TEST_ASSERT_TRUE(store.save(c));
+
+    Configuration loaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(loaded));
+    TEST_ASSERT_TRUE(loaded.serial.enabled);
+    TEST_ASSERT_EQUAL_UINT32(4800, loaded.serial.profile.baudRate);
+    TEST_ASSERT_EQUAL(SerialParity::Even, loaded.serial.profile.parity);
+    TEST_ASSERT_EQUAL_UINT8(2, loaded.serial.profile.stopBits);
+    TEST_ASSERT_EQUAL_UINT32(1500, loaded.serial.profile.responseTimeoutMs);
+}
+
+// A blob written by a firmware from before this field existed -- written raw, because saving
+// through the current code would emit the section and prove nothing. It must load as "the
+// driver decides", which is exactly what those bridges are already doing; anything else would
+// change the line under a working install on a firmware update.
+static void test_a_config_without_a_serial_section_keeps_the_driver_in_charge() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    backend.write(kStorageKeyConfig,
+                  R"({"version":1,"bridge_name":"Zolder","wifi":{"ssid":"thuisnetwerk"},)"
+                  R"("driver":{"id":"eversolar_legacy"}})");
+
+    Configuration loaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(loaded));
+    TEST_ASSERT_FALSE(loaded.serial.enabled);
+    // ...and the defaults underneath are the driver-neutral ones, not zeroes that would
+    // configure an impossible line if the flag were ever flipped by hand.
+    TEST_ASSERT_EQUAL_UINT32(9600, loaded.serial.profile.baudRate);
+    TEST_ASSERT_EQUAL_UINT8(8, loaded.serial.profile.dataBits);
+}
+
 static void test_ota_rejects_a_non_firmware_upload_before_writing() {
     ota::OtaManager ota;
     TEST_ASSERT_EQUAL(ota::OtaResult::Ok, ota.begin(1024));
@@ -658,6 +703,8 @@ int main(int, char**) {
     RUN_TEST(test_setup_ssid_is_stable_and_distinguishable);
     RUN_TEST(test_firmware_magic_is_recognised);
     RUN_TEST(test_non_firmware_is_rejected);
+    RUN_TEST(test_a_serial_override_survives_a_restart);
+    RUN_TEST(test_a_config_without_a_serial_section_keeps_the_driver_in_charge);
     RUN_TEST(test_ota_rejects_a_non_firmware_upload_before_writing);
     RUN_TEST(test_ota_accepts_a_firmware_upload);
     RUN_TEST(test_ota_refuses_a_second_concurrent_upload);

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -548,7 +548,6 @@ static void test_a_serial_override_survives_a_restart() {
     c.serial.profile.baudRate         = 4800;
     c.serial.profile.parity           = SerialParity::Even;
     c.serial.profile.stopBits         = 2;
-    c.serial.profile.responseTimeoutMs = 1500;
     TEST_ASSERT_TRUE(store.save(c));
 
     Configuration loaded;
@@ -557,7 +556,6 @@ static void test_a_serial_override_survives_a_restart() {
     TEST_ASSERT_EQUAL_UINT32(4800, loaded.serial.profile.baudRate);
     TEST_ASSERT_EQUAL(SerialParity::Even, loaded.serial.profile.parity);
     TEST_ASSERT_EQUAL_UINT8(2, loaded.serial.profile.stopBits);
-    TEST_ASSERT_EQUAL_UINT32(1500, loaded.serial.profile.responseTimeoutMs);
 }
 
 // A blob written by a firmware from before this field existed -- written raw, because saving

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -142,6 +142,90 @@ static void test_config_reports_whether_a_secret_is_set() {
     TEST_ASSERT_FALSE(doc["security"]["password_set"].as<bool>());
 }
 
+// --- serial override -------------------------------------------------------------------
+
+// Discovery sweeps every profile a driver advertises and reports the one that answered. Saving
+// the driver alone meant the next boot configured the driver's FIRST profile instead, so a
+// device that had just been positively identified went silent. The override is what carries the
+// answer across the reboot.
+static void test_a_serial_override_round_trips_through_a_patch() {
+    Configuration c;
+    ConfigError   e;
+    TEST_ASSERT_FALSE(c.serial.enabled);  // off unless something asks for it
+
+    TEST_ASSERT_TRUE(applyConfigPatch(
+        R"({"serial":{"override":true,"baud_rate":4800,"parity":"even","data_bits":8,)"
+        R"("stop_bits":2,"response_timeout_ms":1500}})", c, e));
+    TEST_ASSERT_TRUE(c.serial.enabled);
+    TEST_ASSERT_EQUAL_UINT32(4800, c.serial.profile.baudRate);
+    TEST_ASSERT_EQUAL(SerialParity::Even, c.serial.profile.parity);
+    TEST_ASSERT_EQUAL_UINT8(2, c.serial.profile.stopBits);
+    TEST_ASSERT_EQUAL_UINT32(1500, c.serial.profile.responseTimeoutMs);
+
+    std::string json;
+    TEST_ASSERT_TRUE(serializeConfig(c, json));
+    auto doc = parse(json);
+    TEST_ASSERT_TRUE(doc["serial"]["override"].as<bool>());
+    TEST_ASSERT_EQUAL_UINT32(4800, doc["serial"]["baud_rate"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_STRING("even", doc["serial"]["parity"]);
+}
+
+// A typo must not quietly become "none": that configures a line the user did not ask for, and
+// the symptom is a silent bus, which points the diagnosis straight at the cabling instead.
+static void test_an_unknown_parity_is_refused_rather_than_defaulted() {
+    Configuration c;
+    c.serial.profile.parity = SerialParity::Odd;
+    ConfigError e;
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"serial":{"parity":"evne"}})", c, e));
+    TEST_ASSERT_EQUAL_STRING("serial.parity", e.field.c_str());
+    TEST_ASSERT_EQUAL(SerialParity::Odd, c.serial.profile.parity);  // untouched
+}
+
+static void test_serial_bounds_are_checked_only_when_the_override_is_on() {
+    Configuration c;
+    ConfigError   e;
+    // Off: nothing configures the line from these fields, so a stale value must not block a
+    // save of something unrelated.
+    c.serial.profile.baudRate = 300;
+    TEST_ASSERT_TRUE(validate(c, e));
+
+    c.serial.enabled = true;
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("serial.baud_rate", e.field.c_str());
+
+    c.serial.profile.baudRate = 4800;
+    c.serial.profile.dataBits = 9;
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("serial.data_bits", e.field.c_str());
+
+    c.serial.profile.dataBits = 8;
+    TEST_ASSERT_TRUE(validate(c, e));
+}
+
+// The line is configured once, in setup(), immediately after the driver's begin(). Nothing
+// reconfigures a live UART, so claiming the change is already in force would leave someone
+// watching a bus still running at the old rate.
+static void test_changing_the_serial_override_requires_a_reboot() {
+    const Configuration base;
+    auto                on = base;
+    on.serial.enabled      = true;
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, on));
+
+    auto faster = on;
+    faster.serial.profile.baudRate = 19200;
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(on, faster));
+
+    auto slower = on;
+    slower.serial.profile.responseTimeoutMs = 2500;
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(on, slower));
+
+    // While the override is off the stored numbers configure nothing, so editing them is not a
+    // reason to make someone restart a working bridge.
+    auto idle = base;
+    idle.serial.profile.baudRate = 19200;
+    TEST_ASSERT_FALSE(configChangeRequiresReboot(base, idle));
+}
+
 static void test_reboot_required_flag_is_patch_only() {
     auto        c = configWithSecrets();
     std::string json;
@@ -1066,6 +1150,10 @@ int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_config_response_contains_no_secret_anywhere);
     RUN_TEST(test_config_reports_whether_a_secret_is_set);
+    RUN_TEST(test_a_serial_override_round_trips_through_a_patch);
+    RUN_TEST(test_an_unknown_parity_is_refused_rather_than_defaulted);
+    RUN_TEST(test_serial_bounds_are_checked_only_when_the_override_is_on);
+    RUN_TEST(test_changing_the_serial_override_requires_a_reboot);
     RUN_TEST(test_reboot_required_flag_is_patch_only);
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -155,12 +155,11 @@ static void test_a_serial_override_round_trips_through_a_patch() {
 
     TEST_ASSERT_TRUE(applyConfigPatch(
         R"({"serial":{"override":true,"baud_rate":4800,"parity":"even","data_bits":8,)"
-        R"("stop_bits":2,"response_timeout_ms":1500}})", c, e));
+        R"("stop_bits":2}})", c, e));
     TEST_ASSERT_TRUE(c.serial.enabled);
     TEST_ASSERT_EQUAL_UINT32(4800, c.serial.profile.baudRate);
     TEST_ASSERT_EQUAL(SerialParity::Even, c.serial.profile.parity);
     TEST_ASSERT_EQUAL_UINT8(2, c.serial.profile.stopBits);
-    TEST_ASSERT_EQUAL_UINT32(1500, c.serial.profile.responseTimeoutMs);
 
     std::string json;
     TEST_ASSERT_TRUE(serializeConfig(c, json));
@@ -200,6 +199,60 @@ static void test_serial_bounds_are_checked_only_when_the_override_is_on() {
 
     c.serial.profile.dataBits = 8;
     TEST_ASSERT_TRUE(validate(c, e));
+
+    // 7-bit framing is refused rather than coerced. The transport maps a profile onto the
+    // ESP32's SERIAL_* constants and only handles the 8-bit ones; anything else falls through
+    // to SERIAL_8N1, losing the data bits AND the parity while configure() still reports
+    // success. That was unreachable while only drivers picked the line -- this override is what
+    // opened it to the API, and a silent coercion there means a dead bus plus a log line
+    // stating the setting that was not applied.
+    c.serial.profile.dataBits = 7;
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("serial.data_bits", e.field.c_str());
+}
+
+// An override is derived from one driver's profile sweep. Carried across to another driver it
+// forces line settings never measured against it, and the symptom is a silent bus right after
+// the restart the Driver card asked for -- with the cause in a different card.
+static void test_switching_driver_drops_a_line_override_it_did_not_ask_for() {
+    Configuration c;
+    c.driver.id               = "eversolar_legacy";
+    c.serial.enabled          = true;
+    c.serial.profile.baudRate = 115200;
+    ConfigError e;
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"id":"sunspec"}})", c, e));
+    TEST_ASSERT_FALSE(c.serial.enabled);
+    // The numbers stay put; only the flag drops, so turning it back on in Settings does not
+    // mean retyping what discovery measured.
+    TEST_ASSERT_EQUAL_UINT32(115200, c.serial.profile.baudRate);
+}
+
+// ...but not when the caller supplied `serial` in the same request. That is exactly what the
+// wizard does -- driver and line together -- and clearing what the caller just asked for is the
+// mistake the driver-option orphan rule had to be redesigned to avoid.
+static void test_a_patch_that_sets_both_keeps_the_line_it_asked_for() {
+    Configuration c;
+    c.driver.id = "eversolar_legacy";
+    ConfigError e;
+
+    TEST_ASSERT_TRUE(applyConfigPatch(
+        R"({"driver":{"id":"growatt_modbus"},"serial":{"override":true,"baud_rate":115200}})", c,
+        e));
+    TEST_ASSERT_TRUE(c.serial.enabled);
+    TEST_ASSERT_EQUAL_UINT32(115200, c.serial.profile.baudRate);
+}
+
+// And an unchanged driver never triggers it: a save of something unrelated must not quietly
+// undo a working line override.
+static void test_an_unrelated_save_leaves_the_line_override_alone() {
+    Configuration c;
+    c.driver.id      = "growatt_modbus";
+    c.serial.enabled = true;
+    ConfigError e;
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"bridge_name":"Zolder"})", c, e));
+    TEST_ASSERT_TRUE(c.serial.enabled);
 }
 
 // The line is configured once, in setup(), immediately after the driver's begin(). Nothing
@@ -214,10 +267,6 @@ static void test_changing_the_serial_override_requires_a_reboot() {
     auto faster = on;
     faster.serial.profile.baudRate = 19200;
     TEST_ASSERT_TRUE(configChangeRequiresReboot(on, faster));
-
-    auto slower = on;
-    slower.serial.profile.responseTimeoutMs = 2500;
-    TEST_ASSERT_TRUE(configChangeRequiresReboot(on, slower));
 
     // While the override is off the stored numbers configure nothing, so editing them is not a
     // reason to make someone restart a working bridge.
@@ -1153,6 +1202,9 @@ int main(int, char**) {
     RUN_TEST(test_a_serial_override_round_trips_through_a_patch);
     RUN_TEST(test_an_unknown_parity_is_refused_rather_than_defaulted);
     RUN_TEST(test_serial_bounds_are_checked_only_when_the_override_is_on);
+    RUN_TEST(test_switching_driver_drops_a_line_override_it_did_not_ask_for);
+    RUN_TEST(test_a_patch_that_sets_both_keeps_the_line_it_asked_for);
+    RUN_TEST(test_an_unrelated_save_leaves_the_line_override_alone);
     RUN_TEST(test_changing_the_serial_override_requires_a_reboot);
     RUN_TEST(test_reboot_required_flag_is_patch_only);
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);


### PR DESCRIPTION
## The bug

**Extended** discovery tries every serial profile a driver advertises (quick mode only tries the first), so a device can be found at a profile the driver does not lead with — a Modbus inverter answering at 115200 while its driver leads with 9600.

The wizard showed which profile answered, in its own row of the candidate table, and then threw it away. Choosing the driver stored only `driver.id`; the bridge rebooted; `begin()` configured the driver's *first* profile; and the inverter that had just been positively identified went silent.

## The fix

A `config.serial` override — off by default — applied **after** every `begin()`. Before is pointless: `begin()` configures the line itself and would undo it.

The wizard saves the matched profile when it differs from what the chosen driver would configure by itself, and explicitly **clears** the override when it does not. Settings gained an **RS485 line** card so something that can silence the bus is visible and reversible without re-running the wizard.

## What the review caught

The mechanism was right. Almost everything around it was not.

**The same bug, on the path I did not touch.** The override was applied in exactly one place — `setup()`. But `rs485Task` calls `begin()` again after every discovery run, and `begin()` unconditionally configures the driver's own first profile. So running discovery from the web UI on a healthy bridge silently reset the line and the inverter went quiet until the next power cycle. It also broke the wizard's own step 6: the test poll ran *after* the reset, so it reported the device dead one screen before step 7 said its settings were saved. Now hoisted into `applySerialOverride()` and called after every `begin()`.

**The wizard was a one-way ratchet.** It omitted `serial` when the match equalled the driver's default — and an absent key means "leave alone". So once anything had pinned 115200, no later run could undo it, and step 7 stayed silent about the setting that was about to silence the bus. It now sends `{override:false}` and says so.

**An override survived a driver switch** with nothing coupling the two: pinned for one driver, then forced onto another it was never measured against, the symptom appearing right after the restart the Driver card asked for. Switching `driver.id` now drops it — unless the same request supplies `serial` itself, which is what the wizard does. The numbers stay; only the flag goes.

**`data_bits: 7` was validated, stored, documented, logged — and silently became 8N1.** `toSerialConfig` handles only the 8-bit combinations and falls through, losing the parity too, while `configure()` still reports success. The UI said 7E1, the boot log said 7E1, the UART ran 8N1, the bus was dead. Every piece of evidence the device offered was wrong. Refused in `validate()` now.

**"Response timeout (ms)" controlled nothing.** `Rs485Transport::read()` takes its timeout from the caller and every driver passes its own compile-time constant. The field was bounds-checked, documented and reboot-gated — three signals that it was load-bearing. Removed rather than left as a knob that changes nothing.

## Corrections to my own claims

- **"Discovery sweeps every serial profile a driver advertises"** opened the commit and appeared in four more places. False in quick mode — `profiles.resize(1)` — which is the wizard's *primary* button. Corrected everywhere, including a troubleshooting line telling a reader the settings "are known" when a quick run cannot have found them.
- **My browser check used a stub advertising 4800 8E1.** No driver in this build advertises anything but 8N1, so the example in the commit and in `configuration.h` described a state the firmware cannot produce. Reworked around 115200, which Growatt really does list.
- **"A candidate that never answered pins nothing"** tested a dead branch — discovery never emits a candidate with `responded=false`. Guard dropped.
- **The `configure()`-failure log was backwards.** It said the line was still at the driver's setting; in fact `begin()` runs before the direction-pin setup that is the only thing that can fail, so the line is at the override's speed with half-duplex control unconfigured — a worse state, and the message sent the reader to the wrong hypothesis.
- `RESTART_NEEDED` had no `serial` entries, so changing the baud alongside anything else produced a list that read complete and omitted it.
- `architecture.md` still described the driver's profile list as the last word; the MIC bring-up doc still said 9600 8N1 flatly.

Boot now logs the effective line **even when nothing is overridden** — most bridges follow their driver and had no way to learn what the bus runs at, which matters the day a driver's recommendation changes under them.

## Verification

Against the real page, with an override already stored: a candidate at the driver's second profile pins `115200`; one at the driver's own first choice sends `{"serial":{"override":false}}` and step 7 says the override was switched off; a driver with no candidate sends nothing. The settings card renders from the stored override, the timeout field is gone, and changing the baud alone now produces *"These take effect after a restart: RS485 baud rate"* instead of the generic fallback.

**548 tests pass** (was 539 on main), `check_layering.sh` PASS, all four boards build.

## Still open

- The firmware polls exactly one device (`kMaxActiveDevices = 1`) — the blocking one for three inverters on one bus.
- Discovery does not sweep unit ids, so with three inverters it sees only the one at unit 1 and pins whatever *that* one is set to.
- The wizard never sets the `profile` driver option, so a MIC TL-X selected through the wizard boots on the `sph` register map. Wrong map, plausible numbers — worth its own change.
