### PR TITLE
Bound the numeric driver options where they are declared

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -35,14 +35,25 @@ An option is one of three shapes:
 |---|---|---|---|
 | Free text | neither bounds nor `allowed_values` | text field | never |
 | Enumerated | `allowed_values` | select | not one of them |
-| Bounded number | `min_value` / `max_value` | number field with those limits | not a whole number, or outside the range |
+| Bounded number | `min_value` / `max_value` | number field with those limits | not a plain whole number, or outside the range |
 
 The bounded shape exists because a driver's own parser is too late to be the only check. An
 address outside the protocol's range used to pass config validation — which only length-checks
 option strings — get stored, and then fall back to the driver's default at boot with a single
-log line. On a bus of identical inverters that default is the address the *first* one already
-uses, so a typo became an id collision, and the diagnosis pointed at a duplicate address the
-configuration does not contain. `PATCH` refuses it now, before the reboot.
+log line — for two of the three drivers; SunSpec's fallback had no log line at all. On a bus of
+identical inverters that default is the address the *first* one already uses, so a typo became
+an id collision, and the diagnosis pointed at a duplicate address the configuration does not
+contain. `PATCH` refuses it now, before the reboot.
+
+"Plain" is strict on purpose: `" 7"`, `"+7"` and `"007"` all parse, and were then stored
+verbatim — which is how `007` slipped past a duplicate-address check that compares strings.
+They are refused rather than normalised, because silently rewriting what someone typed is the
+substitution these bounds exist to remove.
+
+A value **already stored** when the bounds arrived is a different case: it is healed back to the
+option's default on the next `PATCH`, exactly as an unrecognised enumerated value is. Validating
+the merged configuration without that would have made a pre-existing value refuse every later
+save, including ones touching nothing driver-related.
 
 `/api/v1/drivers` is not in the assignment but is needed for the discovery wizard: it
 must be able to show the available drivers and their support level without hardcoding

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -27,6 +27,23 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 | GET | `/api/v1/events` | — | Server-Sent Events (live updates) |
 | GET | `/metrics` | — | Prometheus |
 
+Each driver in `/api/v1/drivers` declares its own options, and the web UI renders them
+generically from that declaration — a new driver's settings appear with no frontend change.
+An option is one of three shapes:
+
+| Shape | Declared as | Rendered as | Refused when |
+|---|---|---|---|
+| Free text | neither bounds nor `allowed_values` | text field | never |
+| Enumerated | `allowed_values` | select | not one of them |
+| Bounded number | `min_value` / `max_value` | number field with those limits | not a whole number, or outside the range |
+
+The bounded shape exists because a driver's own parser is too late to be the only check. An
+address outside the protocol's range used to pass config validation — which only length-checks
+option strings — get stored, and then fall back to the driver's default at boot with a single
+log line. On a bus of identical inverters that default is the address the *first* one already
+uses, so a typo became an id collision, and the diagnosis pointed at a duplicate address the
+configuration does not contain. `PATCH` refuses it now, before the reboot.
+
 `/api/v1/drivers` is not in the assignment but is needed for the discovery wizard: it
 must be able to show the available drivers and their support level without hardcoding
 them in the frontend.

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 
@@ -541,26 +542,24 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
     // An earlier attempt simply cleared the map whenever the id changed. Review showed that
     // silently wiped a working setup on a discovery-wizard click, on a typo, and on an empty id,
     // and never repaired an already-stuck config (2026-07-25).
-    if (const DriverDescriptor* target = lookupDriver ? lookupDriver(merged.driver.id) : nullptr) {
-        for (auto it = merged.driver.options.begin(); it != merged.driver.options.end();) {
-            const bool supplied = std::find(suppliedOptionKeys.begin(), suppliedOptionKeys.end(),
-                                            it->first) != suppliedOptionKeys.end();
-            const auto stored   = config.driver.options.find(it->first);
-            const bool asserted = supplied && (stored == config.driver.options.end() ||
-                                               stored->second != it->second);
-            if (asserted) {
+    // Heals one option map against what its driver declares. `assertedKey` decides which
+    // entries are off limits -- a value this request asked for is reported, never rewritten.
+    const auto healOptions = [](const DriverDescriptor& target, DriverOptions& options,
+                                const std::function<bool(const std::string&)>& assertedKey) {
+        for (auto it = options.begin(); it != options.end();) {
+            if (assertedKey(it->first)) {
                 ++it;
                 continue;
             }
             const DriverOption* declared = nullptr;
-            for (const auto& o : target->options) {
+            for (const auto& o : target.options) {
                 if (o.key == it->first) {
                     declared = &o;
                     break;
                 }
             }
             if (declared == nullptr) {
-                it = merged.driver.options.erase(it);
+                it = options.erase(it);
                 continue;
             }
             if (!declared->allowedValues.empty() &&
@@ -568,8 +567,33 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
                           it->second) == declared->allowedValues.end()) {
                 it->second = declared->defaultValue;
             }
+            // The third shape, and the one this loop was missing. A numeric option only gained
+            // bounds in this release, so a value that was perfectly legal before is refused
+            // now -- and because the REST gate validates the MERGED map, that made every later
+            // PATCH fail, including one that touches nothing driver-related. Exactly the
+            // lockout the branches above exist to prevent, reopened for a new shape.
+            if (declared->isNumeric()) {
+                char*      end    = nullptr;
+                const long parsed = std::strtol(it->second.c_str(), &end, 10);
+                const bool number = !it->second.empty() && end != it->second.c_str() && *end == '\0';
+                if (!number || parsed < declared->minValue || parsed > declared->maxValue) {
+                    it->second = declared->defaultValue;
+                }
+            }
             ++it;
         }
+    };
+
+    if (const DriverDescriptor* target = lookupDriver ? lookupDriver(merged.driver.id) : nullptr) {
+        healOptions(*target, merged.driver.options, [&](const std::string& key) {
+            const bool supplied =
+                std::find(suppliedOptionKeys.begin(), suppliedOptionKeys.end(), key) !=
+                suppliedOptionKeys.end();
+            const auto stored = config.driver.options.find(key);
+            const auto now    = merged.driver.options.find(key);
+            return supplied && (stored == config.driver.options.end() ||
+                                (now != merged.driver.options.end() && stored->second != now->second));
+        });
     }
 
 
@@ -588,6 +612,7 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
     }
 
     const bool serialSupplied = !doc["serial"].isNull();
+    bool extraDevicesSupplied = false;
     // Whole-list replacement, not a merge: the list has no stable keys to merge on, and
     // "patch element 2" would need an index the caller cannot know is still the same element.
     // Sending the array replaces it; omitting it leaves it alone, like every other section.
@@ -620,7 +645,22 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
             parsed.push_back(std::move(d));
         }
         merged.additionalDevices = std::move(parsed);
+        extraDevicesSupplied     = true;
     }
+
+    // The extra devices get the same healing, and they need it more: nothing healed them at
+    // all before, so any stored value their driver stopped accepting made the whole
+    // configuration unsaveable with no way to see which row was at fault. Nothing here is ever
+    // "asserted" -- the list travels whole or not at all, and when it travels the caller's
+    // values are validated by the REST layer rather than rewritten here.
+    if (lookupDriver && !extraDevicesSupplied) {
+        for (auto& dev : merged.additionalDevices) {
+            if (const DriverDescriptor* d = lookupDriver(dev.id)) {
+                healOptions(*d, dev.options, [](const std::string&) { return false; });
+            }
+        }
+    }
+
 
     if (JsonObjectConst serial = doc["serial"]; !serial.isNull()) {
         if (!patchBool(serial["override"], merged.serial.enabled, "serial.override", error))

--- a/src/drivers/driver_descriptor.h
+++ b/src/drivers/driver_descriptor.h
@@ -30,6 +30,23 @@ struct DriverOption {
     std::string defaultValue;
     /// Empty means free-form text. Otherwise the value must be one of these.
     std::vector<std::string> allowedValues;
+
+    /// Inclusive bounds for a numeric option. Both zero means "not numeric", which is the
+    /// default and leaves the value free-form.
+    ///
+    /// Exists because a driver's own parser is too late to be the only check. An address
+    /// outside the protocol's range was accepted by the config layer -- which only length-checks
+    /// option strings -- stored, and then fell back to the driver's default at boot with one
+    /// warn line. On a bus of identical inverters that default is the address the FIRST one
+    /// already uses, so a typo'd unit id became an id collision, and the diagnosis pointed at a
+    /// duplicate address the configuration does not contain (review, 2026-07-25).
+    ///
+    /// Declared here rather than checked in each driver so the REST gate refuses it at PATCH
+    /// time, before a reboot, and so the settings page can render a bounded number field.
+    long minValue = 0;
+    long maxValue = 0;
+
+    bool isNumeric() const { return minValue != 0 || maxValue != 0; }
 };
 
 using DriverOptions = std::map<std::string, std::string>;

--- a/src/drivers/driver_registry.cpp
+++ b/src/drivers/driver_registry.cpp
@@ -63,9 +63,17 @@ bool validateDriverOptions(const DriverDescriptor& descriptor, const DriverOptio
         if (option->isNumeric()) {
             // Refused, not clamped: a value the user typed and a value we invented must not
             // both end up stored as if they were the same decision.
+            // strtol skips leading whitespace and accepts a leading '+' and leading zeros, so
+            // " 7", "+7" and "007" all parse -- and were then STORED verbatim, which is how
+            // "007" slipped past a duplicate-address check that compares strings. Rejected
+            // rather than normalised: silently rewriting what someone typed is the same class
+            // of substitution this bound exists to remove (review, 2026-07-25).
+            const bool clean = !value.empty() &&
+                               value.find_first_not_of("0123456789") == std::string::npos &&
+                               (value.size() == 1 || value[0] != '0');
             char*      end    = nullptr;
             const long parsed = std::strtol(value.c_str(), &end, 10);
-            if (value.empty() || end == value.c_str() || *end != '\0') {
+            if (!clean || end == value.c_str() || *end != '\0') {
                 error = {key, "must be a whole number between " + std::to_string(option->minValue) +
                                   " and " + std::to_string(option->maxValue)};
                 return false;

--- a/src/drivers/driver_registry.cpp
+++ b/src/drivers/driver_registry.cpp
@@ -2,6 +2,8 @@
 
 #include "driver_registry.h"
 
+#include <cstdlib>
+
 #include <algorithm>
 
 #if ENABLE_DRIVER_EVERSOLAR
@@ -57,6 +59,23 @@ bool validateDriverOptions(const DriverDescriptor& descriptor, const DriverOptio
         if (option == nullptr) {
             error = {key, "unknown option for driver '" + descriptor.id + "'"};
             return false;
+        }
+        if (option->isNumeric()) {
+            // Refused, not clamped: a value the user typed and a value we invented must not
+            // both end up stored as if they were the same decision.
+            char*      end    = nullptr;
+            const long parsed = std::strtol(value.c_str(), &end, 10);
+            if (value.empty() || end == value.c_str() || *end != '\0') {
+                error = {key, "must be a whole number between " + std::to_string(option->minValue) +
+                                  " and " + std::to_string(option->maxValue)};
+                return false;
+            }
+            if (parsed < option->minValue || parsed > option->maxValue) {
+                error = {key, "must be between " + std::to_string(option->minValue) + " and " +
+                                  std::to_string(option->maxValue)};
+                return false;
+            }
+            continue;
         }
         if (option->allowedValues.empty()) {
             continue;  // free-form

--- a/src/drivers/growatt_modbus/descriptor.cpp
+++ b/src/drivers/growatt_modbus/descriptor.cpp
@@ -54,11 +54,15 @@ const DriverDescriptor& descriptor() {
         // the deliberate next step, gated on the map being confirmed.
         x.supportsWrite = false;
         x.options       = {
+            // Bounded here, not only in optionsFrom(): the parser's fallback is silent by the
+            // time it runs, and on a bus of identical inverters the value it falls back to is
+            // the address the first one already uses.
             DriverOption{"unit_id", "Modbus unit id",
                          "The inverter's Modbus slave address (Growatt default is 1). "
                          "Range 1-247.",
                          "1",
-                         {}},
+                         {},
+                         1, 247},
             DriverOption{"profile", "Register-map profile",
                          "Which Growatt register map to use (profiles/growatt/). "
                          "Empty = the default profile.",

--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -67,7 +67,14 @@ DriverDescriptor makeDescriptor(bool writable) {
     x.options = {DriverOption{"day_length_minutes", "Simulated day length",
                               "How long one simulated sunrise-to-sunset cycle takes. Short by "
                               "default so a full curve is visible within minutes of booting.",
-                              "10", {}}};
+                              "10", {},
+                              // Bounded like every other numeric option. Its parser has the
+                              // same silent fallback the others had -- a non-positive or
+                              // garbage value keeps the default with no log line at all -- and
+                              // leaving the one driver everybody has compiled in unbounded
+                              // would make "the numeric driver options" a claim about most of
+                              // them (review, 2026-07-25).
+                              1, 1440}};
     return x;
 }
 

--- a/src/drivers/solax_x1/descriptor.cpp
+++ b/src/drivers/solax_x1/descriptor.cpp
@@ -36,7 +36,8 @@ const DriverDescriptor& descriptor() {
             "Address handed to the inverter at registration (reference default 10 = 0x0A). "
             "Range 1-254.",
             "10",
-            {}}};
+            {},
+            1, 254}};
         return x;
     }();
     return d;

--- a/src/drivers/sunspec/descriptor.cpp
+++ b/src/drivers/sunspec/descriptor.cpp
@@ -44,9 +44,12 @@ const DriverDescriptor& descriptor() {
                                          "would cost a discovery round trip, so this is set rather than searched.",
                                          "40000",
                                          {},
-                                         // A 16-bit register address; the marker cannot sit in
-                                         // the last two registers of the space.
-                                         1, 65533}};
+                                         // Matches what optionsFrom() below actually accepts.
+                                         // Declaring 1 here made the descriptor stricter than
+                                         // its own parser and locked out base 0, which is one
+                                         // of the standard SunSpec bases. The marker is two
+                                         // registers, so 65534 still fits (review).
+                                         0, 65534}};
         return x;
     }();
     return d;

--- a/src/drivers/sunspec/descriptor.cpp
+++ b/src/drivers/sunspec/descriptor.cpp
@@ -36,13 +36,17 @@ const DriverDescriptor& descriptor() {
         x.supportsWrite           = false;
         x.options                 = {
             DriverOption{"unit_id", "Modbus unit id",
-                                         "Slave address of the inverter on the RS485 bus. Range 1-247.", "1", {}},
+                                         "Slave address of the inverter on the RS485 bus. Range 1-247.", "1", {},
+                                         1, 247},
             DriverOption{"base_address", "SunSpec base register",
                                          "Where the 'SunS' marker lives. 40000 covers most devices; 50000 is the "
                                          "other common choice, and some vendors sit elsewhere. Each extra guess "
                                          "would cost a discovery round trip, so this is set rather than searched.",
                                          "40000",
-                                         {}}};
+                                         {},
+                                         // A 16-bit register address; the marker cannot sit in
+                                         // the last two registers of the space.
+                                         1, 65533}};
         return x;
     }();
     return d;

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -525,10 +525,15 @@ bool RestApi::begin() {
             // hybrid's registers and publishing values that look entirely plausible. That is the
             // exact hazard the gate above exists for; the new list walked straight past it.
             //
-            // Unconditional, unlike the driver.id check above: an entry here is only ever
-            // present because this patch sent the whole array, so there is no stored value to
-            // become unresolvable behind the user's back and no lockout to avoid.
-            for (size_t i = 0; i < updated.additionalDevices.size(); ++i) {
+            // Only when this patch actually changed the list. The comment here used to claim an
+            // entry is "only ever present because this patch sent the whole array" -- provably
+            // false: applyConfigPatch leaves the array alone when it is omitted, and there is a
+            // test asserting exactly that. So validating the merged list unconditionally meant a
+            // stored value the firmware stopped accepting -- a numeric option that only gained
+            // bounds this release -- refused every later PATCH, including ones touching nothing
+            // driver-related. Same rule as driver.id below, for the same reason (review).
+            const bool extraDevicesChanged = updated.additionalDevices != before.additionalDevices;
+            for (size_t i = 0; extraDevicesChanged && i < updated.additionalDevices.size(); ++i) {
                 const auto&             dev   = updated.additionalDevices[i];
                 const std::string       where = "additional_devices[" + std::to_string(i) + "]";
                 const DriverDescriptor* d     = lookupDriver(dev.id);

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -410,6 +410,12 @@ bool buildDriversPayload(const std::vector<DriverDescriptor>& drivers, std::stri
             oo["display_name"]   = o.displayName;
             oo["description"]    = o.description;
             oo["default_value"]  = o.defaultValue;
+            // Emitted only for a numeric option, so a client can tell "bounded number" from
+            // "free text" without guessing from the key name.
+            if (o.isNumeric()) {
+                oo["min_value"] = o.minValue;
+                oo["max_value"] = o.maxValue;
+            }
             JsonArray allowed    = oo["allowed_values"].to<JsonArray>();
             for (const auto& v : o.allowedValues) {
                 allowed.add(v);

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -739,7 +739,14 @@ async function saveDriver(){
   if(serial)body.serial=serial;
   const r=await authFetch('/api/v1/config',{method:'PATCH',
     headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
-  if(!r.ok){alert('Save failed: '+httpWhy(r));return}
+  if(!r.ok){
+    // The body, not just the status. httpWhy() gives "HTTP 400", and the firmware's message is
+    // the whole point of a 400 here: it names the field and the range. The wizard is the path
+    // the bring-up docs send people down, and it was the one place that threw that away.
+    const d=await r.json().catch(()=>({}));
+    alert('Save failed: '+((d.error&&d.error.message)||httpWhy(r)));
+    return;
+  }
   wizSavedSerial=serial;
   wizStep=7;renderWizard();
 }

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -702,8 +702,10 @@ function wizRenderOpts(){
             v===''?'— choose —':esc(v)}</option>`).join('')
         }</select>${hint}`;
     }
+    const num=o.min_value!==undefined
+      ? ` type="number" min="${esc(o.min_value)}" max="${esc(o.max_value)}"` : '';
     return `<label for="wopt_${esc(o.key)}">${esc(o.display_name)}</label>
-      <input id="wopt_${esc(o.key)}" data-opt="${esc(o.key)}" value="${esc(cur)}">${hint}`;
+      <input id="wopt_${esc(o.key)}"${num} data-opt="${esc(o.key)}" value="${esc(cur)}">${hint}`;
   }).join('');
   wizGateConfirm();
 }
@@ -901,8 +903,10 @@ async function renderConfig(){
             `<option value="${esc(v)}" ${v===cur?'selected':''}>${v===''?'(driver default)':esc(v)}</option>`).join('')}</select>
           <div class="dim" style="font-size:12px">${esc(o.description||'')}</div>`;
       }
+      const num=o.min_value!==undefined
+        ? ` type="number" min="${esc(o.min_value)}" max="${esc(o.max_value)}"` : '';
       return `<label for="opt_${o.key}">${esc(o.display_name)}</label>
-        <input id="opt_${o.key}" data-opt="${esc(o.key)}" value="${esc(cur)}">`;
+        <input id="opt_${o.key}"${num} data-opt="${esc(o.key)}" value="${esc(cur)}">`;
     }).join('');
   };
   window.reloadDriverOpts=()=>{$('#drvopts').innerHTML=optsFor($('#c_drv').value)};
@@ -955,8 +959,13 @@ async function renderConfig(){
             o.allowed_values.map(v=>`<option value="${esc(v)}" ${known&&v===cur?'selected':''}>${
               v===''?'— choose —':esc(v)}</option>`).join('')}</select>${hint}`;
       }
+      // A bounded option gets a number field with the driver's own limits. The firmware
+      // refuses an out-of-range value either way; showing the bounds is what stops someone
+      // discovering them from an error message after a save.
+      const num=o.min_value!==undefined
+        ? ` type="number" min="${esc(o.min_value)}" max="${esc(o.max_value)}"` : '';
       return `<label for="xd${index}_${esc(o.key)}">${esc(o.display_name)}</label>
-        <input id="xd${index}_${esc(o.key)}" value="${esc(cur)}"
+        <input id="xd${index}_${esc(o.key)}"${num} value="${esc(cur)}"
           oninput="setExtraOption(${index},'${esc(o.key)}',this.value)">${hint}`;
     }).join('');
   };

--- a/test/test_driver_registry/test_main.cpp
+++ b/test/test_driver_registry/test_main.cpp
@@ -269,8 +269,56 @@ static void test_configured_options_reach_the_created_driver() {
     TEST_ASSERT_EQUAL_UINT8(3, transport.writes.front().at(0));
 }
 
+
+// --- numeric option bounds ---------------------------------------------------------------
+
+static DriverDescriptor boundedDescriptor() {
+    DriverDescriptor d;
+    d.id      = "bounded";
+    d.options = {DriverOption{"unit_id", "Modbus unit id", "", "1", {}, 1, 247}};
+    return d;
+}
+
+// A driver's own parser is too late to be the only check: by the time it falls back the value
+// is already stored, and on a bus of identical inverters the address it falls back to is the
+// one the first device uses -- so a typo'd unit id surfaced as an id collision naming a
+// duplicate the configuration does not contain.
+static void test_a_numeric_option_out_of_range_is_refused() {
+    const auto        d = boundedDescriptor();
+    DriverOptionError e;
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", "300"}}, e));
+    TEST_ASSERT_EQUAL_STRING("unit_id", e.key.c_str());
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", "0"}}, e));
+    TEST_ASSERT_TRUE(validateDriverOptions(d, {{"unit_id", "1"}}, e));
+    TEST_ASSERT_TRUE(validateDriverOptions(d, {{"unit_id", "247"}}, e));
+}
+
+// Refused rather than parsed leniently: strtol would read "3x" as 3, and storing 3 for a value
+// the user typed as something else is the same silent substitution this exists to remove.
+static void test_a_numeric_option_that_is_not_a_number_is_refused() {
+    const auto        d = boundedDescriptor();
+    DriverOptionError e;
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", "3x"}}, e));
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", ""}}, e));
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", "one"}}, e));
+}
+
+// An option with no bounds declared stays free-form, which is what every non-addressing option
+// is. isNumeric() keys on the bounds, not on the value looking like a number.
+static void test_an_unbounded_option_stays_free_form() {
+    DriverDescriptor d;
+    d.id      = "free";
+    d.options = {DriverOption{"note", "Note", "", "", {}}};
+    DriverOptionError e;
+    TEST_ASSERT_TRUE(validateDriverOptions(d, {{"note", "anything at all"}}, e));
+    TEST_ASSERT_TRUE(validateDriverOptions(d, {{"note", "999999"}}, e));
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
+    RUN_TEST(test_a_numeric_option_out_of_range_is_refused);
+    RUN_TEST(test_a_numeric_option_that_is_not_a_number_is_refused);
+    RUN_TEST(test_an_unbounded_option_stays_free_form);
     RUN_TEST(test_registered_driver_is_found);
     RUN_TEST(test_unknown_driver_is_not_found);
     RUN_TEST(test_registering_the_same_id_replaces_rather_than_duplicates);

--- a/test/test_driver_registry/test_main.cpp
+++ b/test/test_driver_registry/test_main.cpp
@@ -305,6 +305,32 @@ static void test_a_numeric_option_that_is_not_a_number_is_refused() {
 
 // An option with no bounds declared stays free-form, which is what every non-addressing option
 // is. isNumeric() keys on the bounds, not on the value looking like a number.
+// strtol is lenient in three ways that all end up STORED verbatim: it skips leading
+// whitespace, accepts a leading '+', and accepts leading zeros. "007" then slipped past the
+// settings page's duplicate-address check, which compares strings -- so two rows could claim
+// the same unit and only the boot-time collision guard noticed.
+static void test_a_sloppy_but_parseable_number_is_refused() {
+    const auto        d = boundedDescriptor();
+    DriverOptionError e;
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", " 7"}}, e));
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", "+7"}}, e));
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", "007"}}, e));
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", "7 "}}, e));
+    TEST_ASSERT_TRUE(validateDriverOptions(d, {{"unit_id", "7"}}, e));
+}
+
+// A bound that legitimately starts at zero must still be numeric -- the SunSpec base register
+// is exactly that, and declaring 1 made the descriptor stricter than its own parser.
+static void test_a_range_starting_at_zero_is_still_numeric() {
+    DriverDescriptor d;
+    d.id      = "based";
+    d.options = {DriverOption{"base_address", "Base", "", "40000", {}, 0, 65534}};
+    DriverOptionError e;
+    TEST_ASSERT_TRUE(validateDriverOptions(d, {{"base_address", "0"}}, e));
+    TEST_ASSERT_TRUE(validateDriverOptions(d, {{"base_address", "65534"}}, e));
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"base_address", "65535"}}, e));
+}
+
 static void test_an_unbounded_option_stays_free_form() {
     DriverDescriptor d;
     d.id      = "free";
@@ -318,6 +344,8 @@ int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_a_numeric_option_out_of_range_is_refused);
     RUN_TEST(test_a_numeric_option_that_is_not_a_number_is_refused);
+    RUN_TEST(test_a_sloppy_but_parseable_number_is_refused);
+    RUN_TEST(test_a_range_starting_at_zero_is_still_numeric);
     RUN_TEST(test_an_unbounded_option_stays_free_form);
     RUN_TEST(test_registered_driver_is_found);
     RUN_TEST(test_unknown_driver_is_not_found);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -482,6 +482,67 @@ static void test_a_device_payload_says_when_it_last_answered() {
     TEST_ASSERT_TRUE(parse(json)["last_successful_poll_seconds_ago"].isNull());
 }
 
+static const DriverDescriptor& boundedUnitIdDescriptor() {
+    static const DriverDescriptor d = [] {
+        DriverDescriptor x;
+        x.id      = "growatt_modbus";
+        x.options = {DriverOption{"unit_id", "Modbus unit id", "", "1", {}, 1, 247}};
+        return x;
+    }();
+    return d;
+}
+
+// The lockout this repo has had to remove twice, reopened by a new option shape. A numeric
+// option only gained bounds in this release, so a value that was legal when it was stored is
+// refused now -- and the REST gate validates the MERGED map, so it made every later PATCH fail,
+// including one touching nothing driver-related. Healed on the same terms as the other two
+// shapes: only a value this request did NOT assert.
+static void test_a_stored_out_of_range_option_is_healed_not_fatal() {
+    Configuration c;
+    c.driver.id                  = "growatt_modbus";
+    c.driver.options["unit_id"]  = "300";  // legal before the bounds existed
+    ConfigError e;
+
+    // A locally declared descriptor rather than a real driver's: this suite runs on env:native,
+    // where the drivers are compiled out, and the behaviour under test is the config layer's.
+    const auto lookup = [](const std::string& id) -> const DriverDescriptor* {
+        return id == "growatt_modbus" ? &boundedUnitIdDescriptor() : nullptr;
+    };
+    // A patch that touches nothing driver-related must still go through.
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"logging":{"level":"debug"}})", c, e, lookup));
+    TEST_ASSERT_EQUAL_STRING("1", c.driver.options["unit_id"].c_str());  // back to the default
+}
+
+// ...but a bad value the caller just supplied is reported, not silently rewritten. Swallowing
+// it would tell someone their typo had been accepted.
+static void test_an_asserted_out_of_range_option_is_left_for_the_caller() {
+    Configuration c;
+    c.driver.id = "growatt_modbus";
+    ConfigError e;
+    const auto  lookup = [](const std::string& id) -> const DriverDescriptor* {
+        return id == "growatt_modbus" ? &boundedUnitIdDescriptor() : nullptr;
+    };
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"options":{"unit_id":"300"}}})", c, e, lookup));
+    TEST_ASSERT_EQUAL_STRING("300", c.driver.options["unit_id"].c_str());
+    DriverOptionError optionError;
+    TEST_ASSERT_FALSE(validateDriverOptions(boundedUnitIdDescriptor(), c.driver.options,
+                                           optionError));
+}
+
+// The extra devices had no healing at all, so one stored value their driver stopped accepting
+// made the whole configuration unsaveable with nothing naming the row.
+static void test_a_stored_out_of_range_extra_device_option_is_healed() {
+    Configuration c;
+    c.driver.id = "growatt_modbus";
+    c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {{"unit_id", "300"}}});
+    ConfigError e;
+    const auto  lookup = [](const std::string& id) -> const DriverDescriptor* {
+        return id == "growatt_modbus" ? &boundedUnitIdDescriptor() : nullptr;
+    };
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"logging":{"level":"debug"}})", c, e, lookup));
+    TEST_ASSERT_EQUAL_STRING("1", c.additionalDevices[0].options["unit_id"].c_str());
+}
+
 static void test_reboot_required_flag_is_patch_only() {
     auto        c = configWithSecrets();
     std::string json;
@@ -1427,6 +1488,9 @@ int main(int, char**) {
     RUN_TEST(test_the_status_payload_reports_devices_that_did_not_start);
     RUN_TEST(test_the_problem_list_is_always_present);
     RUN_TEST(test_a_device_payload_says_when_it_last_answered);
+    RUN_TEST(test_a_stored_out_of_range_option_is_healed_not_fatal);
+    RUN_TEST(test_an_asserted_out_of_range_option_is_left_for_the_caller);
+    RUN_TEST(test_a_stored_out_of_range_extra_device_option_is_healed);
     RUN_TEST(test_reboot_required_flag_is_patch_only);
     RUN_TEST(test_reboot_required_only_for_boot_time_settings);
     RUN_TEST(test_patch_leaves_absent_fields_alone);


### PR DESCRIPTION
Closes the hole the previous PR's own opening paragraph claimed to have closed: **a driver-option fallback is invisible.**

A unit id outside 1–247 passed config validation — which only length-checks option strings — got stored, and fell back to the driver's default at boot. On a bus of identical inverters that default is the address the **first** device already uses, so a typo became an id collision, and the banner from the previous PR then reported a duplicate address the configuration does not contain.

`DriverOption` gains inclusive bounds, declared next to the option so the REST gate refuses the value at PATCH time and the three option renderers can show the driver's own limits.

## What the reviews found: the bounds locked out the bridge they were for

Both passes reproduced it. The REST gate validates the **merged** configuration, not what the patch supplied — so a bridge holding `unit_id: 300` had every later PATCH refused, including one that changed only the MQTT host, with an error naming a field the caller never touched. The bridge it hits hardest is the one that already has the typo these bounds exist to catch.

The heal loop covers exactly two shapes — unknown key, and a value outside `allowed_values` — and I added a third without extending it. That is the lockout class this repo has already removed **twice**, with ten lines of comment on the neighbouring check explaining why it must be conditional.

Healed now, on the same terms as the other two: only a value this request did **not** assert. A caller who supplies a bad number still gets it reported. The extra devices had no healing at all and now share the same loop; their gate is conditional on the list having actually changed — which the comment there already claimed and the code did not do, with a test asserting an omitted array is left alone.

## Other findings applied

- **The wizard reported the refusal as `Save failed: HTTP 400`.** `httpWhy` reads the status only, so the firmware's message — which names the field and the range — was discarded on the one path the bring-up docs send people down.
- **`strtol` accepts `" 7"`, `"+7"` and `"007"`, and each was stored verbatim.** That is how `007` slipped past the extra-devices duplicate-address check, which compares strings. Refused rather than normalised.
- **SunSpec's `base_address` was declared 1–65533 while its own parser three lines below accepts 0–65535.** Base 0 is one of the standard SunSpec bases, so the descriptor locked out a device the driver supports. Now 0–65534, which is what fits a two-register marker.
- **The mock driver's `day_length_minutes`** is numeric, has the same silent fallback, is compiled into every board — and I skipped it, which made "the numeric driver options" a claim about most of them.

## Corrections to my own claims

- *"fell back … with one warn line"* is true of two drivers. **SunSpec's fallback has no log line at all.**
- *"instead of letting someone discover them from an error message after saving"* is **false for typed input**: `min`/`max` on a number field constrain the spinner and native form submission, and this page saves with `fetch`. What actually changed for a typed value is that the refusal now names the range.
- **I asserted UI behaviour in three places and exercised none of it.** The reviews measured what the browser does: a non-numeric character makes `.value` return `""`, so the field can read `O3` while an empty string is what travels.

## What this deliberately does not fix

`33` instead of `3` is a perfectly legal unit id that no inverter answers to. Bounds do nothing for it — that case is caught by the Device tab's `never answered` tag, after a restart and one poll interval. Both reviews said so, and one judged this the wrong next piece of work for that reason. It is the easy half; I am not claiming otherwise.

## Tests

Eight in total: out-of-range refused at both ends and accepted at both boundaries, non-numeric refused, an unbounded option still free-form, the sloppy-number refusals, a range legitimately starting at zero, and the healed-not-fatal path for both option maps plus the asserted-value-is-reported path.

**579 tests pass** (was 571), `check_web_js.py` OK, `check_layering.sh` PASS, all four boards build.

## Still open

- Discovery does not sweep unit ids — it would remove this typo class rather than validate it.
- Modbus TCP and Prometheus carry the first device only.
- **A removed or re-addressed device leaves its Home Assistant entities behind, reporting *online* forever with their last retained value** — straight into an energy dashboard. Both reviews rank this as the next one to do.
- The Dashboard tiles and the header status dot still reflect the first device only.
