### PR TITLE
Stop presenting one inverter as the whole bridge

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -108,15 +108,21 @@ once a driver has write capabilities.
 ```
 
 `device` and `measurements` describe the **first** device and always will — that is what existing
-clients read. `devices` and `totals` describe the whole bus, and are what anything presenting
-itself as the bridge's health must use. The built-in web UI does: the header indicator is green
-only when every polled device is answering, and with more than one inverter the Dashboard tiles
-are totals rather than device 1's readings.
+clients read; `devices[0]` is built from the same snapshot, so the two cannot contradict each
+other within one response. `devices` and `totals` cover every **started** device, and are what
+anything presenting itself as the bridge's health must use. Compare them against
+`devices_configured`, not against each other: a device that failed to start has no row at all,
+and the built-in web UI counts it as not reporting rather than leaving it out of the question.
 
-Three rules in `totals`, all of which exist because the alternative reads as a fact:
+Four rules, all of which exist because the alternative reads as a fact:
 
+- **A reading counts only while it is valid and fresh.** When a device goes offline the firmware
+  marks its measurements stale but keeps them *valid*, so a summary that checked validity alone
+  kept a dead inverter's last daylight value in the household total until the next reboot. Both
+  `devices[].ac_power_w` and the sums go `null` instead; `last_successful_poll_seconds_ago` is
+  what the reading has been replaced by.
 - **`devices_answering`** counts devices that are online, hold valid data and are not stale.
-  Started is not answering (see below), and neither is a device whose last reading has aged out.
+  Started is not answering (see below), and neither is a device whose reading has aged out.
 - **A sum is `null` when no device reported the channel**, never `0`.
 - **Every sum carries its own count** (`ac_power_devices` and friends). A total over two of three
   inverters is indistinguishable from a total over three that had a bad afternoon; the count is
@@ -124,6 +130,9 @@ Three rules in `totals`, all of which exist because the alternative reads as a f
 
 Per-device rows use `null` for an absent reading for the same reason: "reports no power" and
 "reports 0 W" are different answers.
+
+Overnight, therefore, every sum is `null` with a count of `0` — the bridge reports that it does
+not know, not that the sun produced 0 W and not yesterday's last reading.
 
 ## Error format
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -91,9 +91,39 @@ once a driver has write capabilities.
   },
   "measurements": {
     "ac.power.total": { "value": 1842.0, "unit": "W", "valid": true, "stale": false }
+  },
+  "devices": [
+    { "id": "growatt_modbus-1", "online": true, "data_valid": true, "data_stale": false,
+      "last_successful_poll_seconds_ago": 3, "ac_power_w": 1240.0 },
+    { "id": "growatt_modbus-2", "online": false, "data_valid": false, "data_stale": false,
+      "last_successful_poll_seconds_ago": null, "ac_power_w": null }
+  ],
+  "totals": {
+    "devices_polled": 2, "devices_answering": 1,
+    "ac_power_w": 1240.0, "ac_power_devices": 1,
+    "energy_today_kwh": 5.25, "energy_today_devices": 1,
+    "energy_total_kwh": 24680.0, "energy_total_devices": 1
   }
 }
 ```
+
+`device` and `measurements` describe the **first** device and always will — that is what existing
+clients read. `devices` and `totals` describe the whole bus, and are what anything presenting
+itself as the bridge's health must use. The built-in web UI does: the header indicator is green
+only when every polled device is answering, and with more than one inverter the Dashboard tiles
+are totals rather than device 1's readings.
+
+Three rules in `totals`, all of which exist because the alternative reads as a fact:
+
+- **`devices_answering`** counts devices that are online, hold valid data and are not stale.
+  Started is not answering (see below), and neither is a device whose last reading has aged out.
+- **A sum is `null` when no device reported the channel**, never `0`.
+- **Every sum carries its own count** (`ac_power_devices` and friends). A total over two of three
+  inverters is indistinguishable from a total over three that had a bad afternoon; the count is
+  the difference. A device that reports no value at all does not contribute a zero to the sum.
+
+Per-device rows use `null` for an absent reading for the same reason: "reports no power" and
+"reports 0 W" are different answers.
 
 ## Error format
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -470,11 +470,20 @@ void serviceOnboard() {
         in.inverterExpected    = g_devicesConfigured > 0;
         in.mqttConnected       = g_mqtt && g_mqtt->connected();
         in.modbusListening      = g_modbus.running();
-        if (g_state) {
-            const auto s      = g_state->snapshot();
-            in.inverterOnline = s->inverterOnline;
-            in.dataValid      = s->dataValid;
-            in.dataStale      = s->dataStale;
+        // Worst-of across every polled device, not the first one. The LED is on the bridge, so
+        // it reports the bridge: with three inverters on one bus it showed device 1 and stayed
+        // green while the other two were dead -- the same defect as the web header (#38), on
+        // the indicator someone standing at the bus is actually looking at. Its three states
+        // are kept: red when any device is offline, amber when any is stale or invalid.
+        in.inverterOnline = !g_deviceIds.empty();
+        in.dataValid      = true;
+        in.dataStale      = false;
+        for (const auto& id : g_deviceIds) {
+            if (StateHandle h = g_devices.state(id)) {
+                in.inverterOnline = in.inverterOnline && h->inverterOnline;
+                in.dataValid      = in.dataValid && h->dataValid;
+                in.dataStale      = in.dataStale || h->dataStale;
+            }
         }
         driveStatusLed(status::decide(in));
     }

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -307,7 +307,7 @@ bool RestApi::begin() {
             std::string       body;
             if (!rest::buildStatusPayload(empty, "", context_.bridgeInfo(),
                                           context_.diagnostics->snapshot(), nullptr,
-                                          context_.clock(), body)) {
+                                          context_.clock(), {}, body)) {
                 sendError(request, {500, "payload_too_large", "status payload exceeded its bound"});
                 return;
             }
@@ -316,10 +316,21 @@ bool RestApi::begin() {
         }
         // The registered id: the key the per-device routes actually answer on.
         const auto ids = context_.devices->devices();
+        // One snapshot per device, taken here so the whole payload describes one instant. The
+        // Dashboard and the header indicator are built from this and never from the first
+        // device alone (#38); walking the per-device routes instead would be 1+N requests a
+        // second on the board that is also driving the bus.
+        std::vector<rest::DeviceSummary> fleet;
+        fleet.reserve(ids.size());
+        for (const auto& id : ids) {
+            if (StateHandle h = context_.devices->state(id)) {
+                fleet.push_back(rest::summariseDevice(*h, id, context_.clock()));
+            }
+        }
         std::string body;
         if (!buildStatusPayload(*snapshot, ids.empty() ? std::string{} : ids.front(),
                                 context_.bridgeInfo(), context_.diagnostics->snapshot(),
-                                activeDescriptor(*snapshot), context_.clock(), body)) {
+                                activeDescriptor(*snapshot), context_.clock(), fleet, body)) {
             sendError(request, {500, "payload_too_large", "status payload exceeded its bound"});
             return;
         }

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -315,22 +315,29 @@ bool RestApi::begin() {
             return;
         }
         // The registered id: the key the per-device routes actually answer on.
-        const auto ids = context_.devices->devices();
-        // One snapshot per device, taken here so the whole payload describes one instant. The
-        // Dashboard and the header indicator are built from this and never from the first
+        const auto     ids = context_.devices->devices();
+        const uint64_t now = context_.clock();
+        // One snapshot per device, each taken at its own instant -- not one instant for the
+        // whole payload, which is not something this can promise. What it does guarantee is
+        // that the first device is snapshotted ONCE: `snapshot` is reused for its row, so
+        // `device` and `devices[0]` cannot contradict each other inside one response.
+        //
+        // The Dashboard and the header indicator are built from this and never from the first
         // device alone (#38); walking the per-device routes instead would be 1+N requests a
         // second on the board that is also driving the bus.
         std::vector<rest::DeviceSummary> fleet;
         fleet.reserve(ids.size());
         for (const auto& id : ids) {
-            if (StateHandle h = context_.devices->state(id)) {
-                fleet.push_back(rest::summariseDevice(*h, id, context_.clock()));
+            if (!ids.empty() && id == ids.front()) {
+                fleet.push_back(rest::summariseDevice(*snapshot, id, now));
+            } else if (StateHandle h = context_.devices->state(id)) {
+                fleet.push_back(rest::summariseDevice(*h, id, now));
             }
         }
         std::string body;
         if (!buildStatusPayload(*snapshot, ids.empty() ? std::string{} : ids.front(),
                                 context_.bridgeInfo(), context_.diagnostics->snapshot(),
-                                activeDescriptor(*snapshot), context_.clock(), fleet, body)) {
+                                activeDescriptor(*snapshot), now, fleet, body)) {
             sendError(request, {500, "payload_too_large", "status payload exceeded its bound"});
             return;
         }

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -59,14 +59,22 @@ DeviceSummary summariseDevice(const DeviceState& state, const std::string& devic
     s.dataValid = state.dataValid;
     s.dataStale = state.dataStale;
     if (state.lastSuccessfulPollMs != 0) {
-        s.everPolled         = true;
-        s.lastPollSecondsAgo = static_cast<uint32_t>((nowMs - state.lastSuccessfulPollMs) / 1000);
+        s.everPolled = true;
+        // Guarded like MeasurementSet::updateStaleness does the same subtraction: unsigned, and
+        // a caller passing a clock older than the snapshot would otherwise get ~584 million
+        // years "ago". Not reachable from the one call site today; this is a public function.
+        s.lastPollSecondsAgo = nowMs > state.lastSuccessfulPollMs
+                                   ? static_cast<uint32_t>((nowMs - state.lastSuccessfulPollMs) / 1000)
+                                   : 0;
     }
     const auto take = [&state](const char* id, bool& has, double& value) {
         const Measurement* m = state.measurements.find(id);
-        // valid, not merely supported: an unread channel holds 0.0, and a zero silently added
-        // to a household total is the kind of wrong that nobody catches.
-        if (m != nullptr && m->supported && m->valid) {
+        // valid AND fresh, the same rule writeMeasurement, the MQTT payloads and the Modbus
+        // register map all use. Two traps, both of which produce a number nobody questions:
+        // an unread channel holds 0.0, and markAllStale() leaves `valid` true when a device
+        // goes offline -- so without !stale a dead inverter's last daylight reading was summed
+        // into the Dashboard total forever. At 03:00 the bridge reported watts (review).
+        if (m != nullptr && m->supported && m->valid && !m->stale) {
             has   = true;
             value = m->value;
         }

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -51,9 +51,36 @@ bool buildProvisionPayload(const std::string& hostname, std::string& out, size_t
     return finish(doc, out, maxBytes);
 }
 
+DeviceSummary summariseDevice(const DeviceState& state, const std::string& deviceId,
+                              uint64_t nowMs) {
+    DeviceSummary s;
+    s.id        = deviceId;
+    s.online    = state.inverterOnline;
+    s.dataValid = state.dataValid;
+    s.dataStale = state.dataStale;
+    if (state.lastSuccessfulPollMs != 0) {
+        s.everPolled         = true;
+        s.lastPollSecondsAgo = static_cast<uint32_t>((nowMs - state.lastSuccessfulPollMs) / 1000);
+    }
+    const auto take = [&state](const char* id, bool& has, double& value) {
+        const Measurement* m = state.measurements.find(id);
+        // valid, not merely supported: an unread channel holds 0.0, and a zero silently added
+        // to a household total is the kind of wrong that nobody catches.
+        if (m != nullptr && m->supported && m->valid) {
+            has   = true;
+            value = m->value;
+        }
+    };
+    take(measurement_id::kAcPowerTotal, s.hasAcPower, s.acPowerW);
+    take(measurement_id::kEnergyToday, s.hasEnergyToday, s.energyTodayKwh);
+    take(measurement_id::kEnergyTotal, s.hasEnergyTotal, s.energyTotalKwh);
+    return s;
+}
+
 bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
                         const BridgeInfo& bridge, const DiagnosticsSnapshot& diagnostics,
-                        const DriverDescriptor* driver, uint64_t nowMs, std::string& out,
+                        const DriverDescriptor* driver, uint64_t nowMs,
+                        const std::vector<DeviceSummary>& fleet, std::string& out,
                         size_t maxBytes) {
     JsonDocument doc;
 
@@ -160,6 +187,69 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     } else {
         doc["error_code"] = nullptr;
     }
+
+    // Every polled device, and the totals over them. The `device` block above is the first
+    // device and stays that way for compatibility, but nothing that presents itself as the
+    // bridge's health may be built from it: on a bus of three, one dead inverter left the
+    // header indicator green and the Dashboard reporting a healthy day (#38).
+    JsonArray devices = doc["devices"].to<JsonArray>();
+    double    acTotal = 0.0, todayTotal = 0.0, lifetimeTotal = 0.0;
+    unsigned  acCount = 0, todayCount = 0, lifetimeCount = 0, answering = 0;
+    for (const auto& f : fleet) {
+        JsonObject o    = devices.add<JsonObject>();
+        o["id"]         = f.id;
+        o["online"]     = f.online;
+        o["data_valid"] = f.dataValid;
+        o["data_stale"] = f.dataStale;
+        if (f.everPolled) {
+            o["last_successful_poll_seconds_ago"] = f.lastPollSecondsAgo;
+        } else {
+            o["last_successful_poll_seconds_ago"] = nullptr;  // 0 would read as "just now"
+        }
+        // Absent channels stay null rather than 0: "this inverter reports no power" and
+        // "this inverter reports 0 W" are different answers and look identical as a number.
+        if (f.hasAcPower) {
+            o["ac_power_w"] = f.acPowerW;
+        } else {
+            o["ac_power_w"] = nullptr;
+        }
+        if (f.online && f.dataValid && !f.dataStale) {
+            ++answering;
+        }
+        if (f.hasAcPower) {
+            acTotal += f.acPowerW;
+            ++acCount;
+        }
+        if (f.hasEnergyToday) {
+            todayTotal += f.energyTodayKwh;
+            ++todayCount;
+        }
+        if (f.hasEnergyTotal) {
+            lifetimeTotal += f.energyTotalKwh;
+            ++lifetimeCount;
+        }
+    }
+    JsonObject t = doc["totals"].to<JsonObject>();
+    // "Answering" is the strict reading: started, online, holding data that is valid and not
+    // stale. A device that started and never returned a byte is not answering, and neither is
+    // one whose last reading has aged out.
+    t["devices_answering"] = answering;
+    t["devices_polled"]    = static_cast<unsigned>(fleet.size());
+    // A total over none is unknown, not zero. The count travels with it so a client can say
+    // "2 of 3 inverters" instead of implying the sum covers everything.
+    const auto total = [&t](const char* key, unsigned count, double sum) {
+        if (count != 0) {
+            t[key] = sum;
+        } else {
+            t[key] = nullptr;
+        }
+    };
+    total("ac_power_w", acCount, acTotal);
+    t["ac_power_devices"] = acCount;
+    total("energy_today_kwh", todayCount, todayTotal);
+    t["energy_today_devices"] = todayCount;
+    total("energy_total_kwh", lifetimeCount, lifetimeTotal);
+    t["energy_total_devices"] = lifetimeCount;
 
     doc["poll_success_total"] = diagnostics.pollSuccessTotal;
     doc["poll_failure_total"] = diagnostics.pollFailureTotal;

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -61,8 +61,13 @@ struct DeviceSummary {
     double      energyTotalKwh   = 0.0;
 };
 
-/// Reduces one device's state to the row above. Only valid, non-stale-agnostic readings count:
-/// a stale value is still the last thing the device said and stays in the total, flagged.
+/// Reduces one device's state to the row above.
+///
+/// A reading counts only while it is valid AND fresh -- the same rule every other output uses.
+/// A stale one is dropped rather than carried: `markAllStale()` keeps `valid` true when a
+/// device goes offline, so carrying it means a dead inverter's last daylight value stays in the
+/// household total until the next reboot. The row still reports how long ago the device
+/// answered, which is what the reading has been replaced by.
 DeviceSummary summariseDevice(const DeviceState& state, const std::string& deviceId,
                               uint64_t nowMs);
 

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -37,13 +37,47 @@ bool buildErrorPayload(const ApiError& error, const std::string& requestId, std:
 bool buildProvisionPayload(const std::string& hostname, std::string& out,
                            size_t maxBytes = kMaxResponseBytes);
 
+/// One polled device, reduced to what an always-visible summary needs.
+///
+/// Exists so the Dashboard and the header indicator can describe every inverter from the one
+/// request they already make. Walking /api/v1/devices/<id> per device would be 1+N requests per
+/// second on the board that is also driving the RS485 bus -- the Device tab does that, and has
+/// to rate-limit itself to once every five seconds because of it.
+///
+/// Every channel is optional and says so separately from its value: a device that does not
+/// report energy must not contribute a zero to a total.
+struct DeviceSummary {
+    std::string id;
+    bool        online    = false;
+    bool        dataValid = false;
+    bool        dataStale = false;
+    bool        everPolled          = false;
+    uint32_t    lastPollSecondsAgo  = 0;
+    bool        hasAcPower       = false;
+    double      acPowerW         = 0.0;
+    bool        hasEnergyToday   = false;
+    double      energyTodayKwh   = 0.0;
+    bool        hasEnergyTotal   = false;
+    double      energyTotalKwh   = 0.0;
+};
+
+/// Reduces one device's state to the row above. Only valid, non-stale-agnostic readings count:
+/// a stale value is still the last thing the device said and stays in the total, flagged.
+DeviceSummary summariseDevice(const DeviceState& state, const std::string& deviceId,
+                              uint64_t nowMs);
+
 /// `deviceId` is the id the device is REGISTERED under -- the key in /api/v1/devices and the
 /// per-device routes. Not identity.deviceId(): that one changes when a late-arriving serial
 /// number completes the identity (the store key was minted at begin(), before registration on
 /// the bus), and reporting it sent clients to a path that 404s. Seen live 2026-07-19.
+///
+/// `fleet` is every polled device, first one included, in registration order. It drives the
+/// Dashboard totals and the header indicator; `device` stays the first device so that every
+/// existing client keeps working unchanged.
 bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
                         const BridgeInfo& bridge, const DiagnosticsSnapshot& diagnostics,
-                        const DriverDescriptor* driver, uint64_t nowMs, std::string& out,
+                        const DriverDescriptor* driver, uint64_t nowMs,
+                        const std::vector<DeviceSummary>& fleet, std::string& out,
                         size_t maxBytes = kMaxResponseBytes);
 
 bool buildDevicesPayload(const std::vector<std::string>& deviceIds, std::string& out,

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -249,11 +249,15 @@ function singleTiles(s,d,g){
 /// voltage, frequency, status and error code have no bridge-wide meaning at all, so they are
 /// not averaged into something plausible -- they live per device, on the strip below and on
 /// the Device tab.
-function fleetTiles(fleet,tot){
+function fleetTiles(fleet,tot,expected){
+  // Against the configured count, so a device that never started is counted as not reporting
+  // rather than quietly left out of the question. esc() on both: this is the only place in the
+  // new code that interpolates a number straight into innerHTML, and the file's rule is that
+  // everything is escaped whatever its type is claimed to be.
   const sub=(n)=>{
-    const of=fleet.length;
-    return n===of?`<div class="k" style="margin-top:6px;text-transform:none">${of} inverters</div>`
-      :`<div class="k" style="margin-top:6px;text-transform:none;color:var(--bad)">${n} of ${of} reporting</div>`;
+    const of=expected??fleet.length;
+    return n===of?`<div class="k" style="margin-top:6px;text-transform:none">${esc(of)} inverters</div>`
+      :`<div class="k" style="margin-top:6px;text-transform:none;color:var(--bad)">${esc(n)} of ${esc(of)} reporting</div>`;
   };
   const t=(label,value,unit,decimals,count)=>tile(label,fmt(value,decimals),unit,sub(count??0));
   return t('AC Power',tot.ac_power_w,'W',0,tot.ac_power_devices)+
@@ -285,22 +289,31 @@ function fleetStrip(fleet){
 function render(s){
   const d=s.device,b=s.bridge,m=s.measurements||{};
   const dot=x=>x?'<span class="dot ok"></span>':'<span class="dot bad"></span>';
-  // The inverter indicator describes EVERY polled device, not the first one. On a bus of three
-  // it was driven by device 1's `online`, so a dead second inverter left the one indicator
-  // anybody glances at green (#38). Green means all of them are answering; anything less is
-  // red, deliberately -- an amber "some" is a state you learn to ignore.
   const fleet=s.devices||[], tot=s.totals||{};
   const polled=tot.devices_polled??fleet.length, answering=tot.devices_answering??0;
-  const invLabel=polled>1?`Inverters ${answering}/${polled}`:'Inverter';
-  // Fall back to the first device only where there is no fleet at all: firmware that predates
-  // this, or a bridge with nothing polling.
-  const invOk=polled>0?answering===polled:d.online;
+  // The CONFIGURED count is the denominator, not the started one. Three identical inverters
+  // left on the default address all resolve to the same id, so two of them are skipped at boot
+  // and `devices_polled` is 1 -- which, keyed off the started count, put the single-device
+  // layout and a green "Inverter" back on screen in the most likely bring-up mistake there is
+  // (review, 2026-07-26). A device that did not start is missing, not absent from the question.
+  const expected=b.devices_configured??polled;
+  // The inverter indicator describes EVERY device, not the first one. On a bus of three it was
+  // driven by device 1's `online`, so a dead second inverter left the one indicator anybody
+  // glances at green (#38). Green means all of them are answering; anything less is red,
+  // deliberately -- an amber "some" is a state you learn to ignore.
+  //
+  // With ONE device this is byte for byte the header it has always been, `online` and its two
+  // tags included. The strict rule would have turned it red during the stale window where it
+  // used to stay green, and that is a change to every existing single-inverter bridge that
+  // nobody asked for.
+  const multi=expected>1||polled>1;
   $('#hdr').innerHTML=dot(b.wifi_connected)+'WiFi '+
     dot(b.mqtt_connected)+'MQTT '+
     dot(b.modbus_listening)+'Modbus '+
-    dot(invOk)+invLabel+
-    (polled>1?'':(d.data_stale?' <span class="tag">stale</span>':'')+
-                 (d.data_valid?'':' <span class="tag">no data</span>'));
+    (multi?dot(answering===expected)+`Inverters ${esc(answering)}/${esc(expected)}`
+          :dot(d.online)+'Inverter'+
+           (d.data_stale?' <span class="tag">stale</span>':'')+
+           (d.data_valid?'':' <span class="tag">no data</span>'));
   $('#ver').textContent='v'+b.firmware_version;
   // Boards without relays never send the field; the settings card keys off this.
   window.g_relayCount=(b.relays||[]).length;
@@ -310,8 +323,8 @@ function render(s){
     // One inverter: exactly the dashboard this has always been. Several: the tiles that can
     // honestly be added become bridge totals, the ones that only mean something per device
     // move to the strip below, and nothing on this page presents one inverter as the bridge.
-    $('#tiles').innerHTML=(polled>1?fleetTiles(fleet,tot):singleTiles(s,d,g))+bridgeTiles(b);
-    $('#fleet').innerHTML=polled>1?fleetStrip(fleet):'';
+    $('#tiles').innerHTML=(multi?fleetTiles(fleet,tot,expected):singleTiles(s,d,g))+bridgeTiles(b);
+    $('#fleet').innerHTML=multi?fleetStrip(fleet):'';
   }
   if(tab==='dev'){
     // Every configured device, not just the first. The bridge polls up to eight; this tab
@@ -433,7 +446,12 @@ async function renderDevices(b){
       const ident={...(dev.identity||{}),online:dev.online,data_valid:dev.data_valid,
                    data_stale:dev.data_stale,support_level:(dev.driver||{}).support_level};
       const ago=dev.last_successful_poll_seconds_ago;
-      if(dev.online&&dev.data_valid)answering++;
+      // The same three conditions the status endpoint counts (totals.devices_answering) and the
+      // header indicator reads. Without the staleness term this tab said "3 of 3 answering"
+      // while the header said 2 of 3 -- for the seventy seconds between a device going stale
+      // and going offline, which is exactly when someone clicks through to this tab to find out
+      // what is wrong (review, 2026-07-26).
+      if(dev.online&&dev.data_valid&&!dev.data_stale)answering++;
       // The line that answers "is this one alive", above the table rather than thirteen rows
       // into it. Never answered at all is its own state: that is a bus fault, not a sleeping
       // inverter, and the two look identical in `online: false` alone.

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -69,7 +69,7 @@ dialog::backdrop{background:#000a}
 </nav>
 <main>
 <div id="banner" class="err hide"></div>
-<section id="dash"><div class="grid" id="tiles"></div></section>
+<section id="dash"><div class="grid" id="tiles"></div><div id="fleet"></div></section>
 <section id="dev" class="hide"><div id="devbox"></div></section>
 <section id="diag" class="hide"><table id="diagtbl"></table></section>
 <section id="logs" class="hide">
@@ -215,41 +215,103 @@ async function authFetch(url,opts={}){
 function tile(k,v,u,extra=''){return `<div class="card"><div class="k">${esc(k)}</div>
 <div class="v">${esc(v)}<span class="u"> ${esc(u)}</span></div>${extra}</div>`}
 
+/// Bridge-wide tiles: true whatever is on the bus, so they are the same in both layouts.
+function bridgeTiles(b){
+  return tile('Uptime',up(b.uptime_seconds),'')+
+    tile('WiFi',b.wifi_rssi_dbm??'—','dBm')+
+    tile('Modbus clients',b.modbus_clients??0,'')+
+    // Honest clock: before the first NTP sync there is no time to show. The extra
+    // null-guard matters: the API can answer time_synced:true with time:null when
+    // formatting failed server-side, and a throw here would kill the whole render loop
+    // and put up the "Cannot reach the bridge" banner for a healthy bridge.
+    tile('Clock',b.time_synced?(b.time?esc(b.time.split(' ')[1]??b.time):'—'):'not synced','');
+    // No firmware tile: the version already sits in the header, permanently.
+}
+
+/// The single-inverter dashboard, unchanged. `g` reads the first device's measurements.
+function singleTiles(s,d,g){
+  return tile('AC Power',fmt(g('ac.power.total'),0),'W')+
+    tile('Today',fmt(g('energy.today'),2),'kWh')+
+    tile('Total',fmt(g('energy.total'),1),'kWh')+
+    tile('Temperature',fmt(g('inverter.temperature')),'°C')+
+    tile('AC Voltage',fmt(g('ac.phase_l1.voltage')),'V')+
+    tile('Frequency',fmt(g('ac.frequency'),2),'Hz')+
+    tile('Status',esc(s.status_text??'—'),'')+
+    // null means this protocol has no error code field at all -- not "no fault".
+    tile('Error code',s.error_code===null?'not reported':esc(s.error_code),'')+
+    tile('Last poll',d.last_successful_poll_seconds_ago??'—','s ago');
+}
+
+/// Totals across every polled inverter, each carrying how many it actually covers.
+///
+/// The count is not decoration. A sum over two of three inverters looks exactly like a sum
+/// over three that had a bad day, and the difference is the whole diagnosis. Temperature,
+/// voltage, frequency, status and error code have no bridge-wide meaning at all, so they are
+/// not averaged into something plausible -- they live per device, on the strip below and on
+/// the Device tab.
+function fleetTiles(fleet,tot){
+  const sub=(n)=>{
+    const of=fleet.length;
+    return n===of?`<div class="k" style="margin-top:6px;text-transform:none">${of} inverters</div>`
+      :`<div class="k" style="margin-top:6px;text-transform:none;color:var(--bad)">${n} of ${of} reporting</div>`;
+  };
+  const t=(label,value,unit,decimals,count)=>tile(label,fmt(value,decimals),unit,sub(count??0));
+  return t('AC Power',tot.ac_power_w,'W',0,tot.ac_power_devices)+
+    t('Today',tot.energy_today_kwh,'kWh',2,tot.energy_today_devices)+
+    t('Total',tot.energy_total_kwh,'kWh',1,tot.energy_total_devices);
+}
+
+/// One line per inverter under the totals, so a dead one cannot hide inside a sum.
+///
+/// Deliberately not a second copy of the Device tab: id, whether it is answering, what it is
+/// producing, and how long ago it last replied. Anything more belongs where there is room.
+function fleetStrip(fleet){
+  const rows=fleet.map(f=>{
+    const answering=f.online&&f.data_valid&&!f.data_stale;
+    const ago=f.last_successful_poll_seconds_ago;
+    // Never answered is its own state: that is a bus fault, not a sleeping inverter, and the
+    // two are indistinguishable in `online:false` alone.
+    const when=(ago===null||ago===undefined)?'<span class="tag" style="background:var(--bad)">never answered</span>'
+      :`<span class="tag">${f.data_stale?'stale — ':''}replied ${esc(ago)} s ago</span>`;
+    const w=(f.ac_power_w===null||f.ac_power_w===undefined)?'—':fmt(f.ac_power_w,0)+' W';
+    return `<tr><td><span class="dot ${answering?'ok':'bad'}"></span>${esc(f.id)}</td>
+      <td class="n">${esc(w)}</td><td class="n">${when}</td></tr>`;
+  }).join('');
+  return `<div class="card" style="margin-top:14px"><table>
+    <tr><th>Inverter</th><th style="text-align:right">AC power</th>
+    <th style="text-align:right">Last reply</th></tr>${rows}</table></div>`;
+}
+
 function render(s){
   const d=s.device,b=s.bridge,m=s.measurements||{};
   const dot=x=>x?'<span class="dot ok"></span>':'<span class="dot bad"></span>';
+  // The inverter indicator describes EVERY polled device, not the first one. On a bus of three
+  // it was driven by device 1's `online`, so a dead second inverter left the one indicator
+  // anybody glances at green (#38). Green means all of them are answering; anything less is
+  // red, deliberately -- an amber "some" is a state you learn to ignore.
+  const fleet=s.devices||[], tot=s.totals||{};
+  const polled=tot.devices_polled??fleet.length, answering=tot.devices_answering??0;
+  const invLabel=polled>1?`Inverters ${answering}/${polled}`:'Inverter';
+  // Fall back to the first device only where there is no fleet at all: firmware that predates
+  // this, or a bridge with nothing polling.
+  const invOk=polled>0?answering===polled:d.online;
   $('#hdr').innerHTML=dot(b.wifi_connected)+'WiFi '+
     dot(b.mqtt_connected)+'MQTT '+
     dot(b.modbus_listening)+'Modbus '+
-    dot(d.online)+'Inverter'+
-    (d.data_stale?' <span class="tag">stale</span>':'')+
-    (d.data_valid?'':' <span class="tag">no data</span>');
+    dot(invOk)+invLabel+
+    (polled>1?'':(d.data_stale?' <span class="tag">stale</span>':'')+
+                 (d.data_valid?'':' <span class="tag">no data</span>'));
   $('#ver').textContent='v'+b.firmware_version;
   // Boards without relays never send the field; the settings card keys off this.
   window.g_relayCount=(b.relays||[]).length;
   window.g_maxDevices=b.max_devices||window.g_maxDevices;
   const g=id=>m[id]?m[id].value:null;
   if(tab==='dash'){
-    $('#tiles').innerHTML=
-      tile('AC Power',fmt(g('ac.power.total'),0),'W')+
-      tile('Today',fmt(g('energy.today'),2),'kWh')+
-      tile('Total',fmt(g('energy.total'),1),'kWh')+
-      tile('Temperature',fmt(g('inverter.temperature')),'°C')+
-      tile('AC Voltage',fmt(g('ac.phase_l1.voltage')),'V')+
-      tile('Frequency',fmt(g('ac.frequency'),2),'Hz')+
-      tile('Status',esc(s.status_text??'—'),'')+
-      // null means this protocol has no error code field at all -- not "no fault".
-      tile('Error code',s.error_code===null?'not reported':esc(s.error_code),'')+
-      tile('Last poll',d.last_successful_poll_seconds_ago??'—','s ago')+
-      tile('Uptime',up(b.uptime_seconds),'')+
-      tile('WiFi',b.wifi_rssi_dbm??'—','dBm')+
-      tile('Modbus clients',b.modbus_clients??0,'')+
-      // Honest clock: before the first NTP sync there is no time to show. The extra
-      // null-guard matters: the API can answer time_synced:true with time:null when
-      // formatting failed server-side, and a throw here would kill the whole render loop
-      // and put up the "Cannot reach the bridge" banner for a healthy bridge.
-      tile('Clock',b.time_synced?(b.time?esc(b.time.split(' ')[1]??b.time):'—'):'not synced','');
-      // No firmware tile: the version already sits in the header, permanently.
+    // One inverter: exactly the dashboard this has always been. Several: the tiles that can
+    // honestly be added become bridge totals, the ones that only mean something per device
+    // move to the strip below, and nothing on this page presents one inverter as the bridge.
+    $('#tiles').innerHTML=(polled>1?fleetTiles(fleet,tot):singleTiles(s,d,g))+bridgeTiles(b);
+    $('#fleet').innerHTML=polled>1?fleetStrip(fleet):'';
   }
   if(tab==='dev'){
     // Every configured device, not just the first. The bridge polls up to eight; this tab

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -429,6 +429,12 @@ static void test_the_status_payload_publishes_the_device_cap() {
 
 /// A device whose readings are whatever the test says, so a fleet can be assembled without
 /// three simulated inverters. Only the channels the summary reads are declared.
+///
+/// `stale` goes through markAllStale(), which is what the firmware actually does: it leaves
+/// every measurement VALID and only sets the stale flag. Setting `dataStale` alone produced a
+/// combination the state machine cannot reach -- fresh measurements under a stale device -- and
+/// that is why the first version of these tests stayed green while a dead inverter's last
+/// daylight reading was being summed into the Dashboard total (review, 2026-07-26).
 static DeviceState fakeDevice(bool online, bool valid, bool stale, double watts,
                               double today, uint64_t lastPollMs) {
     DeviceState s;
@@ -443,6 +449,9 @@ static DeviceState fakeDevice(bool online, bool valid, bool stale, double watts,
     if (valid) {
         s.measurements.set(measurement_id::kAcPowerTotal, watts, lastPollMs);
         s.measurements.set(measurement_id::kEnergyToday, today, lastPollMs);
+    }
+    if (stale) {
+        s.measurements.markAllStale();
     }
     return s;
 }
@@ -494,17 +503,50 @@ static void test_a_device_that_reports_nothing_does_not_count_towards_a_total() 
     TEST_ASSERT_TRUE(doc["devices"][1]["last_successful_poll_seconds_ago"].isNull());
 }
 
-// A stale reading is still the last thing the inverter said, so it stays in the total -- but
-// the device is not "answering", and the row carries the flag that says why.
-static void test_a_stale_device_still_counts_but_is_not_answering() {
+// A stale reading leaves the total, and the row says when the device last answered instead.
+//
+// This is the state every inverter is in all night, and it is the one that has to be right:
+// markAllStale() keeps `valid` true, so a summary that only checked validity kept summing
+// yesterday's watts. The bridge reported production at 03:00 and labelled it "3 inverters"
+// in the same neutral grey as a healthy afternoon.
+static void test_a_stale_reading_leaves_the_total_and_the_device_is_not_answering() {
     const auto stale = rest::summariseDevice(
         fakeDevice(true, true, true, 900.0, 4.0, g_now - 60000), "growatt_modbus-1", g_now);
     const auto doc = statusOf({stale});
 
-    TEST_ASSERT_EQUAL_DOUBLE(900.0, doc["totals"]["ac_power_w"].as<double>());
+    TEST_ASSERT_TRUE(doc["totals"]["ac_power_w"].isNull());
+    TEST_ASSERT_TRUE(doc["totals"]["energy_today_kwh"].isNull());
+    // Zero of one reporting, which is what turns the tile's sub-label red.
+    TEST_ASSERT_EQUAL_UINT32(0, doc["totals"]["ac_power_devices"].as<uint32_t>());
+    TEST_ASSERT_TRUE(doc["devices"][0]["ac_power_w"].isNull());
     TEST_ASSERT_EQUAL_UINT32(0, doc["totals"]["devices_answering"].as<uint32_t>());
     TEST_ASSERT_TRUE(doc["devices"][0]["data_stale"].as<bool>());
     TEST_ASSERT_EQUAL_UINT32(60, doc["devices"][0]["last_successful_poll_seconds_ago"].as<uint32_t>());
+}
+
+// The same thing again, but reached the way the firmware reaches it: a real poll followed by
+// enough failures to take the device offline. No fixture can lie about the state machine here,
+// and it is the state machine -- markAllStale() leaving `valid` set -- that made the earlier
+// version of this summary report watts at three in the morning.
+static void test_the_night_state_reports_no_production() {
+    Rig             r;
+    const auto      polled = r.poll();
+    const StalenessPolicy policy;
+    DeviceState     s = polled;
+    TEST_ASSERT_TRUE(s.measurements.isValid(measurement_id::kAcPowerTotal));
+
+    for (uint32_t i = 0; i <= policy.failuresBeforeOffline; ++i) {
+        s.recordPollFailure(g_now + (i + 1) * 10000, policy);
+    }
+    TEST_ASSERT_FALSE(s.inverterOnline);
+    // The trap in one assertion: still valid, and stale.
+    const Measurement* m = s.measurements.find(measurement_id::kAcPowerTotal);
+    TEST_ASSERT_TRUE(m != nullptr && m->valid && m->stale);
+
+    const auto doc = statusOf({rest::summariseDevice(s, "growatt_modbus-1", g_now + 120000)});
+    TEST_ASSERT_TRUE(doc["totals"]["ac_power_w"].isNull());
+    TEST_ASSERT_EQUAL_UINT32(0, doc["totals"]["ac_power_devices"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(0, doc["totals"]["devices_answering"].as<uint32_t>());
 }
 
 // A bridge with nothing polling still answers /status -- it is the only payload that says how
@@ -1604,7 +1646,8 @@ int main(int, char**) {
     RUN_TEST(test_the_status_payload_publishes_the_device_cap);
     RUN_TEST(test_the_status_payload_totals_every_polled_device);
     RUN_TEST(test_a_device_that_reports_nothing_does_not_count_towards_a_total);
-    RUN_TEST(test_a_stale_device_still_counts_but_is_not_answering);
+    RUN_TEST(test_a_stale_reading_leaves_the_total_and_the_device_is_not_answering);
+    RUN_TEST(test_the_night_state_reports_no_production);
     RUN_TEST(test_totals_over_no_devices_are_null_not_zero);
     RUN_TEST(test_a_full_bus_of_summaries_still_fits);
     RUN_TEST(test_the_status_payload_reports_devices_that_did_not_start);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -416,8 +416,125 @@ static void test_the_status_payload_publishes_the_device_cap() {
     std::string json;
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", makeBridge(),
                                               r.diagnostics.snapshot(),
-                                              &eversolar::descriptor(), g_now, json));
+                                              &eversolar::descriptor(), g_now, {}, json));
     TEST_ASSERT_EQUAL_UINT32(kMaxDevices, parse(json)["bridge"]["max_devices"].as<uint32_t>());
+}
+
+// --- the fleet summary the Dashboard and the header indicator are built from ---------------
+//
+// Everything below exists because the always-visible parts of the UI described the FIRST
+// device as if it were the bridge: the header dot was device 1's `online`, and every tile came
+// from device 1's measurements. On a bus of three, one dead inverter left a green indicator and
+// a healthy-looking dashboard (#38).
+
+/// A device whose readings are whatever the test says, so a fleet can be assembled without
+/// three simulated inverters. Only the channels the summary reads are declared.
+static DeviceState fakeDevice(bool online, bool valid, bool stale, double watts,
+                              double today, uint64_t lastPollMs) {
+    DeviceState s;
+    s.inverterOnline       = online;
+    s.dataValid            = valid;
+    s.dataStale            = stale;
+    s.lastSuccessfulPollMs = lastPollMs;
+    s.measurements.declare(measurement_id::kAcPowerTotal, MeasurementType::Power, Unit::Watt,
+                           "AC Power");
+    s.measurements.declare(measurement_id::kEnergyToday, MeasurementType::Energy,
+                           Unit::KilowattHour, "Energy Today");
+    if (valid) {
+        s.measurements.set(measurement_id::kAcPowerTotal, watts, lastPollMs);
+        s.measurements.set(measurement_id::kEnergyToday, today, lastPollMs);
+    }
+    return s;
+}
+
+static JsonDocument statusOf(const std::vector<rest::DeviceSummary>& fleet) {
+    Rig         r;
+    const auto  state = r.poll();
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", makeBridge(),
+                                              r.diagnostics.snapshot(),
+                                              &eversolar::descriptor(), g_now, fleet, json));
+    return parse(json);
+}
+
+static void test_the_status_payload_totals_every_polled_device() {
+    const auto a = rest::summariseDevice(fakeDevice(true, true, false, 1200.0, 5.0, g_now - 2000),
+                                         "growatt_modbus-1", g_now);
+    const auto b = rest::summariseDevice(fakeDevice(true, true, false, 800.0, 3.5, g_now - 1000),
+                                         "growatt_modbus-2", g_now);
+    const auto doc = statusOf({a, b});
+
+    TEST_ASSERT_EQUAL_UINT32(2, doc["devices"].size());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", doc["devices"][1]["id"]);
+    TEST_ASSERT_EQUAL_DOUBLE(2000.0, doc["totals"]["ac_power_w"].as<double>());
+    TEST_ASSERT_EQUAL_DOUBLE(8.5, doc["totals"]["energy_today_kwh"].as<double>());
+    TEST_ASSERT_EQUAL_UINT32(2, doc["totals"]["devices_answering"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(2, doc["totals"]["devices_polled"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(2, doc["totals"]["ac_power_devices"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(2, doc["devices"][0]["last_successful_poll_seconds_ago"].as<uint32_t>());
+}
+
+// The reason the count travels with every total: a sum over two of three inverters is
+// indistinguishable from a sum over three that had a bad afternoon.
+static void test_a_device_that_reports_nothing_does_not_count_towards_a_total() {
+    const auto live = rest::summariseDevice(
+        fakeDevice(true, true, false, 1200.0, 5.0, g_now - 2000), "growatt_modbus-1", g_now);
+    // Started, never returned a byte: every channel declared, none valid.
+    const auto dead = rest::summariseDevice(fakeDevice(false, false, false, 0.0, 0.0, 0),
+                                            "growatt_modbus-2", g_now);
+    const auto doc = statusOf({live, dead});
+
+    // 1200, not 1200 + a fabricated 0.
+    TEST_ASSERT_EQUAL_DOUBLE(1200.0, doc["totals"]["ac_power_w"].as<double>());
+    TEST_ASSERT_EQUAL_UINT32(1, doc["totals"]["ac_power_devices"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(2, doc["totals"]["devices_polled"].as<uint32_t>());
+    // The header dot keys off this: one of two answering must never read as healthy.
+    TEST_ASSERT_EQUAL_UINT32(1, doc["totals"]["devices_answering"].as<uint32_t>());
+    TEST_ASSERT_TRUE(doc["devices"][1]["ac_power_w"].isNull());
+    TEST_ASSERT_TRUE(doc["devices"][1]["last_successful_poll_seconds_ago"].isNull());
+}
+
+// A stale reading is still the last thing the inverter said, so it stays in the total -- but
+// the device is not "answering", and the row carries the flag that says why.
+static void test_a_stale_device_still_counts_but_is_not_answering() {
+    const auto stale = rest::summariseDevice(
+        fakeDevice(true, true, true, 900.0, 4.0, g_now - 60000), "growatt_modbus-1", g_now);
+    const auto doc = statusOf({stale});
+
+    TEST_ASSERT_EQUAL_DOUBLE(900.0, doc["totals"]["ac_power_w"].as<double>());
+    TEST_ASSERT_EQUAL_UINT32(0, doc["totals"]["devices_answering"].as<uint32_t>());
+    TEST_ASSERT_TRUE(doc["devices"][0]["data_stale"].as<bool>());
+    TEST_ASSERT_EQUAL_UINT32(60, doc["devices"][0]["last_successful_poll_seconds_ago"].as<uint32_t>());
+}
+
+// A bridge with nothing polling still answers /status -- it is the only payload that says how
+// many devices were configured and why each is missing. A total over no devices is unknown.
+static void test_totals_over_no_devices_are_null_not_zero() {
+    const auto doc = statusOf({});
+    TEST_ASSERT_EQUAL_UINT32(0, doc["devices"].size());
+    TEST_ASSERT_TRUE(doc["totals"]["ac_power_w"].isNull());
+    TEST_ASSERT_TRUE(doc["totals"]["energy_today_kwh"].isNull());
+    TEST_ASSERT_TRUE(doc["totals"]["energy_total_kwh"].isNull());
+    TEST_ASSERT_EQUAL_UINT32(0, doc["totals"]["devices_polled"].as<uint32_t>());
+}
+
+// The bound is 8 KB and a full bus is eight devices. The fleet rows are new weight in the one
+// payload the page fetches every second; if they push it over, the whole UI goes dark.
+static void test_a_full_bus_of_summaries_still_fits() {
+    std::vector<rest::DeviceSummary> fleet;
+    for (size_t i = 0; i < kMaxDevices; ++i) {
+        fleet.push_back(rest::summariseDevice(
+            fakeDevice(true, true, false, 1234.5, 6.78, g_now - 1000),
+            "growatt_modbus-" + std::to_string(i + 1), g_now));
+    }
+    Rig         r;
+    const auto  state = r.poll();
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "growatt_modbus-1", makeBridge(),
+                                              r.diagnostics.snapshot(),
+                                              &eversolar::descriptor(), g_now, fleet, json));
+    TEST_ASSERT_TRUE(json.size() < rest::kMaxResponseBytes);
+    TEST_ASSERT_EQUAL_UINT32(kMaxDevices, parse(json)["devices"].size());
 }
 
 // A configured device that is not polling is the failure every mistake on the settings page
@@ -435,7 +552,7 @@ static void test_the_status_payload_reports_devices_that_did_not_start() {
     std::string json;
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", bridge,
                                               r.diagnostics.snapshot(),
-                                              &eversolar::descriptor(), g_now, json));
+                                              &eversolar::descriptor(), g_now, {}, json));
     auto doc = parse(json);
     TEST_ASSERT_EQUAL_UINT32(3, doc["bridge"]["devices_configured"].as<uint32_t>());
     TEST_ASSERT_EQUAL_UINT32(2, doc["bridge"]["devices_started"].as<uint32_t>());
@@ -455,7 +572,7 @@ static void test_the_problem_list_is_always_present() {
     std::string json;
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", makeBridge(),
                                               r.diagnostics.snapshot(),
-                                              &eversolar::descriptor(), g_now, json));
+                                              &eversolar::descriptor(), g_now, {}, json));
     auto doc = parse(json);
     TEST_ASSERT_FALSE(doc["bridge"]["device_problems"].isNull());
     TEST_ASSERT_EQUAL_UINT32(0, doc["bridge"]["device_problems"].size());
@@ -1051,7 +1168,7 @@ static void test_status_payload_reports_clock_sync_state() {
     std::string json;
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", unsynced,
                                               r.diagnostics.snapshot(),
-                                              &eversolar::descriptor(), g_now, json));
+                                              &eversolar::descriptor(), g_now, {}, json));
     auto doc = parse(json);
     TEST_ASSERT_FALSE(doc["bridge"]["time_synced"].as<bool>());
     TEST_ASSERT_TRUE(doc["bridge"]["time"].isNull());
@@ -1069,7 +1186,7 @@ static void test_status_payload_reports_clock_sync_state() {
     synced.ntpFromDhcp      = true;
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", synced,
                                               r.diagnostics.snapshot(),
-                                              &eversolar::descriptor(), g_now, json));
+                                              &eversolar::descriptor(), g_now, {}, json));
     doc = parse(json);
     TEST_ASSERT_TRUE(doc["bridge"]["time_synced"].as<bool>());
     TEST_ASSERT_EQUAL_STRING("2024-01-01 00:00:00", doc["bridge"]["time"]);
@@ -1086,7 +1203,7 @@ static void test_status_payload() {
     std::string json;
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", makeBridge(),
                                               r.diagnostics.snapshot(),
-                                              &eversolar::descriptor(), g_now, json));
+                                              &eversolar::descriptor(), g_now, {}, json));
     auto doc = parse(json);
 
     TEST_ASSERT_EQUAL_STRING("heliograph-a1b2c3", doc["bridge"]["id"]);
@@ -1108,7 +1225,7 @@ static void test_status_reports_unknown_before_the_first_poll() {
     DeviceState state;
     std::string json;
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", makeBridge(),
-                                              DiagnosticsSnapshot{}, nullptr, g_now, json));
+                                              DiagnosticsSnapshot{}, nullptr, g_now, {}, json));
     TEST_ASSERT_TRUE(parse(json)["device"]["last_successful_poll_seconds_ago"].isNull());
 }
 
@@ -1123,7 +1240,7 @@ static void test_stale_status_is_null() {
     }
     std::string json;
     rest::buildStatusPayload(*r.store.snapshot(), "eversolar_legacy", makeBridge(),
-                             r.diagnostics.snapshot(), &eversolar::descriptor(), g_now, json);
+                             r.diagnostics.snapshot(), &eversolar::descriptor(), g_now, {}, json);
     auto doc = parse(json);
 
     TEST_ASSERT_TRUE(doc["measurements"]["ac.power.total"]["value"].isNull());
@@ -1254,7 +1371,7 @@ static void test_oversized_response_is_refused() {
     const auto state = r.poll();
     std::string json = "untouched";
     TEST_ASSERT_FALSE(rest::buildStatusPayload(state, "eversolar_legacy", makeBridge(),
-                                               r.diagnostics.snapshot(), nullptr, g_now, json, 50));
+                                               r.diagnostics.snapshot(), nullptr, g_now, {}, json, 50));
     TEST_ASSERT_EQUAL_STRING("untouched", json.c_str());
 }
 
@@ -1485,6 +1602,11 @@ int main(int, char**) {
     RUN_TEST(test_re_adding_an_id_returns_the_same_store_rather_than_failing);
     RUN_TEST(test_the_device_manager_refuses_past_its_cap);
     RUN_TEST(test_the_status_payload_publishes_the_device_cap);
+    RUN_TEST(test_the_status_payload_totals_every_polled_device);
+    RUN_TEST(test_a_device_that_reports_nothing_does_not_count_towards_a_total);
+    RUN_TEST(test_a_stale_device_still_counts_but_is_not_answering);
+    RUN_TEST(test_totals_over_no_devices_are_null_not_zero);
+    RUN_TEST(test_a_full_bus_of_summaries_still_fits);
     RUN_TEST(test_the_status_payload_reports_devices_that_did_not_start);
     RUN_TEST(test_the_problem_list_is_always_present);
     RUN_TEST(test_a_device_payload_says_when_it_last_answered);


### PR DESCRIPTION
Closes #38.

## The failure

The header indicator was device 1's `online`, under the label "Inverter". Every Dashboard tile came from device 1's measurements. On a bus of three, a dead second inverter left the one indicator anybody glances at **green**, and the default tab — the one you land on after a restart — reporting a healthy day.

#34 already covers "it never came up" with a banner. This is the other half: it started and stopped answering. A sleeping inverter, a swapped A/B pair, an address that resolves but no unit replies.

## The API

`GET /api/v1/status` gains a `devices` array and a `totals` object. `device` and `measurements` still describe the first device and always will — that is what existing clients read — and `devices[0]` is built from the same snapshot, so the two cannot contradict each other inside one response.

Served from the request the page already makes, on purpose: walking the per-device routes instead is 1+N requests a second on the board that is also driving the RS485 bus, which is why the Device tab has to rate-limit itself to once every five seconds.

Four rules, each because the alternative reads as a fact:

- **A reading counts only while it is valid *and* fresh.** `markAllStale()` keeps `valid` true when a device goes offline, so checking validity alone kept a dead inverter's last daylight value in the household total until the next reboot. Overnight every sum is `null` with a count of `0`; `last_successful_poll_seconds_ago` is what the reading has been replaced by.
- **A sum over no device is `null`, never `0`.**
- **Every sum carries the number of devices it covers.** A total over two of three inverters looks exactly like a total over three that had a bad afternoon.
- **"Answering" is strict**: online, valid data, not stale. Started is not answering — a driver whose `begin()` succeeded with A and B swapped never returns a byte.

## The header dot

With **more than one inverter**: green only when every configured device is answering; the label reads `Inverters 2/3`. The denominator is the *configured* count, not the started one — three identical inverters left on the default address all resolve to one id, so two are skipped at boot, and keying off the started count put the single-device layout and a green "Inverter" straight back on screen in the most likely bring-up mistake there is.

Amber for "some" was considered and rejected: with one inverter asleep it would sit amber every evening, and an indicator that is normally amber is one you stop reading.

With **one inverter** the header is unchanged — `online`, plus its "stale" and "no data" tags. Applying the strict rule here would have turned every existing single-inverter bridge's dot red during the stale window where it used to stay green, nightly, for a change nobody asked for.

## The Dashboard

**One device: byte for byte what it was.** Same tiles, same order, same header, no strip. Verified by running `main`'s `render()` and this branch's side by side on the same payloads, healthy and stale, and comparing the emitted HTML — identical in both.

**More than one:** the three tiles that can honestly be added become bridge totals, each with `3 inverters` or `1 of 3 reporting` under it, and a strip below lists every inverter with its power and how long ago it replied — so a dead one cannot hide inside a sum.

Temperature, voltage, frequency, status and error code have no bridge-wide meaning. They are not averaged into something plausible; they stay on the Device tab, where there is room for them.

## Also device-1-only, also fixed

- **The status LED on the board.** It showed device 1 and stayed green with two dead inverters — the same defect as the header, on the indicator someone standing at the bus is actually looking at. Worst-of across every polled device now, its three states kept (red when any is offline, amber when any is stale or invalid). Without this the board would have shown amber while the browser showed red on the same bridge.
- **The Device tab's "n of m answering"** counted without the staleness term, so it read 3 of 3 while the header read 2 of 3 — for the seventy seconds between a device going stale and going offline, which is exactly when someone clicks through to that tab.

## Tests

**595 pass** (was 589 on main). Six new, on the summary rather than on the page: totals across devices, a device that reports nothing not contributing a zero, a stale reading leaving the total, the night state driven through the **real** state machine (a successful poll then eleven failures), totals over no devices being null, and a full bus of eight staying inside the 8 KB response bound.

The last two matter together: the first version of the stale test set `dataStale` on the device while populating channels through `measurements.set()`, which clears each measurement's own stale flag — a combination the state machine cannot produce. It passed for reasons unrelated to staleness. Both stale tests now fail without the fix; I checked by reverting it.

The page itself has no behavioural coverage — `tools/check_web_js.py` is `node --check`, syntax only — so the shipped `render()` was run under Node against night, three-device, one-of-three-started and single-device payloads, and the HTML it produced was read.

`check_layering.sh` PASS, all four boards build.

## Not covered

- **Prometheus and Modbus TCP still serve the first device only** — #36, which needs a design decision about metric labels and register layout.
- `devices` and `totals` are REST-only; Home Assistant gets each inverter separately over MQTT and a bridge-wide total is still a template there.
- The strip shows device ids, not names. With identical inverters the id carries the address, which is the thing you actually need during bring-up.
