### PR TITLE
Clear the retained topics a removed device leaves behind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Embedded JS syntax
         run: python3 tools/check_web_js.py
 
+      - name: Canonical measurement ids are enumerable
+        run: python3 tools/check_measurement_ids.py
+
       - name: Native test suite
         run: pio test -e native
 

--- a/docs/device-profiles/canonical-measurements.md
+++ b/docs/device-profiles/canonical-measurements.md
@@ -21,6 +21,12 @@ $ python3 tools/gen_profiles.py --list-measurements
 | `ac.phase_l1.voltage` | V | Phase L1 voltage |
 | `ac.phase_l1.current` | A | Phase L1 current |
 | `ac.phase_l1.power` | W | Phase L1 active power |
+| `ac.phase_l2.voltage` | V | Phase L2 voltage |
+| `ac.phase_l2.current` | A | Phase L2 current |
+| `ac.phase_l2.power` | W | Phase L2 active power |
+| `ac.phase_l3.voltage` | V | Phase L3 voltage |
+| `ac.phase_l3.current` | A | Phase L3 current |
+| `ac.phase_l3.power` | W | Phase L3 active power |
 | `dc.power.total` | W | Total PV (DC) power over all MPPTs |
 | `dc.mppt_1.voltage` | V | MPPT/string 1 voltage |
 | `dc.mppt_1.current` | A | MPPT/string 1 current |
@@ -39,13 +45,23 @@ $ python3 tools/gen_profiles.py --list-measurements
 | `battery.temperature` | °C | Battery temperature |
 | `battery.energy_charged` | kWh | Lifetime energy charged into the battery |
 | `battery.energy_discharged` | kWh | Lifetime energy discharged from the battery |
+| `battery.charge_power` | W | Charge rail, for a device that reads the two separately |
+| `battery.discharge_power` | W | Discharge rail, ditto |
+| `grid.import_power` | W | Power drawn from the grid, for a hybrid with a meter |
+| `grid.export_power` | W | Power fed back to the grid |
 
 ## Conventions
 
 - **Battery sign.** `battery.power` is positive while charging, negative while
   discharging — the SunSpec energy-storage convention (Model 120). Many vendors report
   "discharge power" as a positive number; check on hardware which way your device points
-  before mapping it, and note the finding in the profile.
+  before mapping it, and note the finding in the profile. Prefer the single signed channel;
+  `battery.charge_power` / `battery.discharge_power` exist for devices that genuinely expose
+  two rails, and have their own Modbus TCP registers.
+- **Never invent an id in a driver.** Anything not in this list is invisible to everything that
+  enumerates the vocabulary — including the code that clears a removed device's retained Home
+  Assistant topics, which means such an entity can never be cleaned up. Add the constant to
+  `measurement_id` first; `tools/check_measurement_ids.py` enforces the rest.
 - **Named after physics, not vendor registers.** The battery channels are shaped after
   the SunSpec storage model on purpose, so hybrids map onto a standard instead of every
   brand inventing its own vocabulary.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -48,10 +48,11 @@ serial arrives during the first poll, long after the id is needed.
 
 ### Removing or re-addressing a device
 
-The bridge clears up after itself. It remembers which device ids it announced, and on the first
-connection after a restart it publishes empty retained payloads for any of them that is no
-longer configured — the device's own `state`, `identity` and `capabilities`, and every Home
-Assistant discovery config it could have announced. Home Assistant drops those entities.
+The bridge clears up after the devices that publish on `…/device/<device_id>/`. It remembers
+which devices it announced and on which topic tree, and on the first connection after a restart
+it publishes empty retained payloads for any that no longer owns that tree — the device's own
+`state`, `identity` and `capabilities`, and every Home Assistant discovery config it could have
+announced there. Home Assistant drops those entities.
 
 Two things follow from *could have*: the topics are enumerated from the canonical measurement
 ids rather than derived from the device's readings, because by then the device is gone and so
@@ -62,17 +63,36 @@ so a sleeping inverter does not make its entities unavailable every night — wh
 orphaned entity does **not** go unavailable either. It reports *online* forever, showing the
 last value it ever read, and a template or automation summing your inverters keeps counting it.
 
-Changing a device's address counts as removing it: the address is part of the device id.
+Two edits trigger it, and for devices 2..N they are the same edit: changing an address counts as
+removing the device, because the address is part of the device id. The other is promotion —
+moving a device into the `driver` slot, which leaves the per-device tree it used to publish on
+with no owner.
 
-The clearing runs once per boot and only after the broker is connected, so a restart with the
-broker down does not silently record the new list as if the clears had gone out. If a bridge
-ran a build from before this existed, its orphans are still there and have to be cleared by
-hand (`mosquitto_pub -r -n -t <topic>`) or deleted in Home Assistant.
+**The first device's own tree is never cleared, and that is the point.** The bridge-scoped
+topics and `unique_id`s always belong to whatever is in the `driver` slot, so re-addressing or
+replacing the first inverter hands the new one those entities and their recorder history rather
+than orphaning them. A single-inverter bridge therefore never orphans anything by changing its
+address. What can be left behind is narrower: if the replacement publishes *fewer* measurements
+than its predecessor, the discovery configs for the difference stay retained. Delete those
+entities in Home Assistant, or clear them with `mosquitto_pub -r -n -t <topic>`.
+
+The clearing runs once per boot and only after the broker is connected, and every publish is
+checked — a clear that the client refused is retried, and until it succeeds the device stays in
+the bookkeeping rather than being recorded as cleared. Not covered:
+
+- **A boot where a configured device did not start.** Nothing is cleared that boot: a device
+  skipped for a duplicate address or a driver that is not compiled in is still configured, and
+  its id cannot be known without its driver. Fix the configuration and reboot. The log says so.
+- **A changed base topic or discovery prefix.** Everything under the old prefix is orphaned,
+  including the bridge's own topics; the bookkeeping records device ids, not prefixes.
+- **A factory reset**, which erases the bookkeeping along with everything else, and a
+  bookkeeping entry that cannot be read back.
+- **A bridge that ran a build from before this existed.** Its orphans have to be cleared by
+  hand (`mosquitto_pub -r -n -t <topic>`) or deleted in Home Assistant.
 
 > **Which device is "first" comes from the configuration, not from boot order.** It is the
 > `driver` entry. If it fails to start, no device takes over the bridge-scoped topics — that is
-> deliberate, so a bad boot cannot transplant one inverter's history onto another. But moving a
-> different inverter into the `driver` slot *does* hand it those topics and that history.
+> deliberate, so a bad boot cannot transplant one inverter's history onto another.
 
 **Last Will and Testament:** topic `availability`, payload `offline`, retained, QoS 1. On a
 clean shutdown, the bridge publishes `offline` itself.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -46,13 +46,28 @@ discovery config topics. Devices beyond the first also carry their address in th
 e.g. `growatt_modbus-2`. It is **not** the serial number even for drivers that report one — the
 serial arrives during the first poll, long after the id is needed.
 
-> **Removing or re-addressing a device leaves its entities behind.** The discovery configs and
-> the last state are retained on the broker, and nothing publishes an empty payload to clear
-> them, so Home Assistant keeps re-creating those entities — and because availability is
-> bridge-scoped they stay *available*, showing the last value ever read. A template or
-> automation summing your inverters will keep counting the ghost. Clear them by hand
-> (`mosquitto_pub -r -n -t <topic>`) or delete the entities in Home Assistant. The relay
-> entities do have an automatic removal path; devices do not, yet.
+### Removing or re-addressing a device
+
+The bridge clears up after itself. It remembers which device ids it announced, and on the first
+connection after a restart it publishes empty retained payloads for any of them that is no
+longer configured — the device's own `state`, `identity` and `capabilities`, and every Home
+Assistant discovery config it could have announced. Home Assistant drops those entities.
+
+Two things follow from *could have*: the topics are enumerated from the canonical measurement
+ids rather than derived from the device's readings, because by then the device is gone and so
+are its readings; and clearing a topic that was never used is harmless.
+
+It matters because of how availability works here. Availability is bridge-scoped, deliberately,
+so a sleeping inverter does not make its entities unavailable every night — which means an
+orphaned entity does **not** go unavailable either. It reports *online* forever, showing the
+last value it ever read, and a template or automation summing your inverters keeps counting it.
+
+Changing a device's address counts as removing it: the address is part of the device id.
+
+The clearing runs once per boot and only after the broker is connected, so a restart with the
+broker down does not silently record the new list as if the clears had gone out. If a bridge
+ran a build from before this existed, its orphans are still there and have to be cleared by
+hand (`mosquitto_pub -r -n -t <topic>`) or deleted in Home Assistant.
 
 > **Which device is "first" comes from the configuration, not from boot order.** It is the
 > `driver` entry. If it fails to start, no device takes over the bridge-scoped topics — that is

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -383,10 +383,10 @@ bool ConfigurationStore::save(const Configuration& config) {
     return backend_.write(kStorageKeyConfig, blob);
 }
 
-std::vector<std::string> ConfigurationStore::announcedDevices() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    std::vector<std::string> out;
-    std::string              raw;
+std::vector<mqtt::AnnouncedDevice> ConfigurationStore::announcedDevices() {
+    std::lock_guard<std::mutex>        lock(mutex_);
+    std::vector<mqtt::AnnouncedDevice> out;
+    std::string                        raw;
     if (!backend_.read(kStorageKeyAnnounced, raw) || raw.empty()) {
         return out;
     }
@@ -395,19 +395,26 @@ std::vector<std::string> ConfigurationStore::announcedDevices() {
         return out;  // unreadable bookkeeping is simply forgotten, never fatal
     }
     for (JsonVariantConst v : doc.as<JsonArrayConst>()) {
+        // A bare string is the shape this key had before it carried the topic tree. Read as
+        // non-primary, which is what it always meant: the flag was added when the primary's
+        // tree turned out to need different handling, not to reinterpret old entries.
         if (v.is<const char*>()) {
-            out.emplace_back(v.as<const char*>());
+            out.push_back({v.as<const char*>(), false});
+        } else if (v.is<JsonObjectConst>() && v["id"].is<const char*>()) {
+            out.push_back({v["id"].as<const char*>(), v["primary"].as<bool>()});
         }
     }
     return out;
 }
 
-bool ConfigurationStore::setAnnouncedDevices(const std::vector<std::string>& ids) {
+bool ConfigurationStore::setAnnouncedDevices(const std::vector<mqtt::AnnouncedDevice>& devices) {
     std::lock_guard<std::mutex> lock(mutex_);
     JsonDocument doc;
     JsonArray    arr = doc.to<JsonArray>();
-    for (const auto& id : ids) {
-        arr.add(id);
+    for (const auto& d : devices) {
+        JsonObject o  = arr.add<JsonObject>();
+        o["id"]       = d.id;
+        o["primary"]  = d.primary;
     }
     std::string raw;
     serializeJson(doc, raw);

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -383,6 +383,37 @@ bool ConfigurationStore::save(const Configuration& config) {
     return backend_.write(kStorageKeyConfig, blob);
 }
 
+std::vector<std::string> ConfigurationStore::announcedDevices() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::string> out;
+    std::string              raw;
+    if (!backend_.read(kStorageKeyAnnounced, raw) || raw.empty()) {
+        return out;
+    }
+    JsonDocument doc;
+    if (deserializeJson(doc, raw) != DeserializationError::Ok || !doc.is<JsonArray>()) {
+        return out;  // unreadable bookkeeping is simply forgotten, never fatal
+    }
+    for (JsonVariantConst v : doc.as<JsonArrayConst>()) {
+        if (v.is<const char*>()) {
+            out.emplace_back(v.as<const char*>());
+        }
+    }
+    return out;
+}
+
+bool ConfigurationStore::setAnnouncedDevices(const std::vector<std::string>& ids) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    JsonDocument doc;
+    JsonArray    arr = doc.to<JsonArray>();
+    for (const auto& id : ids) {
+        arr.add(id);
+    }
+    std::string raw;
+    serializeJson(doc, raw);
+    return backend_.write(kStorageKeyAnnounced, raw);
+}
+
 bool ConfigurationStore::factoryReset() {
     std::lock_guard<std::mutex> lock(mutex_);
     return backend_.erase();

--- a/src/config/configuration_store.h
+++ b/src/config/configuration_store.h
@@ -82,6 +82,18 @@ public:
     /// Wipes everything, including credentials. Used by the provisioning reset.
     bool factoryReset();
 
+    /// Bookkeeping the firmware keeps about itself, kept OUT of Configuration on purpose: it is
+    /// not something a user sets, it must never appear in GET /config, and it must not take
+    /// part in the change-diff that decides whether a save needs a reboot.
+    ///
+    /// Currently one thing: which device ids have been announced to Home Assistant. Discovery
+    /// configs are retained on the broker, so a device that is removed or re-addressed leaves
+    /// its entities behind -- and because availability is bridge-scoped they report ONLINE
+    /// forever with their last value, straight into an energy dashboard. Clearing them needs
+    /// the one fact nothing else survives a reboot with: what we announced last time.
+    std::vector<std::string> announcedDevices();
+    bool                     setAnnouncedDevices(const std::vector<std::string>& ids);
+
 private:
     KeyValueBackend&   backend_;
     KeyValueBackend*   legacy_;
@@ -103,5 +115,8 @@ inline constexpr const char* kStorageNamespace = "heliograph";
 /// migration source; never written to.
 inline constexpr const char* kLegacyStorageNamespace = "solarbridge";
 inline constexpr const char* kStorageKeyConfig = "config";
+/// Separate key, not a field in the config blob: bookkeeping must not be able to make a user's
+/// configuration unloadable, and a factory reset should take it with everything else.
+inline constexpr const char* kStorageKeyAnnounced = "announced";
 
 }  // namespace heliograph

--- a/src/config/configuration_store.h
+++ b/src/config/configuration_store.h
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "configuration.h"
+#include "outputs/mqtt/announced_devices.h"
 
 namespace heliograph {
 
@@ -86,13 +87,13 @@ public:
     /// not something a user sets, it must never appear in GET /config, and it must not take
     /// part in the change-diff that decides whether a save needs a reboot.
     ///
-    /// Currently one thing: which device ids have been announced to Home Assistant. Discovery
-    /// configs are retained on the broker, so a device that is removed or re-addressed leaves
-    /// its entities behind -- and because availability is bridge-scoped they report ONLINE
-    /// forever with their last value, straight into an energy dashboard. Clearing them needs
-    /// the one fact nothing else survives a reboot with: what we announced last time.
-    std::vector<std::string> announcedDevices();
-    bool                     setAnnouncedDevices(const std::vector<std::string>& ids);
+    /// Currently one thing: which devices have been announced to Home Assistant, and on which
+    /// topic tree. Discovery configs are retained on the broker, so a device that is removed or
+    /// re-addressed leaves its entities behind -- and because availability is bridge-scoped they
+    /// report ONLINE forever with their last value, straight into an energy dashboard. Clearing
+    /// them needs the one fact nothing else survives a reboot with: what we announced last time.
+    std::vector<mqtt::AnnouncedDevice> announcedDevices();
+    bool setAnnouncedDevices(const std::vector<mqtt::AnnouncedDevice>& devices);
 
 private:
     KeyValueBackend&   backend_;

--- a/src/device/measurement.h
+++ b/src/device/measurement.h
@@ -102,6 +102,21 @@ inline constexpr const char* kBatteryCurrent      = "battery.current";
 inline constexpr const char* kBatteryTemperature  = "battery.temperature";
 inline constexpr const char* kBatteryEnergyCharged    = "battery.energy_charged";
 inline constexpr const char* kBatteryEnergyDischarged = "battery.energy_discharged";
+
+/// Every id above, in one place.
+///
+/// Needed because a device removed from the configuration leaves retained Home Assistant
+/// discovery topics behind, and clearing them means naming every topic it could have
+/// published -- which is derived from these ids. Kept in sync by tools/check_measurement_ids.py,
+/// which fails the build if a constant above is missing here.
+inline constexpr const char* kAll[] = {
+    kAcPowerTotal,   kAcFrequency,    kAcL1Voltage,    kAcL1Current,    kAcL1Power,
+    kDcPowerTotal,   kDcMppt1Voltage, kDcMppt1Current, kDcMppt1Power,   kDcMppt2Voltage,
+    kDcMppt2Current, kDcMppt2Power,   kEnergyToday,    kEnergyTotal,    kTemperature,
+    kOperatingHours, kBatterySoc,     kBatteryPower,   kBatteryVoltage, kBatteryCurrent,
+    kBatteryTemperature, kBatteryEnergyCharged, kBatteryEnergyDischarged,
+};
+
 }  // namespace measurement_id
 
 /// An ordered collection of measurements keyed by id.

--- a/src/device/measurement.h
+++ b/src/device/measurement.h
@@ -79,6 +79,15 @@ inline constexpr const char* kAcFrequency    = "ac.frequency";
 inline constexpr const char* kAcL1Voltage    = "ac.phase_l1.voltage";
 inline constexpr const char* kAcL1Current    = "ac.phase_l1.current";
 inline constexpr const char* kAcL1Power      = "ac.phase_l1.power";
+// L2/L3 exist as constants because three-phase drivers already publish them: a canonical id
+// that only lives as a string literal inside a driver cannot be enumerated, and so cannot be
+// cleared when the device that published it goes away (review, 2026-07-26).
+inline constexpr const char* kAcL2Voltage    = "ac.phase_l2.voltage";
+inline constexpr const char* kAcL2Current    = "ac.phase_l2.current";
+inline constexpr const char* kAcL2Power      = "ac.phase_l2.power";
+inline constexpr const char* kAcL3Voltage    = "ac.phase_l3.voltage";
+inline constexpr const char* kAcL3Current    = "ac.phase_l3.current";
+inline constexpr const char* kAcL3Power      = "ac.phase_l3.power";
 inline constexpr const char* kDcPowerTotal   = "dc.power.total";
 inline constexpr const char* kDcMppt1Voltage = "dc.mppt_1.voltage";
 inline constexpr const char* kDcMppt1Current = "dc.mppt_1.current";
@@ -102,6 +111,15 @@ inline constexpr const char* kBatteryCurrent      = "battery.current";
 inline constexpr const char* kBatteryTemperature  = "battery.temperature";
 inline constexpr const char* kBatteryEnergyCharged    = "battery.energy_charged";
 inline constexpr const char* kBatteryEnergyDischarged = "battery.energy_discharged";
+/// The raw rails, for a device that reads them separately and a consumer that wants them apart:
+/// the Modbus TCP register map has held registers for both since it was written. They exist as
+/// constants because ids that live only as string literals cannot be enumerated -- and an id
+/// that cannot be enumerated is an entity that can never be cleared (review, 2026-07-26).
+inline constexpr const char* kBatteryChargePower    = "battery.charge_power";
+inline constexpr const char* kBatteryDischargePower = "battery.discharge_power";
+/// House-level flows, for hybrids with a meter. Also long-standing Modbus registers.
+inline constexpr const char* kGridImportPower = "grid.import_power";
+inline constexpr const char* kGridExportPower = "grid.export_power";
 
 /// Every id above, in one place.
 ///
@@ -111,10 +129,12 @@ inline constexpr const char* kBatteryEnergyDischarged = "battery.energy_discharg
 /// which fails the build if a constant above is missing here.
 inline constexpr const char* kAll[] = {
     kAcPowerTotal,   kAcFrequency,    kAcL1Voltage,    kAcL1Current,    kAcL1Power,
-    kDcPowerTotal,   kDcMppt1Voltage, kDcMppt1Current, kDcMppt1Power,   kDcMppt2Voltage,
-    kDcMppt2Current, kDcMppt2Power,   kEnergyToday,    kEnergyTotal,    kTemperature,
-    kOperatingHours, kBatterySoc,     kBatteryPower,   kBatteryVoltage, kBatteryCurrent,
-    kBatteryTemperature, kBatteryEnergyCharged, kBatteryEnergyDischarged,
+    kAcL2Voltage,    kAcL2Current,    kAcL2Power,      kAcL3Voltage,    kAcL3Current,
+    kAcL3Power,      kDcPowerTotal,   kDcMppt1Voltage, kDcMppt1Current, kDcMppt1Power,
+    kDcMppt2Voltage, kDcMppt2Current, kDcMppt2Power,   kEnergyToday,    kEnergyTotal,
+    kTemperature,    kOperatingHours, kBatterySoc,     kBatteryPower,   kBatteryVoltage,
+    kBatteryCurrent, kBatteryTemperature, kBatteryEnergyCharged, kBatteryEnergyDischarged,
+    kBatteryChargePower, kBatteryDischargePower, kGridImportPower, kGridExportPower,
 };
 
 }  // namespace measurement_id

--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -193,12 +193,14 @@ PollResult MockDriver::poll(DeviceState& state) {
     // building them fresh every poll only churned the heap (review, 2026-07-21). The phase
     // number stays in the display name -- Home Assistant builds the entity id from it, and
     // three entities called "Phase Voltage" would collide into _2/_3.
-    static const char* kPhaseVoltage[] = {"ac.phase_l1.voltage", "ac.phase_l2.voltage",
-                                          "ac.phase_l3.voltage"};
-    static const char* kPhaseCurrent[] = {"ac.phase_l1.current", "ac.phase_l2.current",
-                                          "ac.phase_l3.current"};
-    static const char* kPhasePower[]   = {"ac.phase_l1.power", "ac.phase_l2.power",
-                                          "ac.phase_l3.power"};
+    static const char* kPhaseVoltage[] = {measurement_id::kAcL1Voltage,
+                                          measurement_id::kAcL2Voltage,
+                                          measurement_id::kAcL3Voltage};
+    static const char* kPhaseCurrent[] = {measurement_id::kAcL1Current,
+                                          measurement_id::kAcL2Current,
+                                          measurement_id::kAcL3Current};
+    static const char* kPhasePower[]   = {measurement_id::kAcL1Power, measurement_id::kAcL2Power,
+                                          measurement_id::kAcL3Power};
     static const char* kPhaseVName[]   = {"Phase L1 Voltage", "Phase L2 Voltage",
                                           "Phase L3 Voltage"};
     static const char* kPhaseCName[]   = {"Phase L1 Current", "Phase L2 Current",
@@ -238,15 +240,21 @@ PollResult MockDriver::poll(DeviceState& state) {
         m.set(kMpptP[i], power, ts);
     }
 
-    m.declare("battery.soc", MeasurementType::Ratio, Unit::Percent, "Battery SoC");
-    m.declare("battery.voltage", MeasurementType::Voltage, Unit::Volt, "Battery Voltage");
-    m.declare("battery.charge_power", MeasurementType::Power, Unit::Watt, "Battery Charge Power");
-    m.declare("battery.discharge_power", MeasurementType::Power, Unit::Watt, "Battery Discharge Power");
+    // Constants, not string literals -- same channels as before. An id written out by hand is
+    // invisible to anything that enumerates the vocabulary, which is how these four ended up
+    // announceable but not clearable (review, 2026-07-26).
+    m.declare(measurement_id::kBatterySoc, MeasurementType::Ratio, Unit::Percent, "Battery SoC");
+    m.declare(measurement_id::kBatteryVoltage, MeasurementType::Voltage, Unit::Volt,
+              "Battery Voltage");
+    m.declare(measurement_id::kBatteryChargePower, MeasurementType::Power, Unit::Watt,
+              "Battery Charge Power");
+    m.declare(measurement_id::kBatteryDischargePower, MeasurementType::Power, Unit::Watt,
+              "Battery Discharge Power");
     const double soc = 40.0 + 40.0 * fraction;
-    m.set("battery.soc", soc, ts);
-    m.set("battery.voltage", 48.0 + soc * 0.05, ts);
-    m.set("battery.charge_power", fraction > 0.3 ? 1000.0 : 0.0, ts);
-    m.set("battery.discharge_power", fraction == 0.0 ? 400.0 : 0.0, ts);
+    m.set(measurement_id::kBatterySoc, soc, ts);
+    m.set(measurement_id::kBatteryVoltage, 48.0 + soc * 0.05, ts);
+    m.set(measurement_id::kBatteryChargePower, fraction > 0.3 ? 1000.0 : 0.0, ts);
+    m.set(measurement_id::kBatteryDischargePower, fraction == 0.0 ? 400.0 : 0.0, ts);
 
     m.set(measurement_id::kAcPowerTotal, acPower, ts);
     m.set(measurement_id::kAcFrequency, 50.0, ts);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include <esp_task_wdt.h>
 #include <esp_timer.h>
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -115,6 +116,11 @@ std::vector<DeviceId> g_deviceIds;
 /// point: it is what stops a boot where device 1 failed from handing its MQTT topics, its Home
 /// Assistant entities and its recorder history to whichever device did start.
 DeviceId g_primaryDeviceId;
+
+/// Whether the announced-device reconciliation has run this boot. Once per session, and only
+/// once the broker is actually connected: publishing the clears into a disconnected client
+/// would drop them silently and then record the new list as if they had gone out.
+bool g_announcedReconciled = false;
 
 /// How many devices the configuration asked for, whether or not they started. Drives the status
 /// LED: a configured device that failed to start is a fault to show, not an absence to ignore.
@@ -711,6 +717,23 @@ void rs485Task(void* /*arg*/) {
             // label. Both are named in docs/architecture.md as the remaining gap.
             g_modbus.refresh(*first, bridge, diag, nowMs());
             if (g_mqtt) {
+                // Once, on the first connected pass. Retained discovery configs outlive the
+                // device that published them, and because availability is bridge-scoped an
+                // orphaned entity does not go unavailable -- it reports ONLINE forever with its
+                // last value, and anything summing the inverters keeps counting it. Removing a
+                // device from the configuration and changing its address (which changes its id)
+                // both leave that behind. What we announced last time is the one fact nothing
+                // else survives a reboot knowing.
+                if (!g_announcedReconciled && g_mqtt->connected()) {
+                    for (const auto& old : g_store.announcedDevices()) {
+                        if (std::find(g_deviceIds.begin(), g_deviceIds.end(), old) ==
+                            g_deviceIds.end()) {
+                            g_mqtt->forgetDevice(old, bridge, old == g_primaryDeviceId);
+                        }
+                    }
+                    g_store.setAnnouncedDevices(g_deviceIds);
+                    g_announcedReconciled = true;
+                }
                 g_mqtt->loop(views, bridge, diag, nowMs());
             }
             if (g_rest) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,10 +117,12 @@ std::vector<DeviceId> g_deviceIds;
 /// Assistant entities and its recorder history to whichever device did start.
 DeviceId g_primaryDeviceId;
 
-/// Whether the announced-device reconciliation has run this boot. Once per session, and only
-/// once the broker is actually connected: publishing the clears into a disconnected client
-/// would drop them silently and then record the new list as if they had gone out.
-bool g_announcedReconciled = false;
+/// Whether the announced-device reconciliation is done for this boot. Once per session, and
+/// only once the broker is actually connected: publishing the clears into a disconnected client
+/// would drop them silently and then record the new list as if they had gone out. A refused
+/// publish leaves this false so the next pass retries, bounded by the counter below.
+bool     g_announcedReconciled = false;
+unsigned g_announcedAttempts   = 0;
 
 /// How many devices the configuration asked for, whether or not they started. Drives the status
 /// LED: a configured device that failed to start is a fault to show, not an absence to ignore.
@@ -616,6 +618,60 @@ void startRestApi() {
     g_rest->begin();
 }
 
+/// Clears the retained topics of devices that are no longer where we announced them.
+///
+/// Retained discovery configs outlive the device that published them, and because availability
+/// is bridge-scoped an orphaned entity does not go unavailable -- it reports ONLINE forever with
+/// its last value, and anything summing the inverters keeps counting it. What we announced last
+/// time is the one fact nothing else survives a reboot knowing.
+void reconcileAnnouncedDevices(const BridgeInfo& bridge) {
+    // Only when every configured device actually started. g_deviceIds holds the devices that
+    // STARTED; one skipped for a duplicate id, a driver that is not compiled in or a full slot
+    // table is still configured, and tearing its Home Assistant entities down over a typo that
+    // gets corrected in a minute is worse than leaving them one boot longer. Nothing here can
+    // know the id of a device that never got a driver -- the id comes from the driver -- so the
+    // honest move is to defer the whole reconciliation and leave the bookkeeping untouched
+    // (review, 2026-07-26). Zero configured devices lands here too, and never reaches this
+    // function at all: with nothing started there is no state and MQTT does not run.
+    if (g_deviceIds.size() != g_devicesConfigured) {
+        log::warn("MQTT: not clearing retained device topics this boot -- %u of %u configured "
+                  "devices started; fix them and reboot",
+                  static_cast<unsigned>(g_deviceIds.size()),
+                  static_cast<unsigned>(g_devicesConfigured));
+        g_announcedReconciled = true;
+        return;
+    }
+
+    std::vector<mqtt::AnnouncedDevice> record;
+    record.reserve(g_deviceIds.size());
+    for (const auto& id : g_deviceIds) {
+        record.push_back({id, id == g_primaryDeviceId});
+    }
+
+    bool allCleared = true;
+    for (const auto& id :
+         mqtt::devicesToForget(g_store.announcedDevices(), g_deviceIds, g_primaryDeviceId)) {
+        if (!g_mqtt->forgetDevice(id, bridge)) {
+            allCleared = false;
+            // Kept in the record even though it is gone from the configuration: dropping it
+            // here would be the last time anything knew it existed, and its entities would then
+            // be orphaned for good.
+            record.push_back({id, false});
+        }
+    }
+    if (!allCleared && ++g_announcedAttempts < 5) {
+        return;  // link hiccup or a full outbox; try again next pass
+    }
+    if (!allCleared) {
+        log::warn("MQTT: could not clear every removed device's topics; will retry next boot");
+    }
+    if (!g_store.setAnnouncedDevices(record)) {
+        log::warn("MQTT: could not record which devices were announced; removing one later will "
+                  "leave its Home Assistant entities behind");
+    }
+    g_announcedReconciled = true;
+}
+
 void rs485Task(void* /*arg*/) {
     for (;;) {
         // One feed per iteration; the 120 s budget covers the longest legitimate iteration
@@ -717,22 +773,10 @@ void rs485Task(void* /*arg*/) {
             // label. Both are named in docs/architecture.md as the remaining gap.
             g_modbus.refresh(*first, bridge, diag, nowMs());
             if (g_mqtt) {
-                // Once, on the first connected pass. Retained discovery configs outlive the
-                // device that published them, and because availability is bridge-scoped an
-                // orphaned entity does not go unavailable -- it reports ONLINE forever with its
-                // last value, and anything summing the inverters keeps counting it. Removing a
-                // device from the configuration and changing its address (which changes its id)
-                // both leave that behind. What we announced last time is the one fact nothing
-                // else survives a reboot knowing.
+                // Once, on the first connected pass -- before loop() below, so the clears are
+                // queued ahead of this boot's own discovery announcements.
                 if (!g_announcedReconciled && g_mqtt->connected()) {
-                    for (const auto& old : g_store.announcedDevices()) {
-                        if (std::find(g_deviceIds.begin(), g_deviceIds.end(), old) ==
-                            g_deviceIds.end()) {
-                            g_mqtt->forgetDevice(old, bridge, old == g_primaryDeviceId);
-                        }
-                    }
-                    g_store.setAnnouncedDevices(g_deviceIds);
-                    g_announcedReconciled = true;
+                    reconcileAnnouncedDevices(bridge);
                 }
                 g_mqtt->loop(views, bridge, diag, nowMs());
             }

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -268,15 +268,17 @@ void RegisterMap::update(const DeviceState& state, const BridgeInfo& bridge,
     }
 
     // --- battery and grid: empty for a driver without them, and that is visible ---
-    publishMeasurement(state, "battery.soc", reg::kBatterySoc, ValidityBit::BatterySoc);
-    publishMeasurement(state, "battery.voltage", reg::kBatteryVoltage, ValidityBit::BatteryVoltage);
-    publishMeasurement(state, "battery.charge_power", reg::kBatteryChargePower,
+    publishMeasurement(state, measurement_id::kBatterySoc, reg::kBatterySoc,
+                       ValidityBit::BatterySoc);
+    publishMeasurement(state, measurement_id::kBatteryVoltage, reg::kBatteryVoltage,
+                       ValidityBit::BatteryVoltage);
+    publishMeasurement(state, measurement_id::kBatteryChargePower, reg::kBatteryChargePower,
                        ValidityBit::BatteryChargePower);
-    publishMeasurement(state, "battery.discharge_power", reg::kBatteryDischargePower,
+    publishMeasurement(state, measurement_id::kBatteryDischargePower, reg::kBatteryDischargePower,
                        ValidityBit::BatteryDischargePower);
-    publishMeasurement(state, "grid.import_power", reg::kGridImportPower,
+    publishMeasurement(state, measurement_id::kGridImportPower, reg::kGridImportPower,
                        ValidityBit::GridImportPower);
-    publishMeasurement(state, "grid.export_power", reg::kGridExportPower,
+    publishMeasurement(state, measurement_id::kGridExportPower, reg::kGridExportPower,
                        ValidityBit::GridExportPower);
 
     // --- capabilities ---

--- a/src/outputs/mqtt/announced_devices.h
+++ b/src/outputs/mqtt/announced_devices.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace heliograph::mqtt {
+
+/// One device as it was last announced to the broker, with the topic tree it was announced on.
+///
+/// The id alone is not enough. A device's topics are a function of (id, primary): the primary
+/// device publishes on the bridge-scoped tree it has always used, every other device on
+/// `<base>/<bridgeId>/device/<id>/`. A device that keeps its id but moves between those two
+/// trees leaves the one it came from behind, and without this flag nothing could tell.
+struct AnnouncedDevice {
+    std::string id;
+    bool        primary = false;
+};
+
+/// Which previously announced devices left a DEVICE-SCOPED topic tree that nothing publishes to
+/// any more, and whose retained payloads therefore have to be cleared.
+///
+/// Two cases, both of which put a device's entities in Home Assistant forever with their last
+/// value (availability is bridge-scoped by design, so an orphan never goes unavailable):
+///   - it is gone from the configuration, or its address changed, which changes its id;
+///   - it was promoted into the `driver` slot, so it publishes on the bridge-scoped tree now
+///     and its old per-device tree has no owner.
+///
+/// The bridge-scoped tree is never cleared, and that is deliberate rather than an omission.
+/// It is either owned by the device that is primary now, or it is about to be inherited by
+/// the next one -- which is exactly the back-compat contract: an existing install's entities
+/// and their recorder history survive the first device being re-addressed or replaced.
+/// Clearing it would delete the live primary's entities. The residue is the discovery configs
+/// of measurements the old primary published and the new one does not; docs/mqtt.md says so.
+///
+/// Pure and host-testable on purpose: MqttOutput is compiled only for ESP32, so a rule that
+/// lived inside it could not be tested at all. The previous shape of this decision -- a
+/// `primary` flag computed at the call site from a variable that could never hold a removed
+/// device's id -- was provably dead and no test could have seen it (review, 2026-07-26).
+inline std::vector<std::string> devicesToForget(const std::vector<AnnouncedDevice>& announced,
+                                                const std::vector<std::string>&     current,
+                                                const std::string&                  primaryNow) {
+    std::vector<std::string> out;
+    for (const auto& a : announced) {
+        if (a.primary) {
+            continue;
+        }
+        const bool stillDeviceScoped =
+            a.id != primaryNow &&
+            std::find(current.begin(), current.end(), a.id) != current.end();
+        if (!stillDeviceScoped &&
+            std::find(out.begin(), out.end(), a.id) == out.end()) {
+            out.push_back(a.id);
+        }
+    }
+    return out;
+}
+
+}  // namespace heliograph::mqtt

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -11,6 +11,8 @@
 
 #include <cstring>
 
+#include "diagnostics/logger.h"
+
 #if defined(ESP32)
 
 #include <espMqttClient.h>
@@ -340,6 +342,38 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
     }
 }
 
+void MqttOutput::forgetDevice(const DeviceId& id, const BridgeInfo& bridge, bool primary) {
+    if (!started_ || !g_client.connected()) {
+        return;
+    }
+    const MqttTopics  topics(config_.baseTopic, bridge.bridgeId, deviceTopicKey(primary, id));
+    const std::string base = deviceUniqueBase(primary, bridge.bridgeId, id);
+
+    // The device's own retained payloads. Empty, retained: a subscriber that connects later
+    // must not be handed a reading from an inverter that is no longer configured.
+    for (const auto& topic : {topics.state(), topics.identity(), topics.capabilities()}) {
+        g_client.publish(topic.c_str(), 1, true, "");
+    }
+
+    // Every discovery config it could have announced. Enumerated rather than derived from the
+    // measurement set, which is gone along with the device. Publishing an empty retained
+    // payload to a topic that was never used is harmless -- Home Assistant has nothing to
+    // remove and the broker drops the retained entry.
+    for (const char* mid : measurement_id::kAll) {
+        const std::string slug = sanitizeId(mid);
+        g_client.publish((config_.discoveryPrefix + "/sensor/" + base + "/" + slug + "/config")
+                             .c_str(), 1, true, "");
+    }
+    g_client.publish((config_.discoveryPrefix + "/sensor/" + base + "/status/config").c_str(), 1,
+                     true, "");
+    g_client.publish(
+        (config_.discoveryPrefix + "/binary_sensor/" + base + "/inverter_online/config").c_str(),
+        1, true, "");
+
+    heliograph::log::info("MQTT: cleared retained topics for removed device %s",
+                          id.c_str());
+}
+
 void MqttOutput::stop() {
     if (started_) {
         // Say goodbye properly so subscribers do not have to wait for the will.
@@ -364,6 +398,7 @@ void MqttOutput::loop(const std::vector<DeviceView>&, const BridgeInfo&,
                       const DiagnosticsSnapshot&,
                       uint64_t) {}
 void MqttOutput::stop() { started_ = false; }
+void MqttOutput::forgetDevice(const DeviceId&, const BridgeInfo&, bool) {}
 bool MqttOutput::connected() const { return false; }
 void MqttOutput::onConnected(Channel&, const DeviceState&, const BridgeInfo&) {}
 void MqttOutput::publishDiscovery(Channel&, const DeviceState&, const BridgeInfo&) {}

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -342,17 +342,26 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
     }
 }
 
-void MqttOutput::forgetDevice(const DeviceId& id, const BridgeInfo& bridge, bool primary) {
+bool MqttOutput::forgetDevice(const DeviceId& id, const BridgeInfo& bridge) {
     if (!started_ || !g_client.connected()) {
-        return;
+        return false;
     }
-    const MqttTopics  topics(config_.baseTopic, bridge.bridgeId, deviceTopicKey(primary, id));
-    const std::string base = deviceUniqueBase(primary, bridge.bridgeId, id);
+    // Always the device-scoped tree; see the header for why the bridge-scoped one is off limits.
+    const MqttTopics  topics(config_.baseTopic, bridge.bridgeId, deviceTopicKey(false, id));
+    const std::string base = deviceUniqueBase(false, bridge.bridgeId, id);
+
+    // Every publish is checked. A packet id of 0 means the client refused it -- the link went
+    // down between the connected() check and here, or the outbox could not allocate -- and a
+    // clear that never left must not be recorded as done (review, 2026-07-26).
+    bool ok = true;
+    const auto clear = [&](const std::string& topic) {
+        ok = (g_client.publish(topic.c_str(), 1, true, "") != 0) && ok;
+    };
 
     // The device's own retained payloads. Empty, retained: a subscriber that connects later
     // must not be handed a reading from an inverter that is no longer configured.
     for (const auto& topic : {topics.state(), topics.identity(), topics.capabilities()}) {
-        g_client.publish(topic.c_str(), 1, true, "");
+        clear(topic);
     }
 
     // Every discovery config it could have announced. Enumerated rather than derived from the
@@ -360,18 +369,15 @@ void MqttOutput::forgetDevice(const DeviceId& id, const BridgeInfo& bridge, bool
     // payload to a topic that was never used is harmless -- Home Assistant has nothing to
     // remove and the broker drops the retained entry.
     for (const char* mid : measurement_id::kAll) {
-        const std::string slug = sanitizeId(mid);
-        g_client.publish((config_.discoveryPrefix + "/sensor/" + base + "/" + slug + "/config")
-                             .c_str(), 1, true, "");
+        clear(config_.discoveryPrefix + "/sensor/" + base + "/" + sanitizeId(mid) + "/config");
     }
-    g_client.publish((config_.discoveryPrefix + "/sensor/" + base + "/status/config").c_str(), 1,
-                     true, "");
-    g_client.publish(
-        (config_.discoveryPrefix + "/binary_sensor/" + base + "/inverter_online/config").c_str(),
-        1, true, "");
+    clear(config_.discoveryPrefix + "/sensor/" + base + "/status/config");
+    clear(config_.discoveryPrefix + "/binary_sensor/" + base + "/inverter_online/config");
 
-    heliograph::log::info("MQTT: cleared retained topics for removed device %s",
-                          id.c_str());
+    if (ok) {
+        heliograph::log::info("MQTT: cleared retained topics for removed device %s", id.c_str());
+    }
+    return ok;
 }
 
 void MqttOutput::stop() {
@@ -398,7 +404,7 @@ void MqttOutput::loop(const std::vector<DeviceView>&, const BridgeInfo&,
                       const DiagnosticsSnapshot&,
                       uint64_t) {}
 void MqttOutput::stop() { started_ = false; }
-void MqttOutput::forgetDevice(const DeviceId&, const BridgeInfo&, bool) {}
+bool MqttOutput::forgetDevice(const DeviceId&, const BridgeInfo&) { return false; }
 bool MqttOutput::connected() const { return false; }
 void MqttOutput::onConnected(Channel&, const DeviceState&, const BridgeInfo&) {}
 void MqttOutput::publishDiscovery(Channel&, const DeviceState&, const BridgeInfo&) {}

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -85,6 +85,22 @@ public:
     void loop(const std::vector<DeviceView>& devices, const BridgeInfo& bridge,
               const DiagnosticsSnapshot& diagnostics, uint64_t nowMs);
 
+    /// Clears everything a device left on the broker: its retained state, identity and
+    /// capabilities, and every Home Assistant discovery config it could have published.
+    ///
+    /// Retained messages outlive the device that sent them. Because availability is
+    /// bridge-scoped -- deliberately, so a sleeping inverter does not vanish at night -- an
+    /// orphaned entity does not go "unavailable"; it reports ONLINE forever, showing whatever
+    /// it last read, and anything summing the inverters keeps counting it. Removing a device
+    /// from the configuration, or changing its address (which changes its id), both leave that
+    /// behind.
+    ///
+    /// Empty retained payloads are how Home Assistant is told to forget an entity -- the same
+    /// mechanism the relay switches already use when the feature is disabled. The topics are
+    /// enumerated from the canonical measurement ids rather than from the device's state,
+    /// because by the time this runs there is no state: the device is gone.
+    void forgetDevice(const DeviceId& id, const BridgeInfo& bridge, bool primary);
+
     void stop();
     bool connected() const;
 

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -85,21 +85,28 @@ public:
     void loop(const std::vector<DeviceView>& devices, const BridgeInfo& bridge,
               const DiagnosticsSnapshot& diagnostics, uint64_t nowMs);
 
-    /// Clears everything a device left on the broker: its retained state, identity and
-    /// capabilities, and every Home Assistant discovery config it could have published.
+    /// Clears what a device left on its own `<base>/<bridgeId>/device/<id>/` tree: the retained
+    /// state, identity and capabilities, and every Home Assistant discovery config it could have
+    /// published there.
     ///
     /// Retained messages outlive the device that sent them. Because availability is
     /// bridge-scoped -- deliberately, so a sleeping inverter does not vanish at night -- an
     /// orphaned entity does not go "unavailable"; it reports ONLINE forever, showing whatever
-    /// it last read, and anything summing the inverters keeps counting it. Removing a device
-    /// from the configuration, or changing its address (which changes its id), both leave that
-    /// behind.
+    /// it last read, and anything summing the inverters keeps counting it.
+    ///
+    /// Device-scoped ONLY, and takes no `primary` flag by design: the bridge-scoped tree always
+    /// has a live or incoming owner, and clearing it would delete that owner's entities. Which
+    /// devices qualify is decided by mqtt::devicesToForget(), which is host-testable; this is
+    /// not.
     ///
     /// Empty retained payloads are how Home Assistant is told to forget an entity -- the same
     /// mechanism the relay switches already use when the feature is disabled. The topics are
     /// enumerated from the canonical measurement ids rather than from the device's state,
     /// because by the time this runs there is no state: the device is gone.
-    void forgetDevice(const DeviceId& id, const BridgeInfo& bridge, bool primary);
+    ///
+    /// Returns false if any publish was refused (link down, outbox out of memory). The caller
+    /// must not record the device as forgotten in that case -- nothing else remembers it.
+    bool forgetDevice(const DeviceId& id, const BridgeInfo& bridge);
 
     void stop();
     bool connected() const;

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -972,8 +972,39 @@ static void test_two_devices_produce_distinct_unique_ids_and_ha_devices() {
 }
 
 
+// The topics a removed device has to be cleared on are enumerated from the canonical ids,
+// because by the time the clearing runs the device's measurement set is gone with it. If a
+// canonical id were missing from that list its entity would stay in Home Assistant reporting
+// online forever -- so this pins that every id a discovery entity can be built from is in it.
+static void test_every_announceable_measurement_is_clearable() {
+    Rig               r;
+    const DeviceState state  = r.poll();
+    const BridgeInfo  bridge = makeBridge();
+    const MqttTopics  topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                                                 kDefaultDiscoveryPrefix, bridge.bridgeId);
+
+    std::vector<std::string> clearable;
+    for (const char* id : measurement_id::kAll) {
+        clearable.push_back(sanitizeId(id));
+    }
+    clearable.push_back("status");
+    clearable.push_back("inverter_online");
+
+    TEST_ASSERT_TRUE(!entities.empty());
+    for (const auto& e : entities) {
+        // unique_id is "<base>_<slug>"; the slug is what the config topic is keyed on.
+        const std::string slug = e.uniqueId.substr(bridge.bridgeId.size() + 1);
+        TEST_ASSERT_TRUE_MESSAGE(
+            std::find(clearable.begin(), clearable.end(), slug) != clearable.end(),
+            ("announced a slug that cannot be cleared: " + slug).c_str());
+    }
+}
+
+
 int main(int, char**) {
     UNITY_BEGIN();
+    RUN_TEST(test_every_announceable_measurement_is_clearable);
     RUN_TEST(test_the_primary_device_keeps_the_bridge_scoped_identity);
     RUN_TEST(test_a_non_primary_device_gets_its_own_identity);
     RUN_TEST(test_every_device_tracks_the_bridge_availability_topic);

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -13,6 +13,7 @@
 #include "device/device_context.h"
 #include "drivers/eversolar_legacy/eversolar_driver.h"
 #include "drivers/mock/mock_driver.h"
+#include "outputs/mqtt/announced_devices.h"
 #include "outputs/mqtt/home_assistant_discovery.h"
 #include "outputs/mqtt/mqtt_payloads.h"
 #include "outputs/mqtt/mqtt_topics.h"
@@ -976,11 +977,9 @@ static void test_two_devices_produce_distinct_unique_ids_and_ha_devices() {
 // because by the time the clearing runs the device's measurement set is gone with it. If a
 // canonical id were missing from that list its entity would stay in Home Assistant reporting
 // online forever -- so this pins that every id a discovery entity can be built from is in it.
-static void test_every_announceable_measurement_is_clearable() {
-    Rig               r;
-    const DeviceState state  = r.poll();
-    const BridgeInfo  bridge = makeBridge();
-    const MqttTopics  topics(kDefaultBaseTopic, bridge.bridgeId);
+static void assertEveryAnnouncedSlugIsClearable(const DeviceState& state, const char* who) {
+    const BridgeInfo bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
     const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
                                                  kDefaultDiscoveryPrefix, bridge.bridgeId);
 
@@ -997,14 +996,89 @@ static void test_every_announceable_measurement_is_clearable() {
         const std::string slug = e.uniqueId.substr(bridge.bridgeId.size() + 1);
         TEST_ASSERT_TRUE_MESSAGE(
             std::find(clearable.begin(), clearable.end(), slug) != clearable.end(),
-            ("announced a slug that cannot be cleared: " + slug).c_str());
+            (std::string(who) + " announced a slug that cannot be cleared: " + slug).c_str());
     }
+}
+
+static void test_every_announceable_measurement_is_clearable() {
+    // Both drivers, because one driver's channel set proves nothing about the enumeration. The
+    // EverSolar rig alone happened to be all-canonical, so the first version of this test passed
+    // while the mock -- three phases and a battery, which is what it exists for -- announced
+    // eight ids that no consumer could enumerate or clear (review, 2026-07-26).
+    Rig r;
+    assertEveryAnnouncedSlugIsClearable(r.poll(), "eversolar");
+
+    mock::MockDriver driver(clockFn, mock::MockOptions{});
+    StateStore       store;
+    Diagnostics      diag;
+    g_now = 12ULL * 60 * 60 * 1000;
+    DeviceContext ctx(driver, store, diag, clockFn);
+    ctx.pollOnce();
+    assertEveryAnnouncedSlugIsClearable(*store.snapshot(), "mock");
+}
+
+// --- which devices have to be forgotten ---------------------------------------------------
+//
+// The decision, not the publishing: MqttOutput is ESP32-only, so this rule is the part that can
+// be held to account. Its predecessor -- a `primary` flag computed at the call site from a
+// variable that could never hold a removed device's id -- was dead code no test could reach.
+
+static void test_a_removed_device_is_forgotten() {
+    const auto gone = devicesToForget({{"eversolar-1", true}, {"growatt_modbus-2", false}},
+                                      {"eversolar-1"}, "eversolar-1");
+    TEST_ASSERT_EQUAL_UINT32(1, gone.size());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", gone[0].c_str());
+}
+
+static void test_a_re_addressed_device_is_forgotten_under_its_old_id() {
+    // Bring-up reality: unit 3 turns out to sit at address 4. The address is part of the id.
+    const auto gone = devicesToForget({{"growatt_modbus-1", true}, {"growatt_modbus-3", false}},
+                                      {"growatt_modbus-1", "growatt_modbus-4"},
+                                      "growatt_modbus-1");
+    TEST_ASSERT_EQUAL_UINT32(1, gone.size());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-3", gone[0].c_str());
+}
+
+static void test_a_promoted_device_gives_up_its_device_scoped_tree() {
+    // Device 1 deleted, device 2 moved into the `driver` slot. Its id never changed, so nothing
+    // ever saw it as removed -- and its whole per-device entity set stayed in Home Assistant.
+    const auto gone = devicesToForget({{"eversolar-1", true}, {"growatt_modbus-2", false}},
+                                      {"growatt_modbus-2"}, "growatt_modbus-2");
+    TEST_ASSERT_EQUAL_UINT32(1, gone.size());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", gone[0].c_str());
+}
+
+static void test_the_bridge_scoped_tree_is_never_cleared() {
+    // The old primary is gone and a different device owns the bridge-scoped tree now. Clearing
+    // what the old one published would delete the live primary's entities and their history --
+    // handing them over is the back-compat contract, not a leak to be plugged.
+    const auto gone = devicesToForget({{"eversolar-1", true}}, {"growatt_modbus-1"},
+                                      "growatt_modbus-1");
+    TEST_ASSERT_TRUE(gone.empty());
+
+    // Same when nothing is primary this boot: still not ours to delete.
+    TEST_ASSERT_TRUE(devicesToForget({{"eversolar-1", true}}, {}, "").empty());
+}
+
+static void test_an_unchanged_line_up_forgets_nothing() {
+    const std::vector<AnnouncedDevice> announced{{"growatt_modbus-1", true},
+                                                 {"growatt_modbus-2", false},
+                                                 {"growatt_modbus-3", false}};
+    const std::vector<std::string>     current{"growatt_modbus-1", "growatt_modbus-2",
+                                               "growatt_modbus-3"};
+    TEST_ASSERT_TRUE(devicesToForget(announced, current, "growatt_modbus-1").empty());
+    TEST_ASSERT_TRUE(devicesToForget({}, current, "growatt_modbus-1").empty());
 }
 
 
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_every_announceable_measurement_is_clearable);
+    RUN_TEST(test_a_removed_device_is_forgotten);
+    RUN_TEST(test_a_re_addressed_device_is_forgotten_under_its_old_id);
+    RUN_TEST(test_a_promoted_device_gives_up_its_device_scoped_tree);
+    RUN_TEST(test_the_bridge_scoped_tree_is_never_cleared);
+    RUN_TEST(test_an_unchanged_line_up_forgets_nothing);
     RUN_TEST(test_the_primary_device_keeps_the_bridge_scoped_identity);
     RUN_TEST(test_a_non_primary_device_gets_its_own_identity);
     RUN_TEST(test_every_device_tracks_the_bridge_availability_topic);

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -631,6 +631,49 @@ static void test_a_nameless_stored_device_is_dropped_not_fatal() {
     TEST_ASSERT_TRUE(validate(loaded, e));  // and what survived is saveable
 }
 
+// Which device ids were announced to the broker is the one fact nothing else survives a reboot
+// knowing -- and without it a removed device's retained Home Assistant entities can never be
+// cleared. Kept out of Configuration on purpose: it is not a user setting, must not appear in
+// GET /config, and must not take part in the reboot-required diff.
+static void test_announced_devices_round_trip_and_start_empty() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    TEST_ASSERT_TRUE(store.announcedDevices().empty());
+
+    TEST_ASSERT_TRUE(store.setAnnouncedDevices({"growatt_modbus-1", "growatt_modbus-2"}));
+    const auto back = store.announcedDevices();
+    TEST_ASSERT_EQUAL_UINT32(2, back.size());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", back[1].c_str());
+
+    // Removing the last device must be storable as such, not indistinguishable from "never set".
+    TEST_ASSERT_TRUE(store.setAnnouncedDevices({}));
+    TEST_ASSERT_TRUE(store.announcedDevices().empty());
+}
+
+// Unreadable bookkeeping is forgotten, never fatal: it lives in its own key precisely so it
+// cannot take a working configuration down with it.
+static void test_corrupt_announced_bookkeeping_is_not_fatal() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    backend.write(kStorageKeyAnnounced, "{not json");
+    TEST_ASSERT_TRUE(store.announcedDevices().empty());
+
+    auto c = provisionedConfig();
+    TEST_ASSERT_TRUE(store.save(c));
+    Configuration loaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(loaded));
+}
+
+// A factory reset erases the whole namespace, so the bookkeeping goes with it -- a bridge that
+// has been wiped must not then try to clear topics for devices from a previous life.
+static void test_a_factory_reset_forgets_what_was_announced() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    store.setAnnouncedDevices({"growatt_modbus-1"});
+    TEST_ASSERT_TRUE(store.factoryReset());
+    TEST_ASSERT_TRUE(store.announcedDevices().empty());
+}
+
 static void test_ota_rejects_a_non_firmware_upload_before_writing() {
     ota::OtaManager ota;
     TEST_ASSERT_EQUAL(ota::OtaResult::Ok, ota.begin(1024));
@@ -759,6 +802,9 @@ int main(int, char**) {
     RUN_TEST(test_extra_devices_survive_a_restart);
     RUN_TEST(test_a_config_without_the_device_list_stays_single_device);
     RUN_TEST(test_a_nameless_stored_device_is_dropped_not_fatal);
+    RUN_TEST(test_announced_devices_round_trip_and_start_empty);
+    RUN_TEST(test_corrupt_announced_bookkeeping_is_not_fatal);
+    RUN_TEST(test_a_factory_reset_forgets_what_was_announced);
     RUN_TEST(test_ota_rejects_a_non_firmware_upload_before_writing);
     RUN_TEST(test_ota_accepts_a_firmware_upload);
     RUN_TEST(test_ota_refuses_a_second_concurrent_upload);

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -640,14 +640,36 @@ static void test_announced_devices_round_trip_and_start_empty() {
     ConfigurationStore store(backend);
     TEST_ASSERT_TRUE(store.announcedDevices().empty());
 
-    TEST_ASSERT_TRUE(store.setAnnouncedDevices({"growatt_modbus-1", "growatt_modbus-2"}));
+    const std::vector<mqtt::AnnouncedDevice> announced{{"growatt_modbus-1", true},
+                                                       {"growatt_modbus-2", false}};
+    TEST_ASSERT_TRUE(store.setAnnouncedDevices(announced));
     const auto back = store.announcedDevices();
     TEST_ASSERT_EQUAL_UINT32(2, back.size());
-    TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", back[1].c_str());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", back[1].id.c_str());
+    // Which tree a device was announced on is half the fact: without it, a device promoted into
+    // the `driver` slot keeps its id, is never seen as removed, and leaves its whole per-device
+    // entity set behind forever.
+    TEST_ASSERT_TRUE(back[0].primary);
+    TEST_ASSERT_FALSE(back[1].primary);
 
     // Removing the last device must be storable as such, not indistinguishable from "never set".
     TEST_ASSERT_TRUE(store.setAnnouncedDevices({}));
     TEST_ASSERT_TRUE(store.announcedDevices().empty());
+}
+
+// The key first shipped as a plain array of ids. Reading one back as non-primary is not a
+// courtesy: it is what those entries meant, so a bridge flashed with a build from between the
+// two shapes still clears its per-device topics instead of starting from nothing.
+static void test_announced_bookkeeping_reads_the_flat_id_list() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    backend.write(kStorageKeyAnnounced, R"(["eversolar-1","growatt_modbus-2"])");
+
+    const auto back = store.announcedDevices();
+    TEST_ASSERT_EQUAL_UINT32(2, back.size());
+    TEST_ASSERT_EQUAL_STRING("eversolar-1", back[0].id.c_str());
+    TEST_ASSERT_FALSE(back[0].primary);
+    TEST_ASSERT_FALSE(back[1].primary);
 }
 
 // Unreadable bookkeeping is forgotten, never fatal: it lives in its own key precisely so it
@@ -669,7 +691,7 @@ static void test_corrupt_announced_bookkeeping_is_not_fatal() {
 static void test_a_factory_reset_forgets_what_was_announced() {
     MemoryBackend      backend;
     ConfigurationStore store(backend);
-    store.setAnnouncedDevices({"growatt_modbus-1"});
+    store.setAnnouncedDevices(std::vector<mqtt::AnnouncedDevice>{{"growatt_modbus-1", true}});
     TEST_ASSERT_TRUE(store.factoryReset());
     TEST_ASSERT_TRUE(store.announcedDevices().empty());
 }
@@ -803,6 +825,7 @@ int main(int, char**) {
     RUN_TEST(test_a_config_without_the_device_list_stays_single_device);
     RUN_TEST(test_a_nameless_stored_device_is_dropped_not_fatal);
     RUN_TEST(test_announced_devices_round_trip_and_start_empty);
+    RUN_TEST(test_announced_bookkeeping_reads_the_flat_id_list);
     RUN_TEST(test_corrupt_announced_bookkeeping_is_not_fatal);
     RUN_TEST(test_a_factory_reset_forgets_what_was_announced);
     RUN_TEST(test_ota_rejects_a_non_firmware_upload_before_writing);

--- a/tools/check_measurement_ids.py
+++ b/tools/check_measurement_ids.py
@@ -22,7 +22,12 @@ def main() -> int:
         print("FAIL: measurement_id namespace not found")
         return 1
     body = block.group(1)
-    declared = set(re.findall(r"inline constexpr const char\*\s+(k\w+)\s*=", body))
+    # `const char *k` and `const char* k` are the same declaration; so is one without `inline`.
+    # The strict spelling was the whole guard, and there is no .clang-format to enforce it, so a
+    # constant one space away was invisible here and un-clearable in the firmware (review).
+    declared = set(
+        re.findall(r"(?:inline\s+)?constexpr\s+const\s+char\s*\*\s*(k\w+)\s*=", body)
+    )
     declared.discard("kAll")
     listed_block = re.search(r"kAll\[\] = \{(.*?)\};", body, re.DOTALL)
     if not listed_block:

--- a/tools/check_measurement_ids.py
+++ b/tools/check_measurement_ids.py
@@ -16,8 +16,11 @@ import sys
 def main() -> int:
     root = pathlib.Path(__file__).resolve().parent.parent
     text = (root / "src/device/measurement.h").read_text()
-    block = re.search(r"namespace measurement_id \{(.*?)\}\s*//\s*namespace measurement_id",
-                      text, re.DOTALL)
+    block = re.search(
+        r"namespace measurement_id \{(.*?)\}\s*//\s*namespace measurement_id",
+        text,
+        re.DOTALL,
+    )
     if not block:
         print("FAIL: measurement_id namespace not found")
         return 1

--- a/tools/check_measurement_ids.py
+++ b/tools/check_measurement_ids.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+#
+# Every canonical measurement id must appear in measurement_id::kAll.
+#
+# kAll exists so the firmware can enumerate the topics a removed device could have published,
+# and clear the retained Home Assistant discovery configs it left behind. A constant that is
+# declared and not listed there is silently un-clearable: the entity stays in Home Assistant
+# reporting online forever. Nothing in C++ can reflect over the constants, so this checks it.
+
+import pathlib
+import re
+import sys
+
+
+def main() -> int:
+    root = pathlib.Path(__file__).resolve().parent.parent
+    text = (root / "src/device/measurement.h").read_text()
+    block = re.search(r"namespace measurement_id \{(.*?)\}\s*//\s*namespace measurement_id",
+                      text, re.DOTALL)
+    if not block:
+        print("FAIL: measurement_id namespace not found")
+        return 1
+    body = block.group(1)
+    declared = set(re.findall(r"inline constexpr const char\*\s+(k\w+)\s*=", body))
+    declared.discard("kAll")
+    listed_block = re.search(r"kAll\[\] = \{(.*?)\};", body, re.DOTALL)
+    if not listed_block:
+        print("FAIL: measurement_id::kAll not found")
+        return 1
+    listed = set(re.findall(r"\b(k\w+)\b", listed_block.group(1)))
+    missing = sorted(declared - listed)
+    extra = sorted(listed - declared)
+    if missing:
+        print("FAIL: not listed in measurement_id::kAll: " + ", ".join(missing))
+    if extra:
+        print("FAIL: listed in kAll but not declared: " + ", ".join(extra))
+    if missing or extra:
+        return 1
+    print(f"measurement_id::kAll: OK ({len(listed)} ids)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gen_profiles.py
+++ b/tools/gen_profiles.py
@@ -105,11 +105,17 @@ def load_vocabulary() -> dict[str, str]:
     one source of truth; a renamed constant shows up here immediately.
     """
     text = MEASUREMENT_H.read_text(encoding="utf-8")
-    block = re.search(r"namespace measurement_id \{(.*?)\}", text, re.DOTALL)
+    # Bounded by the namespace's own closing comment, not by the first `}` in it: kAll's
+    # initializer brace comes first, so the loose form silently stopped parsing there and a
+    # constant declared after kAll would have been invisible here while check_measurement_ids.py
+    # still saw it -- a profile mapping it would be rejected as "unknown measurement".
+    block = re.search(
+        r"namespace measurement_id \{(.*?)\}\s*//\s*namespace measurement_id", text, re.DOTALL
+    )
     if not block:
         raise SystemExit(f"could not find namespace measurement_id in {MEASUREMENT_H}")
     pairs = re.findall(
-        r'inline constexpr const char\*\s+(k\w+)\s*=\s*"([^"]+)"', block.group(1)
+        r'(?:inline\s+)?constexpr\s+const\s+char\s*\*\s*(k\w+)\s*=\s*"([^"]+)"', block.group(1)
     )
     if not pairs:
         raise SystemExit(f"no measurement ids parsed from {MEASUREMENT_H}")

--- a/tools/gen_profiles.py
+++ b/tools/gen_profiles.py
@@ -110,12 +110,15 @@ def load_vocabulary() -> dict[str, str]:
     # constant declared after kAll would have been invisible here while check_measurement_ids.py
     # still saw it -- a profile mapping it would be rejected as "unknown measurement".
     block = re.search(
-        r"namespace measurement_id \{(.*?)\}\s*//\s*namespace measurement_id", text, re.DOTALL
+        r"namespace measurement_id \{(.*?)\}\s*//\s*namespace measurement_id",
+        text,
+        re.DOTALL,
     )
     if not block:
         raise SystemExit(f"could not find namespace measurement_id in {MEASUREMENT_H}")
     pairs = re.findall(
-        r'(?:inline\s+)?constexpr\s+const\s+char\s*\*\s*(k\w+)\s*=\s*"([^"]+)"', block.group(1)
+        r'(?:inline\s+)?constexpr\s+const\s+char\s*\*\s*(k\w+)\s*=\s*"([^"]+)"',
+        block.group(1),
     )
     if not pairs:
         raise SystemExit(f"no measurement ids parsed from {MEASUREMENT_H}")


### PR DESCRIPTION
Both reviews of the last few PRs ranked this as the one that bites **silently, after bring-up**.

## The failure

Discovery configs and state are retained on the broker, so they outlive the device that published them. And because availability is bridge-scoped — deliberately, so a sleeping inverter does not make its entities unavailable every night — an orphaned entity does **not** go unavailable either.

It reports **online forever**, showing the last value it ever read. A template or automation summing your inverters keeps counting it, straight into an energy dashboard.

For devices 2..N, changing an address does it too: the address is part of the device id, so re-addressing is removing.

## The fix

The bridge remembers which devices it announced **and on which topic tree**, and on the first connected pass after a restart it publishes empty retained payloads for any that no longer owns a per-device tree — the device's own `state`, `identity` and `capabilities`, plus every discovery config it could have announced there. Empty retained payloads are how Home Assistant is told to forget an entity, the same mechanism the relay switches already use when the feature is turned off.

**"Could have" rather than "did":** the topics are enumerated from the canonical measurement ids, because by the time this runs the device is gone and so is its measurement set. Clearing a topic that was never used costs nothing.

**Device-scoped only, on purpose.** The bridge-scoped tree always has an owner — whatever sits in the `driver` slot now, or the next thing to take it. Handing it over is the back-compat contract, so re-addressing or replacing the first inverter keeps its entities and their recorder history instead of orphaning them. Clearing it would delete a live device's entities.

The decision lives in `mqtt::devicesToForget()`: pure, host-tested, and separate from the publishing, which is ESP32-only and therefore untestable. It covers a case that is easy to miss — a device **promoted** into the `driver` slot keeps its id, so nothing ever saw it as removed, and its entire per-device entity set stayed behind forever.

## What it refuses to do

- **A boot where a configured device did not start clears nothing.** The reconciliation compares against the devices that started; a device skipped for a duplicate address or a driver that is not compiled in is still configured, and its id cannot be known without its driver. On a three-inverter bus a mistyped unit id is likelier than the orphan this exists for, and tearing down its entities would be the worse failure. It defers and says so in the log.
- **A refused publish is not recorded as a clear.** Every publish is checked; the device stays in the bookkeeping and the clear is retried.

## The sync hazard, and its guards

Enumerating from `measurement_id::kAll` means an id that is declared but not listed there — or not declared at all — is an entity that can never be cleared. Six ids were in exactly that state: three-phase L2/L3 in the mock driver, and the battery rails and grid flows the Modbus TCP register map has had registers for since it was written. All string literals, all announceable, none enumerable. They are canonical constants now.

- `tools/check_measurement_ids.py` compares the declarations against `kAll` and fails the build on a mismatch. Wired into CI. It no longer misses `const char *k` (a space, and there is no `.clang-format` to prevent it).
- The test that pins "every slug the discovery builder can announce is clearable" runs **two** drivers, including the mock — three phases and a battery, which is what the mock exists for. Run against one driver whose channels happened to be all-canonical, it proved nothing; it fails without this change.
- `tools/gen_profiles.py` no longer stops parsing the vocabulary at `kAll`'s brace, which would have made a constant added after it invisible to the profile validator while the guard still saw it.

## Where the bookkeeping lives

Its own NVS key, not `Configuration`. It is not a user setting, it must never appear in `GET /config`, it must not take part in the reboot-required diff, and unreadable bookkeeping must not be able to take a working configuration down with it. A factory reset erases the namespace and takes it along, so a wiped bridge does not try to clear topics from a previous life.

## Tests

**589 pass** (was 579 on main). New: the bookkeeping round-trips including the topic tree, reads the earlier flat id list, survives corruption, and is erased by a factory reset; plus five on `devicesToForget` — removal, re-addressing, promotion, an unchanged line-up, and that the bridge-scoped tree is never cleared.

`check_layering.sh` PASS, `check_measurement_ids.py` OK (33 ids), all four boards build.

## Not covered

- **A changed base topic or discovery prefix** orphans everything under the old one, the bridge's own topics included. The bookkeeping records device ids, not prefixes. Filed as #41.
- **A replacement first device that publishes fewer measurements than its predecessor** leaves the discovery configs for the difference retained — same tree, so they cannot be cleared blindly.
- **A factory reset**, and a bookkeeping entry that cannot be read back: both forget what was announced.
- **A bridge that ran a build from before this existed** already has orphans with no record of them; still by hand (`mosquitto_pub -r -n -t <topic>`) or deleted in Home Assistant.

`docs/mqtt.md` says all of this.

## Still open

Tracked as issues rather than as footnotes: #36 Modbus TCP and Prometheus per device, #37 discovery does not sweep unit ids, #38 the Dashboard tiles and header status dot still show the first device.
