### PR TITLE
Settings screen for the extra devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ own address before you connect them together.
 
 > **Several inverters on one bus are polled in turn**, up to eight, each with its own address.
 > The first is configured under *Settings → Driver*, the rest under *Settings → Extra devices* —
-> one row per inverter, each with its own driver and address. Save, then restart.
+> one row per inverter, each with its own driver and whatever that driver needs to address it.
+> The page refuses to save a row with no driver, an unset register map, or an address already
+> in use, because all three are mistakes the firmware can only report as a log line at boot.
+> Save, then restart.
 >
 > Over the API it is one field, and sending the array **replaces** it:
 >

--- a/README.md
+++ b/README.md
@@ -143,16 +143,16 @@ where the 120 Ω termination goes (two places, not one per device), and why each
 own address before you connect them together.
 
 > **Several inverters on one bus are polled in turn**, up to eight, each with its own address.
-> The first is configured under *Settings → Driver*; **the rest have no settings screen yet** and
-> are set over the API:
+> The first is configured under *Settings → Driver*, the rest under *Settings → Extra devices* —
+> one row per inverter, each with its own driver and address. Save, then restart.
+>
+> Over the API it is one field, and sending the array **replaces** it:
 >
 > ```
 > curl -u admin:PASSWORD -X PATCH http://<bridge>/api/v1/config \
 >   -H 'Content-Type: application/json' \
 >   -d '{"additional_devices":[{"driver_id":"growatt_modbus","options":{"unit_id":"2"}}]}'
 > ```
->
-> Sending the array **replaces** it, so list every extra unit in one call. Then restart.
 >
 > Three more things before wiring three: discovery probes only the default address, so the
 > others must be added by hand; **Modbus TCP and Prometheus still carry the first device only**

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -194,8 +194,9 @@ address in turn and confirm exactly one answers, at the address you expect.
    you pick one. That is deliberate: getting the map wrong is the one mistake here that does
    not announce itself. See the warning below.
 
-   > **For the second and third unit** there is no settings screen yet — they go in over the
-   > API, same driver and register map, their own `unit_id`:
+   > **For the second and third unit**, add a row each under *Settings → Extra devices*: same
+   > driver and register map, its own `unit_id`. Save and restart. Over the API it is the same
+   > field, and sending the array replaces it:
    >
    > ```
    > curl -u admin:PASSWORD -X PATCH http://<bridge>/api/v1/config \

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -61,6 +61,9 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     b["id"]                 = bridge.bridgeId;
     b["name"]               = bridge.name;
     b["firmware_version"]   = bridge.firmwareVersion;
+    // A firmware constant, not configuration: the settings page needs it to stop offering an
+    // "Add a device" button past the point the bridge would refuse the save.
+    b["max_devices"]        = static_cast<unsigned>(kMaxDevices);
     b["uptime_seconds"]     = bridge.uptimeSeconds;
     b["wifi_connected"]     = bridge.wifiConnected;
     if (bridge.wifiConnected) {

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -692,6 +692,7 @@ const RESTART_NEEDED={
   'serial.override':'RS485 line override','serial.baud_rate':'RS485 baud rate',
   'serial.parity':'RS485 parity','serial.data_bits':'RS485 data bits',
   'serial.stop_bits':'RS485 stop bits',
+  'additional_devices':'Extra devices',
 };
 // Applied immediately, no restart:
 //   bridge_name          - read fresh on every status response
@@ -802,19 +803,46 @@ async function renderConfig(){
   // the primary uses would collide and be skipped at boot with only a log line to say so.
   let xdevs = ((c.additional_devices)||[]).map(d=>({id:d.driver_id||'',options:{...(d.options||{})}}));
 
+  // Fills a row's model with the driver's declared defaults. Called when a row is added or its
+  // driver changes, so the model always holds what the fields SHOW.
+  //
+  // The bug this exists to close: the fields rendered `row.options[key] ?? default_value`, but
+  // only an edit wrote to the model, so an untouched field displayed the driver's default and
+  // sent nothing. The firmware then applied that same default anyway -- unit id 1, the primary's
+  // address -- and skipped the device at boot with one log line. The commit that added this card
+  // claimed a new row "starts empty on purpose" to prevent exactly that; it did not (review).
+  const seedRowOptions=row=>{
+    const drv=(cfgDrivers.drivers||[]).find(x=>x.id===row.id);
+    for(const o of ((drv&&drv.options)||[])){
+      if(row.options[o.key]===undefined)row.options[o.key]=o.default_value??'';
+    }
+  };
+
   const xdevOptionFields=(row,index)=>{
     const drv=(cfgDrivers.drivers||[]).find(x=>x.id===row.id);
     return ((drv&&drv.options)||[]).map(o=>{
       const cur=row.options[o.key]??o.default_value??'';
+      const hint=o.description?`<div class="dim" style="font-size:12px">${esc(o.description)}</div>`:'';
       if(o.allowed_values&&o.allowed_values.length){
+        // A stored value the firmware no longer recognises keeps its own entry, exactly as the
+        // Driver card does. Without it the browser silently selects the first option while the
+        // model keeps the old value, every save resends it, and the REST gate refuses the whole
+        // configuration -- the lockout class this codebase has already had to remove once.
+        const known=o.allowed_values.includes(cur);
+        // An empty entry among the allowed values is the driver saying "unset means my default".
+        // On this card that is a trap: for a register map it silently means the DEFAULT map, so
+        // it is labelled and left unselected until someone picks, like the wizard does.
+        const hasBlank=o.allowed_values.includes('');
         return `<label for="xd${index}_${esc(o.key)}">${esc(o.display_name)}</label>
-          <select id="xd${index}_${esc(o.key)}" onchange="setExtraOption(${index},'${esc(o.key)}',this.value)">${
-            o.allowed_values.map(v=>`<option value="${esc(v)}" ${v===cur?'selected':''}>${
-              v===''?'(driver default)':esc(v)}</option>`).join('')}</select>`;
+          <select id="xd${index}_${esc(o.key)}" ${hasBlank?'data-mustpick="1"':''}
+            onchange="setExtraOption(${index},'${esc(o.key)}',this.value)">${
+            (known?'':`<option value="${esc(cur)}" selected>${esc(cur)} — not recognised</option>`)+
+            o.allowed_values.map(v=>`<option value="${esc(v)}" ${known&&v===cur?'selected':''}>${
+              v===''?'— choose —':esc(v)}</option>`).join('')}</select>${hint}`;
       }
       return `<label for="xd${index}_${esc(o.key)}">${esc(o.display_name)}</label>
         <input id="xd${index}_${esc(o.key)}" value="${esc(cur)}"
-          oninput="setExtraOption(${index},'${esc(o.key)}',this.value)">`;
+          oninput="setExtraOption(${index},'${esc(o.key)}',this.value)">${hint}`;
     }).join('');
   };
 
@@ -846,10 +874,49 @@ async function renderConfig(){
     // Options belong to a driver, so switching driver drops the old one's values rather than
     // carrying keys the new driver never declared -- which the firmware would refuse anyway.
     xdevs[i]={id,options:{}};
+    seedRowOptions(xdevs[i]);
     renderExtraDevices();
   };
   window.setExtraOption=(i,key,value)=>{xdevs[i].options[key]=value};
   window.extraDevicesBody=()=>xdevs.map(d=>({driver_id:d.id,options:{...d.options}}));
+
+  // What the firmware would refuse, or accept and then quietly skip at boot -- said here, next
+  // to the row, instead of as `additional_devices[2].driver_id: ...` under the Save button,
+  // naming an index the card never shows. A boot-time skip is one warn line in a log buffer
+  // nobody is watching, so a mistake made here has to be caught here.
+  window.extraDevicesProblem=()=>{
+    const seen={};
+    // The primary's address counts too -- it is the one every default collides with.
+    const drvNow=$('#c_drv')?$('#c_drv').value:'';
+    const primaryAddr=(()=>{
+      const e=document.querySelector('#cfgform [data-opt="unit_id"], #cfgform [data-opt="address"]');
+      return e?drvNow+'|'+e.value.trim():null;
+    })();
+    if(primaryAddr)seen[primaryAddr]='the inverter under Driver';
+    for(let i=0;i<xdevs.length;i++){
+      const label='Device '+(i+2);
+      const row=xdevs[i];
+      if(!row.id)return label+': pick a driver, or remove the row.';
+      const drv=(cfgDrivers.drivers||[]).find(x=>x.id===row.id);
+      for(const o of ((drv&&drv.options)||[])){
+        const v=(row.options[o.key]??'').trim();
+        if(o.allowed_values&&o.allowed_values.includes('')&&v===''){
+          return label+': choose a '+o.display_name.toLowerCase()+
+                 ' — leaving it unset silently uses the driver default.';
+        }
+      }
+      // Same driver at the same address is the same device. The firmware skips the second with
+      // a log line; here it is a sentence.
+      const addr=row.options.unit_id??row.options.address;
+      if(addr!==undefined){
+        const key=row.id+'|'+String(addr).trim();
+        if(seen[key])return label+' has the same address as '+seen[key]+
+                             '. Each inverter on the bus needs its own.';
+        seen[key]=label;
+      }
+    }
+    return null;
+  };
   const driverOpts=`<span id="drvopts">${optsFor(c.driver.id)}</span>`;
 
   $('#cfgform').innerHTML=`
@@ -925,9 +992,9 @@ async function renderConfig(){
     <div id="xdevs"></div>
     <button type="button" id="xdevadd" onclick="addExtraDevice()"
       style="background:none;border:1px solid var(--line);color:var(--fg);margin-top:10px">Add a device</button>
-    <div class="dim" style="font-size:12px;margin-top:8px">Removing one here does not remove
-    what it already published: its Home Assistant entities stay behind showing their last
-    value. See docs/mqtt.md.</div>
+    <div class="dim" style="font-size:12px;margin-top:8px">Removing a device here — or changing
+    its address — does not remove what it already published: the old entities stay in Home
+    Assistant, <b>available</b>, showing their last value. See docs/mqtt.md.</div>
   </div>
   ${window.g_relayCount>0?`<div class="card"><b>Relays</b> <span class="tag" style="font-weight:400">applied immediately</span>
     ${chk('c_rle','Enabled',(c.relays||{}).enabled)}
@@ -1054,10 +1121,26 @@ async function saveConfig(){
   // half-finished choices into the active driver's config.
   document.querySelectorAll('#cfgform [data-opt]')
     .forEach(e=>body.driver.options[e.dataset.opt]=e.value);
-  // The whole list, always: the API replaces the array rather than merging, and there is no
-  // stable key to merge on. Sent even when empty, because that is how a device is REMOVED --
-  // omitting the key would leave the stored list untouched and the removal would do nothing.
-  if(window.extraDevicesBody)body.additional_devices=window.extraDevicesBody();
+  // The list travels whole -- the API replaces the array rather than merging, and there is no
+  // stable key to merge on -- but ONLY when it differs from what this page loaded. Sending it
+  // unconditionally gave it the one thing every other section is protected from: this form can
+  // sit open for hours, so a save of something unrelated wrote its stale copy over a list
+  // changed since, from another tab or a curl. An empty array still travels when the stored one
+  // was not empty, which is how a device is removed.
+  if(window.extraDevicesBody){
+    const problem=window.extraDevicesProblem();
+    if(problem){
+      const m=$('#cm');
+      m.className='msg err';m.textContent=problem;m.style.display='block';
+      return;
+    }
+    // Compared here rather than with same() below: that helper is declared further down and
+    // would be in its temporal dead zone at this point.
+    const wanted=window.extraDevicesBody();
+    if(JSON.stringify(wanted)!==JSON.stringify(cfgBefore.additional_devices||[])){
+      body.additional_devices=wanted;
+    }
+  }
 
   // Send only what actually changed. This form may have been open for hours; PATCHing every
   // field would write its stale copy over anything changed elsewhere in the meantime (another

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -228,6 +228,7 @@ function render(s){
   $('#ver').textContent='v'+b.firmware_version;
   // Boards without relays never send the field; the settings card keys off this.
   window.g_relayCount=(b.relays||[]).length;
+  window.g_maxDevices=b.max_devices||window.g_maxDevices;
   const g=id=>m[id]?m[id].value:null;
   if(tab==='dash'){
     $('#tiles').innerHTML=
@@ -709,7 +710,8 @@ async function renderConfig(){
   // than caching a card-less form for the whole session.
   if(window.g_relayCount===undefined){
     try{const s=await(await fetch('/api/v1/status')).json();
-      window.g_relayCount=(s.bridge.relays||[]).length}
+      window.g_relayCount=(s.bridge.relays||[]).length;
+      window.g_maxDevices=s.bridge.max_devices||window.g_maxDevices}
     catch(e){window.g_relayCount=0}
   }
 
@@ -788,6 +790,66 @@ async function renderConfig(){
     }).join('');
   };
   window.reloadDriverOpts=()=>{$('#drvopts').innerHTML=optsFor($('#c_drv').value)};
+
+  // --- extra devices -------------------------------------------------------------------
+  // Rendered from an array rather than from the DOM, so adding, removing and re-rendering a
+  // row cannot get out of step with what will be saved. Every row carries a driver id and that
+  // driver's declared options at their stored-or-declared values -- the same generic mechanism
+  // the Driver card uses, so a new driver's options appear here with no change either.
+  //
+  // Deliberately NOT pre-filled with anything when a row is added: an extra device that names
+  // no driver is refused by the firmware, and an address silently defaulting to the same one
+  // the primary uses would collide and be skipped at boot with only a log line to say so.
+  let xdevs = ((c.additional_devices)||[]).map(d=>({id:d.driver_id||'',options:{...(d.options||{})}}));
+
+  const xdevOptionFields=(row,index)=>{
+    const drv=(cfgDrivers.drivers||[]).find(x=>x.id===row.id);
+    return ((drv&&drv.options)||[]).map(o=>{
+      const cur=row.options[o.key]??o.default_value??'';
+      if(o.allowed_values&&o.allowed_values.length){
+        return `<label for="xd${index}_${esc(o.key)}">${esc(o.display_name)}</label>
+          <select id="xd${index}_${esc(o.key)}" onchange="setExtraOption(${index},'${esc(o.key)}',this.value)">${
+            o.allowed_values.map(v=>`<option value="${esc(v)}" ${v===cur?'selected':''}>${
+              v===''?'(driver default)':esc(v)}</option>`).join('')}</select>`;
+      }
+      return `<label for="xd${index}_${esc(o.key)}">${esc(o.display_name)}</label>
+        <input id="xd${index}_${esc(o.key)}" value="${esc(cur)}"
+          oninput="setExtraOption(${index},'${esc(o.key)}',this.value)">`;
+    }).join('');
+  };
+
+  window.renderExtraDevices=()=>{
+    const box=$('#xdevs');
+    if(!box)return;
+    box.innerHTML=xdevs.map((row,i)=>`
+      <div style="border:1px solid var(--line);border-radius:8px;padding:12px;margin-top:10px">
+        <div style="display:flex;justify-content:space-between;align-items:baseline">
+          <b>Device ${i+2}</b>
+          <a href="#" onclick="removeExtraDevice(${i});return false">Remove</a></div>
+        <label for="xd${i}_drv">Driver</label>
+        <select id="xd${i}_drv" onchange="setExtraDriver(${i},this.value)">
+          <option value="" ${row.id?'':'selected'}>— choose —</option>${
+          (cfgDrivers.drivers||[]).map(d=>
+            `<option value="${esc(d.id)}" ${d.id===row.id?'selected':''}>${esc(d.display_name)}</option>`).join('')}
+          ${row.id&&!(cfgDrivers.drivers||[]).some(d=>d.id===row.id)?
+            `<option value="${esc(row.id)}" selected>${esc(row.id)} — not recognised</option>`:''}
+        </select>
+        ${xdevOptionFields(row,i)}
+      </div>`).join('')||
+      '<div class="dim" style="font-size:12px;margin-top:8px">None. This bridge polls one inverter.</div>';
+    const add=$('#xdevadd');
+    if(add)add.disabled=xdevs.length+1>=(window.g_maxDevices||8);
+  };
+  window.addExtraDevice=()=>{xdevs.push({id:'',options:{}});renderExtraDevices()};
+  window.removeExtraDevice=i=>{xdevs.splice(i,1);renderExtraDevices()};
+  window.setExtraDriver=(i,id)=>{
+    // Options belong to a driver, so switching driver drops the old one's values rather than
+    // carrying keys the new driver never declared -- which the firmware would refuse anyway.
+    xdevs[i]={id,options:{}};
+    renderExtraDevices();
+  };
+  window.setExtraOption=(i,key,value)=>{xdevs[i].options[key]=value};
+  window.extraDevicesBody=()=>xdevs.map(d=>({driver_id:d.id,options:{...d.options}}));
   const driverOpts=`<span id="drvopts">${optsFor(c.driver.id)}</span>`;
 
   $('#cfgform').innerHTML=`
@@ -855,6 +917,18 @@ async function renderConfig(){
       `<option value="${esc(d.id)}" ${d.id===c.driver.id?'selected':''}>${esc(d.display_name)} (${esc(d.support_level)})</option>`).join('')}</select>
     ${driverOpts}
   </div>
+  <div class="card"><b>Extra devices</b> <span class="tag" style="font-weight:400">needs restart</span>
+    <div class="dim" style="font-size:12px">More inverters on the SAME RS485 bus, polled in
+    turn after the one above. Each needs its own address — set that in the device's own menu
+    first, and give it the driver's address option here. Up to ${window.g_maxDevices||8} devices
+    in total, this card holds the rest.</div>
+    <div id="xdevs"></div>
+    <button type="button" id="xdevadd" onclick="addExtraDevice()"
+      style="background:none;border:1px solid var(--line);color:var(--fg);margin-top:10px">Add a device</button>
+    <div class="dim" style="font-size:12px;margin-top:8px">Removing one here does not remove
+    what it already published: its Home Assistant entities stay behind showing their last
+    value. See docs/mqtt.md.</div>
+  </div>
   ${window.g_relayCount>0?`<div class="card"><b>Relays</b> <span class="tag" style="font-weight:400">applied immediately</span>
     ${chk('c_rle','Enabled',(c.relays||{}).enabled)}
     <!-- The second gate, named where it bites. Enabling relays while read-only mode is still
@@ -917,6 +991,9 @@ async function renderConfig(){
     <button style="background:var(--bad)" onclick="factoryReset()">Erase and restart</button>
   </div>`;
 
+  // After the card exists in the DOM, not before: renderExtraDevices() writes into #xdevs.
+  renderExtraDevices();
+
   // Keep the Relays card's gate warning in step with both checkboxes as they are clicked --
   // the user is told the combination is dead before saving it, not after wondering why the
   // relays are silent.
@@ -977,6 +1054,10 @@ async function saveConfig(){
   // half-finished choices into the active driver's config.
   document.querySelectorAll('#cfgform [data-opt]')
     .forEach(e=>body.driver.options[e.dataset.opt]=e.value);
+  // The whole list, always: the API replaces the array rather than merging, and there is no
+  // stable key to merge on. Sent even when empty, because that is how a device is REMOVED --
+  // omitting the key would leave the stored list untouched and the removal would do nothing.
+  if(window.extraDevicesBody)body.additional_devices=window.extraDevicesBody();
 
   // Send only what actually changed. This form may have been open for hours; PATCHing every
   // field would write its stale copy over anything changed elsewhere in the meantime (another
@@ -1007,6 +1088,12 @@ async function saveConfig(){
   if(same(body.driver.id,cfgBefore.driver.id)&&!optsTouched)delete body.driver.options;
   for(const sect of Object.keys(body)){
     if(typeof body[sect]!=='object')continue;
+    // An ARRAY section is replaced wholesale by the API, so there is nothing to diff -- and
+    // diffing it is actively harmful: Object.keys() on an array yields indices, so an unchanged
+    // element got `delete`d, leaving a hole that JSON.stringify writes as `null`. The firmware
+    // then refuses the whole patch with "expected an object". Found by driving the real page
+    // against a stub, which is the only reason it did not ship.
+    if(Array.isArray(body[sect]))continue;
     for(const k of Object.keys(body[sect])){
       // Credential-like keys (passwords, both usernames) and driver options are only in the
       // body when the user acted; GET never returns them, so there is nothing to diff against

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -407,6 +407,19 @@ static void test_the_device_manager_refuses_past_its_cap() {
     TEST_ASSERT_EQUAL_UINT32(kMaxDevices, devices.size());
 }
 
+// The settings page stops offering "Add a device" at this number, so it is a contract between
+// the firmware and the page, not a decoration. Nothing guarded it: renaming or dropping the
+// field would have degraded the UI to its hardcoded fallback with every test still green.
+static void test_the_status_payload_publishes_the_device_cap() {
+    Rig         r;
+    const auto  state = r.poll();
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", makeBridge(),
+                                              r.diagnostics.snapshot(),
+                                              &eversolar::descriptor(), g_now, json));
+    TEST_ASSERT_EQUAL_UINT32(kMaxDevices, parse(json)["bridge"]["max_devices"].as<uint32_t>());
+}
+
 static void test_reboot_required_flag_is_patch_only() {
     auto        c = configWithSecrets();
     std::string json;
@@ -1348,6 +1361,7 @@ int main(int, char**) {
     RUN_TEST(test_a_lone_device_without_either_keeps_the_bare_driver_id);
     RUN_TEST(test_re_adding_an_id_returns_the_same_store_rather_than_failing);
     RUN_TEST(test_the_device_manager_refuses_past_its_cap);
+    RUN_TEST(test_the_status_payload_publishes_the_device_cap);
     RUN_TEST(test_reboot_required_flag_is_patch_only);
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);


### PR DESCRIPTION
Two PRs ago the bridge learned to poll several inverters. Configuring them was a hand-written `curl` PATCH — and the docs I wrote first pointed at a *Settings → Extra devices* screen that did not exist, which I had to retract. This is that screen.

## What it does

One row per inverter beyond the first, each with a driver select and that driver's declared options, Add and Remove, bounded by the firmware's `kMaxDevices` (now published in the status payload and covered by a test).

The page refuses to save a row with **no driver**, an **unset register map**, or an **address already in use** — by another row or by the inverter under *Driver*. All three are mistakes the firmware can only report as a single log line at boot, on a bridge nobody is watching.

## What the review found: the card showed values it did not save

The commit that added this card claimed a new row *"starts empty on purpose"*, so an address quietly defaulting to the primary's could not collide. The model started empty; **the fields did not**. They rendered the driver's declared default — unit id `1`, the primary's address — while only an edit wrote to the model. An untouched row displayed a value and sent nothing, and the firmware applied that same default anyway. The protection I described does not exist, and the code reached exactly the outcome the paragraph said it prevented.

Worse for a MIC TL-X: no `profile` key means the driver falls back to the **default** register map — the SPH hybrid map — silently, because the warn only fires on a typo, not on absence. Two measurements instead of twelve and one AC figure that happens to look right.

Rows are now seeded from the declared defaults, so what is shown is what is sent. Ambiguous options are not pre-answered: an allowed value of `""` means "the driver decides", which for a register map is a trap, so it renders as `— choose —` and blocks the save — the gate the discovery wizard already had and this card did not.

## And the save stopped guarding the list

It sent `additional_devices` unconditionally, three lines below the comment explaining why every other section is diffed first: this form can sit open for hours, so an unrelated save writes its stale copy over anything changed since. Reproduced: a log-level change reverted a device added meanwhile by `curl`.

The array now travels only when it differs — which still sends `[]` when the stored list was not empty, so removal keeps working, and `"Nothing changed."` stops being dead code.

## Other findings applied

- The option selects lacked the **not-recognised fallback** the Driver card carries. A firmware update renaming a profile would have left the select showing a valid choice, the model holding the old one, and every save refused — the lockout class already removed once from `driver.id`.
- A row left on `— choose —` sank the whole PATCH with a message naming `additional_devices[2]`, an index the card never shows.
- `RESTART_NEEDED` had no entry, so adding a device gave the generic wording — and adding a device *plus* a hostname gave a list naming only the hostname.
- The option descriptions were missing; this was the one renderer of three not showing them.
- The card's note covered removal but not re-addressing, which this card makes trivial.

One finding not taken: an agent flagged the AI-attribution line in this body. That rule is about commits, which stay clean.

## The null-holes bug, from the first pass

The settings change-diff walks the **keys** of each section, and for an array those are indices. An unchanged element was `delete`d, leaving a hole that `JSON.stringify` writes as `null`, which the firmware refuses with `expected an object`. Array sections are skipped by the diff now.

## Verification

Against the real page, starting from an **empty** list — the fresh bring-up my first verification never reached:

- a new row shows `unit id 1` / `— choose —` and now sends exactly that;
- the save is refused with *"Device 2: choose a register-map profile…"*, then with *"Device 2 has the same address as the inverter under Driver."*, then with *"Device 3 has the same address as Device 2."*;
- with both fixed it saves the full two-element array;
- a later save of only the log level sends `{"logging":{"level":"debug"}}` — the list stays out of it.

**568 tests pass**, `check_web_js.py` OK, `check_layering.sh` PASS, all four boards build.

## Next

Both reviews judged this the second-best next piece of work, and they are right: **nothing in the UI confirms a configured device actually started**. Every failure this card can produce — collision, wrong map, typo — lands as one log line, and the two screens that could show it render one device. A devices view is the next PR.

Also still open: discovery does not sweep unit ids; Modbus TCP and Prometheus carry the first device only; a removed or re-addressed device leaves its Home Assistant entities behind, *available*, showing their last value.
