### PR TITLE
Give every inverter its own MQTT topics and Home Assistant device

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,14 @@ own address before you connect them together.
 >   -d '{"additional_devices":[{"driver_id":"growatt_modbus","options":{"unit_id":"2"}}]}'
 > ```
 >
-> Then restart. Two more things to know before wiring three: discovery probes only the default
-> address, so the others must be added by hand; and **Modbus TCP and Prometheus still carry the first
-> device only** — REST, `/api/v1/devices` and Home Assistant have all of them. Both are next on
-> the list, not wiring faults.
+> Sending the array **replaces** it, so list every extra unit in one call. Then restart.
+>
+> Three more things before wiring three: discovery probes only the default address, so the
+> others must be added by hand; **Modbus TCP and Prometheus still carry the first device only**
+> — REST, `/api/v1/devices` and Home Assistant have all of them; and **the bridge's own
+> dashboard shows the first device only** too. All three are next on the list, not wiring
+> faults. Note also that the units share one bus and one poll interval, so each is read roughly
+> every N intervals with N inverters.
 
 ### 2. Flash the firmware
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ own address before you connect them together.
 > ```
 >
 > Then restart. Two more things to know before wiring three: discovery probes only the default
-> address, so the others must be added by hand; and **Home Assistant, Modbus TCP and Prometheus
-> still carry the first device only** — the REST API and `/api/v1/devices` have all of them.
-> Both are next on the list, not wiring faults.
+> address, so the others must be added by hand; and **Modbus TCP and Prometheus still carry the first
+> device only** — REST, `/api/v1/devices` and Home Assistant have all of them. Both are next on
+> the list, not wiring faults.
 
 ### 2. Flash the firmware
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -672,12 +672,21 @@ unit, speak up" -- with no serial in the request, so two instances of the same P
 the same handshake and which physical unit each ends up owning is undefined. One PMU device per
 bus; mixing a PMU driver with Modbus drivers is fine.
 
-**The outputs have not caught up.** `MqttOutput::loop`, `ModbusTcpServer::refresh` and
-`buildMetrics` each take a single `DeviceState`, so they are fed the first device only. The REST
-API is already device-keyed and carries all of them. Giving the other three a device dimension —
-a topic segment, a register-map offset, a metric label — is the next piece of work, and until it
-lands the limitation is stated in the README, `docs/rest-api.md` and next to the code in
-`main.cpp` rather than left to be discovered from a missing Home Assistant entity.
+**Two of the outputs have not caught up.** `ModbusTcpServer::refresh` and `buildMetrics` each
+take a single `DeviceState`, so they are fed the first device only: the register map holds one
+device's worth of registers and the metric names have no device label. REST is device-keyed, and
+MQTT/Home Assistant became so — `MqttOutput` keeps one `Channel` per device (its own topics,
+throttle and discovery signature) and `buildDiscoveryEntities` takes a `uniqueBase` that scopes
+every `unique_id`, `object_id`, retained config topic and HA device identifier.
+
+The first device deliberately keeps the bridge-scoped topics and unique ids it has always used,
+so an existing install's entities and recorder history survive the change; devices 2..N live
+under `<base>/<bridgeId>/device/<deviceId>/`. Availability, diagnostics and the relay/DRM topics
+stay bridge-scoped, because they describe the bridge.
+
+Until Modbus TCP and Prometheus follow, that limitation is stated in the README,
+`docs/rest-api.md`, `docs/mqtt.md` and next to the code in `main.cpp` rather than left to be
+discovered from a missing entity.
 
 ## Test strategy
 

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -211,9 +211,9 @@ address in turn and confirm exactly one answers, at the address you expect.
    > fault. Check `/api/v1/devices` after the restart: you should see one entry per unit, named
    > `growatt_modbus-1`, `-2`, `-3`.
    >
-   > **Home Assistant, Modbus TCP and Prometheus still publish the first device only.** All
-   > three appear in the REST API and in the device list; only one reaches those outputs. Next
-   > piece of work.
+   > **Modbus TCP and Prometheus still publish the first device only.** All three units appear
+   > in the REST API, in the device list and in Home Assistant, each as its own HA device; only
+   > one reaches those two outputs. Next piece of work.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.
 5. Check the dump against the inverter's own app: PV voltage, AC power, today's energy,

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -20,6 +20,29 @@ Configurable; defaults to being derived from the MAC so that two bridges never c
 | `heliograph/<bridge_id>/relay/<n>/state` | ✔ | 1 | `ON` / `OFF` — relay boards only |
 | `heliograph/<bridge_id>/relay/<n>/set` | — | 1 | Command topic (subscribed) — relay boards only |
 
+### More than one inverter
+
+The **first** device publishes on the topics above, unchanged from when a bridge polled only
+one. That is deliberate: moving it would change every Home Assistant entity's `unique_id` and
+cost an existing install its recorder history for a feature it is not using.
+
+Devices 2..N get their own subtree, keyed by device id:
+
+| Topic | Retained | QoS | Payload |
+|---|---|---|---|
+| `heliograph/<bridge_id>/device/<device_id>/state` | ✔ | 0 | Measurements + status (JSON) |
+| `heliograph/<bridge_id>/device/<device_id>/identity` | ✔ | 1 | Device identity (JSON) |
+| `heliograph/<bridge_id>/device/<device_id>/capabilities` | ✔ | 1 | Capabilities (JSON) |
+
+`availability`, `diagnostics` and the relay/DRM topics stay bridge-scoped — they describe the
+bridge, not any inverter. Availability tracking the bridge is also why a sleeping inverter does
+not make its entities unavailable at night.
+
+Each device gets its own Home Assistant device block, its own `unique_id`s and its own retained
+discovery config topics. `<device_id>` is the same id REST uses: the serial number when the
+driver reports one, otherwise the driver id plus the configured address, e.g.
+`growatt_modbus-2`.
+
 **Last Will and Testament:** topic `availability`, payload `offline`, retained, QoS 1. On a
 clean shutdown, the bridge publishes `offline` itself.
 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -39,9 +39,25 @@ bridge, not any inverter. Availability tracking the bridge is also why a sleepin
 not make its entities unavailable at night.
 
 Each device gets its own Home Assistant device block, its own `unique_id`s and its own retained
-discovery config topics. `<device_id>` is the same id REST uses: the serial number when the
-driver reports one, otherwise the driver id plus the configured address, e.g.
-`growatt_modbus-2`.
+discovery config topics. Devices beyond the first also carry their address in the HA device name
+(`… #2`), because identical inverters report an identical model and no serial number.
+
+`<device_id>` is the id REST uses, frozen at boot: the driver id plus the configured address,
+e.g. `growatt_modbus-2`. It is **not** the serial number even for drivers that report one — the
+serial arrives during the first poll, long after the id is needed.
+
+> **Removing or re-addressing a device leaves its entities behind.** The discovery configs and
+> the last state are retained on the broker, and nothing publishes an empty payload to clear
+> them, so Home Assistant keeps re-creating those entities — and because availability is
+> bridge-scoped they stay *available*, showing the last value ever read. A template or
+> automation summing your inverters will keep counting the ghost. Clear them by hand
+> (`mosquitto_pub -r -n -t <topic>`) or delete the entities in Home Assistant. The relay
+> entities do have an automatic removal path; devices do not, yet.
+
+> **Which device is "first" comes from the configuration, not from boot order.** It is the
+> `driver` entry. If it fails to start, no device takes over the bridge-scoped topics — that is
+> deliberate, so a bad boot cannot transplant one inverter's history onto another. But moving a
+> different inverter into the `driver` slot *does* hand it those topics and that history.
 
 **Last Will and Testament:** topic `availability`, payload `offline`, retained, QoS 1. On a
 clean shutdown, the bridge publishes `offline` itself.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -145,10 +145,10 @@ can never be filled.
 Adding, removing or retuning a device needs a restart: the drivers and their poll contexts are
 built once, at boot.
 
-**The outputs are not all there yet.** The REST API and the device list carry every configured
-device; **MQTT/Home Assistant, Modbus TCP and Prometheus carry the first one only**, because
-their topic tree, register map and metric names have no device dimension. That is the next piece
-of work and is stated in `docs/architecture.md` too.
+**The outputs are not all there yet.** REST, the device list and MQTT/Home Assistant carry every
+configured device; **Modbus TCP and Prometheus carry the first one only**, because the register
+map holds one device's registers and the metric names have no device label. That is the next
+piece of work and is stated in `docs/architecture.md` too.
 
 ## `serial` — overriding the line the driver picks
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -667,15 +667,30 @@ void rs485Task(void* /*arg*/) {
         // stated here, in docs/architecture.md, and in the REST status payload rather than left
         // for someone to discover from a missing entity.
         if (g_state) {
-            const auto snapshot = g_state->snapshot();
-            const auto bridge   = bridgeInfo();
-            const auto diag     = g_diagnostics.snapshot();
-            g_modbus.refresh(*snapshot, bridge, diag, nowMs());
+            const auto bridge = bridgeInfo();
+            const auto diag   = g_diagnostics.snapshot();
+            // Snapshots held for the whole block: MqttOutput::DeviceView keeps raw pointers
+            // into them, so the shared_ptrs have to outlive the loop() call.
+            std::vector<StateHandle>               held;
+            std::vector<mqtt::MqttOutput::DeviceView> views;
+            held.reserve(g_deviceIds.size());
+            views.reserve(g_deviceIds.size());
+            for (const auto& id : g_deviceIds) {
+                if (StateHandle h = g_devices.state(id)) {
+                    held.push_back(std::move(h));
+                    views.push_back({id, held.back().get()});
+                }
+            }
+            const auto first = g_state->snapshot();
+            // Still first-device-only, and now the ONLY two that are: the Modbus TCP register
+            // map has one device's worth of registers and the metric names have no device
+            // label. Both are named in docs/architecture.md as the remaining gap.
+            g_modbus.refresh(*first, bridge, diag, nowMs());
             if (g_mqtt) {
-                g_mqtt->loop(*snapshot, bridge, diag, nowMs());
+                g_mqtt->loop(views, bridge, diag, nowMs());
             }
             if (g_rest) {
-                g_rest->notifyState(*snapshot, nowMs());
+                g_rest->notifyState(*first, nowMs());
             }
         }
         // Never a long delay: an unreachable inverter must not stall the task or the watchdog.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -660,12 +660,10 @@ void rs485Task(void* /*arg*/) {
                 break;
             }
         }
-        // FIRST DEVICE ONLY, deliberately and for now. MQTT, Home Assistant, Modbus TCP and
-        // Prometheus all take a single DeviceState: their topic trees, register map and metric
-        // names have no device dimension yet. Polling several devices without saying so would
-        // put two more inverters in the REST device list and silently nowhere else, so this is
-        // stated here, in docs/architecture.md, and in the REST status payload rather than left
-        // for someone to discover from a missing entity.
+        // MQTT/Home Assistant take every device; Modbus TCP and Prometheus still take one --
+        // the register map holds a single device's registers and the metric names have no
+        // device label. Stated here, in docs/architecture.md, docs/rest-api.md, docs/mqtt.md
+        // and the README rather than left to be found from a missing entity.
         if (g_state) {
             const auto bridge = bridgeInfo();
             const auto diag   = g_diagnostics.snapshot();

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -119,7 +119,19 @@ void addDeviceBlock(JsonObject entity, const BridgeInfo& bridge, const DeviceIde
     const std::string& descriptor = !identity.model.empty()          ? identity.model
                                     : !identity.manufacturer.empty() ? identity.manufacturer
                                                                      : kUnknownInverterName;
-    device["name"] = bridge.name.empty() ? descriptor : bridge.name + " - " + descriptor;
+    std::string name = bridge.name.empty() ? descriptor : bridge.name + " - " + descriptor;
+    // Three identical inverters on one bus produce three identical model strings and no serial
+    // number, so without this Home Assistant lists three devices called exactly the same thing
+    // and twelve entities each called "AC Power". The address is the only thing that tells them
+    // apart, and the driver already put it in the identity.
+    //
+    // Only for devices 2..N: the primary keeps the name it has always had, like its topics and
+    // its unique ids. Same reasoning, same test.
+    const bool primary = uniqueBase == bridge.bridgeId;
+    if (!primary && !identity.instanceKey.empty()) {
+        name += " #" + identity.instanceKey;
+    }
+    device["name"] = name;
     if (!identity.manufacturer.empty()) {
         device["manufacturer"] = identity.manufacturer;
     }
@@ -201,6 +213,7 @@ uint64_t stringListFingerprint(const std::vector<std::string>& items) {
 std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
                                                     const BridgeInfo&  bridge,
                                                     const MqttTopics&  topics,
+                                                    const std::string& availabilityTopic,
                                                     const std::string& discoveryPrefix,
                                                     const std::string& uniqueBase) {
     std::vector<DiscoveryEntity> entities;
@@ -225,7 +238,7 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         // than as a reading of 0.
         e["value_template"] =
             std::string("{{ value_json.measurements['") + m.id + "'].value }}";
-        e["availability_topic"]  = topics.availability();
+        e["availability_topic"]  = availabilityTopic;
         e["payload_available"]   = kPayloadOnline;
         e["payload_not_available"] = kPayloadOffline;
 
@@ -264,7 +277,7 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         e["name"]           = "Status";
         e["state_topic"]    = topics.state();
         e["value_template"] = "{{ value_json.status_text }}";
-        e["availability_topic"] = topics.availability();
+        e["availability_topic"] = availabilityTopic;
         e["icon"]           = "mdi:information-outline";
         addDeviceBlock(e, bridge, state.identity, false, uniqueBase);
 
@@ -285,7 +298,7 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         e["name"]           = "Inverter Online";
         e["state_topic"]    = topics.state();
         e["value_template"] = "{{ 'ON' if value_json.inverter_online else 'OFF' }}";
-        e["availability_topic"] = topics.availability();
+        e["availability_topic"] = availabilityTopic;
         e["device_class"]   = "connectivity";
         e["entity_category"] = "diagnostic";
         addDeviceBlock(e, bridge, state.identity, false, uniqueBase);

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -95,7 +95,7 @@ std::string humanise(const std::string& id) {
 }
 
 void addDeviceBlock(JsonObject entity, const BridgeInfo& bridge, const DeviceIdentity& identity,
-                    bool isBridgeEntity) {
+                    bool isBridgeEntity, const std::string& uniqueBase) {
     JsonObject device = entity["device"].to<JsonObject>();
     if (isBridgeEntity) {
         device["identifiers"].to<JsonArray>().add(bridge.bridgeId);
@@ -108,7 +108,11 @@ void addDeviceBlock(JsonObject entity, const BridgeInfo& bridge, const DeviceIde
 
     // The inverter is modelled as its own device behind the bridge, so that a second inverter
     // later simply appears alongside it rather than merging into one confused device.
-    device["identifiers"].to<JsonArray>().add(bridge.bridgeId + "_inverter");
+    // Per device, not per bridge: with one identifier for all of them Home Assistant merges
+    // three physical inverters into a single device and their entities fight over the same
+    // names. uniqueBase is the bridge id for device 1, so an existing install's device block
+    // is byte-identical to before.
+    device["identifiers"].to<JsonArray>().add(uniqueBase + "_inverter");
     // Model, not manufacturer: the manufacturer is already its own field, and repeating it here
     // produced names like "Heliograph - Heliograph open-source project". The model is what
     // distinguishes one inverter from the next, which is the whole point of the name.
@@ -197,7 +201,8 @@ uint64_t stringListFingerprint(const std::vector<std::string>& items) {
 std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
                                                     const BridgeInfo&  bridge,
                                                     const MqttTopics&  topics,
-                                                    const std::string& discoveryPrefix) {
+                                                    const std::string& discoveryPrefix,
+                                                    const std::string& uniqueBase) {
     std::vector<DiscoveryEntity> entities;
 
     for (const auto& m : state.measurements.all()) {
@@ -211,8 +216,8 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         JsonDocument      doc;
         JsonObject        e = doc.to<JsonObject>();
 
-        e["unique_id"] = bridge.bridgeId + "_" + slug;
-        e["object_id"] = bridge.bridgeId + "_" + slug;
+        e["unique_id"] = uniqueBase + "_" + slug;
+        e["object_id"] = uniqueBase + "_" + slug;
         const bool noName = m.displayName == nullptr || m.displayName[0] == '\0';
         e["name"]      = noName ? humanise(m.id) : std::string(m.displayName);
         e["state_topic"] = topics.state();
@@ -237,11 +242,14 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         if (const int precision = displayPrecisionFor(m.type); precision >= 0) {
             e["suggested_display_precision"] = precision;
         }
-        addDeviceBlock(e, bridge, state.identity, /*isBridgeEntity=*/false);
+        addDeviceBlock(e, bridge, state.identity, /*isBridgeEntity=*/false, uniqueBase);
 
         DiscoveryEntity entity;
         entity.uniqueId    = e["unique_id"].as<std::string>();
-        entity.configTopic = discoveryPrefix + "/sensor/" + bridge.bridgeId + "/" + slug + "/config";
+        // The RETAINED config topic has to be per device too. With the bridge id in the node
+        // name, device 2 published its config over device 1's and Home Assistant kept only
+        // the last one -- the unique_id alone was not enough (caught by its own test).
+        entity.configTopic = discoveryPrefix + "/sensor/" + uniqueBase + "/" + slug + "/config";
         if (serialise(doc, entity.payload)) {
             entities.push_back(std::move(entity));
         }
@@ -251,18 +259,18 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
     if (state.capabilities.has(InverterCapability::ReadStatus)) {
         JsonDocument doc;
         JsonObject   e = doc.to<JsonObject>();
-        e["unique_id"]      = bridge.bridgeId + "_status";
-        e["object_id"]      = bridge.bridgeId + "_status";
+        e["unique_id"]      = uniqueBase + "_status";
+        e["object_id"]      = uniqueBase + "_status";
         e["name"]           = "Status";
         e["state_topic"]    = topics.state();
         e["value_template"] = "{{ value_json.status_text }}";
         e["availability_topic"] = topics.availability();
         e["icon"]           = "mdi:information-outline";
-        addDeviceBlock(e, bridge, state.identity, false);
+        addDeviceBlock(e, bridge, state.identity, false, uniqueBase);
 
         DiscoveryEntity entity;
         entity.uniqueId    = e["unique_id"].as<std::string>();
-        entity.configTopic = discoveryPrefix + "/sensor/" + bridge.bridgeId + "/status/config";
+        entity.configTopic = discoveryPrefix + "/sensor/" + uniqueBase + "/status/config";
         if (serialise(doc, entity.payload)) {
             entities.push_back(std::move(entity));
         }
@@ -272,20 +280,20 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
     {
         JsonDocument doc;
         JsonObject   e = doc.to<JsonObject>();
-        e["unique_id"]      = bridge.bridgeId + "_inverter_online";
-        e["object_id"]      = bridge.bridgeId + "_inverter_online";
+        e["unique_id"]      = uniqueBase + "_inverter_online";
+        e["object_id"]      = uniqueBase + "_inverter_online";
         e["name"]           = "Inverter Online";
         e["state_topic"]    = topics.state();
         e["value_template"] = "{{ 'ON' if value_json.inverter_online else 'OFF' }}";
         e["availability_topic"] = topics.availability();
         e["device_class"]   = "connectivity";
         e["entity_category"] = "diagnostic";
-        addDeviceBlock(e, bridge, state.identity, false);
+        addDeviceBlock(e, bridge, state.identity, false, uniqueBase);
 
         DiscoveryEntity entity;
         entity.uniqueId = e["unique_id"].as<std::string>();
         entity.configTopic =
-            discoveryPrefix + "/binary_sensor/" + bridge.bridgeId + "/inverter_online/config";
+            discoveryPrefix + "/binary_sensor/" + uniqueBase + "/inverter_online/config";
         if (serialise(doc, entity.payload)) {
             entities.push_back(std::move(entity));
         }
@@ -342,7 +350,7 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
         if (spec.unit) {
             e["unit_of_measurement"] = spec.unit;
         }
-        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true);
+        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true, bridge.bridgeId);
 
         DiscoveryEntity entity;
         entity.uniqueId = e["unique_id"].as<std::string>();
@@ -376,6 +384,8 @@ std::vector<DiscoveryEntity> buildRelayEntities(const BridgeInfo&  bridge,
         }
         JsonDocument doc;
         JsonObject   e = doc.to<JsonObject>();
+        // Bridge-scoped on purpose: the relays are the BRIDGE's contacts, not any inverter's,
+        // so they keep the bridge id even on a multi-device install.
         e["unique_id"] = bridge.bridgeId + "_" + slug;
         e["object_id"] = bridge.bridgeId + "_" + slug;
         // The configured DRM role lands in the entity name, so the HA UI says what the
@@ -398,7 +408,7 @@ std::vector<DiscoveryEntity> buildRelayEntities(const BridgeInfo&  bridge,
         // gates (read-only mode flipped back on, rate limit) visibly snaps back in HA.
         e["optimistic"]         = false;
         e["availability_topic"] = topics.availability();
-        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true);
+        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true, bridge.bridgeId);
 
         entity.uniqueId = e["unique_id"].as<std::string>();
         if (serialise(doc, entity.payload)) {
@@ -437,7 +447,7 @@ std::vector<DiscoveryEntity> buildRelayEntities(const BridgeInfo&  bridge,
         // command; HA requires the state to be one of the options, so it is listed.
         opts.add(drm::kModeCustom);
         e["availability_topic"] = topics.availability();
-        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true);
+        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true, bridge.bridgeId);
         if (serialise(doc, entity.payload)) {
             entities.push_back(std::move(entity));
         }

--- a/src/outputs/mqtt/home_assistant_discovery.h
+++ b/src/outputs/mqtt/home_assistant_discovery.h
@@ -33,10 +33,16 @@ struct DiscoveryEntity {
 ///     bitset, never on the driver id;
 ///   - availability tracks the BRIDGE, so a sleeping inverter leaves entities available and
 ///     reporting unknown, instead of vanishing from the dashboard every night.
+///   - `uniqueBase` prefixes every unique_id and the inverter's HA device identifier. It is
+///     the bridge id for the FIRST device -- unchanged from when a bridge polled only one, so
+///     an existing install keeps its entities and its recorder history -- and bridge id plus
+///     device id for the rest. Two inverters sharing a base would land on each other's
+///     entities, which is exactly what happened before this argument existed.
 std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
                                                     const BridgeInfo&  bridge,
                                                     const MqttTopics&  topics,
-                                                    const std::string& discoveryPrefix);
+                                                    const std::string& discoveryPrefix,
+                                                    const std::string& uniqueBase);
 
 /// Diagnostic entities for the bridge itself (RSSI, uptime, heap, poll counters).
 std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  bridge,

--- a/src/outputs/mqtt/home_assistant_discovery.h
+++ b/src/outputs/mqtt/home_assistant_discovery.h
@@ -38,9 +38,16 @@ struct DiscoveryEntity {
 ///     an existing install keeps its entities and its recorder history -- and bridge id plus
 ///     device id for the rest. Two inverters sharing a base would land on each other's
 ///     entities, which is exactly what happened before this argument existed.
+///   - `availabilityTopic` is the BRIDGE's, always -- never the device's. Availability tracks
+///     the bridge so a sleeping inverter stays visible, and only the bridge topic is ever
+///     published. Taking it from the device's own MqttTopics announced
+///     `<base>/<bridge>/device/<id>/availability`, which nothing publishes and which has no
+///     retained value, so every entity on devices 2..N sat at `unavailable` in Home Assistant
+///     forever -- the whole feature, silently not working (review, 2026-07-25).
 std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
                                                     const BridgeInfo&  bridge,
                                                     const MqttTopics&  topics,
+                                                    const std::string& availabilityTopic,
                                                     const std::string& discoveryPrefix,
                                                     const std::string& uniqueBase);
 

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -142,21 +142,22 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
 
 bool MqttOutput::connected() const { return started_ && g_client.connected(); }
 
-MqttOutput::Channel& MqttOutput::channelFor(const DeviceId& id, const BridgeInfo& bridge) {
+MqttOutput::Channel& MqttOutput::channelFor(const DeviceView& view, const BridgeInfo& bridge) {
     for (auto& c : channels_) {
-        if (c.id == id) {
+        if (c.id == view.id) {
             return c;
         }
     }
-    // The first channel is the bridge-scoped one, which is what every install had before this
-    // became plural: same topics, same unique_ids, same Home Assistant entities and history.
-    const bool  first = channels_.empty();
-    Channel     c{id,
-                  MqttTopics(config_.baseTopic, bridge.bridgeId, first ? std::string{} : id),
-                  first ? bridge.bridgeId : bridge.bridgeId + "_" + id,
-                  PublishThrottle(publishPolicy_),
-                  false,
-                  0};
+    // The primary device keeps the bridge-scoped tree every install had before this became
+    // plural: same topics, same unique ids, same Home Assistant entities and history. Which
+    // device that is comes from the caller, not from arrival order -- see DeviceView::primary.
+    Channel c{view.id,
+              MqttTopics(config_.baseTopic, bridge.bridgeId,
+                         deviceTopicKey(view.primary, view.id)),
+              deviceUniqueBase(view.primary, bridge.bridgeId, view.id),
+              PublishThrottle(publishPolicy_),
+              false,
+              0};
     channels_.push_back(std::move(c));
     return channels_.back();
 }
@@ -168,13 +169,17 @@ void MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
     }
     // Purely derived from measurements and capabilities. Nothing in here knows which device
     // it is talking to; a driver reporting a battery gets battery entities for free.
+    // topics_ for availability, deliberately: it is the BRIDGE's liveness, and it is the only
+    // availability topic anything publishes.
     for (const auto& e : buildDiscoveryEntities(state, bridge, channel.topics,
-                                                config_.discoveryPrefix, channel.uniqueBase)) {
+                                                topics_.availability(), config_.discoveryPrefix,
+                                                channel.uniqueBase)) {
         g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
     }
-    // Bridge entities belong to the bridge and are announced once, with the first device --
-    // publishing them per device would create N copies of the same RSSI sensor.
-    if (&channel == &channels_.front()) {
+    // Bridge entities belong to the bridge and are announced once -- publishing them per
+    // device would create N copies of the same RSSI sensor. Tied to the bridge-scoped channel
+    // rather than to whichever channel happens to be first in the vector.
+    if (channel.uniqueBase == bridge.bridgeId) {
         for (const auto& e :
              buildBridgeDiagnosticEntities(bridge, topics_, config_.discoveryPrefix)) {
             g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
@@ -270,7 +275,7 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
             continue;
         }
         const DeviceState& state   = *view.state;
-        Channel&           channel = channelFor(view.id, bridge);
+        Channel&           channel = channelFor(view, bridge);
 
         const auto signature = discoverySignature(state);
         if (!channel.discoveryPublished || signature != channel.discoveredSignature) {
@@ -298,9 +303,11 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
         if (bridge.relaysEnabled != lastRelaysEnabled_ || rolesSig != lastRelayRolesSig_) {
             lastRelaysEnabled_  = bridge.relaysEnabled;
             lastRelayRolesSig_  = rolesSig;
-            // Relay entities ride along with the first device's announcement.
-            if (!channels_.empty()) {
-                channels_.front().discoveryPublished = false;
+            // Relay entities ride along with the bridge-scoped channel's announcement.
+            for (auto& c : channels_) {
+                if (c.uniqueBase == bridge.bridgeId) {
+                    c.discoveryPublished = false;
+                }
             }
             relayStateForced_ = true;
         }
@@ -360,7 +367,7 @@ void MqttOutput::stop() { started_ = false; }
 bool MqttOutput::connected() const { return false; }
 void MqttOutput::onConnected(Channel&, const DeviceState&, const BridgeInfo&) {}
 void MqttOutput::publishDiscovery(Channel&, const DeviceState&, const BridgeInfo&) {}
-MqttOutput::Channel& MqttOutput::channelFor(const DeviceId&, const BridgeInfo&) {
+MqttOutput::Channel& MqttOutput::channelFor(const DeviceView&, const BridgeInfo&) {
     static Channel unused{"", MqttTopics("", ""), "", PublishThrottle({}), false, 0};
     return unused;
 }

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -26,7 +26,7 @@ espMqttClient g_client;
 MqttOutput::MqttOutput(MqttConfig config, PublishPolicy publishPolicy)
     : config_(std::move(config)),
       topics_(config_.baseTopic, "pending"),
-      throttle_(publishPolicy) {}
+      publishPolicy_(publishPolicy) {}
 
 bool MqttOutput::begin(const BridgeInfo& bridge) {
     if (!config_.enabled || config_.host.empty()) {
@@ -142,37 +142,64 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
 
 bool MqttOutput::connected() const { return started_ && g_client.connected(); }
 
-void MqttOutput::publishDiscovery(const DeviceState& state, const BridgeInfo& bridge) {
+MqttOutput::Channel& MqttOutput::channelFor(const DeviceId& id, const BridgeInfo& bridge) {
+    for (auto& c : channels_) {
+        if (c.id == id) {
+            return c;
+        }
+    }
+    // The first channel is the bridge-scoped one, which is what every install had before this
+    // became plural: same topics, same unique_ids, same Home Assistant entities and history.
+    const bool  first = channels_.empty();
+    Channel     c{id,
+                  MqttTopics(config_.baseTopic, bridge.bridgeId, first ? std::string{} : id),
+                  first ? bridge.bridgeId : bridge.bridgeId + "_" + id,
+                  PublishThrottle(publishPolicy_),
+                  false,
+                  0};
+    channels_.push_back(std::move(c));
+    return channels_.back();
+}
+
+void MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
+                                  const BridgeInfo& bridge) {
     if (!config_.discoveryEnabled) {
         return;
     }
     // Purely derived from measurements and capabilities. Nothing in here knows which device
     // it is talking to; a driver reporting a battery gets battery entities for free.
-    for (const auto& e : buildDiscoveryEntities(state, bridge, topics_, config_.discoveryPrefix)) {
+    for (const auto& e : buildDiscoveryEntities(state, bridge, channel.topics,
+                                                config_.discoveryPrefix, channel.uniqueBase)) {
         g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
     }
-    for (const auto& e : buildBridgeDiagnosticEntities(bridge, topics_, config_.discoveryPrefix)) {
-        g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
+    // Bridge entities belong to the bridge and are announced once, with the first device --
+    // publishing them per device would create N copies of the same RSSI sensor.
+    if (&channel == &channels_.front()) {
+        for (const auto& e :
+             buildBridgeDiagnosticEntities(bridge, topics_, config_.discoveryPrefix)) {
+            g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
+        }
+        // Relay switches -- or, when the feature is disabled on a relay board, empty retained
+        // payloads that remove previously announced switches from Home Assistant.
+        for (const auto& e : buildRelayEntities(bridge, topics_, config_.discoveryPrefix)) {
+            g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
+        }
     }
-    // Relay switches -- or, when the feature is disabled on a relay board, empty retained
-    // payloads that remove previously announced switches from Home Assistant.
-    for (const auto& e : buildRelayEntities(bridge, topics_, config_.discoveryPrefix)) {
-        g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
-    }
-    discoveryPublished_ = true;
+    channel.discoveryPublished = true;
 }
 
-void MqttOutput::onConnected(const DeviceState& state, const BridgeInfo& bridge) {
+void MqttOutput::onConnected(Channel& channel, const DeviceState& state,
+                             const BridgeInfo& bridge) {
     g_client.publish(topics_.availability().c_str(), 1, true, kPayloadOnline);
 
     std::string payload;
     if (buildIdentityPayload(state.identity, payload)) {
-        g_client.publish(topics_.identity().c_str(), 1, true, payload.c_str());
+        g_client.publish(channel.topics.identity().c_str(), 1, true, payload.c_str());
     }
     if (buildCapabilitiesPayload(state.capabilities, payload)) {
-        g_client.publish(topics_.capabilities().c_str(), 1, true, payload.c_str());
+        g_client.publish(channel.topics.capabilities().c_str(), 1, true, payload.c_str());
     }
-    publishDiscovery(state, bridge);
+    publishDiscovery(channel, state, bridge);
 
     // The relay command topic is the only subscription; inverter drivers stay read-only
     // and get no command topic -- that follows from the capabilities, not a decision here.
@@ -183,7 +210,7 @@ void MqttOutput::onConnected(const DeviceState& state, const BridgeInfo& bridge)
     }
 }
 
-void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
+void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& bridge,
                       const DiagnosticsSnapshot& diagnostics, uint64_t nowMs) {
     if (!started_) {
         return;
@@ -226,30 +253,41 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
     // anyway, and this way throttle_ and discoveryPublished_ are only ever touched on the
     // task that runs loop().
     if (resyncRequested_.exchange(false)) {
-        throttle_.reset();
-        discoveryPublished_ = false;
-    }
-
-    // Re-announce when the measurement model has grown since the last discovery publish.
-    // Discovery is derived from measurements, and against a real inverter the first MQTT
-    // connect regularly wins the race against the first successful poll -- registration takes
-    // seconds on the bus. Publishing once and never again left Home Assistant with only the
-    // status entities (observed live, 2026-07-19). Retained config topics make republishing
-    // idempotent.
-    const auto signature = discoverySignature(state);
-    if (!discoveryPublished_ || signature != discoveredSignature_) {
-        onConnected(state, bridge);
-        discoveredSignature_ = signature;
-    }
-
-    if (throttle_.shouldPublish(state, nowMs)) {
-        std::string payload;
-        if (buildStatePayload(state, payload)) {
-            g_client.publish(topics_.state().c_str(), config_.qos, true, payload.c_str());
-            throttle_.recordPublished(state, nowMs);
+        for (auto& c : channels_) {
+            c.throttle.reset();
+            c.discoveryPublished = false;
         }
-        // If the payload did not fit it is dropped rather than truncated, and the throttle
-        // is left untouched so the next attempt retries.
+    }
+
+    // Per device: its own discovery announcement, its own throttle. Re-announce when the
+    // measurement model has grown since the last publish -- discovery is derived from
+    // measurements, and against a real inverter the first MQTT connect regularly wins the race
+    // against the first successful poll. Publishing once and never again left Home Assistant
+    // with only the status entities (observed live, 2026-07-19). Retained config topics make
+    // republishing idempotent.
+    for (const auto& view : devices) {
+        if (view.state == nullptr) {
+            continue;
+        }
+        const DeviceState& state   = *view.state;
+        Channel&           channel = channelFor(view.id, bridge);
+
+        const auto signature = discoverySignature(state);
+        if (!channel.discoveryPublished || signature != channel.discoveredSignature) {
+            onConnected(channel, state, bridge);
+            channel.discoveredSignature = signature;
+        }
+
+        if (channel.throttle.shouldPublish(state, nowMs)) {
+            std::string payload;
+            if (buildStatePayload(state, payload)) {
+                g_client.publish(channel.topics.state().c_str(), config_.qos, true,
+                                 payload.c_str());
+                channel.throttle.recordPublished(state, nowMs);
+            }
+            // If the payload did not fit it is dropped rather than truncated, and the throttle
+            // is left untouched so the next attempt retries.
+        }
     }
 
     if (bridge.relayCount > 0) {
@@ -260,8 +298,11 @@ void MqttOutput::loop(const DeviceState& state, const BridgeInfo& bridge,
         if (bridge.relaysEnabled != lastRelaysEnabled_ || rolesSig != lastRelayRolesSig_) {
             lastRelaysEnabled_  = bridge.relaysEnabled;
             lastRelayRolesSig_  = rolesSig;
-            discoveryPublished_ = false;
-            relayStateForced_   = true;
+            // Relay entities ride along with the first device's announcement.
+            if (!channels_.empty()) {
+                channels_.front().discoveryPublished = false;
+            }
+            relayStateForced_ = true;
         }
         if (relayStateForced_ || relayAckRequested_.exchange(false) ||
             bridge.relayMask != lastRelayMask_) {
@@ -308,15 +349,21 @@ void MqttOutput::stop() {
 namespace heliograph::mqtt {
 
 MqttOutput::MqttOutput(MqttConfig config, PublishPolicy publishPolicy)
-    : config_(std::move(config)), topics_(config_.baseTopic, "host"), throttle_(publishPolicy) {}
+    : config_(std::move(config)), topics_(config_.baseTopic, "host"),
+      publishPolicy_(publishPolicy) {}
 
 bool MqttOutput::begin(const BridgeInfo&) { return false; }
-void MqttOutput::loop(const DeviceState&, const BridgeInfo&, const DiagnosticsSnapshot&,
+void MqttOutput::loop(const std::vector<DeviceView>&, const BridgeInfo&,
+                      const DiagnosticsSnapshot&,
                       uint64_t) {}
 void MqttOutput::stop() { started_ = false; }
 bool MqttOutput::connected() const { return false; }
-void MqttOutput::onConnected(const DeviceState&, const BridgeInfo&) {}
-void MqttOutput::publishDiscovery(const DeviceState&, const BridgeInfo&) {}
+void MqttOutput::onConnected(Channel&, const DeviceState&, const BridgeInfo&) {}
+void MqttOutput::publishDiscovery(Channel&, const DeviceState&, const BridgeInfo&) {}
+MqttOutput::Channel& MqttOutput::channelFor(const DeviceId&, const BridgeInfo&) {
+    static Channel unused{"", MqttTopics("", ""), "", PublishThrottle({}), false, 0};
+    return unused;
+}
 
 }  // namespace heliograph::mqtt
 

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -29,6 +29,7 @@
 #include "diagnostics/diagnostics.h"
 #include "mqtt_topics.h"
 #include "publish_policy.h"
+#include "state/state_store.h"
 
 namespace heliograph::mqtt {
 
@@ -53,8 +54,19 @@ public:
     /// Sets up the client and starts connecting. Non-blocking.
     bool begin(const BridgeInfo& bridge);
 
+    /// One inverter's current state, as handed to loop().
+    struct DeviceView {
+        DeviceId           id;
+        const DeviceState* state;
+    };
+
     /// Drives reconnects and publishing. Call regularly from the MQTT task; never blocks.
-    void loop(const DeviceState& state, const BridgeInfo& bridge,
+    ///
+    /// `devices` is every polled device, in a stable order -- the FIRST one keeps the
+    /// bridge-scoped topics and unique_ids it has always had, so an existing install's Home
+    /// Assistant entities and their history survive this becoming plural. An empty list is
+    /// legal and publishes only the bridge's own topics.
+    void loop(const std::vector<DeviceView>& devices, const BridgeInfo& bridge,
               const DiagnosticsSnapshot& diagnostics, uint64_t nowMs);
 
     void stop();
@@ -75,13 +87,31 @@ public:
     void setDrmCommandHandler(DrmCommandFn handler) { drmCommand_ = std::move(handler); }
 
 private:
-    void onConnected(const DeviceState& state, const BridgeInfo& bridge);
-    void publishDiscovery(const DeviceState& state, const BridgeInfo& bridge);
+    /// Everything that is per-inverter rather than per-bridge. Keyed by device id and created
+    /// on first sight, so a device appearing later (a driver that only registers at sunrise)
+    /// gets its own throttle and its own discovery announcement rather than inheriting
+    /// another's.
+    struct Channel {
+        DeviceId        id;
+        MqttTopics      topics;
+        std::string     uniqueBase;
+        PublishThrottle throttle;
+        bool            discoveryPublished  = false;
+        uint64_t        discoveredSignature = 0;
+    };
 
-    MqttConfig      config_;
-    MqttTopics      topics_;
-    PublishThrottle throttle_;
-    Diagnostics*    diagnostics_ = nullptr;
+    Channel& channelFor(const DeviceId& id, const BridgeInfo& bridge);
+
+    void onConnected(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);
+    void publishDiscovery(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);
+
+    MqttConfig   config_;
+    /// Bridge-scoped: availability, diagnostics, relay and DRM. Never a device's.
+    MqttTopics   topics_;
+    Diagnostics* diagnostics_ = nullptr;
+
+    std::vector<Channel> channels_;
+    PublishPolicy        publishPolicy_;
 
     // espMqttClient's setClientId/setWill/setServer/setCredentials store the POINTER, not a
     // copy (MqttClientSetup.h: `_clientId = clientId;`). Every string handed to them must
@@ -92,13 +122,7 @@ private:
     std::string clientId_;
     std::string willTopic_;
 
-    bool     started_            = false;
-    bool     discoveryPublished_ = false;
-    /// discoverySignature() at the last discovery publish. Discovery re-announces when the
-    /// model changes: the first MQTT connect often beats the first successful poll of a real
-    /// inverter. A signature rather than a count, so a same-size swap of channels is caught.
-    /// 0 = never published; the FNV offset basis makes a real signature never 0 in practice.
-    uint64_t discoveredSignature_ = 0;
+    bool     started_           = false;
     uint64_t lastDiagnosticsMs_  = 0;
     uint64_t nextReconnectMs_    = 0;
     /// Exponential back-off, capped. An unreachable broker must not turn into a busy loop.

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -58,6 +58,11 @@ public:
     struct DeviceView {
         DeviceId           id;
         const DeviceState* state;
+        /// True for the device that keeps the bridge-scoped topics and unique ids. Decided by
+        /// the caller from the CONFIGURED order, not by arrival: keying it on "first one seen"
+        /// meant that a boot where device 1 failed to start handed device 2 its topics, its
+        /// entities and its recorder history (review, 2026-07-25). At most one, possibly none.
+        bool primary = false;
     };
 
     /// Drives reconnects and publishing. Call regularly from the MQTT task; never blocks.
@@ -87,10 +92,9 @@ public:
     void setDrmCommandHandler(DrmCommandFn handler) { drmCommand_ = std::move(handler); }
 
 private:
-    /// Everything that is per-inverter rather than per-bridge. Keyed by device id and created
-    /// on first sight, so a device appearing later (a driver that only registers at sunrise)
-    /// gets its own throttle and its own discovery announcement rather than inheriting
-    /// another's.
+    /// Everything that is per-inverter rather than per-bridge, keyed by device id. Every
+    /// channel is created in the first loop() pass -- the device list is fixed at boot -- but
+    /// keying by id rather than by position means nothing depends on that staying true.
     struct Channel {
         DeviceId        id;
         MqttTopics      topics;
@@ -100,7 +104,7 @@ private:
         uint64_t        discoveredSignature = 0;
     };
 
-    Channel& channelFor(const DeviceId& id, const BridgeInfo& bridge);
+    Channel& channelFor(const DeviceView& view, const BridgeInfo& bridge);
 
     void onConnected(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);
     void publishDiscovery(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);

--- a/src/outputs/mqtt/mqtt_topics.h
+++ b/src/outputs/mqtt/mqtt_topics.h
@@ -58,6 +58,25 @@ private:
     std::string prefix_;
 };
 
+/// Which topic subtree a device publishes on, and what prefixes its Home Assistant ids.
+///
+/// Pure and host-testable on purpose: this pair of decisions IS the back-compat contract of
+/// multi-device MQTT, and it used to live inside MqttOutput -- which is compiled only for
+/// ESP32, so no test could reach it. The tests that "pinned the contract" were exercising the
+/// MqttTopics constructor instead, and would have passed with this rule inverted (review).
+///
+/// `primary` marks the device that keeps the bridge-scoped tree it has always used. Exactly
+/// one device may be primary, and none may be: when the configured first device fails to
+/// start, nobody inherits its topics, its unique ids or its recorder history.
+inline std::string deviceTopicKey(bool primary, const std::string& deviceId) {
+    return primary ? std::string{} : deviceId;
+}
+
+inline std::string deviceUniqueBase(bool primary, const std::string& bridgeId,
+                                    const std::string& deviceId) {
+    return primary ? bridgeId : bridgeId + "_" + deviceId;
+}
+
 inline constexpr const char* kPayloadOnline  = "online";
 inline constexpr const char* kPayloadOffline = "offline";
 

--- a/src/outputs/mqtt/mqtt_topics.h
+++ b/src/outputs/mqtt/mqtt_topics.h
@@ -10,8 +10,20 @@ namespace heliograph::mqtt {
 /// call site, where a typo silently publishes into the void.
 class MqttTopics {
 public:
-    MqttTopics(std::string baseTopic, std::string bridgeId)
-        : prefix_(std::move(baseTopic) + "/" + std::move(bridgeId)) {}
+    /// `deviceKey` empty means the bridge-scoped tree: `<base>/<bridgeId>/...`. That is also
+    /// what the FIRST device publishes on, unchanged from before this bridge could poll more
+    /// than one -- deliberately, because moving it would change every Home Assistant entity's
+    /// unique_id and cost an existing install its whole recorder history for a feature it is
+    /// not using. Devices 2..N get `<base>/<bridgeId>/device/<key>/...`.
+    ///
+    /// The asymmetry is the price of not breaking what already works, and it is confined to
+    /// this constructor: everything downstream just uses the prefix it is given.
+    MqttTopics(std::string baseTopic, std::string bridgeId, std::string deviceKey = {})
+        : prefix_(std::move(baseTopic) + "/" + std::move(bridgeId)) {
+        if (!deviceKey.empty()) {
+            prefix_ += "/device/" + std::move(deviceKey);
+        }
+    }
 
     /// Whether the BRIDGE is reachable -- not the inverter.
     ///
@@ -24,7 +36,9 @@ public:
     std::string identity() const { return prefix_ + "/identity"; }
     std::string capabilities() const { return prefix_ + "/capabilities"; }
 
-    /// Bridge relay control (DRM contacts). Commands come in on relaySet, acknowledged
+    /// Bridge relay control (DRM contacts). These belong to the BRIDGE, not to any inverter,
+    /// so they are only ever built from a bridge-scoped MqttTopics -- never from a device one.
+    /// Commands come in on relaySet, acknowledged
     /// state goes out on relayState. The one wildcard subscription this firmware has.
     std::string relaySet(uint8_t index) const {
         return prefix_ + "/relay/" + std::to_string(index) + "/set";

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -148,7 +148,8 @@ static void test_no_discovery_entity_for_an_unsupported_declared_channel() {
                                           "Battery SoC");
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     TEST_ASSERT_NULL(findEntity(entities, "heliograph-a1b2c3_battery_soc"));
 }
@@ -437,7 +438,8 @@ static void test_discovery_creates_an_entity_per_supported_measurement() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     TEST_ASSERT_NOT_NULL(findEntity(entities, "heliograph-a1b2c3_ac_power_total"));
     TEST_ASSERT_NOT_NULL(findEntity(entities, "heliograph-a1b2c3_energy_total"));
@@ -452,7 +454,8 @@ static void test_discovery_metadata_matches_the_measurement_type() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     auto power = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
     TEST_ASSERT_EQUAL_STRING("power", power["device_class"]);
@@ -479,7 +482,8 @@ static void test_value_template_reads_the_right_key() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     TEST_ASSERT_EQUAL_STRING("{{ value_json.measurements['ac.power.total'].value }}",
@@ -494,7 +498,8 @@ static void test_availability_tracks_the_bridge_not_the_inverter() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/availability", doc["availability_topic"]);
@@ -507,7 +512,8 @@ static void test_inverter_is_a_separate_device_behind_the_bridge() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     TEST_ASSERT_EQUAL_STRING("heliograph-a1b2c3_inverter", doc["device"]["identifiers"][0]);
@@ -522,7 +528,8 @@ static void test_the_inverter_device_is_named_after_its_model_not_its_manufactur
     auto bridge      = makeBridge();
     bridge.name      = "Heliograph";
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     // The manufacturer is already its own field. Repeating it in the name gave Home Assistant
@@ -540,7 +547,8 @@ static void test_an_inverter_without_a_model_still_gets_a_usable_name() {
     auto bridge = makeBridge();
     bridge.name = "Heliograph";
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     // Falling back to the manufacturer is the one case where the repetition is acceptable:
@@ -561,8 +569,8 @@ static void test_every_entity_on_a_device_has_a_distinct_display_name() {
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
     const auto entities =
-        buildDiscoveryEntities(*store.snapshot(), bridge, topics, kDefaultDiscoveryPrefix,
-                               bridge.bridgeId);
+        buildDiscoveryEntities(*store.snapshot(), bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     // Home Assistant derives the entity id from the display name and silently disambiguates
     // duplicates with _2/_3 -- a suffix that carries no meaning and reorders itself whenever a
@@ -585,7 +593,8 @@ static void test_no_control_entities_for_a_read_only_driver() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     // Nothing that can be commanded: no number, switch or select component anywhere.
     for (const auto& e : entities) {
@@ -601,7 +610,8 @@ static void test_config_topics_are_well_formed() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     const auto* e = findEntity(entities, "heliograph-a1b2c3_ac_power_total");
     TEST_ASSERT_EQUAL_STRING("homeassistant/sensor/heliograph-a1b2c3/ac_power_total/config",
@@ -626,8 +636,8 @@ static void test_the_mock_hybrid_gets_battery_and_phase_entities_for_free() {
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
     const auto entities =
-        buildDiscoveryEntities(*store.snapshot(), bridge, topics, kDefaultDiscoveryPrefix,
-                               bridge.bridgeId);
+        buildDiscoveryEntities(*store.snapshot(), bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     TEST_ASSERT_NOT_NULL(findEntity(entities, "heliograph-a1b2c3_battery_soc"));
     TEST_ASSERT_NOT_NULL(findEntity(entities, "heliograph-a1b2c3_ac_phase_l3_voltage"));
@@ -845,15 +855,31 @@ static void test_reset_forces_the_next_publish() {
 
 // --- several inverters on one bus ---------------------------------------------------------
 
-// The whole back-compat contract of this change in one assertion: the FIRST device keeps the
-// topics it has always published on. Moving it would change every Home Assistant entity's
-// unique_id, and an existing install would lose its recorder history for a feature it is not
-// even using.
-static void test_the_first_device_keeps_the_bridge_scoped_topics() {
-    const MqttTopics legacy(kDefaultBaseTopic, "heliograph-a1b2c3");
-    const MqttTopics first(kDefaultBaseTopic, "heliograph-a1b2c3", "");
-    TEST_ASSERT_EQUAL_STRING(legacy.state().c_str(), first.state().c_str());
-    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/state", first.state().c_str());
+// The back-compat contract, asserted against the functions that MAKE the decision rather than
+// against the MqttTopics constructor. The previous version of this test compared
+// MqttTopics(b, id) with MqttTopics(b, id, "") -- the same call via its default argument -- so
+// it would have passed with the primary rule inverted. The rule itself lived inside MqttOutput,
+// which is compiled only for ESP32 and therefore unreachable from any test (review).
+static void test_the_primary_device_keeps_the_bridge_scoped_identity() {
+    const std::string bridgeId = "heliograph-a1b2c3";
+    TEST_ASSERT_EQUAL_STRING("", deviceTopicKey(true, "eversolar_legacy-10").c_str());
+    TEST_ASSERT_EQUAL_STRING(bridgeId.c_str(),
+                             deviceUniqueBase(true, bridgeId, "eversolar_legacy-10").c_str());
+
+    const MqttTopics primary(kDefaultBaseTopic, bridgeId,
+                             deviceTopicKey(true, "eversolar_legacy-10"));
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/state", primary.state().c_str());
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/availability",
+                             primary.availability().c_str());
+}
+
+// ...and a NON-primary device gets its own everything. Both halves matter: this is the pair a
+// wrong branch would swap.
+static void test_a_non_primary_device_gets_its_own_identity() {
+    const std::string bridgeId = "heliograph-a1b2c3";
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", deviceTopicKey(false, "growatt_modbus-2").c_str());
+    TEST_ASSERT_EQUAL_STRING("heliograph-a1b2c3_growatt_modbus-2",
+                             deviceUniqueBase(false, bridgeId, "growatt_modbus-2").c_str());
 }
 
 static void test_further_devices_get_their_own_subtree() {
@@ -867,6 +893,62 @@ static void test_further_devices_get_their_own_subtree() {
 // Two inverters must not land on each other's entities. Before the unique base existed, every
 // unique_id was built from the bridge id alone, so three identical inverters announced three
 // times over the SAME entity -- and Home Assistant merged them into one.
+// Every entity on devices 2..N announced an availability topic that NOTHING publishes -- the
+// device's own, rather than the bridge's -- so Home Assistant held all of them at `unavailable`
+// forever, with no retained value to recover from on restart. The measurements were on the
+// broker and invisible in HA: the whole feature, silently not working (review).
+static void test_every_device_tracks_the_bridge_availability_topic() {
+    Rig               r;
+    const DeviceState state  = r.poll();
+    const BridgeInfo  bridge = makeBridge();
+
+    const MqttTopics primary(kDefaultBaseTopic, bridge.bridgeId);
+    const MqttTopics second(kDefaultBaseTopic, bridge.bridgeId, "growatt_modbus-2");
+    const auto entities = buildDiscoveryEntities(state, bridge, second, primary.availability(),
+                                                 kDefaultDiscoveryPrefix,
+                                                 bridge.bridgeId + "_growatt_modbus-2");
+    TEST_ASSERT_TRUE(!entities.empty());
+    for (const auto& e : entities) {
+        JsonDocument doc;
+        TEST_ASSERT_EQUAL(DeserializationError::Ok, deserializeJson(doc, e.payload).code());
+        TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/availability",
+                                 doc["availability_topic"]);
+        // ...while the state it reads still comes from its OWN subtree.
+        if (!doc["state_topic"].isNull()) {
+            TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/device/growatt_modbus-2/state",
+                                     doc["state_topic"]);
+        }
+    }
+}
+
+// Three identical inverters report the same model and no serial, so without the address in the
+// name Home Assistant lists three devices called exactly the same thing.
+static void test_devices_beyond_the_first_carry_their_address_in_the_name() {
+    Rig         r;
+    DeviceState state          = r.poll();
+    state.identity.instanceKey = "2";
+    const BridgeInfo bridge    = makeBridge();
+
+    const MqttTopics t1(kDefaultBaseTopic, bridge.bridgeId);
+    const MqttTopics t2(kDefaultBaseTopic, bridge.bridgeId, "growatt_modbus-2");
+    const auto first  = buildDiscoveryEntities(state, bridge, t1, t1.availability(),
+                                               kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto second = buildDiscoveryEntities(state, bridge, t2, t1.availability(),
+                                               kDefaultDiscoveryPrefix,
+                                               bridge.bridgeId + "_growatt_modbus-2");
+
+    JsonDocument a;
+    JsonDocument b;
+    deserializeJson(a, first.front().payload);
+    deserializeJson(b, second.front().payload);
+    const std::string nameA = a["device"]["name"].as<std::string>();
+    const std::string nameB = b["device"]["name"].as<std::string>();
+    TEST_ASSERT_TRUE(nameA != nameB);
+    TEST_ASSERT_TRUE(nameB.find("#2") != std::string::npos);
+    // The primary's name is untouched -- same reasoning as its topics.
+    TEST_ASSERT_TRUE(nameA.find('#') == std::string::npos);
+}
+
 static void test_two_devices_produce_distinct_unique_ids_and_ha_devices() {
     Rig               r;
     const DeviceState state  = r.poll();
@@ -874,9 +956,10 @@ static void test_two_devices_produce_distinct_unique_ids_and_ha_devices() {
 
     const MqttTopics t1(kDefaultBaseTopic, bridge.bridgeId);
     const MqttTopics t2(kDefaultBaseTopic, bridge.bridgeId, "growatt_modbus-2");
-    const auto       first  = buildDiscoveryEntities(state, bridge, t1, kDefaultDiscoveryPrefix,
-                                                     bridge.bridgeId);
-    const auto       second = buildDiscoveryEntities(state, bridge, t2, kDefaultDiscoveryPrefix,
+    const auto       first  = buildDiscoveryEntities(state, bridge, t1, t1.availability(),
+                                                     kDefaultDiscoveryPrefix, bridge.bridgeId);
+    const auto       second = buildDiscoveryEntities(state, bridge, t2, t1.availability(),
+                                                     kDefaultDiscoveryPrefix,
                                                      bridge.bridgeId + "_growatt_modbus-2");
 
     TEST_ASSERT_TRUE(!first.empty() && first.size() == second.size());
@@ -891,7 +974,10 @@ static void test_two_devices_produce_distinct_unique_ids_and_ha_devices() {
 
 int main(int, char**) {
     UNITY_BEGIN();
-    RUN_TEST(test_the_first_device_keeps_the_bridge_scoped_topics);
+    RUN_TEST(test_the_primary_device_keeps_the_bridge_scoped_identity);
+    RUN_TEST(test_a_non_primary_device_gets_its_own_identity);
+    RUN_TEST(test_every_device_tracks_the_bridge_availability_topic);
+    RUN_TEST(test_devices_beyond_the_first_carry_their_address_in_the_name);
     RUN_TEST(test_further_devices_get_their_own_subtree);
     RUN_TEST(test_two_devices_produce_distinct_unique_ids_and_ha_devices);
     RUN_TEST(test_topics_are_built_consistently);

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -148,7 +148,7 @@ static void test_no_discovery_entity_for_an_unsupported_declared_channel() {
                                           "Battery SoC");
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     TEST_ASSERT_NULL(findEntity(entities, "heliograph-a1b2c3_battery_soc"));
 }
@@ -437,7 +437,7 @@ static void test_discovery_creates_an_entity_per_supported_measurement() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     TEST_ASSERT_NOT_NULL(findEntity(entities, "heliograph-a1b2c3_ac_power_total"));
     TEST_ASSERT_NOT_NULL(findEntity(entities, "heliograph-a1b2c3_energy_total"));
@@ -452,7 +452,7 @@ static void test_discovery_metadata_matches_the_measurement_type() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     auto power = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
     TEST_ASSERT_EQUAL_STRING("power", power["device_class"]);
@@ -479,7 +479,7 @@ static void test_value_template_reads_the_right_key() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     TEST_ASSERT_EQUAL_STRING("{{ value_json.measurements['ac.power.total'].value }}",
@@ -494,7 +494,7 @@ static void test_availability_tracks_the_bridge_not_the_inverter() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/availability", doc["availability_topic"]);
@@ -507,7 +507,7 @@ static void test_inverter_is_a_separate_device_behind_the_bridge() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     TEST_ASSERT_EQUAL_STRING("heliograph-a1b2c3_inverter", doc["device"]["identifiers"][0]);
@@ -522,7 +522,7 @@ static void test_the_inverter_device_is_named_after_its_model_not_its_manufactur
     auto bridge      = makeBridge();
     bridge.name      = "Heliograph";
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     // The manufacturer is already its own field. Repeating it in the name gave Home Assistant
@@ -540,7 +540,7 @@ static void test_an_inverter_without_a_model_still_gets_a_usable_name() {
     auto bridge = makeBridge();
     bridge.name = "Heliograph";
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
     auto doc = parse(findEntity(entities, "heliograph-a1b2c3_ac_power_total")->payload);
 
     // Falling back to the manufacturer is the one case where the repetition is acceptable:
@@ -561,7 +561,8 @@ static void test_every_entity_on_a_device_has_a_distinct_display_name() {
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
     const auto entities =
-        buildDiscoveryEntities(*store.snapshot(), bridge, topics, kDefaultDiscoveryPrefix);
+        buildDiscoveryEntities(*store.snapshot(), bridge, topics, kDefaultDiscoveryPrefix,
+                               bridge.bridgeId);
 
     // Home Assistant derives the entity id from the display name and silently disambiguates
     // duplicates with _2/_3 -- a suffix that carries no meaning and reorders itself whenever a
@@ -584,7 +585,7 @@ static void test_no_control_entities_for_a_read_only_driver() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     // Nothing that can be commanded: no number, switch or select component anywhere.
     for (const auto& e : entities) {
@@ -600,7 +601,7 @@ static void test_config_topics_are_well_formed() {
     const auto state  = r.poll();
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
-    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, kDefaultDiscoveryPrefix, bridge.bridgeId);
 
     const auto* e = findEntity(entities, "heliograph-a1b2c3_ac_power_total");
     TEST_ASSERT_EQUAL_STRING("homeassistant/sensor/heliograph-a1b2c3/ac_power_total/config",
@@ -625,7 +626,8 @@ static void test_the_mock_hybrid_gets_battery_and_phase_entities_for_free() {
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
     const auto entities =
-        buildDiscoveryEntities(*store.snapshot(), bridge, topics, kDefaultDiscoveryPrefix);
+        buildDiscoveryEntities(*store.snapshot(), bridge, topics, kDefaultDiscoveryPrefix,
+                               bridge.bridgeId);
 
     TEST_ASSERT_NOT_NULL(findEntity(entities, "heliograph-a1b2c3_battery_soc"));
     TEST_ASSERT_NOT_NULL(findEntity(entities, "heliograph-a1b2c3_ac_phase_l3_voltage"));
@@ -841,8 +843,57 @@ static void test_reset_forces_the_next_publish() {
     TEST_ASSERT_TRUE(t.shouldPublish(state, g_now + 1000));
 }
 
+// --- several inverters on one bus ---------------------------------------------------------
+
+// The whole back-compat contract of this change in one assertion: the FIRST device keeps the
+// topics it has always published on. Moving it would change every Home Assistant entity's
+// unique_id, and an existing install would lose its recorder history for a feature it is not
+// even using.
+static void test_the_first_device_keeps_the_bridge_scoped_topics() {
+    const MqttTopics legacy(kDefaultBaseTopic, "heliograph-a1b2c3");
+    const MqttTopics first(kDefaultBaseTopic, "heliograph-a1b2c3", "");
+    TEST_ASSERT_EQUAL_STRING(legacy.state().c_str(), first.state().c_str());
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/state", first.state().c_str());
+}
+
+static void test_further_devices_get_their_own_subtree() {
+    const MqttTopics second(kDefaultBaseTopic, "heliograph-a1b2c3", "growatt_modbus-2");
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/device/growatt_modbus-2/state",
+                             second.state().c_str());
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/device/growatt_modbus-2/identity",
+                             second.identity().c_str());
+}
+
+// Two inverters must not land on each other's entities. Before the unique base existed, every
+// unique_id was built from the bridge id alone, so three identical inverters announced three
+// times over the SAME entity -- and Home Assistant merged them into one.
+static void test_two_devices_produce_distinct_unique_ids_and_ha_devices() {
+    Rig               r;
+    const DeviceState state  = r.poll();
+    const BridgeInfo  bridge = makeBridge();
+
+    const MqttTopics t1(kDefaultBaseTopic, bridge.bridgeId);
+    const MqttTopics t2(kDefaultBaseTopic, bridge.bridgeId, "growatt_modbus-2");
+    const auto       first  = buildDiscoveryEntities(state, bridge, t1, kDefaultDiscoveryPrefix,
+                                                     bridge.bridgeId);
+    const auto       second = buildDiscoveryEntities(state, bridge, t2, kDefaultDiscoveryPrefix,
+                                                     bridge.bridgeId + "_growatt_modbus-2");
+
+    TEST_ASSERT_TRUE(!first.empty() && first.size() == second.size());
+    for (const auto& e : first) {
+        for (const auto& o : second) {
+            TEST_ASSERT_TRUE(e.uniqueId != o.uniqueId);
+            TEST_ASSERT_TRUE(e.configTopic != o.configTopic);
+        }
+    }
+}
+
+
 int main(int, char**) {
     UNITY_BEGIN();
+    RUN_TEST(test_the_first_device_keeps_the_bridge_scoped_topics);
+    RUN_TEST(test_further_devices_get_their_own_subtree);
+    RUN_TEST(test_two_devices_produce_distinct_unique_ids_and_ha_devices);
     RUN_TEST(test_topics_are_built_consistently);
     RUN_TEST(test_state_payload_is_valid_json_with_the_expected_values);
     RUN_TEST(test_unsupported_measurements_are_absent_not_null);


### PR DESCRIPTION
Second of two. PR 1 made the bridge **read** several inverters; they all still reached Home Assistant through one set of topics and one set of entities.

## What changed

`MqttOutput` keeps a **`Channel` per device** — its own topics, throttle and discovery signature. `buildDiscoveryEntities` takes a `uniqueBase` scoping every `unique_id`, `object_id`, retained config topic and Home Assistant device identifier.

**The primary device keeps the bridge-scoped topics and unique ids it has always used.** Moving it would change every entity's `unique_id` and cost an existing install its recorder history for a feature it is not using. Devices 2..N live under `<base>/<bridgeId>/device/<deviceId>/`.

## The review found the feature did not work

**Every entity on devices 2..N was announced as permanently `unavailable`.** They declared an availability topic that nothing publishes — their own, rather than the bridge's. Availability is published in exactly three places (the will, `onConnected`, `stop()`) and all three are bridge-scoped. No retained value either, so an HA restart does not help. The measurements were on the broker and invisible in Home Assistant.

My own PR text said *"availability stays bridge-scoped"* — true of what gets **published**, false of what gets **announced**. `buildDiscoveryEntities` now takes the bridge availability topic separately.

**The primary channel was keyed on which device started first, not which is configured first.** A boot where device 1 failed — bus fault, typo'd unit id — handed device 2 the bridge-scoped topics and unique ids, so its production would be appended to device 1's recorder history, and the next boot would revert the topics but not the data. `DeviceView` now carries an explicit `primary` flag from the configured order; when the first configured device does not start, **nobody** is primary and nobody inherits it.

**Three identical inverters produced three identical HA device names** — same model string, no serial, nothing to tell them apart in the device list or in twelve entities each called "AC Power". Devices beyond the first carry their address in the name (`… #2`).

## Why none of it was caught — and a claim I withdraw

The whole of `MqttOutput` is inside `#if defined(ESP32)`, so the native build compiles a stub. `channelFor`, the primary rule and the announce-once gate were **unreachable from any test**. The three tests I said "pin the contract that matters" were exercising the `MqttTopics` constructor against its own default argument — they would have passed with the primary rule inverted.

The decision is now two pure functions, `deviceTopicKey` / `deviceUniqueBase`, called by `MqttOutput` and tested directly, plus tests that parse the discovery payloads and assert the availability topic and the device names.

## Other corrections

- The comment directly above the changed block still said MQTT and Home Assistant take a single `DeviceState`, contradicting the new comment twelve lines below it — and claimed the limitation is stated in the REST status payload, which emits no such field.
- The `DeviceView` lifetime comment gave the wrong reason for a correct rule.
- `docs/mqtt.md` said the device id is the serial number when the driver reports one. It never is — the id is frozen at boot, before any serial exists.
- The README curl example showed a one-element array without saying the array **replaces** the whole list.

## Written down rather than fixed

- **Removing or re-addressing a device leaves its entities behind.** Retained discovery configs and last state stay on the broker with no empty-payload cleanup, and because availability is bridge-scoped those orphans stay *available* showing a stale value — so anything summing your inverters double-counts a ghost. The relay entities do have a removal path; devices do not, yet.
- Moving a different inverter into the `driver` slot hands it the bridge-scoped topics and that history.
- The bridge's own dashboard shows the first device only.
- N inverters share one bus and one poll interval.

## Still open

**Modbus TCP and Prometheus carry the first device only** — the register map holds one device's registers and the metric names have no device label. Discovery still probes only the default unit id, and there is still no settings screen for extra devices.

## Verification

**567 tests pass** (was 561), `check_layering.sh` PASS, all four boards build — in CI too: `firmware.yml` runs the board matrix on `pull_request`. (An earlier version of this text said CI does not build boards on a PR. That came from a review finding I took at face value; it is wrong, and the four green Build jobs on this PR are the evidence.)
