### PR TITLE
Let the discovery wizard choose the register map

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ inverters on one bus**, read **[docs/rs485-bus.md](docs/rs485-bus.md)** first: c
 where the 120 Ω termination goes (two places, not one per device), and why each unit needs its
 own address before you connect them together.
 
+> **This firmware polls one device at a time.** Several inverters can share the bus and the
+> wiring guidance above applies, but the bridge reads whichever address is configured and
+> ignores the rest — and discovery probes only the default address, so only the unit there can
+> be found automatically. Known gap, not a wiring fault.
+
 ### 2. Flash the firmware
 
 - **In your browser (easiest):** open the
@@ -201,9 +206,10 @@ first, **swapping A and B is the single most common fix** — it cannot damage a
 ### 5. Find your inverter
 
 Open the dashboard and run the wizard on the *Discovery* tab. It tries the supported
-protocols and selects the matching driver. If nothing answers, turn the log level up to
-`trace` under *Settings* and watch the *Logs* tab — it shows exactly what is being sent and
-whether anything comes back.
+protocols and proposes a driver. It identifies the **protocol**, not the model — so a driver
+that ships several register maps still needs the map chosen, and the wizard's confirm step
+asks for it. If nothing answers, turn the log level up to `trace` under *Settings* and watch
+the *Logs* tab — it shows exactly what is being sent and whether anything comes back.
 
 ### 6. Connect your tooling
 

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -188,8 +188,11 @@ address in turn and confirm exactly one answers, at the address you expect.
    something else, run **extended** discovery (quick only tries the first profile) and the
    wizard stores the line settings that answered.
 3. Configure the driver: `growatt_modbus`, register map `mic_tl_x`, `unit_id` as set in step 1.
-   Both are fields in the discovery wizard's confirm step, and in *Settings → Driver*. Getting
-   the map wrong is the one mistake here that does not announce itself — see the warning below.
+   Both are fields in the discovery wizard's confirm step, and in *Settings → Driver*. The
+   wizard offers back whatever is already stored, so re-running it does not undo a working
+   setup — but on a fresh bridge the map starts unset and the step cannot be completed until
+   you pick one. That is deliberate: getting the map wrong is the one mistake here that does
+   not announce itself. See the warning below.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.
 5. Check the dump against the inverter's own app: PV voltage, AC power, today's energy,
@@ -197,9 +200,18 @@ address in turn and confirm exactly one answers, at the address you expect.
 
 > **The register map is a choice, not a detection.** Probing identifies the *protocol* — a valid
 > Modbus reply proves the device speaks Modbus at that address and nothing more. It cannot tell
-> a MIC TL-X from an SPH. The two maps share the base block, so leaving the map on the wrong one
-> still yields values, and the ones the base block covers are even correct — which is exactly
-> what makes it dangerous. Set the map yourself, and use step 5 to confirm it.
+> a MIC TL-X from an SPH.
+>
+> On the wrong map, **not one published value is correct.** The two maps overlap only in which
+> registers are *fetched* (both read the input block 0–124); they share no mapped address at
+> all. This map reads AC power from register 35 and DC power from 1; the SPH map reads them
+> from 40 and 116, as a different width and sign, and then looks for battery data in a 1000-block
+> a MIC does not implement. So a wrong map yields numbers that are the right shape and the right
+> order of magnitude and are all wrong — which is exactly what makes it dangerous.
+>
+> That also means step 5's test poll cannot confirm the map: it shows an AC power figure, and a
+> wrong map produces a believable one. The check that works is step 4 below — the raw block dump
+> against the inverter's own app.
 6. Confirm the two odd scales specifically — frequency should read ~50.0 Hz (not 5.0 or
    500.0), and operating hours should be plausible for the age of the unit.
 7. **Settle the generation question.** Look at what the 3000-block dump did. Three outcomes,

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -187,11 +187,19 @@ address in turn and confirm exactly one answers, at the address you expect.
    the 120 Ω termination rule. 9600 8N1 is what the profile declares — if your units are set to
    something else, run **extended** discovery (quick only tries the first profile) and the
    wizard stores the line settings that answered.
-3. Configure the driver: `growatt_modbus`, profile `mic_tl_x`, `unit_id` as set in step 1.
+3. Configure the driver: `growatt_modbus`, register map `mic_tl_x`, `unit_id` as set in step 1.
+   Both are fields in the discovery wizard's confirm step, and in *Settings → Driver*. Getting
+   the map wrong is the one mistake here that does not announce itself — see the warning below.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.
 5. Check the dump against the inverter's own app: PV voltage, AC power, today's energy,
    total energy. All four should match without any arithmetic on your part.
+
+> **The register map is a choice, not a detection.** Probing identifies the *protocol* — a valid
+> Modbus reply proves the device speaks Modbus at that address and nothing more. It cannot tell
+> a MIC TL-X from an SPH. The two maps share the base block, so leaving the map on the wrong one
+> still yields values, and the ones the base block covers are even correct — which is exactly
+> what makes it dangerous. Set the map yourself, and use step 5 to confirm it.
 6. Confirm the two odd scales specifically — frequency should read ~50.0 Hz (not 5.0 or
    500.0), and operating hours should be plausible for the age of the unit.
 7. **Settle the generation question.** Look at what the 3000-block dump did. Three outcomes,

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -193,6 +193,13 @@ address in turn and confirm exactly one answers, at the address you expect.
    setup — but on a fresh bridge the map starts unset and the step cannot be completed until
    you pick one. That is deliberate: getting the map wrong is the one mistake here that does
    not announce itself. See the warning below.
+
+   > **This firmware polls one device.** With three units on the bus you will see only the one
+   > at the address configured here — the other two are wired, addressed and ignored, with
+   > nothing on any screen saying so. Discovery does not sweep addresses either: it probes the
+   > default unit id, so only the inverter at address 1 can ever appear as a candidate. Both
+   > are known gaps, not symptoms of a wiring fault; bring the units up one at a time by
+   > changing `unit_id` here.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.
 5. Check the dump against the inverter's own app: PV voltage, AC power, today's energy,
@@ -202,16 +209,22 @@ address in turn and confirm exactly one answers, at the address you expect.
 > Modbus reply proves the device speaks Modbus at that address and nothing more. It cannot tell
 > a MIC TL-X from an SPH.
 >
-> On the wrong map, **not one published value is correct.** The two maps overlap only in which
-> registers are *fetched* (both read the input block 0–124); they share no mapped address at
-> all. This map reads AC power from register 35 and DC power from 1; the SPH map reads them
-> from 40 and 116, as a different width and sign, and then looks for battery data in a 1000-block
-> a MIC does not implement. So a wrong map yields numbers that are the right shape and the right
-> order of magnitude and are all wrong — which is exactly what makes it dangerous.
+> The two maps overlap only in which registers are *fetched*: both read the input block 0–124.
+> They share **no mapped address at all**. Put a MIC on the SPH map and you get:
 >
-> That also means step 5's test poll cannot confirm the map: it shows an AC power figure, and a
-> wrong map produces a believable one. The check that works is step 4 below — the raw block dump
-> against the inverter's own app.
+> - **two measurements instead of twelve** — that count is the reliable tell, not the values;
+> - an AC power figure that may well look right, because the SPH map reads 40–41 and on this
+>   inverter that is Pac1, which on a single-phase unit tracks total AC power. One number
+>   coinciding is exactly what makes the rest believable;
+> - a DC power figure decoded from register 116, which this map does not use — wrong or zero;
+> - no battery rows, and a steadily climbing RS485 error count, because the SPH map also reads a
+>   1000-block a MIC does not implement.
+>
+> Two consequences for checking your work. The wizard's own test poll **cannot** confirm the map:
+> it displays exactly the AC power figure that coincides. Neither can the raw dump in step 4 —
+> the dump is raw registers, byte-identical under either map, so it confirms the addresses in the
+> TOML rather than which map is configured. Compare the **published measurements**
+> (`GET /api/v1/status`, or the dashboard): twelve entries means `mic_tl_x`, two means `sph`.
 6. Confirm the two odd scales specifically — frequency should read ~50.0 Hz (not 5.0 or
    500.0), and operating hours should be plausible for the age of the unit.
 7. **Settle the generation question.** Look at what the 3000-block dump did. Three outcomes,

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -346,7 +346,8 @@ async function loadLogs(){
 }
 
 // ---------------- Discovery wizard (§28: 7 steps) ----------------
-let wizStep=1, wizPoll=null, wizChosen=null, wizReport=null, wizSavedSerial=null;
+let wizStep=1, wizPoll=null, wizChosen=null, wizReport=null, wizSavedSerial=null,
+    wizOptions={};
 const STEPS=['Interface','Mode','Probing','Candidates','Confirm','Test poll','Save'];
 
 function stepBar(){
@@ -403,9 +404,12 @@ function renderWizard(){
   } else if(wizStep===5){
     h+=`<div class="card"><b>Step 5 — Confirm</b>
     <p class="dim">Nothing is saved until step 7. An uncertain match is never selected for you
-    — that is deliberate: reading the wrong register map produces believable numbers.</p>
-    <label for="wd">Driver</label><select id="wd"></select>
-    <button onclick="wizChosen=$('#wd').value;wizStep=6;renderWizard();testPoll()">Confirm and test</button>
+    — that is deliberate: reading the wrong register map produces believable numbers. Which is
+    why the map is a field here and not an assumption: probing identifies the <i>protocol</i>,
+    never the model, so a driver that ships several register maps cannot pick one for you.</p>
+    <label for="wd">Driver</label><select id="wd" onchange="wizRenderOpts()"></select>
+    <div id="wizopts"></div>
+    <button onclick="wizCapture();wizStep=6;renderWizard();testPoll()">Confirm and test</button>
     <button onclick="wizStep=4;renderWizard()" style="background:none;border:1px solid var(--line);color:var(--fg)">Back</button></div>`;
   } else if(wizStep===6){
     h+=`<div class="card"><b>Step 6 — Test poll</b><div id="tp" class="dim">Polling…</div></div>`;
@@ -432,6 +436,7 @@ function renderWizard(){
 
   if(wizStep===5){
     fetch('/api/v1/drivers').then(r=>r.json()).then(d=>{
+      cfgDrivers=d;
       const sel=$('#wd');sel.innerHTML='';
       (d.drivers||[]).forEach(x=>{
         const o=document.createElement('option');
@@ -439,6 +444,7 @@ function renderWizard(){
         if(x.id===wizChosen)o.selected=true;
         sel.appendChild(o);
       });
+      wizRenderOpts();
     });
   }
 }
@@ -511,6 +517,47 @@ async function discoveredSerialOverride(id){
           data_bits:found.data_bits,stop_bits:found.stop_bits};
 }
 
+// The selected driver's declared options, at their declared defaults.
+//
+// Discovery identifies a PROTOCOL, never a model: a probe that gets a valid Modbus reply has
+// proved the protocol and nothing about which register map that unit speaks. A driver shipping
+// several maps therefore cannot have one chosen for it, and until this existed the wizard
+// silently saved the driver alone -- so the firmware fell back to whichever map is marked
+// default, and every reading came from the wrong table. Step 5's own text warns that reading
+// the wrong map "produces believable numbers"; the wizard was the thing producing them.
+//
+// Rendered from the driver's own declaration, so a new driver's options appear here with no
+// frontend change, exactly as they already do in Settings.
+// Captured on the way out of step 5, for the same reason wizChosen is: renderWizard() replaces
+// the whole #wiz subtree on every step change, so by the time saveDriver() runs at step 7 both
+// the select and these fields are gone. Reading them there would silently save nothing.
+function wizCapture(){
+  wizChosen=($('#wd')||{}).value||null;
+  wizOptions={};
+  document.querySelectorAll('#wizopts [data-opt]').forEach(e=>{ wizOptions[e.dataset.opt]=e.value });
+}
+
+function wizRenderOpts(){
+  const box=$('#wizopts');
+  if(!box)return;
+  const id=($('#wd')||{}).value;
+  const drv=((cfgDrivers&&cfgDrivers.drivers)||[]).find(x=>x.id===id);
+  const opts=(drv&&drv.options)||[];
+  if(!opts.length){box.innerHTML='';return}
+  box.innerHTML=opts.map(o=>{
+    const cur=o.default_value??'';
+    const hint=o.description?`<div class="dim" style="font-size:12px">${esc(o.description)}</div>`:'';
+    if(o.allowed_values&&o.allowed_values.length){
+      return `<label for="wopt_${esc(o.key)}">${esc(o.display_name)}</label>
+        <select id="wopt_${esc(o.key)}" data-opt="${esc(o.key)}">${
+          o.allowed_values.map(v=>`<option value="${esc(v)}" ${v===cur?'selected':''}>${esc(v)}</option>`).join('')
+        }</select>${hint}`;
+    }
+    return `<label for="wopt_${esc(o.key)}">${esc(o.display_name)}</label>
+      <input id="wopt_${esc(o.key)}" data-opt="${esc(o.key)}" value="${esc(cur)}">${hint}`;
+  }).join('');
+}
+
 async function saveDriver(){
   // wizChosen is captured when leaving step 5 -- the #wd select no longer exists here (step 6
   // re-rendered the wizard). Before that capture existed, the manual path saved
@@ -519,6 +566,9 @@ async function saveDriver(){
   const id=wizChosen;
   if(!id){alert('No driver selected.');wizStep=5;renderWizard();return}
   const body={driver:{id}};
+  // Only when the driver actually declares options -- an empty object would still be a change
+  // the backend has to merge, and for a driver with no options it says nothing.
+  if(Object.keys(wizOptions).length)body.driver.options=wizOptions;
   const serial=await discoveredSerialOverride(id);
   if(serial)body.serial=serial;
   const r=await authFetch('/api/v1/config',{method:'PATCH',
@@ -655,13 +705,15 @@ async function renderConfig(){
   const optsFor=id=>{
     const drv=(cfgDrivers.drivers||[]).find(x=>x.id===id);
     if(!drv)return'';
-    // The line settings are a property of the protocol, not a user choice: the driver
-    // configures the UART itself when it starts. An editable field here used to exist and
-    // did nothing at all -- shown read-only instead, which is always true.
+    // What this driver would configure on its own. Read-only here on purpose: it is a property
+    // of the protocol, not a per-install choice. It stopped being the last word once the RS485
+    // line card gained an override, so it says which one is actually in force rather than
+    // stating the driver's list as fact.
     const serial=(drv.serial_profiles||[]).map(p=>
       `${p.baud_rate} ${p.data_bits}${p.parity[0].toUpperCase()}${p.stop_bits}`).join(', ');
+    const overridden=c.serial&&c.serial.override;
     return `<div class="dim" style="font-size:12px;margin-top:4px">${esc(drv.description||'')}</div>`+
-      (serial?`<div class="dim" style="font-size:12px;margin-top:4px">Serial: ${serial} — set by the driver${drv.serial_profiles.length>1?' (tried in order during discovery)':''}.</div>`:'')+
+      (serial?`<div class="dim" style="font-size:12px;margin-top:4px">Serial: ${serial} — set by the driver${drv.serial_profiles.length>1?' (extended discovery tries them in order)':''}.${overridden?' <b>Overridden</b> by the RS485 line card above.':''}</div>`:'')+
       (drv.options||[]).map(o=>{
       const stored=id===c.driver.id?(c.driver.options||{})[o.key]:undefined;
       const cur=stored??o.default_value;
@@ -872,7 +924,11 @@ async function saveConfig(){
   if(v('c_au').trim())body.security.admin_username=v('c_au').trim();
   if(v('c_mqpw'))body.mqtt.password=v('c_mqpw');
   if(v('c_ap'))body.security.admin_password=v('c_ap');
-  document.querySelectorAll('[data-opt]').forEach(e=>body.driver.options[e.dataset.opt]=e.value);
+  // Scoped to the settings form. The wizard renders its own [data-opt] fields at step 5, and
+  // both views live in the DOM at the same time -- an unscoped query saved the wizard's
+  // half-finished choices into the active driver's config.
+  document.querySelectorAll('#cfgform [data-opt]')
+    .forEach(e=>body.driver.options[e.dataset.opt]=e.value);
 
   // Send only what actually changed. This form may have been open for hours; PATCHing every
   // field would write its stale copy over anything changed elsewhere in the meantime (another

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -348,6 +348,8 @@ async function loadLogs(){
 // ---------------- Discovery wizard (§28: 7 steps) ----------------
 let wizStep=1, wizPoll=null, wizChosen=null, wizReport=null, wizSavedSerial=null,
     wizOptions={};
+// What the bridge already has configured, so step 5 can offer it back instead of overwriting it.
+let wizStoredDriverId=null, wizStoredOptions={};
 const STEPS=['Interface','Mode','Probing','Candidates','Confirm','Test poll','Save'];
 
 function stepBar(){
@@ -409,7 +411,9 @@ function renderWizard(){
     never the model, so a driver that ships several register maps cannot pick one for you.</p>
     <label for="wd">Driver</label><select id="wd" onchange="wizRenderOpts()"></select>
     <div id="wizopts"></div>
-    <button onclick="wizCapture();wizStep=6;renderWizard();testPoll()">Confirm and test</button>
+    <div id="wizoptnote" class="msg err" style="display:none">Pick a register map first — it
+    cannot be detected, and the wrong one produces believable numbers.</div>
+    <button id="wizconfirm" onclick="wizCapture();wizStep=6;renderWizard();testPoll()">Confirm and test</button>
     <button onclick="wizStep=4;renderWizard()" style="background:none;border:1px solid var(--line);color:var(--fg)">Back</button></div>`;
   } else if(wizStep===6){
     h+=`<div class="card"><b>Step 6 — Test poll</b><div id="tp" class="dim">Polling…</div></div>`;
@@ -435,9 +439,15 @@ function renderWizard(){
   $('#wiz').innerHTML=h;
 
   if(wizStep===5){
-    fetch('/api/v1/drivers').then(r=>r.json()).then(d=>{
+    // Both, before rendering: the option fields must offer what is stored, not blow it away.
+    Promise.all([fetch('/api/v1/drivers').then(r=>r.json()),
+                 fetch('/api/v1/config').then(r=>r.json()).catch(()=>null)])
+    .then(([d,cfg])=>{
       cfgDrivers=d;
-      const sel=$('#wd');sel.innerHTML='';
+      if(cfg&&cfg.driver){wizStoredDriverId=cfg.driver.id;wizStoredOptions=cfg.driver.options||{}}
+      const sel=$('#wd');
+      if(!sel)return;  // the user left step 5 while this was in flight
+      sel.innerHTML='';
       (d.drivers||[]).forEach(x=>{
         const o=document.createElement('option');
         o.value=x.id;o.textContent=`${x.display_name} (${x.support_level})`;
@@ -543,19 +553,48 @@ function wizRenderOpts(){
   const id=($('#wd')||{}).value;
   const drv=((cfgDrivers&&cfgDrivers.drivers)||[]).find(x=>x.id===id);
   const opts=(drv&&drv.options)||[];
-  if(!opts.length){box.innerHTML='';return}
+  if(!opts.length){box.innerHTML='';wizGateConfirm();return}
   box.innerHTML=opts.map(o=>{
-    const cur=o.default_value??'';
+    // Seeded from what is STORED when this is the driver already configured, exactly as the
+    // settings page does. Rendering declared defaults unconditionally meant re-running the
+    // wizard -- which the bring-up docs tell you to do when the line speed is wrong -- silently
+    // rewrote a working {profile:"mic_tl_x", unit_id:"3"} back to the defaults and reported
+    // success. Every rendered key is asserted in the PATCH, so nothing survives by omission.
+    const stored=(id===wizStoredDriverId)?(wizStoredOptions||{})[o.key]:undefined;
+    const cur=stored??o.default_value??'';
     const hint=o.description?`<div class="dim" style="font-size:12px">${esc(o.description)}</div>`:'';
     if(o.allowed_values&&o.allowed_values.length){
+      // An empty entry among the allowed values is the driver saying "unset means my own
+      // default". In Settings that is fine -- you are editing a device you already set up.
+      // Here it is not: this is the screen where the register map gets decided, and an unlabeled
+      // blank line that silently resolves to whichever map is marked default is precisely the
+      // failure this change exists to remove. Labelled, and left unselected so the step cannot
+      // be completed until someone has actually chosen.
+      const hasBlank=o.allowed_values.includes('');
+      const needs=hasBlank&&cur==='';
       return `<label for="wopt_${esc(o.key)}">${esc(o.display_name)}</label>
-        <select id="wopt_${esc(o.key)}" data-opt="${esc(o.key)}">${
-          o.allowed_values.map(v=>`<option value="${esc(v)}" ${v===cur?'selected':''}>${esc(v)}</option>`).join('')
+        <select id="wopt_${esc(o.key)}" data-opt="${esc(o.key)}" ${hasBlank?'data-mustpick="1"':''}
+          onchange="wizGateConfirm()">${
+          o.allowed_values.map(v=>`<option value="${esc(v)}" ${v===cur&&!needs?'selected':''}>${
+            v===''?'— choose —':esc(v)}</option>`).join('')
         }</select>${hint}`;
     }
     return `<label for="wopt_${esc(o.key)}">${esc(o.display_name)}</label>
       <input id="wopt_${esc(o.key)}" data-opt="${esc(o.key)}" value="${esc(cur)}">${hint}`;
   }).join('');
+  wizGateConfirm();
+}
+
+// Blocks "Confirm and test" while any option the driver marked as ambiguous-when-empty is still
+// empty. Cheaper than letting someone click through and discover months later that the numbers
+// came from the wrong table.
+function wizGateConfirm(){
+  const btn=$('#wizconfirm');
+  if(!btn)return;
+  const missing=[...document.querySelectorAll('#wizopts [data-mustpick]')].some(e=>e.value==='');
+  btn.disabled=missing;
+  const note=$('#wizoptnote');
+  if(note)note.style.display=missing?'block':'none';
 }
 
 async function saveDriver(){

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -413,10 +413,17 @@ function renderWizard(){
     <div id="wizopts"></div>
     <div id="wizoptnote" class="msg err" style="display:none">Pick a register map first — it
     cannot be detected, and the wrong one produces believable numbers.</div>
-    <button id="wizconfirm" onclick="wizCapture();wizStep=6;renderWizard();testPoll()">Confirm and test</button>
+    <!-- Starts disabled: wizGateConfirm() cannot run until two fetches resolve, and on a slow
+         bridge that is long enough to click through with no map chosen. -->
+    <button id="wizconfirm" disabled onclick="wizCapture();wizStep=6;renderWizard();testPoll()">Confirm and test</button>
     <button onclick="wizStep=4;renderWizard()" style="background:none;border:1px solid var(--line);color:var(--fg)">Back</button></div>`;
   } else if(wizStep===6){
-    h+=`<div class="card"><b>Step 6 — Test poll</b><div id="tp" class="dim">Polling…</div></div>`;
+    h+=`<div class="card"><b>Step 6 — Test poll</b>
+    <p class="dim">This polls the configuration the bridge is <b>running now</b> — the driver is
+    built once at boot, so nothing chosen in step 5 is in force yet. Useful for "is anything
+    alive on this bus", not for confirming the register map. Check that after the restart, by
+    the number of published measurements.</p>
+    <div id="tp" class="dim">Polling…</div></div>`;
   } else if(wizStep===7){
     h+=`<div class="card"><b>Step 7 — Saved</b>
     <p class="dim">The driver is stored. It takes effect after a restart.</p>`+
@@ -591,6 +598,8 @@ function wizRenderOpts(){
 function wizGateConfirm(){
   const btn=$('#wizconfirm');
   if(!btn)return;
+  // Runs on every render, including for drivers with no options at all -- that is what releases
+  // the button from the disabled state it is rendered in.
   const missing=[...document.querySelectorAll('#wizopts [data-mustpick]')].some(e=>e.value==='');
   btn.disabled=missing;
   const note=$('#wizoptnote');


### PR DESCRIPTION
## The bug is the wizard's own warning

Step 5 says, in its own text:

> An uncertain match is never selected for you — that is deliberate: reading the wrong register map produces believable numbers.

And then it saved `{"driver":{"id":…}}` and nothing else. With no `profile` option stored, the driver falls back to whichever map is marked default — so selecting `growatt_modbus` for a **MIC TL-X** booted it on the **SPH** map. The wizard was the thing producing the numbers its own warning is about.

Discovery identifies a **protocol**, never a model, so this cannot be detected — it has to be asked. Step 5 now renders the selected driver's declared options, the same generic way Settings does. `unit_id` comes along for free.

## What a wrong map actually looks like

I got this wrong twice, in opposite directions, before getting it right.

First I wrote that the maps "share the base block" so those readings "are even correct" — which would have taught a reader to *accept* a wrong-map install. They share **zero mapped addresses**; both merely read the input block 0–124, which is the range fetched, not the meaning of anything in it.

Then I corrected it to "not one published value is correct" — also false. My own profile comment says Pac1 at 40–41 duplicates AC power on a single-phase unit, and the SPH map reads `ac.power.total` from exactly 40–41. So:

- **two measurements instead of twelve** — the count is the reliable tell, not the values;
- one **plausible AC power figure**, by coincidence, which is what makes the rest believable;
- a DC figure decoded from register 116, which this map does not use;
- no battery rows, and a climbing RS485 error count from the 1000-block a MIC does not implement.

And the check I first pointed at does not work: the raw TRACE dump is raw registers, byte-identical under either map, so it confirms the TOML's addresses rather than the configured map. The published measurements are the discriminator.

## What the reviews caught in the change itself

**The control was added and the bug was not fixed.** The `profile` option declares `""` as its default *and* as a legal value, so the new select opened on an unlabeled blank line resolving to the default map. Clicking through produced the identical wrong outcome. It is now labelled `— choose —`, starts unselected on a fresh bridge, and **Confirm and test is rendered disabled** until a real map is picked.

**A regression of my own making.** The fields rendered declared defaults unconditionally, and every rendered key is asserted in the PATCH — so re-running the wizard (which the bring-up doc tells you to do when the line speed is wrong) rewrote a working `{profile:"mic_tl_x", unit_id:"3"}` back to `{"", "1"}` and reported success. The same one-way-ratchet hazard I reasoned about carefully for the serial override two PRs ago. Now seeded from the stored config.

**Step 6 presents itself as validation and cannot be.** It polls the driver built at boot, so nothing chosen in step 5 is in force — on a fresh bridge it polls a different driver entirely. It now says what it does test.

## The gap that will actually stop the install

The one-device limit was written down **only in a C++ header comment**, while the README and the MIC checklist walk you through chaining several inverters and addressing each one. You would wire three, address them 1/2/3, get one, and have nothing to read. Both documents now say it next to the step that matters, including that discovery probes only the default address.

## Corrections to my own claims

- **The unscoped `[data-opt]` collector.** On `main` the wizard had no such elements, so the collision could not have happened — it is introduced by this commit and the scoping is its companion, not a pre-existing find. The real pre-merge symptom would also not have been a silent overwrite: document order puts `#cfgform` last, so the settings value wins, and a foreign key makes `validateDriverOptions` reject the whole save with a `400`.
- **"The orphan rule heals that."** It does not — an injected key counts as asserted, so the erase is skipped and the save is refused. Loud, not healed.
- **My first verification bullets reported stub values as the real page** — the label, the option list and the default were all my stub's, and the default was wrong in exactly the direction that hid the blank-preselect bug.
- README said the wizard "selects the matching driver", with no hint that a multi-map driver still needs a map.

## Verification

Against the real page, using the option shape the firmware actually declares, on a bridge already set up as a MIC on unit 3:

- a re-run offers back `mic_tl_x` and unit `3` and saves exactly that — the working config survives;
- a fresh bridge opens on `— choose —` with Confirm disabled and the note shown; picking a map unblocks it;
- a driver with no options is never blocked;
- the captured values still arrive after `#wizopts` has been destroyed by the step change.

**548 tests pass**, `check_web_js.py` OK, `check_layering.sh` PASS, boards build. No C++ changed, so the count is unmoved — and nothing in the tree covers this JS beyond a syntax check, which is worth knowing when reading the verification above.

## Still open

- The firmware polls exactly one device (`kMaxActiveDevices = 1`) — now documented, still the blocking one.
- Discovery does not sweep unit ids.
- Which register map is in force is not shown anywhere outside the stored option value.
