### PR TITLE
Show every device, and say which configured one is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ own address before you connect them together.
 > one row per inverter, each with its own driver and whatever that driver needs to address it.
 > The page refuses to save a row with no driver, an unset register map, or an address already
 > in use, because all three are mistakes the firmware can only report as a log line at boot.
-> Save, then restart.
+> Save, then restart. Afterwards the **Device** tab lists every inverter that is actually being
+> polled, and says so plainly when one of the configured ones is missing and why.
 >
 > Over the API it is one field, and sending the array **replaces** it:
 >

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -238,8 +238,10 @@ address in turn and confirm exactly one answers, at the address you expect.
 > Two consequences for checking your work. The wizard's own test poll **cannot** confirm the map:
 > it displays exactly the AC power figure that coincides. Neither can the raw dump in step 4 —
 > the dump is raw registers, byte-identical under either map, so it confirms the addresses in the
-> TOML rather than which map is configured. Compare the **published measurements**
-> (`GET /api/v1/status`, or the dashboard): twelve entries means `mic_tl_x`, two means `sph`.
+> TOML rather than which map is configured. Compare the **published measurements**: the
+> bridge's **Device** tab lists every polled inverter with its measurement count in the header,
+> side by side — twelve means `mic_tl_x`, two means `sph`. Same data at
+> `GET /api/v1/devices/<id>/measurements`.
 6. Confirm the two odd scales specifically — frequency should read ~50.0 Hz (not 5.0 or
    500.0), and operating hours should be plausible for the age of the unit.
 7. **Settle the generation question.** Look at what the 3000-block dump did. Three outcomes,

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -129,10 +129,23 @@ nothing — `PATCH {"mqtt":{"username":null}}` returns `200` and leaves the stor
 Send `""` to clear the MQTT username. `security.admin_username` cannot be cleared at all:
 `validate()` refuses an empty one.
 
-`devices_configured` is how many devices the configuration asks for; `/api/v1/devices` lists the
-ones actually being polled. When they differ, `device_problems` says why for each missing one —
-the same sentences the boot log carries. The array is always present, empty when there is
-nothing to report, so "no problems" cannot be mistaken for "this firmware does not report them".
+`devices_configured` is how many devices the **current** configuration asks for; `devices_started`
+is how many the firmware built at the last boot. They differ both when something failed and in
+the window between saving a new device and restarting. `device_problems` says why for each
+missing one — the same sentences the boot log carries, each naming the configuration row
+("device 3"), because several rows normally share one driver id. The array is always present,
+empty when there is nothing to report, so "no problems" cannot be mistaken for "this firmware
+does not report them".
+
+**Started is not answering.** A driver whose `begin()` succeeded counts as started whether or
+not the inverter has ever replied — with A and B swapped it never will. Per device,
+`/api/v1/devices/<id>` carries `online`, `data_valid`, `data_stale`,
+`consecutive_poll_failures` and `last_successful_poll_seconds_ago` (`null` when it has never
+answered, which is a different thing from `0`).
+
+`GET /api/v1/status` answers **200 even when nothing is polling**, with an empty device object.
+That is the case where these fields matter most, and refusing the payload for lack of a device
+to describe hid the explanation behind a "cannot reach the bridge" error.
 
 ## `additional_devices` — more than one inverter on the bus
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -45,7 +45,10 @@ once a driver has write capabilities.
     "wifi_rssi_dbm": -57,
     "wifi_connected": true,
     "mqtt_connected": true,
-    "modbus_clients": 2
+    "modbus_clients": 2,
+    "max_devices": 8,
+    "devices_configured": 3,
+    "device_problems": ["'growatt_modbus' shares the address of a device already added (growatt_modbus-2); give them different addresses"]
   },
   "device": {
     "id": "eversolar_legacy-XH300060115506193600V610",
@@ -125,6 +128,11 @@ through `patchString`, where `null` is indistinguishable from absent and therefo
 nothing — `PATCH {"mqtt":{"username":null}}` returns `200` and leaves the stored value in place.
 Send `""` to clear the MQTT username. `security.admin_username` cannot be cleared at all:
 `validate()` refuses an empty one.
+
+`devices_configured` is how many devices the configuration asks for; `/api/v1/devices` lists the
+ones actually being polled. When they differ, `device_problems` says why for each missing one —
+the same sentences the boot log carries. The array is always present, empty when there is
+nothing to report, so "no problems" cannot be mistaken for "this firmware does not report them".
 
 ## `additional_devices` — more than one inverter on the bus
 

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -78,6 +78,10 @@ struct BridgeInfo {
     /// showed one, and the difference was a warn in a ring buffer. Every mistake the settings
     /// page can produce lands here, which is why it is here and not only in the log.
     size_t                   devicesConfigured = 0;
+    /// How many of them the firmware actually managed to create at boot. Started is not
+    /// answering -- a driver whose begin() succeeded counts here whether or not the inverter
+    /// has ever replied -- but configured-minus-started is a fault by definition.
+    size_t                   devicesStarted    = 0;
     /// One human-readable line per configured device that is NOT polling. Never a payload byte,
     /// never a secret -- the same strings the boot log carries.
     std::vector<std::string> deviceProblems;

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -69,6 +69,19 @@ struct BridgeInfo {
     /// relayCount, missing = "none"). Drives switch names and the DRM mode select.
     std::vector<std::string> relayRoles;
 
+    /// How many devices the configuration asks for, and what went wrong with the ones that are
+    /// not being polled.
+    ///
+    /// The firmware already knew both at boot and said so in one log line each. Nothing else
+    /// surfaced them, so a configured inverter that collided on an address or refused to start
+    /// was invisible on every screen: the device list showed the ones that worked, the dashboard
+    /// showed one, and the difference was a warn in a ring buffer. Every mistake the settings
+    /// page can produce lands here, which is why it is here and not only in the log.
+    size_t                   devicesConfigured = 0;
+    /// One human-readable line per configured device that is NOT polling. Never a payload byte,
+    /// never a secret -- the same strings the boot log carries.
+    std::vector<std::string> deviceProblems;
+
     /// Onboard indicators, present only on boards that have them (board::kHasBootButton /
     /// kHasStatusLed). `bootButtonPressed` makes the hold-to-factory-reset input observable
     /// over REST -- the way its wiring gets verified without a scope. `statusLedColor` is the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,10 @@ std::vector<DeviceId> g_deviceIds;
 /// LED: a configured device that failed to start is a fault to show, not an absence to ignore.
 size_t g_devicesConfigured = 0;
 
+/// One line per configured device that is not being polled, in configuration order. Filled at
+/// boot alongside the log lines, so the same facts reach a screen instead of only a ring buffer.
+std::vector<std::string> g_deviceProblems;
+
 bool g_outputsStarted = false;
 
 /// Guards g_config against the one cross-task hazard it has: the AsyncTCP task replacing
@@ -247,6 +251,9 @@ BridgeInfo bridgeInfo() {
             info.relayRoles = g_config.relays.roles;
         }
     }
+    // No lock: both are written once in setup(), before any task that reads them exists.
+    info.devicesConfigured = g_devicesConfigured;
+    info.deviceProblems    = g_deviceProblems;
     info.hasBootButton     = board::kHasBootButton;
     info.bootButtonPressed = g_bootPressed.load();
     info.hasStatusLed      = board::kHasStatusLed;
@@ -834,6 +841,7 @@ void setup() {
             // their poll. A bus with three inverters where the second has a typo'd driver id
             // should still report the first and third.
             log::warn("device '%s' could not be started; the others still poll", p.id.c_str());
+            g_deviceProblems.push_back("'" + p.id + "' could not be started");
             continue;
         }
         Serial.printf("[driver] %s (%s)\n", driver->descriptor().id.c_str(),
@@ -848,12 +856,15 @@ void setup() {
         if (g_devices.contains(id)) {
             log::warn("device '%s' skipped: another configured device already resolves to id "
                       "'%s' -- give them different addresses", p.id.c_str(), id.c_str());
+            g_deviceProblems.push_back("'" + p.id + "' shares the address of a device already "
+                                       "added (" + id + "); give them different addresses");
             continue;
         }
         StateStore* store = g_devices.add(id);
         if (store == nullptr) {
             log::warn("device '%s' skipped: no free device slot (max %u)", p.id.c_str(),
                       static_cast<unsigned>(kMaxDevices));
+            g_deviceProblems.push_back("'" + p.id + "' has no free device slot");
             continue;
         }
         PollPolicy policy;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -251,9 +251,20 @@ BridgeInfo bridgeInfo() {
             info.relayRoles = g_config.relays.roles;
         }
     }
-    // No lock: both are written once in setup(), before any task that reads them exists.
-    info.devicesConfigured = g_devicesConfigured;
-    info.deviceProblems    = g_deviceProblems;
+    {
+        // From the LIVE configuration, not the boot-time count. A device added on the settings
+        // page takes effect at the next restart, so between save and reboot the boot count says
+        // "1 configured, 1 polling" and the page cheerfully reports that everything is
+        // accounted for -- while the configuration it just stored asks for two. Reading it here
+        // makes the same screen say "polling 1 of 2", which is both true and the nudge to
+        // restart (review, 2026-07-25).
+        std::lock_guard<std::mutex> lock(g_configMutex);
+        info.devicesConfigured =
+            (g_config.driver.id.empty() ? 0 : 1) + g_config.additionalDevices.size();
+    }
+    // No lock: written once in setup(), before any task that reads them exists.
+    info.devicesStarted = g_deviceIds.size();
+    info.deviceProblems = g_deviceProblems;
     info.hasBootButton     = board::kHasBootButton;
     info.bootButtonPressed = g_bootPressed.load();
     info.hasStatusLed      = board::kHasStatusLed;
@@ -834,14 +845,20 @@ void setup() {
         log::warn("no driver configured and none compiled in; nothing will be polled");
     }
 
-    for (const auto& p : planned) {
+    for (size_t plannedIndex = 0; plannedIndex < planned.size(); ++plannedIndex) {
+        const auto& p = planned[plannedIndex];
+        // "Device 1" is the `driver` section; 2..N are additional_devices, which is how the
+        // settings page numbers them. Naming only the driver id was useless on the very bus
+        // this exists for: three inverters share one driver id, so all three failures read
+        // identically (review, 2026-07-25).
+        const std::string row = "device " + std::to_string(plannedIndex + 1);
         auto driver = g_registry.create(p.id, g_transport, *p.options);
         if (!driver || !driver->begin(g_transport)) {
             // Named, and the loop continues: one unconfigurable device must not cost the others
             // their poll. A bus with three inverters where the second has a typo'd driver id
             // should still report the first and third.
             log::warn("device '%s' could not be started; the others still poll", p.id.c_str());
-            g_deviceProblems.push_back("'" + p.id + "' could not be started");
+            g_deviceProblems.push_back(row + " ('" + p.id + "') could not be started");
             continue;
         }
         Serial.printf("[driver] %s (%s)\n", driver->descriptor().id.c_str(),
@@ -856,15 +873,16 @@ void setup() {
         if (g_devices.contains(id)) {
             log::warn("device '%s' skipped: another configured device already resolves to id "
                       "'%s' -- give them different addresses", p.id.c_str(), id.c_str());
-            g_deviceProblems.push_back("'" + p.id + "' shares the address of a device already "
-                                       "added (" + id + "); give them different addresses");
+            g_deviceProblems.push_back(row + " ('" + p.id + "') resolves to " + id +
+                                       ", which another configured device already uses; give "
+                                       "them different addresses");
             continue;
         }
         StateStore* store = g_devices.add(id);
         if (store == nullptr) {
             log::warn("device '%s' skipped: no free device slot (max %u)", p.id.c_str(),
                       static_cast<unsigned>(kMaxDevices));
-            g_deviceProblems.push_back("'" + p.id + "' has no free device slot");
+            g_deviceProblems.push_back(row + " ('" + p.id + "') has no free device slot");
             continue;
         }
         PollPolicy policy;

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -295,7 +295,23 @@ bool RestApi::begin() {
         context_.diagnostics->recordRestRequest();
         const auto snapshot = firstDevice();
         if (!snapshot) {
-            sendError(request, {503, "not_ready", "no device is configured yet"});
+            // A bridge with nothing polling is exactly when someone needs this payload: it is
+            // the only place that says how many devices were CONFIGURED and why each one is
+            // missing. Refusing it with 503 meant the whole UI fell back to "cannot reach the
+            // bridge" in the one case the diagnosis was already sitting in memory (review).
+            //
+            // An empty DeviceState, not a fabricated one: every measurement is absent, online
+            // and data_valid are false, and the bridge half of the payload is what carries the
+            // answer.
+            const DeviceState empty;
+            std::string       body;
+            if (!rest::buildStatusPayload(empty, "", context_.bridgeInfo(),
+                                          context_.diagnostics->snapshot(), nullptr,
+                                          context_.clock(), body)) {
+                sendError(request, {500, "payload_too_large", "status payload exceeded its bound"});
+                return;
+            }
+            request->send(200, kJson, body.c_str());
             return;
         }
         // The registered id: the key the per-device routes actually answer on.
@@ -354,7 +370,8 @@ bool RestApi::begin() {
         std::string body;
         bool        ok = false;
         if (sub.empty()) {
-            ok = buildDevicePayload(*snapshot, deviceId, activeDescriptor(*snapshot), body);
+            ok = buildDevicePayload(*snapshot, deviceId, activeDescriptor(*snapshot),
+                                    context_.clock(), body);
         } else if (sub == "measurements") {
             ok = buildMeasurementsPayload(*snapshot, body);
         } else if (sub == "capabilities") {

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -64,6 +64,13 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     // A firmware constant, not configuration: the settings page needs it to stop offering an
     // "Add a device" button past the point the bridge would refuse the save.
     b["max_devices"]        = static_cast<unsigned>(kMaxDevices);
+    b["devices_configured"] = static_cast<unsigned>(bridge.devicesConfigured);
+    // Always emitted, empty or not: "no problems" and "this firmware does not report problems"
+    // must not look the same to a client.
+    JsonArray problems      = b["device_problems"].to<JsonArray>();
+    for (const auto& p : bridge.deviceProblems) {
+        problems.add(p);
+    }
     b["uptime_seconds"]     = bridge.uptimeSeconds;
     b["wifi_connected"]     = bridge.wifiConnected;
     if (bridge.wifiConnected) {

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -65,6 +65,9 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     // "Add a device" button past the point the bridge would refuse the save.
     b["max_devices"]        = static_cast<unsigned>(kMaxDevices);
     b["devices_configured"] = static_cast<unsigned>(bridge.devicesConfigured);
+    // How many actually got built at boot. The difference from devices_configured is the
+    // whole point: it is what any tab can show without walking the device list.
+    b["devices_started"]    = static_cast<unsigned>(bridge.devicesStarted);
     // Always emitted, empty or not: "no problems" and "this firmware does not report problems"
     // must not look the same to a client.
     JsonArray problems      = b["device_problems"].to<JsonArray>();
@@ -174,7 +177,8 @@ bool buildDevicesPayload(const std::vector<std::string>& deviceIds, std::string&
 }
 
 bool buildDevicePayload(const DeviceState& state, const std::string& deviceId,
-                        const DriverDescriptor* driver, std::string& out, size_t maxBytes) {
+                        const DriverDescriptor* driver, uint64_t nowMs, std::string& out,
+                        size_t maxBytes) {
     JsonDocument doc;
     doc["id"] = deviceId;
 
@@ -199,6 +203,16 @@ bool buildDevicePayload(const DeviceState& state, const std::string& deviceId,
     doc["online"]     = state.inverterOnline;
     doc["data_valid"] = state.dataValid;
     doc["data_stale"] = state.dataStale;
+    // The same two fields the status payload has always carried for the first device. Started
+    // is not answering: a driver whose begin() succeeded is in the device list whether or not
+    // the inverter has ever replied, and with A and B swapped it never will.
+    doc["consecutive_poll_failures"] = state.consecutiveFailures;
+    if (state.lastSuccessfulPollMs == 0) {
+        doc["last_successful_poll_seconds_ago"] = nullptr;  // 0 would read as "just now"
+    } else {
+        doc["last_successful_poll_seconds_ago"] =
+            static_cast<uint32_t>((nowMs - state.lastSuccessfulPollMs) / 1000);
+    }
     return finish(doc, out, maxBytes);
 }
 

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -49,8 +49,12 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
 bool buildDevicesPayload(const std::vector<std::string>& deviceIds, std::string& out,
                          size_t maxBytes = kMaxResponseBytes);
 
+/// `nowMs` is only used to age the last successful poll. Without it this payload said whether a
+/// device was online and never when it last answered -- and for every device but the first,
+/// this is the ONLY payload there is, so "started but has never returned a byte" and "working"
+/// were indistinguishable outside the status endpoint (review, 2026-07-25).
 bool buildDevicePayload(const DeviceState& state, const std::string& deviceId,
-                        const DriverDescriptor* driver, std::string& out,
+                        const DriverDescriptor* driver, uint64_t nowMs, std::string& out,
                         size_t maxBytes = kMaxResponseBytes);
 
 bool buildMeasurementsPayload(const DeviceState& state, std::string& out,

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -70,7 +70,7 @@ dialog::backdrop{background:#000a}
 <main>
 <div id="banner" class="err hide"></div>
 <section id="dash"><div class="grid" id="tiles"></div></section>
-<section id="dev" class="hide"><table id="devtbl"></table></section>
+<section id="dev" class="hide"><div id="devbox"></div></section>
 <section id="diag" class="hide"><table id="diagtbl"></table></section>
 <section id="logs" class="hide">
   <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
@@ -253,32 +253,88 @@ function render(s){
       // No firmware tile: the version already sits in the header, permanently.
   }
   if(tab==='dev'){
-    let r=`<tr><th>Field</th><th>Value</th></tr>`;
-    const add=(k,v)=>r+=`<tr><td class="dim">${esc(k)}</td><td>${esc(v??'—')}</td></tr>`;
-    add('Manufacturer',d.manufacturer);add('Model',d.model);add('Serial',d.serial_number);
-    add('Driver',d.driver_id);add('Support level',d.support_level);
-    add('Online',d.online);add('Data valid',d.data_valid);add('Data stale',d.data_stale);
-    if(caps){
-      r+=`<tr><th>Capability</th><th></th></tr>`;
-      // "Driver read-only", not "Read-only": this is the driver's own write capability, a
-      // different thing from the security.read_only_mode switch under Settings. Two rows named
-      // "Read-only" meaning different things is how someone looks for the kill switch here.
-      r+=`<tr><td class="dim">Driver read-only</td><td>${caps.read_only}</td></tr>`;
-      r+=`<tr><td class="dim">Phases / MPPTs</td><td>${caps.phase_count} / ${caps.mppt_count}</td></tr>`;
-      r+=`<tr><td class="dim">Battery</td><td>${caps.has_battery}</td></tr>`;
-      r+=`<tr><td class="dim">Read</td><td>${(caps.read||[]).map(esc).join(', ')||'—'}</td></tr>`;
-      // Empty for every driver in this build, and that is the point: the UI shows what the
-      // device can do, it does not assume.
-      r+=`<tr><td class="dim">Write</td><td>${(caps.write||[]).map(esc).join(', ')||'<span class="dim">none</span>'}</td></tr>`;
-    }
-    r+=`<tr><th>Measurement</th><th>Value</th></tr>`;
-    for(const [k,v] of Object.entries(m)){
-      r+=`<tr><td class="dim">${esc(k)}${v.derived?' <span class="tag">derived</span>':''}</td>
-      <td class="n">${v.value===null?'<span class="dim">unknown</span>':esc(v.value)+' '+esc(v.unit)}
-      ${v.stale?'<span class="tag">stale</span>':''}</td></tr>`;
-    }
-    $('#devtbl').innerHTML=r;
+    // Every configured device, not just the first. The bridge polls up to eight; this tab
+    // rendered s.device, which is the first one, so a second inverter that was wired,
+    // addressed and configured was invisible on every screen the owner has -- and every way
+    // it can fail to start was a single warn line in a ring buffer.
+    renderDevices(b);
   }
+}
+
+/// One device's table. Extracted unchanged from the single-device version so that the rows,
+/// their order and their wording stay exactly what they were.
+function deviceTable(d,caps,m){
+  let r=`<tr><th>Field</th><th>Value</th></tr>`;
+  const add=(k,v)=>r+=`<tr><td class="dim">${esc(k)}</td><td>${esc(v??'—')}</td></tr>`;
+  add('Manufacturer',d.manufacturer);add('Model',d.model);add('Serial',d.serial_number);
+  add('Driver',d.driver_id);add('Support level',d.support_level);
+  add('Online',d.online);add('Data valid',d.data_valid);add('Data stale',d.data_stale);
+  if(caps){
+    r+=`<tr><th>Capability</th><th></th></tr>`;
+    // "Driver read-only", not "Read-only": this is the driver's own write capability, a
+    // different thing from the security.read_only_mode switch under Settings. Two rows named
+    // "Read-only" meaning different things is how someone looks for the kill switch here.
+    r+=`<tr><td class="dim">Driver read-only</td><td>${caps.read_only}</td></tr>`;
+    r+=`<tr><td class="dim">Phases / MPPTs</td><td>${caps.phase_count} / ${caps.mppt_count}</td></tr>`;
+    r+=`<tr><td class="dim">Battery</td><td>${caps.has_battery}</td></tr>`;
+    r+=`<tr><td class="dim">Read</td><td>${(caps.read||[]).map(esc).join(', ')||'—'}</td></tr>`;
+    // Empty for every driver in this build, and that is the point: the UI shows what the
+    // device can do, it does not assume.
+    r+=`<tr><td class="dim">Write</td><td>${(caps.write||[]).map(esc).join(', ')||'<span class="dim">none</span>'}</td></tr>`;
+  }
+  const entries=Object.entries(m||{});
+  // The count is the tell for a wrong register map. A driver that ships several maps will
+  // happily decode the wrong one: a couple of measurements instead of a dozen, and the couple
+  // it does publish look entirely plausible. See the per-device protocol docs.
+  r+=`<tr><th>Measurement</th><th>Value (${entries.length})</th></tr>`;
+  for(const [k,v] of entries){
+    r+=`<tr><td class="dim">${esc(k)}${v.derived?' <span class="tag">derived</span>':''}</td>
+    <td class="n">${v.value===null?'<span class="dim">unknown</span>':esc(v.value)+' '+esc(v.unit)}
+    ${v.stale?'<span class="tag">stale</span>':''}</td></tr>`;
+  }
+  return r;
+}
+
+/// Renders one block per polled device, preceded by the reconciliation the firmware alone can
+/// do: how many devices the configuration asks for versus how many are actually being polled,
+/// and why each missing one is missing. Those strings come from the boot loop, not from
+/// re-deriving device ids in the browser -- the page must not have its own opinion about what
+/// a device id looks like.
+let devsBusy=false;
+async function renderDevices(b){
+  if(devsBusy)return;
+  devsBusy=true;
+  const box=$('#devbox');
+  try{
+    const ids=((await (await fetch('/api/v1/devices')).json()).devices)||[];
+    const configured=b.devices_configured??ids.length;
+    const problems=b.device_problems||[];
+    let h='';
+    if(problems.length||configured!==ids.length){
+      h+=`<div class="msg err" style="display:block">Polling ${ids.length} of ${configured}
+        configured device${configured===1?'':'s'}.${problems.length?'<ul style="margin:6px 0 0 18px">'+
+        problems.map(p=>`<li>${esc(p)}</li>`).join('')+'</ul>':''}</div>`;
+    }else{
+      h+=`<div class="dim" style="font-size:13px;margin-bottom:10px">Polling
+        ${ids.length} device${ids.length===1?'':'s'}, all configured devices accounted for.</div>`;
+    }
+    for(const id of ids){
+      // Sequential on purpose: eight devices in parallel is eight concurrent handlers on a
+      // single-core web task, and this page already has a 5 s refresh behind it.
+      const dev=await (await fetch('/api/v1/devices/'+encodeURIComponent(id))).json();
+      const m=(await (await fetch('/api/v1/devices/'+encodeURIComponent(id)+'/measurements')).json()).measurements||{};
+      let caps=null;
+      try{caps=await (await fetch('/api/v1/devices/'+encodeURIComponent(id)+'/capabilities')).json()}catch(e){}
+      const ident={...(dev.identity||{}),online:dev.online,data_valid:dev.data_valid,
+                   data_stale:dev.data_stale,support_level:(dev.driver||{}).support_level};
+      h+=`<div class="card"><b>${esc(id)}</b><table>${deviceTable(ident,caps,m)}</table></div>`;
+    }
+    box.innerHTML=h||'<div class="dim">No device is being polled.</div>';
+  }catch(e){
+    // Leave whatever was on screen rather than blanking it: this runs on a 5 s timer and a
+    // single failed fetch must not wipe a page someone is reading.
+    if(!box.innerHTML)box.innerHTML='<div class="dim">Could not read the device list.</div>';
+  }finally{devsBusy=false}
 }
 
 // Settings-page network picker: same scan as the setup wizard, admin-gated (the endpoint

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -215,7 +215,6 @@ async function authFetch(url,opts={}){
 function tile(k,v,u,extra=''){return `<div class="card"><div class="k">${esc(k)}</div>
 <div class="v">${esc(v)}<span class="u"> ${esc(u)}</span></div>${extra}</div>`}
 
-let caps=null;
 function render(s){
   const d=s.device,b=s.bridge,m=s.measurements||{};
   const dot=x=>x?'<span class="dot ok"></span>':'<span class="dot bad"></span>';
@@ -300,39 +299,99 @@ function deviceTable(d,caps,m){
 /// and why each missing one is missing. Those strings come from the boot loop, not from
 /// re-deriving device ids in the browser -- the page must not have its own opinion about what
 /// a device id looks like.
-let devsBusy=false;
+// Only keep an OK response. fetch() does not reject on 4xx/5xx, and the error body is valid
+// JSON, so `await r.json()` on a 500 yields a truthy object with none of the expected fields --
+// which this page then renders as `undefined` rows, or as a measurement count of 0. That count
+// is the wrong-register-map tell, so a single failed request would fabricate the exact symptom
+// someone is here to diagnose. The old single-device path carried this guard and a comment
+// about the day it bit; the first version of this function dropped both (review, 2026-07-25).
+async function getJson(url){
+  const r=await fetch(url);
+  if(!r.ok)throw new Error('HTTP '+r.status);
+  return r.json();
+}
+
+// Identity and capabilities do not change while the firmware runs -- they are fixed by the
+// driver at boot. Cached per device so a tab left open re-fetches only what actually moves.
+const devCache={};
+
+/// The one line that must be visible from any tab: some configured device is not running.
+/// Detail stays on the Device tab; this only says look there.
+function deviceBanner(b){
+  const el=$('#banner');
+  if(!el||!b)return;
+  const configured=b.devices_configured;
+  const problems=(b.device_problems||[]).length;
+  // Undefined means this firmware does not report it -- which is not the same as "nothing is
+  // wrong", so say nothing rather than reassure.
+  if(configured===undefined){return}
+  const started=b.devices_started;
+  if(started!==undefined&&(problems||started<configured)){
+    el.textContent=`${started} of ${configured} configured devices started — see the Device tab.`;
+    el.classList.remove('hide');
+  }
+}
+
+let devsBusy=false, devsNextMs=0;
 async function renderDevices(b){
-  if(devsBusy)return;
-  devsBusy=true;
+  // Rate-limited independently of what triggered it. refresh() runs on the 5 s timer AND on
+  // every SSE state event, which the server emits up to once a second -- so without this the
+  // tab issued 1+3N requests per second, back to back, on the one board that is also driving
+  // an RS485 bus. The data underneath changes at the poll interval, ten seconds by default.
+  const now=Date.now();
+  if(devsBusy||now<devsNextMs)return;
+  devsBusy=true;devsNextMs=now+5000;
   const box=$('#devbox');
   try{
-    const ids=((await (await fetch('/api/v1/devices')).json()).devices)||[];
+    const ids=((await getJson('/api/v1/devices')).devices)||[];
     const configured=b.devices_configured??ids.length;
     const problems=b.device_problems||[];
     let h='';
+    // "Started", not "polling": this compares what the configuration asks for against what the
+    // firmware managed to CREATE at boot. A device with A and B swapped starts perfectly and
+    // never returns a byte, so a count alone must not be read as health -- the per-device rows
+    // below carry that, and the summary says which ones are actually answering.
     if(problems.length||configured!==ids.length){
-      h+=`<div class="msg err" style="display:block">Polling ${ids.length} of ${configured}
+      h+=`<div class="msg err" style="display:block">Started ${ids.length} of ${configured}
         configured device${configured===1?'':'s'}.${problems.length?'<ul style="margin:6px 0 0 18px">'+
-        problems.map(p=>`<li>${esc(p)}</li>`).join('')+'</ul>':''}</div>`;
-    }else{
-      h+=`<div class="dim" style="font-size:13px;margin-bottom:10px">Polling
-        ${ids.length} device${ids.length===1?'':'s'}, all configured devices accounted for.</div>`;
+        problems.map(p=>`<li>${esc(p)}</li>`).join('')+'</ul>':
+        '<div style="margin-top:6px">A device added since the last restart only starts after one.</div>'}</div>`;
     }
+    const cards=[];
+    let answering=0;
     for(const id of ids){
-      // Sequential on purpose: eight devices in parallel is eight concurrent handlers on a
-      // single-core web task, and this page already has a 5 s refresh behind it.
-      const dev=await (await fetch('/api/v1/devices/'+encodeURIComponent(id))).json();
-      const m=(await (await fetch('/api/v1/devices/'+encodeURIComponent(id)+'/measurements')).json()).measurements||{};
-      let caps=null;
-      try{caps=await (await fetch('/api/v1/devices/'+encodeURIComponent(id)+'/capabilities')).json()}catch(e){}
+      // Sequential rather than parallel, and cached: eight devices is eight handlers on the
+      // web task, and identity and capabilities never change once the driver has started.
+      const dev=await getJson('/api/v1/devices/'+encodeURIComponent(id));
+      const m=(await getJson('/api/v1/devices/'+encodeURIComponent(id)+'/measurements')).measurements||{};
+      if(devCache[id]===undefined){
+        try{devCache[id]=await getJson('/api/v1/devices/'+encodeURIComponent(id)+'/capabilities')}
+        catch(e){devCache[id]=null}
+      }
       const ident={...(dev.identity||{}),online:dev.online,data_valid:dev.data_valid,
                    data_stale:dev.data_stale,support_level:(dev.driver||{}).support_level};
-      h+=`<div class="card"><b>${esc(id)}</b><table>${deviceTable(ident,caps,m)}</table></div>`;
+      const ago=dev.last_successful_poll_seconds_ago;
+      if(dev.online&&dev.data_valid)answering++;
+      // The line that answers "is this one alive", above the table rather than thirteen rows
+      // into it. Never answered at all is its own state: that is a bus fault, not a sleeping
+      // inverter, and the two look identical in `online: false` alone.
+      const live=ago===null||ago===undefined
+        ? '<span class="tag" style="background:var(--bad)">never answered</span>'
+        : (dev.data_stale?`<span class="tag">stale — last reply ${esc(ago)} s ago</span>`
+                         :`<span class="tag">replied ${esc(ago)} s ago</span>`);
+      cards.push(`<div class="card"><div style="display:flex;justify-content:space-between;
+        align-items:baseline;gap:10px"><b>${esc(id)}</b>${live}</div>
+        <table>${deviceTable(ident,devCache[id],m)}</table></div>`);
     }
-    box.innerHTML=h||'<div class="dim">No device is being polled.</div>';
+    if(ids.length&&!problems.length&&configured===ids.length){
+      h+=`<div class="${answering===ids.length?'dim':'msg err'}"
+        style="font-size:13px;margin-bottom:10px${answering===ids.length?'':';display:block'}">
+        ${answering} of ${ids.length} started device${ids.length===1?'':'s'} answering.</div>`;
+    }
+    box.innerHTML=h+cards.join('')||'<div class="dim">No device is being polled.</div>';
   }catch(e){
-    // Leave whatever was on screen rather than blanking it: this runs on a 5 s timer and a
-    // single failed fetch must not wipe a page someone is reading.
+    // Leave whatever was on screen rather than blanking it: a single failed request must not
+    // wipe a page someone is reading.
     if(!box.innerHTML)box.innerHTML='<div class="dim">Could not read the device list.</div>';
   }finally{devsBusy=false}
 }
@@ -1372,22 +1431,20 @@ async function refresh(){
     const r=await fetch('/api/v1/status');
     if(!r.ok)throw new Error('HTTP '+r.status);
     const s=await r.json();
-    // Capabilities change only when the driver does, so fetch them once rather than every
-    // refresh -- the device page needs them, the dashboard does not.
-    if(tab==='dev'&&!caps&&s.device.id){
-      // Only keep an OK response: storing an error body here handed render() an object
-      // without read/write arrays and took the whole page down with a misleading banner.
-      try{
-        const cr=await fetch('/api/v1/devices/'+encodeURIComponent(s.device.id)+'/capabilities');
-        if(cr.ok)caps=await cr.json();
-      }catch(e){}
-    }
+    // The device page fetches its own capabilities, per device and cached there; this global
+    // one served the single-device table that renderDevices replaced. Its OK-response guard
+    // moved with it, into getJson().
     render(s);
     if(tab==='diag')await loadDiag();
     if(tab==='logs')await loadLogs();
     if(tab==='disc'&&!$('#wiz').innerHTML)renderWizard();
     if(tab==='cfg'&&!$('#cfgform').innerHTML)await renderConfig();
+    // Cleared first, then possibly re-raised: the reachability banner owns this element, and
+    // a device warning must not survive a later refresh that finds everything fine.
     $('#banner').classList.add('hide');
+    // Every tab, not only the device page. A restart lands on the Dashboard, and "one of your
+    // three inverters did not start" is not something to find by clicking around.
+    deviceBanner(s.bridge);
   }catch(e){
     $('#banner').textContent='Cannot reach the bridge: '+e.message;
     $('#banner').classList.remove('hide');

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -428,7 +428,9 @@ static void test_the_status_payload_reports_devices_that_did_not_start() {
     const auto state  = r.poll();
     BridgeInfo bridge = makeBridge();
     bridge.devicesConfigured = 3;
-    bridge.deviceProblems    = {"'growatt_modbus' shares the address of a device already added"};
+    bridge.devicesStarted    = 2;
+    bridge.deviceProblems    = {"device 3 ('growatt_modbus') resolves to growatt_modbus-2, "
+                                "which another configured device already uses"};
 
     std::string json;
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", bridge,
@@ -436,7 +438,13 @@ static void test_the_status_payload_reports_devices_that_did_not_start() {
                                               &eversolar::descriptor(), g_now, json));
     auto doc = parse(json);
     TEST_ASSERT_EQUAL_UINT32(3, doc["bridge"]["devices_configured"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(2, doc["bridge"]["devices_started"].as<uint32_t>());
     TEST_ASSERT_EQUAL_UINT32(1, doc["bridge"]["device_problems"].size());
+    // The string has to name the configuration ROW, not just the driver: three inverters on
+    // one bus share a driver id, so "'growatt_modbus' could not be started" identifies none
+    // of them. This asserts the shape the boot loop produces.
+    TEST_ASSERT_TRUE(std::string(doc["bridge"]["device_problems"][0]).find("device 3") !=
+                     std::string::npos);
 }
 
 // Emitted empty rather than omitted: "no problems" and "this firmware cannot report problems"
@@ -451,6 +459,27 @@ static void test_the_problem_list_is_always_present() {
     auto doc = parse(json);
     TEST_ASSERT_FALSE(doc["bridge"]["device_problems"].isNull());
     TEST_ASSERT_EQUAL_UINT32(0, doc["bridge"]["device_problems"].size());
+}
+
+// Every device carries when it last answered, not only the first. Without it "started" and
+// "answering" were indistinguishable for devices 2..N in the UI and in the API both -- and an
+// inverter with A and B swapped starts perfectly and never returns a byte.
+static void test_a_device_payload_says_when_it_last_answered() {
+    Rig        r;
+    const auto state = r.poll();
+
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDevicePayload(state, "growatt_modbus-2",
+                                              &eversolar::descriptor(), g_now + 45000, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(45, doc["last_successful_poll_seconds_ago"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(0, doc["consecutive_poll_failures"].as<uint32_t>());
+
+    // Never answered is its own state, not "0 seconds ago" -- that is a bus fault, and it must
+    // not read as a device that replied a moment ago.
+    DeviceState fresh;
+    TEST_ASSERT_TRUE(rest::buildDevicePayload(fresh, "growatt_modbus-3", nullptr, g_now, json));
+    TEST_ASSERT_TRUE(parse(json)["last_successful_poll_seconds_ago"].isNull());
 }
 
 static void test_reboot_required_flag_is_patch_only() {
@@ -1397,6 +1426,7 @@ int main(int, char**) {
     RUN_TEST(test_the_status_payload_publishes_the_device_cap);
     RUN_TEST(test_the_status_payload_reports_devices_that_did_not_start);
     RUN_TEST(test_the_problem_list_is_always_present);
+    RUN_TEST(test_a_device_payload_says_when_it_last_answered);
     RUN_TEST(test_reboot_required_flag_is_patch_only);
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -420,6 +420,39 @@ static void test_the_status_payload_publishes_the_device_cap() {
     TEST_ASSERT_EQUAL_UINT32(kMaxDevices, parse(json)["bridge"]["max_devices"].as<uint32_t>());
 }
 
+// A configured device that is not polling is the failure every mistake on the settings page
+// ends in, and until this it existed only as one warn line in a ring buffer: the device list
+// showed the ones that worked and the dashboard showed one.
+static void test_the_status_payload_reports_devices_that_did_not_start() {
+    Rig        r;
+    const auto state  = r.poll();
+    BridgeInfo bridge = makeBridge();
+    bridge.devicesConfigured = 3;
+    bridge.deviceProblems    = {"'growatt_modbus' shares the address of a device already added"};
+
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", bridge,
+                                              r.diagnostics.snapshot(),
+                                              &eversolar::descriptor(), g_now, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(3, doc["bridge"]["devices_configured"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(1, doc["bridge"]["device_problems"].size());
+}
+
+// Emitted empty rather than omitted: "no problems" and "this firmware cannot report problems"
+// must not look identical to a client.
+static void test_the_problem_list_is_always_present() {
+    Rig         r;
+    const auto  state = r.poll();
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", makeBridge(),
+                                              r.diagnostics.snapshot(),
+                                              &eversolar::descriptor(), g_now, json));
+    auto doc = parse(json);
+    TEST_ASSERT_FALSE(doc["bridge"]["device_problems"].isNull());
+    TEST_ASSERT_EQUAL_UINT32(0, doc["bridge"]["device_problems"].size());
+}
+
 static void test_reboot_required_flag_is_patch_only() {
     auto        c = configWithSecrets();
     std::string json;
@@ -1362,6 +1395,8 @@ int main(int, char**) {
     RUN_TEST(test_re_adding_an_id_returns_the_same_store_rather_than_failing);
     RUN_TEST(test_the_device_manager_refuses_past_its_cap);
     RUN_TEST(test_the_status_payload_publishes_the_device_cap);
+    RUN_TEST(test_the_status_payload_reports_devices_that_did_not_start);
+    RUN_TEST(test_the_problem_list_is_always_present);
     RUN_TEST(test_reboot_required_flag_is_patch_only);
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);


### PR DESCRIPTION
Both reviews of the settings card landed on the same gap: **nothing in the UI confirmed a configured device had actually started.** The Device tab rendered the first device only, so a second inverter that was wired, addressed and configured was invisible on every screen, and every way it can fail was one warn line in a ring buffer.

## What it does

The Device tab lists **every polled device**, each with the table the single-device version had, extracted unchanged. Above them, the reconciliation only the firmware can do:

> **Started 2 of 3 configured devices.**
> • device 3 (`'growatt_modbus'`) resolves to `growatt_modbus-2`, which another configured device already uses

Those strings come from the boot loop — `BridgeInfo` carries them, the status payload publishes them. Not re-derived in JavaScript: the page would need its own opinion of what a device id looks like, and that opinion would rot.

Each device also says, above its table, whether it **replied N seconds ago**, is **stale**, or has **never answered**.

## What the review found

**The screen was unreachable in the one case it exists for.** `/api/v1/status` answers 503 when nothing is polling, and the page throws on that — so a bridge where all three configured devices failed to start showed *"cannot reach the bridge"*, while three sentences explaining exactly why sat in memory. Status now answers 200 with an empty device object.

**The word was wrong.** *"Polling N of M"* compared what the configuration asks for against what `begin()` managed to **create**. An inverter with A and B swapped starts perfectly and never returns a byte — and it counted. It says **"Started"** now, with a second line for how many are actually answering, and `buildDevicePayload` gained the two liveness fields the status payload always had for the first device. For devices 2..N there was previously no way to ask "when did it last answer" in the UI *or* the API.

**My load argument was anchored on the wrong number.** I wrote "a page that already refreshes every 5 s"; `refresh()` is also driven by SSE, which the server emits up to once a second — so the tab issued `1+3N` requests per second, back to back. Making the fetches sequential addressed concurrency, which was never the problem. There is a 5 s floor now, and identity and capabilities are cached per device.

**Three fetches had no `.ok` check.** `fetch()` does not reject on 4xx/5xx and the error body is valid JSON, so a 500 produced a truthy object with no fields: `undefined` capability rows and — worse — a measurement count of **0**, which is precisely the wrong-register-map signature this PR introduces. One failed request would have fabricated the symptom someone is here to diagnose. The old single-device path had that guard *and* a comment about the day it bit; I dropped both and left the dead code in place.

## Also

- `devices_configured` came from the boot count, so between saving a new device and restarting the page said *"all configured devices accounted for"* while the stored config asked for one more. It reads the live config now — which turns that into *"started 1 of 2"*, true and the nudge to restart.
- The problem strings named only the driver id. Three inverters on one bus share one, so all three failures read identically. They name the configuration row now.
- The reconciliation lived on the Device tab only, and a restart lands on the Dashboard. A one-line banner shows on every tab.

## Claims corrected

- *"Extracted unchanged"* is true of the table and was **not** true of its caller — which is where both regressions were.
- My earlier *"verified against the real page … the two cards show 12 and 2 measurements"*: the page was real, **the numbers came from my stub**. No hardware has seen this.

## Verification

Against the real page: the Dashboard banner reads *"2 of 3 configured devices started — see the Device tab"* without clicking anything; the Device tab says *"Started 2 of 3"* and names the row; the two devices show `replied 4 s ago` and `never answered`; a 500 from `/capabilities` renders no `undefined` rows. With **zero** started, the banner reads *"0 of 3"* and lists all three reasons — the case that used to show "cannot reach the bridge".

**571 tests pass** (was 568), `check_web_js.py` OK, `check_layering.sh` PASS, all four boards build.

## Still open

- Discovery does not sweep unit ids.
- Silent driver-option fallbacks (a `unit_id` out of range, an unknown profile over the API) log a warning but never become a `device_problem`.
- Modbus TCP and Prometheus carry the first device only.
- A removed or re-addressed device leaves its Home Assistant entities behind, *available*, showing their last value.
- The Dashboard tiles and the header status dot still reflect the first device only.
