### PR TITLE
Poll several inverters on one bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,12 @@ inverters on one bus**, read **[docs/rs485-bus.md](docs/rs485-bus.md)** first: c
 where the 120 Ω termination goes (two places, not one per device), and why each unit needs its
 own address before you connect them together.
 
-> **This firmware polls one device at a time.** Several inverters can share the bus and the
-> wiring guidance above applies, but the bridge reads whichever address is configured and
-> ignores the rest — and discovery probes only the default address, so only the unit there can
-> be found automatically. Known gap, not a wiring fault.
+> **Several inverters on one bus are polled in turn**, up to eight, each with its own address.
+> Configure the first under *Settings → Driver* and the rest under *Settings → Extra devices*
+> (`additional_devices` over the API). Two caveats worth knowing before you wire three:
+> discovery still probes only the default address, so the others have to be added by hand; and
+> **Home Assistant, Modbus TCP and Prometheus still carry the first device only** — the REST
+> API has all of them. That last one is the next piece of work, not a wiring fault.
 
 ### 2. Flash the firmware
 

--- a/README.md
+++ b/README.md
@@ -143,11 +143,19 @@ where the 120 Ω termination goes (two places, not one per device), and why each
 own address before you connect them together.
 
 > **Several inverters on one bus are polled in turn**, up to eight, each with its own address.
-> Configure the first under *Settings → Driver* and the rest under *Settings → Extra devices*
-> (`additional_devices` over the API). Two caveats worth knowing before you wire three:
-> discovery still probes only the default address, so the others have to be added by hand; and
-> **Home Assistant, Modbus TCP and Prometheus still carry the first device only** — the REST
-> API has all of them. That last one is the next piece of work, not a wiring fault.
+> The first is configured under *Settings → Driver*; **the rest have no settings screen yet** and
+> are set over the API:
+>
+> ```
+> curl -u admin:PASSWORD -X PATCH http://<bridge>/api/v1/config \
+>   -H 'Content-Type: application/json' \
+>   -d '{"additional_devices":[{"driver_id":"growatt_modbus","options":{"unit_id":"2"}}]}'
+> ```
+>
+> Then restart. Two more things to know before wiring three: discovery probes only the default
+> address, so the others must be added by hand; and **Home Assistant, Modbus TCP and Prometheus
+> still carry the first device only** — the REST API and `/api/v1/devices` have all of them.
+> Both are next on the list, not wiring faults.
 
 ### 2. Flash the firmware
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,7 +241,7 @@ EverSolar:
   .supportLevel = DriverSupportLevel::Experimental,   // → Beta after Phase 3, Stable after Phase 9
   .probePriority = 10,
   .supportsAutoDetection = true,
-  .supportsMultipleDevices = true,    // protocol supports it; MVP allows 1
+  .supportsMultipleDevices = true,    // protocol supports it
   .supportsRead = true,
   .supportsWrite = false,             // 0x12/0x13 empty in the protocol
 }
@@ -632,6 +632,29 @@ Modbus TCP has no encryption, no authentication, and no authorization. This is s
 explicitly in the README and `docs/security.md`: only expose it on a trusted or filtered
 network.
 
+## Several devices on one bus
+
+`DeviceManager` holds up to `kMaxDevices` (8) stores, one per device. `setup()` builds one
+driver and one `DeviceContext` per configured device — `driver` first, then `additional_devices`
+in order — and `rs485Task` polls **one device per loop iteration**, round-robin.
+
+One per iteration rather than a loop over all of them: the watchdog is fed once per iteration,
+and a bus of eight silent devices would otherwise spend eight transaction deadlines back to back
+before the outputs ran. Each context keeps its own interval and back-off, so a dead inverter
+backs off on its own without slowing the others, and the cursor stops a device whose back-off
+has just expired from always losing to the one before it in the list.
+
+A device that cannot be created or started is named on the console and skipped; the others still
+poll. Two configured devices that resolve to the same identity (a duplicated unit id) collide in
+`DeviceManager::add`, which is reported rather than silently polling one twice.
+
+**The outputs have not caught up.** `MqttOutput::loop`, `ModbusTcpServer::refresh` and
+`buildMetrics` each take a single `DeviceState`, so they are fed the first device only. The REST
+API is already device-keyed and carries all of them. Giving the other three a device dimension —
+a topic segment, a register-map offset, a metric label — is the next piece of work, and until it
+lands the limitation is stated in the README, `docs/rest-api.md` and next to the code in
+`main.cpp` rather than left to be discovered from a missing Home Assistant entity.
+
 ## Test strategy
 
 `env:native` runs on the host, without an ESP32. The protocol core (`eversolar_protocol.cpp`,
@@ -648,6 +671,7 @@ network.
 | `test_measurements` | supported/valid/stale matrix, capability filtering |
 | `test_commands` | Read-only rejection per command type, range validation, rate limiting |
 | `test_device_context` | Bus errors reaching the metrics per transaction rather than per poll verdict, including the construction baseline and a counter wrap |
+| `test_provisioning` | NVS round-trips, migrations, OTA gates, and that a config written before a field existed still loads |
 
 Fixtures: `test/fixtures/` with frames from the reference, supplemented in Phase 3 with **real
 recordings** from the TL3000-20, plus deliberately corrupted frames and a night scenario.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -393,10 +393,20 @@ public:
 };
 ```
 
-The MVP allows a maximum of one active physical device (`MAX_ACTIVE_DEVICES = 1`), but no
-interface is a singleton. `DeviceId` for the MVP = `"<driverId>-<serialNumber>"`, e.g.
-`eversolar_legacy-XH300060115506193600V610`. REST and MQTT already use that ID in their paths,
-so adding more devices later requires no API change.
+A bridge polls up to `kMaxDevices` (8) physical devices, and no interface is a singleton.
+
+`DeviceId` prefers the serial number — `"<driverId>-<serialNumber>"`, e.g.
+`eversolar_legacy-XH300060115506193600V610` — because that identifies the physical unit however
+it happens to be addressed. It falls back to `"<driverId>-<instanceKey>"`, where the instance key
+is the Modbus unit id or PMU address the driver was configured with, and only then to the bare
+driver id.
+
+The fallback is not cosmetic. `deviceId()` is read once, in `setup()`, to key the state store —
+and at that moment **no driver in this build has a serial number**: Growatt never reads one,
+EverSolar and SunSpec learn theirs on the first poll or chain walk. Without the instance key,
+three identical inverters on one bus all resolved to the bare driver id, `DeviceManager::add`
+handed all three the same store (it is idempotent by contract), and they overwrote each other's
+readings into one set of entities. REST and MQTT use this id in their paths.
 
 ## Capability model
 
@@ -645,8 +655,22 @@ backs off on its own without slowing the others, and the cursor stops a device w
 has just expired from always losing to the one before it in the list.
 
 A device that cannot be created or started is named on the console and skipped; the others still
-poll. Two configured devices that resolve to the same identity (a duplicated unit id) collide in
-`DeviceManager::add`, which is reported rather than silently polling one twice.
+poll. Two configured devices that resolve to the same id are caught by a `contains()` check before
+`add()` — not by `add()` itself, which is idempotent and would hand back the existing store. The
+second is skipped with a log line naming both. With the instance key in the id this only happens
+when two entries really are configured for the same address.
+
+**Not every protocol supports two devices on one bus.** The Modbus drivers address each unit
+explicitly, so several are fine. The PMU drivers (EverSolar, SoLAX) register by *broadcast* --
+"any unregistered unit, speak up" -- with no serial in the request, so two instances of the same
+PMU driver race the same handshake and which physical unit each ends up owning is undefined.
+One PMU device per bus; mixing a PMU driver with Modbus drivers is fine.
+
+**Not every protocol supports two devices on one bus.** The Modbus drivers address each unit
+explicitly, so several are fine. The PMU drivers register by *broadcast* -- "any unregistered
+unit, speak up" -- with no serial in the request, so two instances of the same PMU driver race
+the same handshake and which physical unit each ends up owning is undefined. One PMU device per
+bus; mixing a PMU driver with Modbus drivers is fine.
 
 **The outputs have not caught up.** `MqttOutput::loop`, `ModbusTcpServer::refresh` and
 `buildMetrics` each take a single `DeviceState`, so they are fed the first device only. The REST

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -194,12 +194,22 @@ address in turn and confirm exactly one answers, at the address you expect.
    you pick one. That is deliberate: getting the map wrong is the one mistake here that does
    not announce itself. See the warning below.
 
-   > **For the second and third unit**, add an entry each under *Settings → Extra devices*:
-   > same driver and register map, its own `unit_id`. They are polled in turn on the one bus,
-   > and the change takes effect after a restart. Discovery still probes only the default
-   > address, so it will find the unit at address 1 and not the others — that is a known gap,
-   > not a wiring fault. Bring them up one at a time and check each in `/api/v1/devices`
-   > before adding the next.
+   > **For the second and third unit** there is no settings screen yet — they go in over the
+   > API, same driver and register map, their own `unit_id`:
+   >
+   > ```
+   > curl -u admin:PASSWORD -X PATCH http://<bridge>/api/v1/config \
+   >   -H 'Content-Type: application/json' \
+   >   -d '{"additional_devices":[
+   >         {"driver_id":"growatt_modbus","options":{"unit_id":"2","profile":"mic_tl_x"}},
+   >         {"driver_id":"growatt_modbus","options":{"unit_id":"3","profile":"mic_tl_x"}}]}'
+   > ```
+   >
+   > Note `driver_id` here where the `driver` section uses `id`. Sending the array replaces it,
+   > so send all the extra units at once. Restart afterwards. Discovery probes only the default
+   > address, so it finds the unit at address 1 and not the others — a known gap, not a wiring
+   > fault. Check `/api/v1/devices` after the restart: you should see one entry per unit, named
+   > `growatt_modbus-1`, `-2`, `-3`.
    >
    > **Home Assistant, Modbus TCP and Prometheus still publish the first device only.** All
    > three appear in the REST API and in the device list; only one reaches those outputs. Next

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -194,12 +194,16 @@ address in turn and confirm exactly one answers, at the address you expect.
    you pick one. That is deliberate: getting the map wrong is the one mistake here that does
    not announce itself. See the warning below.
 
-   > **This firmware polls one device.** With three units on the bus you will see only the one
-   > at the address configured here — the other two are wired, addressed and ignored, with
-   > nothing on any screen saying so. Discovery does not sweep addresses either: it probes the
-   > default unit id, so only the inverter at address 1 can ever appear as a candidate. Both
-   > are known gaps, not symptoms of a wiring fault; bring the units up one at a time by
-   > changing `unit_id` here.
+   > **For the second and third unit**, add an entry each under *Settings → Extra devices*:
+   > same driver and register map, its own `unit_id`. They are polled in turn on the one bus,
+   > and the change takes effect after a restart. Discovery still probes only the default
+   > address, so it will find the unit at address 1 and not the others — that is a known gap,
+   > not a wiring fault. Bring them up one at a time and check each in `/api/v1/devices`
+   > before adding the next.
+   >
+   > **Home Assistant, Modbus TCP and Prometheus still publish the first device only.** All
+   > three appear in the REST API and in the device list; only one reaches those outputs. Next
+   > piece of work.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.
 5. Check the dump against the inverter's own app: PV voltage, AC power, today's energy,

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -126,6 +126,30 @@ nothing — `PATCH {"mqtt":{"username":null}}` returns `200` and leaves the stor
 Send `""` to clear the MQTT username. `security.admin_username` cannot be cleared at all:
 `validate()` refuses an empty one.
 
+## `additional_devices` — more than one inverter on the bus
+
+`driver` is device 1. `additional_devices` is a list of devices 2..N, in poll order, each
+`{ "driver_id": "...", "options": { ... } }`. Up to eight devices in total. Empty on every
+single-inverter install.
+
+```json
+{ "additional_devices": [ { "driver_id": "growatt_modbus", "options": { "unit_id": "2" } } ] }
+```
+
+Sending the array **replaces** it; omitting it leaves it alone. There is no per-element patch:
+the list has no stable key to merge on, and an index the caller believes is element 2 may not be
+after someone else's edit. `driver_id` may not be empty — for `driver` an empty id means "pick
+the highest-priority driver compiled in", but for an extra device it would be a poll slot that
+can never be filled.
+
+Adding, removing or retuning a device needs a restart: the drivers and their poll contexts are
+built once, at boot.
+
+**The outputs are not all there yet.** The REST API and the device list carry every configured
+device; **MQTT/Home Assistant, Modbus TCP and Prometheus carry the first one only**, because
+their topic tree, register map and metric names have no device dimension. That is the next piece
+of work and is stated in `docs/architecture.md` too.
+
 ## `serial` — overriding the line the driver picks
 
 Every driver advertises the serial profiles plausible for its protocol and configures the first

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -252,6 +252,29 @@ bool validate(const Configuration& config, ConfigError& error) {
     if (!checkLength(config.ntp.server, 64, "ntp.server", error)) return false;
     if (!checkLength(config.ntp.timezone, 48, "ntp.timezone", error)) return false;
     if (!checkLength(config.ntp.timezoneName, 48, "ntp.timezone_name", error)) return false;
+    if (1 + config.additionalDevices.size() > kMaxDevices) {
+        error = {"additional_devices",
+                 "at most " + std::to_string(kMaxDevices) + " devices per bridge"};
+        return false;
+    }
+    for (size_t i = 0; i < config.additionalDevices.size(); ++i) {
+        const auto&       d     = config.additionalDevices[i];
+        const std::string where = "additional_devices[" + std::to_string(i) + "]";
+        // An empty id is fine for `driver` -- it means "let the application pick the
+        // highest-priority driver". For an extra device it means nothing at all: there is no
+        // second driver to pick, and an entry that names no driver would just be a poll slot
+        // that can never be filled.
+        if (d.id.empty()) {
+            error = {where + ".driver_id", "must name a driver"};
+            return false;
+        }
+        if (!checkLength(d.id, 64, (where + ".driver_id").c_str(), error)) return false;
+        for (const auto& [key, value] : d.options) {
+            if (!checkLength(key, 32, (where + ".options").c_str(), error)) return false;
+            if (!checkLength(value, 128, (where + ".options").c_str(), error)) return false;
+        }
+    }
+
     if (config.serial.enabled) {
         // Bounds, not a whitelist of "known good" rates. RS485 devices in the field run at
         // 1200 and at 115200, and refusing an odd-but-real rate would be the firmware deciding
@@ -343,6 +366,18 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     }
 
 
+    // Always emitted, empty or not, so a client can tell "this firmware has no idea about
+    // extra devices" from "this bridge has none configured".
+    JsonArray extra = doc["additional_devices"].to<JsonArray>();
+    for (const auto& d : config.additionalDevices) {
+        JsonObject e   = extra.add<JsonObject>();
+        e["driver_id"] = d.id;
+        JsonObject o   = e["options"].to<JsonObject>();
+        for (const auto& [key, value] : d.options) {
+            o[key] = value;
+        }
+    }
+
     JsonObject ntp       = doc["ntp"].to<JsonObject>();
     ntp["enabled"]       = config.ntp.enabled;
     ntp["use_dhcp"]      = config.ntp.useDhcp;
@@ -400,6 +435,9 @@ bool configChangeRequiresReboot(const Configuration& a, const Configuration& b) 
            a.modbus.diagnosticsUnitId != b.modbus.diagnosticsUnitId ||
            a.polling.intervalSeconds != b.polling.intervalSeconds ||
            a.driver.id != b.driver.id || a.driver.options != b.driver.options ||
+           // The drivers and their poll contexts are built once, in setup(). Adding or
+           // removing an inverter therefore changes nothing until the next boot.
+           a.additionalDevices != b.additionalDevices ||
            a.ntp.enabled != b.ntp.enabled || a.ntp.useDhcp != b.ntp.useDhcp ||
            a.ntp.server != b.ntp.server || a.ntp.timezone != b.ntp.timezone ||
            // The line is configured once, in setup(), right after the driver's begin(). Nothing
@@ -550,6 +588,40 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
     }
 
     const bool serialSupplied = !doc["serial"].isNull();
+    // Whole-list replacement, not a merge: the list has no stable keys to merge on, and
+    // "patch element 2" would need an index the caller cannot know is still the same element.
+    // Sending the array replaces it; omitting it leaves it alone, like every other section.
+    if (JsonVariantConst extra = doc["additional_devices"]; !extra.isNull()) {
+        if (!extra.is<JsonArrayConst>()) {
+            error = {"additional_devices", "expected an array"};
+            return false;
+        }
+        std::vector<DriverSettings> parsed;
+        size_t                      index = 0;
+        for (JsonVariantConst item : extra.as<JsonArrayConst>()) {
+            const std::string where = "additional_devices[" + std::to_string(index++) + "]";
+            if (!item.is<JsonObjectConst>()) {
+                error = {where, "expected an object"};
+                return false;
+            }
+            JsonObjectConst obj = item.as<JsonObjectConst>();
+            DriverSettings  d;
+            if (!patchString(obj["driver_id"], d.id, (where + ".driver_id").c_str(), error))
+                return false;
+            if (JsonObjectConst options = obj["options"]; !options.isNull()) {
+                for (JsonPairConst kv : options) {
+                    if (!kv.value().is<const char*>()) {
+                        error = {where + ".options", "option values must be strings"};
+                        return false;
+                    }
+                    d.options[kv.key().c_str()] = kv.value().as<const char*>();
+                }
+            }
+            parsed.push_back(std::move(d));
+        }
+        merged.additionalDevices = std::move(parsed);
+    }
+
     if (JsonObjectConst serial = doc["serial"]; !serial.isNull()) {
         if (!patchBool(serial["override"], merged.serial.enabled, "serial.override", error))
             return false;

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "device/device_state.h"
 #include "drivers/driver_descriptor.h"
 #include "transport/serial_profile.h"
 
@@ -66,6 +67,11 @@ struct DriverSettings {
     /// Driver-specific settings, opaque here. The driver declares which keys exist and what
     /// they accept (DriverDescriptor::options); validateDriverOptions checks them against it.
     DriverOptions options;
+
+    friend bool operator==(const DriverSettings& a, const DriverSettings& b) {
+        return a.id == b.id && a.autoDetect == b.autoDetect && a.options == b.options;
+    }
+    friend bool operator!=(const DriverSettings& a, const DriverSettings& b) { return !(a == b); }
 };
 
 // There is deliberately no RS485/serial section here. Line settings are a property of the
@@ -143,7 +149,16 @@ struct Configuration {
     MqttSettings     mqtt;
     ModbusSettings   modbus;
     PollingSettings  polling;
+    /// Device 1. Kept as its own field rather than folded into a list: every existing config,
+    /// every REST client and the whole settings page address it by this name, and renaming it
+    /// would be a migration with no benefit to show for it.
     DriverSettings   driver;
+    /// Devices 2..N on the same bus, in poll order. Empty on every single-inverter install,
+    /// which is what keeps this invisible until someone actually chains a second unit.
+    ///
+    /// Deliberately NOT called `devices`: a field of that name sitting next to `driver` reads
+    /// as "all of them", and a client that iterated it would silently skip the first inverter.
+    std::vector<DriverSettings> additionalDevices;
     RelaySettings    relays;
     NtpSettings      ntp;
     SerialOverride   serial;

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -121,6 +121,16 @@ bool serializeConfigForStorage(const Configuration& config, std::string& out) {
     ntp["timezone"]      = config.ntp.timezone;
     ntp["timezone_name"] = config.ntp.timezoneName;
 
+    JsonArray extra = doc["additional_devices"].to<JsonArray>();
+    for (const auto& d : config.additionalDevices) {
+        JsonObject e   = extra.add<JsonObject>();
+        e["driver_id"] = d.id;
+        JsonObject o   = e["options"].to<JsonObject>();
+        for (const auto& [key, value] : d.options) {
+            o[key] = value;
+        }
+    }
+
     JsonObject serial   = doc["serial"].to<JsonObject>();
     serial["override"]  = config.serial.enabled;
     serial["baud_rate"] = config.serial.profile.baudRate;
@@ -261,6 +271,23 @@ LoadResult deserializeConfigFromStorage(const std::string& json, Configuration& 
         if (ntp["server"].is<const char*>())   parsed.ntp.server   = ntp["server"].as<const char*>();
         if (ntp["timezone"].is<const char*>()) parsed.ntp.timezone = ntp["timezone"].as<const char*>();
         if (ntp["timezone_name"].is<const char*>()) parsed.ntp.timezoneName = ntp["timezone_name"].as<const char*>();
+    }
+    if (JsonArrayConst extra = doc["additional_devices"]; !extra.isNull()) {
+        for (JsonObjectConst e : extra) {
+            DriverSettings d;
+            if (e["driver_id"].is<const char*>()) d.id = e["driver_id"].as<const char*>();
+            if (JsonObjectConst o = e["options"]; !o.isNull()) {
+                for (JsonPairConst kv : o) {
+                    if (kv.value().is<const char*>()) {
+                        d.options[kv.key().c_str()] = kv.value().as<const char*>();
+                    }
+                }
+            }
+            // A nameless entry is dropped rather than loaded: validate() would refuse the whole
+            // configuration for it, and refusing to boot over a corrupted list entry is worse
+            // than polling one inverter fewer.
+            if (!d.id.empty()) parsed.additionalDevices.push_back(std::move(d));
+        }
     }
     if (JsonObjectConst serial = doc["serial"]; !serial.isNull()) {
         if (serial["override"].is<bool>()) parsed.serial.enabled = serial["override"].as<bool>();

--- a/src/device/device_identity.h
+++ b/src/device/device_identity.h
@@ -17,18 +17,37 @@ struct DeviceIdentity {
     std::string protocolName;
     std::string protocolVersion;
     std::string driverId;
+    /// What distinguishes THIS device from another one served by the same driver on the same
+    /// bus: the Modbus unit id, the PMU address. Set by the driver from its own options, which
+    /// is the only place that knows which option does the addressing.
+    ///
+    /// Exists because the serial number does not, at the moment it is needed. deviceId() is
+    /// read once, in setup(), to key the state store -- and at that point no driver in this
+    /// build has a serial: some never read one at all, and the rest only learn theirs during
+    /// the first poll or chain walk. So several identical inverters all resolved to the bare
+    /// driver id, DeviceManager handed them the SAME store, and they overwrote each other's
+    /// readings into one set of Home Assistant entities (review, 2026-07-25).
+    std::string instanceKey;
 
     /// A field is "not available" precisely when it is empty. Outputs must omit such fields
     /// rather than emit an empty string, so consumers can tell "unknown" from "blank".
     static bool available(const std::string& field) { return !field.empty(); }
 
-    /// Stable per-device id, used in REST paths and MQTT topics. Chosen so that adding a
-    /// second physical device later needs no API change.
+    /// Stable per-device id, used in REST paths and MQTT topics.
+    ///
+    /// Prefers the serial number, which identifies the physical unit no matter how it is
+    /// addressed. Falls back to the instance key, which is known at boot and is what keeps two
+    /// inverters of the same model on one bus apart. Only when neither exists is it the bare
+    /// driver id -- which is correct for the single-device case that has always been the norm,
+    /// and is why the collision went unnoticed.
     std::string deviceId() const {
-        if (serialNumber.empty()) {
-            return driverId;
+        if (!serialNumber.empty()) {
+            return driverId + "-" + serialNumber;
         }
-        return driverId + "-" + serialNumber;
+        if (!instanceKey.empty()) {
+            return driverId + "-" + instanceKey;
+        }
+        return driverId;
     }
 };
 

--- a/src/device/device_state.h
+++ b/src/device/device_state.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -12,6 +13,13 @@
 #include "measurement.h"
 
 namespace heliograph {
+
+/// How many devices one bridge will poll, and the size of the state table that holds them.
+///
+/// Lives here rather than in the config or the state store because both need it and neither
+/// should depend on the other. A bound, not a target: every device shares one half-duplex bus,
+/// so each one added stretches the poll cycle by its own transaction time.
+inline constexpr size_t kMaxDevices = 8;
 
 /// Thresholds for the online/stale state machine. Defaults follow docs/architecture.md.
 struct StalenessPolicy {

--- a/src/drivers/eversolar_legacy/eversolar_driver.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_driver.cpp
@@ -81,6 +81,7 @@ bool EversolarDriver::begin(Transport& transport) {
     identity_.manufacturer  = "Ever-Solar";
     identity_.protocolName  = "EverSolar PMU RS485";
     identity_.driverId      = eversolar::descriptor().id;
+    identity_.instanceKey   = std::to_string(options_.assignedAddress);
 
     reRegisterAll();
     return true;

--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -279,6 +279,9 @@ DeviceIdentity GrowattDriver::identity() const {
     id.model        = options_.profile->displayName;
     id.protocolName = "Modbus RTU";
     id.driverId     = descriptor().id;
+    // The unit id is what distinguishes three identical inverters on one bus, and it is known
+    // before a single byte goes out. Without it all three key the same state store.
+    id.instanceKey  = std::to_string(options_.unitId);
     // Serial number lives in a register block we do not map yet; it stays empty rather than
     // being invented, so deviceId() falls back to the driver id.
     return id;

--- a/src/drivers/solax_x1/solax_driver.cpp
+++ b/src/drivers/solax_x1/solax_driver.cpp
@@ -80,6 +80,7 @@ bool SolaxDriver::begin(Transport& transport) {
     identity_.manufacturer = "SolaX";
     identity_.protocolName = "SolaX X1 RS485 (PMU)";
     identity_.driverId     = solax::descriptor().id;
+    identity_.instanceKey  = std::to_string(options_.assignedAddress);
     return true;
 }
 

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -195,6 +195,7 @@ bool SunspecDriver::begin(Transport& transport) {
     walked_                = false;
     identity_              = DeviceIdentity{};
     identity_.driverId     = descriptor().id;
+    identity_.instanceKey  = std::to_string(options_.unitId);
     identity_.protocolName = descriptor().protocol;
 
     // Configure the line, exactly as the sibling Modbus driver does and for the reason its

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,9 +89,24 @@ modbus::ModbusTcpServer           g_modbus;
 std::unique_ptr<mqtt::MqttOutput> g_mqtt;
 std::unique_ptr<rest::RestApi>    g_rest;
 
-std::unique_ptr<InverterDriver> g_driver;
-std::unique_ptr<DeviceContext>  g_context;
-StateStore*                     g_state = nullptr;
+/// One entry per configured device, in poll order. Element 0 is the `driver` section; the rest
+/// come from `additional_devices`. Held as parallel owning vectors rather than one struct so
+/// the existing single-device call sites (g_driver / g_context / g_state below) keep meaning
+/// exactly what they meant: the FIRST device.
+std::vector<std::unique_ptr<InverterDriver>> g_drivers;
+std::vector<std::unique_ptr<DeviceContext>>  g_contexts;
+
+/// The first device, or nullptr. Everything that still speaks about "the" inverter -- the
+/// status LED, the boot-confirm check, the outputs -- reads these. Naming them rather than
+/// indexing at each call site keeps the remaining single-device assumptions countable: every
+/// use of g_driver/g_context/g_state is a place that has not been taught about the others yet.
+InverterDriver* g_driver  = nullptr;
+DeviceContext*  g_context = nullptr;
+StateStore*     g_state   = nullptr;
+
+/// Round-robin cursor for the poll loop, so a device whose backoff has expired does not always
+/// lose to the one before it in the list.
+size_t g_pollCursor = 0;
 
 bool g_outputsStarted = false;
 
@@ -579,8 +594,11 @@ void rs485Task(void* /*arg*/) {
             Serial.printf("[discovery] %s\n", g_discovery.report().outcome.reason.c_str());
             // The probe left the bus re-registered; make the driver pick that up rather than
             // poll a stale address.
-            if (g_driver) {
-                g_driver->begin(g_transport);
+            // Every device, not just the first: the probe re-registered the whole bus.
+            for (auto& d : g_drivers) {
+                d->begin(g_transport);
+            }
+            if (!g_drivers.empty()) {
                 // ...and begin() has just put the line back on the driver's own first profile,
                 // exactly as it does at boot. Without this, running discovery from the web UI
                 // on a healthy bridge silently undid the override and the inverter went quiet
@@ -591,16 +609,42 @@ void rs485Task(void* /*arg*/) {
             vTaskDelay(pdMS_TO_TICKS(250));
             continue;
         }
-        // A requested manual poll (wizard test poll, REST action) runs now rather than at the
-        // next interval; exchange() clears the flag so one request is one poll.
-        if (g_context &&
-            (g_manualPollRequested.exchange(false) || g_context->due(nowMs()))) {
-            const PollResult result = g_context->pollOnce();
-            if (result != PollResult::Ok) {
-                // Bounded: one line per attempt, no payload, no growth over time.
-                log::warn("poll: %s", pollResultName(result));
+        // At most ONE device per iteration, round-robin. Not a loop over all of them: the
+        // watchdog is fed once per iteration, and a bus of eight silent devices would spend
+        // eight transaction deadlines back to back before the outputs below ever ran. One per
+        // pass keeps the loop's timing independent of how many inverters are chained, and the
+        // cursor keeps a device whose backoff has expired from always losing to the one before
+        // it in the list.
+        //
+        // The manual-poll request is honoured by whichever device comes up first. exchange()
+        // clears the flag, so one request is still one poll.
+        if (!g_contexts.empty()) {
+            bool manual = g_manualPollRequested.exchange(false);
+            for (size_t i = 0; i < g_contexts.size(); ++i) {
+                const size_t index = (g_pollCursor + i) % g_contexts.size();
+                DeviceContext& ctx = *g_contexts[index];
+                if (!manual && !ctx.due(nowMs())) {
+                    continue;
+                }
+                manual             = false;
+                const PollResult r = ctx.pollOnce();
+                if (r != PollResult::Ok) {
+                    // Bounded: one line per attempt, no payload, no growth over time. The index
+                    // is in it because "poll: timeout" on a three-inverter bus otherwise names
+                    // no inverter at all.
+                    log::warn("poll device %u: %s", static_cast<unsigned>(index + 1),
+                              pollResultName(r));
+                }
+                g_pollCursor = (index + 1) % g_contexts.size();
+                break;
             }
         }
+        // FIRST DEVICE ONLY, deliberately and for now. MQTT, Home Assistant, Modbus TCP and
+        // Prometheus all take a single DeviceState: their topic trees, register map and metric
+        // names have no device dimension yet. Polling several devices without saying so would
+        // put two more inverters in the REST device list and silently nowhere else, so this is
+        // stated here, in docs/architecture.md, and in the REST status payload rather than left
+        // for someone to discover from a missing entity.
         if (g_state) {
             const auto snapshot = g_state->snapshot();
             const auto bridge   = bridgeInfo();
@@ -733,23 +777,62 @@ void setup() {
     const std::string driverId = selectedDriverId();
     // Pass the configured driver options through: a unit_id or profile set in the web UI
     // must reach the driver, not silently fall back to factory defaults (2026-07-21 review).
-    g_driver = driverId.empty() ? nullptr
-                                : g_registry.create(driverId, g_transport,
-                                                    g_config.driver.options);
-    if (g_driver && g_driver->begin(g_transport)) {
-        Serial.printf("[driver] %s (%s)\n", g_driver->descriptor().id.c_str(),
-                      supportLevelName(g_driver->descriptor().supportLevel));
-        applySerialOverride();
-        const DeviceId id = g_driver->identity().deviceId();
-        g_state           = g_devices.add(id);
-        if (g_state) {
-            PollPolicy policy;
-            policy.intervalMs = g_config.polling.intervalSeconds * 1000;
-            g_context =
-                std::make_unique<DeviceContext>(*g_driver, *g_state, g_diagnostics, nowMs, policy);
-        }
-    } else {
+    // Device 1 comes from `driver`, the rest from `additional_devices`, in that order. One list
+    // so the poll loop has one thing to walk, and so a bring-up log reads in the same order the
+    // settings page shows.
+    struct Planned { std::string id; const DriverOptions* options; };
+    std::vector<Planned> planned;
+    if (!driverId.empty()) {
+        planned.push_back({driverId, &g_config.driver.options});
+    }
+    for (const auto& d : g_config.additionalDevices) {
+        planned.push_back({d.id, &d.options});
+    }
+    if (planned.empty()) {
         Serial.printf("[driver] '%s' unavailable\n", driverId.c_str());
+    }
+
+    for (const auto& p : planned) {
+        auto driver = g_registry.create(p.id, g_transport, *p.options);
+        if (!driver || !driver->begin(g_transport)) {
+            // Named, and the loop continues: one unconfigurable device must not cost the others
+            // their poll. A bus with three inverters where the second has a typo'd driver id
+            // should still report the first and third.
+            Serial.printf("[driver] '%s' unavailable\n", p.id.c_str());
+            continue;
+        }
+        Serial.printf("[driver] %s (%s)\n", driver->descriptor().id.c_str(),
+                      supportLevelName(driver->descriptor().supportLevel));
+        // Once, after the last begin(): every begin() reconfigures the line to its own driver's
+        // first profile, so applying the override per device would only be undone by the next
+        // one. All devices share the bus, so there is one line to set, not one per device.
+        const DeviceId id    = driver->identity().deviceId();
+        StateStore*    store = g_devices.add(id);
+        if (store == nullptr) {
+            // Either the cap, or two devices that resolve to the SAME identity -- which is what
+            // a duplicated unit id looks like from here. Both are configuration mistakes that
+            // would otherwise present as "the second inverter never updates".
+            Serial.printf("[driver] '%s' has no free device slot, or its identity collides with "
+                          "a device already added\n", p.id.c_str());
+            continue;
+        }
+        PollPolicy policy;
+        policy.intervalMs = g_config.polling.intervalSeconds * 1000;
+        g_contexts.push_back(std::make_unique<DeviceContext>(*driver, *store, g_diagnostics,
+                                                             nowMs, policy));
+        g_drivers.push_back(std::move(driver));
+        if (g_driver == nullptr) {
+            g_driver  = g_drivers.front().get();
+            g_context = g_contexts.front().get();
+            g_state   = store;
+        }
+    }
+    if (!g_drivers.empty()) {
+        applySerialOverride();
+        if (g_drivers.size() > 1) {
+            Serial.printf("[driver] polling %u devices in turn on one bus\n",
+                          static_cast<unsigned>(g_drivers.size()));
+        }
     }
 
     // The web server runs on the portal AP too -- that is how setup happens at all.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,6 +108,13 @@ StateStore*     g_state   = nullptr;
 /// lose to the one before it in the list.
 size_t g_pollCursor = 0;
 
+/// Device ids, index-aligned with g_contexts, so a log line can name the inverter it means.
+std::vector<DeviceId> g_deviceIds;
+
+/// How many devices the configuration asked for, whether or not they started. Drives the status
+/// LED: a configured device that failed to start is a fault to show, not an absence to ignore.
+size_t g_devicesConfigured = 0;
+
 bool g_outputsStarted = false;
 
 /// Guards g_config against the one cross-task hazard it has: the AsyncTCP task replacing
@@ -425,7 +432,11 @@ void serviceOnboard() {
         }
         in.factoryResetHolding = holding;
         in.wifiConnected       = g_wifi.connected();
-        in.inverterExpected    = g_driver != nullptr;
+        // "A device was configured", not "a device started". The old expression was
+        // `g_driver != nullptr`, and the multi-device loop destroys the unique_ptr when begin()
+        // fails -- so a bridge whose only configured driver refused to start went from RED to
+        // GREEN, reporting "all healthy" while polling nothing (review, 2026-07-25).
+        in.inverterExpected    = g_devicesConfigured > 0;
         in.mqttConnected       = g_mqtt && g_mqtt->connected();
         in.modbusListening      = g_modbus.running();
         if (g_state) {
@@ -619,21 +630,31 @@ void rs485Task(void* /*arg*/) {
         // The manual-poll request is honoured by whichever device comes up first. exchange()
         // clears the flag, so one request is still one poll.
         if (!g_contexts.empty()) {
-            bool manual = g_manualPollRequested.exchange(false);
+            // A manual poll always goes to device 1, never to whichever device the cursor
+            // happens to sit on. The wizard's test poll and POST /actions/poll are both read
+            // back through /api/v1/status, which serves the FIRST device -- so sending the poll
+            // anywhere else made the button report that nothing had happened.
+            if (g_manualPollRequested.exchange(false)) {
+                const PollResult r = g_contexts.front()->pollOnce();
+                if (r != PollResult::Ok) {
+                    log::warn("manual poll of %s: %s", g_deviceIds.front().c_str(),
+                              pollResultName(r));
+                }
+            }
             for (size_t i = 0; i < g_contexts.size(); ++i) {
                 const size_t index = (g_pollCursor + i) % g_contexts.size();
                 DeviceContext& ctx = *g_contexts[index];
-                if (!manual && !ctx.due(nowMs())) {
+                if (!ctx.due(nowMs())) {
                     continue;
                 }
-                manual             = false;
                 const PollResult r = ctx.pollOnce();
                 if (r != PollResult::Ok) {
-                    // Bounded: one line per attempt, no payload, no growth over time. The index
-                    // is in it because "poll: timeout" on a three-inverter bus otherwise names
-                    // no inverter at all.
-                    log::warn("poll device %u: %s", static_cast<unsigned>(index + 1),
-                              pollResultName(r));
+                    // Bounded: one line per attempt, no payload, no growth over time. The device
+                    // ID rather than a position: a position among the STARTED devices is not the
+                    // position in the config, so "device 2" would name the wrong inverter as
+                    // soon as one failed to start -- and it carries the address, which is what
+                    // someone standing at the bus actually needs.
+                    log::warn("poll %s: %s", g_deviceIds[index].c_str(), pollResultName(r));
                 }
                 g_pollCursor = (index + 1) % g_contexts.size();
                 break;
@@ -788,8 +809,9 @@ void setup() {
     for (const auto& d : g_config.additionalDevices) {
         planned.push_back({d.id, &d.options});
     }
+    g_devicesConfigured = planned.size();
     if (planned.empty()) {
-        Serial.printf("[driver] '%s' unavailable\n", driverId.c_str());
+        log::warn("no driver configured and none compiled in; nothing will be polled");
     }
 
     for (const auto& p : planned) {
@@ -798,28 +820,34 @@ void setup() {
             // Named, and the loop continues: one unconfigurable device must not cost the others
             // their poll. A bus with three inverters where the second has a typo'd driver id
             // should still report the first and third.
-            Serial.printf("[driver] '%s' unavailable\n", p.id.c_str());
+            log::warn("device '%s' could not be started; the others still poll", p.id.c_str());
             continue;
         }
         Serial.printf("[driver] %s (%s)\n", driver->descriptor().id.c_str(),
                       supportLevelName(driver->descriptor().supportLevel));
-        // Once, after the last begin(): every begin() reconfigures the line to its own driver's
-        // first profile, so applying the override per device would only be undone by the next
-        // one. All devices share the bus, so there is one line to set, not one per device.
-        const DeviceId id    = driver->identity().deviceId();
-        StateStore*    store = g_devices.add(id);
+        const DeviceId id = driver->identity().deviceId();
+        // Checked BEFORE add(), because add() is idempotent: re-adding a known id hands back
+        // the existing store rather than refusing. That is right for a caller re-registering
+        // the same device, and exactly wrong here -- two configured devices sharing an id would
+        // have silently shared one store and overwritten each other's readings into one set of
+        // Home Assistant entities. An earlier version of this loop treated a null return as the
+        // collision signal; it never came (review, 2026-07-25).
+        if (g_devices.contains(id)) {
+            log::warn("device '%s' skipped: another configured device already resolves to id "
+                      "'%s' -- give them different addresses", p.id.c_str(), id.c_str());
+            continue;
+        }
+        StateStore* store = g_devices.add(id);
         if (store == nullptr) {
-            // Either the cap, or two devices that resolve to the SAME identity -- which is what
-            // a duplicated unit id looks like from here. Both are configuration mistakes that
-            // would otherwise present as "the second inverter never updates".
-            Serial.printf("[driver] '%s' has no free device slot, or its identity collides with "
-                          "a device already added\n", p.id.c_str());
+            log::warn("device '%s' skipped: no free device slot (max %u)", p.id.c_str(),
+                      static_cast<unsigned>(kMaxDevices));
             continue;
         }
         PollPolicy policy;
         policy.intervalMs = g_config.polling.intervalSeconds * 1000;
         g_contexts.push_back(std::make_unique<DeviceContext>(*driver, *store, g_diagnostics,
                                                              nowMs, policy));
+        g_deviceIds.push_back(id);
         g_drivers.push_back(std::move(driver));
         if (g_driver == nullptr) {
             g_driver  = g_drivers.front().get();
@@ -828,6 +856,11 @@ void setup() {
         }
     }
     if (!g_drivers.empty()) {
+        // Once, after the LAST begin(): every begin() reconfigures the line to its own driver's
+        // first profile, so applying the override per device would only be undone by the next
+        // one. All devices share the bus, so there is one line to set, not one per device --
+        // which also means that on a MIXED bus, with the override off, the line is left on the
+        // last driver's profile. Drivers whose profiles differ need the override set explicitly.
         applySerialOverride();
         if (g_drivers.size() > 1) {
             Serial.printf("[driver] polling %u devices in turn on one bus\n",

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -501,6 +501,34 @@ bool RestApi::begin() {
                 return;
             }
 
+            // The same two gates for every additional device. Without them the list was the one
+            // way into the configuration that validated nothing: an unknown driver id was stored
+            // and surfaced only as a boot log line, and a typo'd register-map option fell back at
+            // boot to the DEFAULT profile -- which for a string inverter means quietly reading a
+            // hybrid's registers and publishing values that look entirely plausible. That is the
+            // exact hazard the gate above exists for; the new list walked straight past it.
+            //
+            // Unconditional, unlike the driver.id check above: an entry here is only ever
+            // present because this patch sent the whole array, so there is no stored value to
+            // become unresolvable behind the user's back and no lockout to avoid.
+            for (size_t i = 0; i < updated.additionalDevices.size(); ++i) {
+                const auto&             dev   = updated.additionalDevices[i];
+                const std::string       where = "additional_devices[" + std::to_string(i) + "]";
+                const DriverDescriptor* d     = lookupDriver(dev.id);
+                if (d == nullptr) {
+                    sendError(request, {400, "invalid_config",
+                                        where + ".driver_id: unknown driver '" + dev.id + "'"});
+                    return;
+                }
+                DriverOptionError optionError;
+                if (!validateDriverOptions(*d, dev.options, optionError)) {
+                    sendError(request, {400, "invalid_config",
+                                        where + ".options." + optionError.key + ": " +
+                                            optionError.message});
+                    return;
+                }
+            }
+
             if (!context_.saveConfig(updated)) {
                 sendError(request, {500, "save_failed", "could not persist the configuration"});
                 return;

--- a/src/state/state_store.h
+++ b/src/state/state_store.h
@@ -43,11 +43,13 @@ private:
 
 /// Owns the stores for every known device.
 ///
-/// The MVP allows one active device, enforced by DeviceManager rather than by the interfaces:
-/// nothing here is a singleton, so multiple RS485 devices later need no redesign.
+/// Nothing here is a singleton, which is what made lifting the old one-device cap a matter of
+/// changing this number rather than a redesign. The cap is a bound on memory and on bus time,
+/// not a statement about the protocols: every device shares one half-duplex line, so each one
+/// added stretches the poll cycle by its own transaction time.
 class DeviceManager {
 public:
-    static constexpr size_t kMaxActiveDevices = 1;
+    static constexpr size_t kMaxActiveDevices = kMaxDevices;
 
     /// Returns nullptr when kMaxActiveDevices is reached. Re-adding an existing id returns
     /// the existing store.

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -578,6 +578,59 @@ static void test_a_config_without_a_serial_section_keeps_the_driver_in_charge() 
     TEST_ASSERT_EQUAL_UINT8(8, loaded.serial.profile.dataBits);
 }
 
+// Three inverters on one bus is a configuration, so it has to survive the reboot that makes it
+// take effect at all.
+static void test_extra_devices_survive_a_restart() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    auto               c = provisionedConfig();
+    c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {{"unit_id", "2"}}});
+    c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {{"unit_id", "3"}}});
+    TEST_ASSERT_TRUE(store.save(c));
+
+    Configuration loaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(loaded));
+    TEST_ASSERT_EQUAL_UINT32(2, loaded.additionalDevices.size());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus", loaded.additionalDevices[0].id.c_str());
+    TEST_ASSERT_EQUAL_STRING("2", loaded.additionalDevices[0].options["unit_id"].c_str());
+    TEST_ASSERT_EQUAL_STRING("3", loaded.additionalDevices[1].options["unit_id"].c_str());
+}
+
+// A blob written before this field existed -- raw, because saving through the current code
+// would emit the section and prove nothing. Must load as one device, which is what those
+// bridges are already doing.
+static void test_a_config_without_the_device_list_stays_single_device() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    backend.write(kStorageKeyConfig,
+                  R"({"version":1,"bridge_name":"Zolder","wifi":{"ssid":"thuisnetwerk"},)"
+                  R"("driver":{"id":"eversolar_legacy"}})");
+
+    Configuration loaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(loaded));
+    TEST_ASSERT_TRUE(loaded.additionalDevices.empty());
+    TEST_ASSERT_EQUAL_STRING("eversolar_legacy", loaded.driver.id.c_str());
+}
+
+// A stored entry with no driver id is dropped rather than loaded: validate() would refuse the
+// whole configuration for it, and refusing to boot over one corrupted list entry is worse than
+// polling one inverter fewer.
+static void test_a_nameless_stored_device_is_dropped_not_fatal() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    backend.write(kStorageKeyConfig,
+                  R"({"version":1,"wifi":{"ssid":"thuisnetwerk"},)"
+                  R"("driver":{"id":"eversolar_legacy"},)"
+                  R"("additional_devices":[{"options":{"unit_id":"2"}},{"driver_id":"sunspec"}]})");
+
+    Configuration loaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(loaded));
+    TEST_ASSERT_EQUAL_UINT32(1, loaded.additionalDevices.size());
+    TEST_ASSERT_EQUAL_STRING("sunspec", loaded.additionalDevices[0].id.c_str());
+    ConfigError e;
+    TEST_ASSERT_TRUE(validate(loaded, e));  // and what survived is saveable
+}
+
 static void test_ota_rejects_a_non_firmware_upload_before_writing() {
     ota::OtaManager ota;
     TEST_ASSERT_EQUAL(ota::OtaResult::Ok, ota.begin(1024));
@@ -703,6 +756,9 @@ int main(int, char**) {
     RUN_TEST(test_non_firmware_is_rejected);
     RUN_TEST(test_a_serial_override_survives_a_restart);
     RUN_TEST(test_a_config_without_a_serial_section_keeps_the_driver_in_charge);
+    RUN_TEST(test_extra_devices_survive_a_restart);
+    RUN_TEST(test_a_config_without_the_device_list_stays_single_device);
+    RUN_TEST(test_a_nameless_stored_device_is_dropped_not_fatal);
     RUN_TEST(test_ota_rejects_a_non_firmware_upload_before_writing);
     RUN_TEST(test_ota_accepts_a_firmware_upload);
     RUN_TEST(test_ota_refuses_a_second_concurrent_upload);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -275,6 +275,81 @@ static void test_changing_the_serial_override_requires_a_reboot() {
     TEST_ASSERT_FALSE(configChangeRequiresReboot(base, idle));
 }
 
+// --- several devices on one bus ----------------------------------------------------------
+
+static void test_additional_devices_round_trip_through_a_patch() {
+    Configuration c;
+    ConfigError   e;
+    TEST_ASSERT_TRUE(c.additionalDevices.empty());  // invisible on a single-inverter install
+
+    TEST_ASSERT_TRUE(applyConfigPatch(
+        R"({"additional_devices":[{"driver_id":"growatt_modbus","options":{"unit_id":"2"}},)"
+        R"({"driver_id":"growatt_modbus","options":{"unit_id":"3"}}]})", c, e));
+    TEST_ASSERT_EQUAL_UINT32(2, c.additionalDevices.size());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus", c.additionalDevices[1].id.c_str());
+    TEST_ASSERT_EQUAL_STRING("3", c.additionalDevices[1].options["unit_id"].c_str());
+
+    std::string json;
+    TEST_ASSERT_TRUE(serializeConfig(c, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(2, doc["additional_devices"].size());
+    TEST_ASSERT_EQUAL_STRING("2", doc["additional_devices"][0]["options"]["unit_id"]);
+}
+
+// Whole-list replacement, not a merge: there is no stable key to merge on, and an index the
+// caller believes is element 2 may not be after someone else's edit.
+static void test_sending_the_list_replaces_it_and_omitting_it_does_not() {
+    Configuration c;
+    ConfigError   e;
+    applyConfigPatch(R"({"additional_devices":[{"driver_id":"sunspec"}]})", c, e);
+    TEST_ASSERT_EQUAL_UINT32(1, c.additionalDevices.size());
+
+    applyConfigPatch(R"({"bridge_name":"Zolder"})", c, e);
+    TEST_ASSERT_EQUAL_UINT32(1, c.additionalDevices.size());  // untouched
+
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"additional_devices":[]})", c, e));
+    TEST_ASSERT_EQUAL_UINT32(0, c.additionalDevices.size());  // explicitly cleared
+}
+
+static void test_an_extra_device_must_name_a_driver() {
+    Configuration c;
+    ConfigError   e;
+    // Empty is legal for `driver` -- it means "pick the highest-priority one". For an extra
+    // device it is a poll slot that can never be filled, so the whole patch is refused and the
+    // config is left untouched (applyConfigPatch validates the merged copy before adopting it).
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"additional_devices":[{"options":{"unit_id":"2"}}]})",
+                                       c, e));
+    TEST_ASSERT_EQUAL_STRING("additional_devices[0].driver_id", e.field.c_str());
+    TEST_ASSERT_TRUE(c.additionalDevices.empty());
+}
+
+static void test_the_device_count_is_bounded() {
+    Configuration c;
+    ConfigError   e;
+    for (size_t i = 0; i < kMaxDevices - 1; ++i) {
+        c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {}});
+    }
+    TEST_ASSERT_TRUE(validate(c, e));  // driver + kMaxDevices-1 == the cap
+
+    c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {}});
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("additional_devices", e.field.c_str());
+}
+
+// The drivers and their poll contexts are built once, in setup(). Adding an inverter changes
+// nothing until the next boot, and saying otherwise would leave someone waiting for a device
+// that is never going to appear.
+static void test_adding_a_device_requires_a_reboot() {
+    const Configuration base;
+    auto                more = base;
+    more.additionalDevices.push_back(DriverSettings{"sunspec", false, {}});
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(base, more));
+
+    auto retuned = more;
+    retuned.additionalDevices[0].options["unit_id"] = "4";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(more, retuned));
+}
+
 static void test_reboot_required_flag_is_patch_only() {
     auto        c = configWithSecrets();
     std::string json;
@@ -1206,6 +1281,11 @@ int main(int, char**) {
     RUN_TEST(test_a_patch_that_sets_both_keeps_the_line_it_asked_for);
     RUN_TEST(test_an_unrelated_save_leaves_the_line_override_alone);
     RUN_TEST(test_changing_the_serial_override_requires_a_reboot);
+    RUN_TEST(test_additional_devices_round_trip_through_a_patch);
+    RUN_TEST(test_sending_the_list_replaces_it_and_omitting_it_does_not);
+    RUN_TEST(test_an_extra_device_must_name_a_driver);
+    RUN_TEST(test_the_device_count_is_bounded);
+    RUN_TEST(test_adding_a_device_requires_a_reboot);
     RUN_TEST(test_reboot_required_flag_is_patch_only);
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -350,6 +350,63 @@ static void test_adding_a_device_requires_a_reboot() {
     TEST_ASSERT_TRUE(configChangeRequiresReboot(more, retuned));
 }
 
+// The blocker this design turned on. Three identical inverters on one bus differ only in their
+// address, and no driver in this build has a serial number at the moment setup() keys the state
+// store -- Growatt never reads one, EverSolar and SunSpec learn theirs on the first poll. So all
+// three resolved to the bare driver id, DeviceManager handed them the SAME store, and they
+// overwrote each other into one set of Home Assistant entities.
+static void test_devices_on_one_bus_get_distinct_ids_without_a_serial() {
+    DeviceIdentity a;
+    a.driverId    = "growatt_modbus";
+    a.instanceKey = "1";
+    DeviceIdentity b = a;
+    b.instanceKey    = "2";
+
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-1", a.deviceId().c_str());
+    TEST_ASSERT_TRUE(a.deviceId() != b.deviceId());
+}
+
+// A real serial still wins: it identifies the physical unit however it happens to be addressed,
+// so re-addressing an inverter must not make it look like a new device.
+static void test_a_serial_number_outranks_the_address() {
+    DeviceIdentity id;
+    id.driverId     = "eversolar_legacy";
+    id.instanceKey  = "10";
+    id.serialNumber = "XH300060115506193600V610";
+    TEST_ASSERT_EQUAL_STRING("eversolar_legacy-XH300060115506193600V610", id.deviceId().c_str());
+}
+
+// One device and no address option: unchanged from before multi-device existed, which is what
+// keeps every existing install's REST path and MQTT topic exactly where it was.
+static void test_a_lone_device_without_either_keeps_the_bare_driver_id() {
+    DeviceIdentity id;
+    id.driverId = "eversolar_legacy";
+    TEST_ASSERT_EQUAL_STRING("eversolar_legacy", id.deviceId().c_str());
+}
+
+// add() is idempotent by contract -- re-adding a known id hands back the existing store. That is
+// right for a caller re-registering the same device and exactly wrong for two CONFIGURED devices
+// sharing an id, so the boot loop has to ask contains() first. This pins the contract the loop
+// depends on; an earlier version treated a null return as the collision signal and it never came.
+static void test_re_adding_an_id_returns_the_same_store_rather_than_failing() {
+    DeviceManager devices;
+    StateStore*   first = devices.add("growatt_modbus-1");
+    TEST_ASSERT_NOT_NULL(first);
+    TEST_ASSERT_EQUAL_PTR(first, devices.add("growatt_modbus-1"));
+    TEST_ASSERT_EQUAL_UINT32(1, devices.size());
+    TEST_ASSERT_TRUE(devices.contains("growatt_modbus-1"));
+    TEST_ASSERT_FALSE(devices.contains("growatt_modbus-2"));
+}
+
+static void test_the_device_manager_refuses_past_its_cap() {
+    DeviceManager devices;
+    for (size_t i = 0; i < kMaxDevices; ++i) {
+        TEST_ASSERT_NOT_NULL(devices.add("d" + std::to_string(i)));
+    }
+    TEST_ASSERT_NULL(devices.add("one-too-many"));
+    TEST_ASSERT_EQUAL_UINT32(kMaxDevices, devices.size());
+}
+
 static void test_reboot_required_flag_is_patch_only() {
     auto        c = configWithSecrets();
     std::string json;
@@ -1286,6 +1343,11 @@ int main(int, char**) {
     RUN_TEST(test_an_extra_device_must_name_a_driver);
     RUN_TEST(test_the_device_count_is_bounded);
     RUN_TEST(test_adding_a_device_requires_a_reboot);
+    RUN_TEST(test_devices_on_one_bus_get_distinct_ids_without_a_serial);
+    RUN_TEST(test_a_serial_number_outranks_the_address);
+    RUN_TEST(test_a_lone_device_without_either_keeps_the_bare_driver_id);
+    RUN_TEST(test_re_adding_an_id_returns_the_same_store_rather_than_failing);
+    RUN_TEST(test_the_device_manager_refuses_past_its_cap);
     RUN_TEST(test_reboot_required_flag_is_patch_only);
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);


### PR DESCRIPTION
First of two. This one makes the bridge **read** several inverters on one bus; the next gives Home Assistant, Modbus TCP and Prometheus a device dimension.

## What was in the way

`kMaxActiveDevices = 1` was not a flag but an assumption in the boot path: one `g_driver`, one `g_context`, one `g_state`. The model underneath was already plural — `DeviceManager` keys stores by id and nothing in it is a singleton.

Config gains `additional_devices` (devices 2..N, each a driver id + options, eight total). `setup()` builds one driver and one `DeviceContext` per device; `rs485Task` polls **one device per iteration**, round-robin — the watchdog is fed once per iteration, and eight silent devices would otherwise spend eight transaction deadlines back to back before the outputs ran.

## The review found the feature did not work for the case it was built for

Both passes landed on the same blocker and they were right.

`deviceId()` falls back to the bare driver id when there is no serial number — and **at the moment `setup()` reads it to key the store, no driver in this build has one.** Some never read a serial; the rest learn theirs on the first poll or chain walk, long after. So three MIC TL-X all resolved to the same id, and `DeviceManager::add` handed all three the **same store**, because `add()` is idempotent by contract: a known id returns the existing store, never `nullptr`. My "collision is reported" branch was dead code — and I asserted it in the commit, the PR body *and* `architecture.md`.

The consequence was not "two inverters missing". Three contexts polling three real inverters published into one store, so one set of Home Assistant entities would oscillate between three physical machines — and a `total_increasing` energy sensor fed three different lifetime counters reads as repeated meter resets and invents energy. **This half would have broken a working single-inverter install the moment a second was added.**

`DeviceIdentity` gains `instanceKey`: the Modbus unit id or PMU address the driver was configured with, set by each driver from its own options — the only place that knows which option does the addressing. `deviceId()` prefers the serial, falls back to the instance key, then to the bare driver id, so an existing single install keeps exactly the id, REST path and MQTT topic it had. The boot loop asks `contains()` before `add()`, which is what actually catches a duplicate.

## Also from the reviews

- **`additional_devices` bypassed `validateDriverOptions` and the unknown-driver check entirely** — the one way into the config that validated nothing. A typo'd register-map option was stored and fell back at boot to the *default* profile: a string inverter quietly reading a hybrid's registers. Both gates now cover the list.
- **A configured driver that failed `begin()` turned the status LED from red to green** — "all healthy" while polling nothing. Now driven by how many devices were *configured*, not how many started.
- The device lines were `Serial.printf`, invisible over the network. A headless three-inverter bring-up needs them in `/api/v1/logs`.
- The poll log said "device 2" using the position among *started* devices, which is not the position in the config. It names the device id, which carries the address.
- A manual poll went to whatever the cursor was on, while the wizard reads the result back from `/api/v1/status` — the first device.

## Corrections to my own claims

- **"Settings → Extra devices" does not exist.** The README and the MIC bring-up doc both sent the reader to a screen I did not build. Replaced with the `curl` PATCH that actually works — including the `driver_id`-vs-`id` trap.
- "The REST API carries all of them" was true of the code and false in practice, for exactly the reason above.
- `architecture.md` still said `MAX_ACTIVE_DEVICES = 1` two hundred lines from the new section saying eight, and documented `DeviceId` as driver id + serial — the mechanism that is empty when it is used.
- "Nine new tests"; there were eight.
- A comment claimed the limitation is stated in the REST status payload. It is not — the diff does not touch `src/outputs`.
- **Two PMU devices on one bus cannot work**: they register by broadcast with no serial in the request, so two instances race the same handshake. Nothing said so.

## What this still does not do

**MQTT/Home Assistant, Modbus TCP and Prometheus carry the first device only.** Each takes a single `DeviceState`; their topic tree, register map and metric names have no device dimension. Stated in the README, `docs/rest-api.md`, `docs/architecture.md` and next to the code. That is PR 2.

Discovery also still probes only the default unit id, so devices 2 and 3 are added by hand.

## Tests

Thirteen new: the config patch round-trip, replace-vs-omit, the empty-`driver_id` refusal, the eight-device bound, reboot-required on add and retune, NVS survival, a raw pre-field blob loading as single-device, a nameless stored entry being dropped — plus five pinning the identity contract and `DeviceManager`'s idempotence, the part that was asserted in prose and nowhere else.

**561 tests pass** (was 548), `check_layering.sh` PASS, `check_web_js.py` OK, all four boards build.
