### PR TITLE
Mark the primary device: the flag shipped never being set

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,11 @@ size_t g_pollCursor = 0;
 /// Device ids, index-aligned with g_contexts, so a log line can name the inverter it means.
 std::vector<DeviceId> g_deviceIds;
 
+/// The id of the CONFIGURED first device, if it started. Empty otherwise -- and empty is the
+/// point: it is what stops a boot where device 1 failed from handing its MQTT topics, its Home
+/// Assistant entities and its recorder history to whichever device did start.
+DeviceId g_primaryDeviceId;
+
 /// How many devices the configuration asked for, whether or not they started. Drives the status
 /// LED: a configured device that failed to start is a fault to show, not an absence to ignore.
 size_t g_devicesConfigured = 0;
@@ -694,7 +699,10 @@ void rs485Task(void* /*arg*/) {
             for (const auto& id : g_deviceIds) {
                 if (StateHandle h = g_devices.state(id)) {
                     held.push_back(std::move(h));
-                    views.push_back({id, held.back().get()});
+                    // Primary is the CONFIGURED first device, not the first that happened to
+                    // start. When it fails to start no device is primary and nobody inherits
+                    // its topics, its Home Assistant entities or its history.
+                    views.push_back({id, held.back().get(), id == g_primaryDeviceId});
                 }
             }
             const auto first = g_state->snapshot();
@@ -890,6 +898,11 @@ void setup() {
         g_contexts.push_back(std::make_unique<DeviceContext>(*driver, *store, g_diagnostics,
                                                              nowMs, policy));
         g_deviceIds.push_back(id);
+        // `planned` is in configuration order and `p` is the entry being started, so this is
+        // true only for the first configured device -- never for a later one that starts first.
+        if (&p == &planned.front()) {
+            g_primaryDeviceId = id;
+        }
         g_drivers.push_back(std::move(driver));
         if (g_driver == nullptr) {
             g_driver  = g_drivers.front().get();

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -61,8 +61,19 @@ public:
         /// True for the device that keeps the bridge-scoped topics and unique ids. Decided by
         /// the caller from the CONFIGURED order, not by arrival: keying it on "first one seen"
         /// meant that a boot where device 1 failed to start handed device 2 its topics, its
-        /// entities and its recorder history (review, 2026-07-25). At most one, possibly none.
-        bool primary = false;
+        /// entities and its recorder history. At most one, possibly none.
+        bool primary;
+
+        /// Spelled out rather than aggregate-initialised, and with no default on `primary`, so
+        /// that omitting it does not compile.
+        ///
+        /// It shipped omitted. The field was added with a default of false and the caller was
+        /// never updated, so every device -- including the first -- took the device-scoped
+        /// topics, and the back-compat guarantee the whole design rests on was quietly not in
+        /// force. `{id, state}` still compiled and still meant something reasonable, which is
+        /// exactly why nothing caught it (2026-07-25).
+        DeviceView(DeviceId deviceId, const DeviceState* deviceState, bool isPrimary)
+            : id(std::move(deviceId)), state(deviceState), primary(isPrimary) {}
     };
 
     /// Drives reconnects and publishing. Call regularly from the MQTT task; never blocks.


### PR DESCRIPTION
**This fixes a regression already on `main`, in the release that introduced per-device MQTT.**

PR #32 rests on one guarantee: the first configured device keeps the bridge-scoped MQTT topics and Home Assistant unique ids it has always had, so an existing install keeps its entities and its recorder history. The review round found the flag was keyed on arrival order and the fix was to pass it explicitly from the configured order.

**That fix did not land.** The struct field is there, with the comment explaining it. `main.cpp` never sets it.

## What that means on a real bridge

`primary` is `false` for every device, so `deviceTopicKey` takes the non-primary branch every time and the **first** device publishes to `<base>/<bridgeId>/device/<id>/` with unique ids of `<bridgeId>_<id>`.

A single-inverter bridge upgrading past that release gets a new `unique_id` for every Home Assistant entity: new entities, the old ones orphaned, and the recorder history behind them stranded. That is precisely the outcome the design existed to prevent — and my commit message asserted it was in force.

## How it got through

The edit was one of five replacements in a script that asserts each anchor before writing the file. A later assert failed, the script exited, and **nothing** from that block was written. I re-applied the one hunk the error named and did not re-check the rest. The commit message was written from what I intended rather than from the diff.

Neither safety net could catch it: the tests cannot reach `MqttOutput` at all on the native build, and both review agents read the header, where the field looks correct.

## The guard

`DeviceView` gains a constructor and drops the default on `primary`, so omitting it no longer compiles. `{id, state}` compiled before and meant something reasonable — that is exactly why it went unnoticed.

**579 tests pass**, `check_layering.sh` PASS, all four boards build.

## Note for anyone who already flashed it

If a bridge ran the affected build and connected to a broker, it published retained discovery configs under the device-scoped ids. Those do not disappear when this fix lands — the entities stay in Home Assistant, reporting online with their last value. Clearing orphaned retained topics is the branch I was working on when I found this, and is coming next.
