### PR TITLE
docs(eversolar): record the 2026-07-26 dawn OP_MODE observation

### DIFF
--- a/docs/eversolar-protocol.md
+++ b/docs/eversolar-protocol.md
@@ -337,12 +337,12 @@ scale are unknown.
 
 The reference reads `OP_MODE` and publishes it as a raw number, without a value table.
 No table is invented here — but two codes have now been **measured** on a real
-TL3000-20 (day/night cycle via HA history, 2026-07-19 through 2026-07-22):
+TL3000-20 (day/night cycle via HA history, 2026-07-19 through 2026-07-26):
 
 | Code | Meaning (measured) | Evidence |
 |---|---|---|
 | 1 | Grid-connected (normal) | Full production days show code 1; independently confirmed by the calibrated Zeversolar 2000s capture (ha-zeversolar-modbus) |
-| 0 | Standby (not feeding) | Four independent events: dusk on July 19/20/21 (last minutes before shutdown show code 0) and dawn on July 22 at 06:01 (four minutes of code 0, then code 1 at first production) |
+| 0 | Standby (not feeding) | Five independent events: dusk on July 19/20/21 (last minutes before shutdown show code 0) and two dawns — July 22 at 06:01 (four minutes of code 0, then code 1 at first production) and July 26 at 06:20:42 (≈5 minutes of code 0, then code 1 at 06:25:46, AC power 0 W→7 W then ramping). The July 26 dawn is a clean self-recovery on firmware 0.12.0: `unknown` straight to code 0 the moment the inverter re-registered, no stuck `poll: timeout` in between — the failure the sunrise-registration fix targets (see `eversolar_driver.h`, the 2026-07-21 note). |
 
 Mapping in `eversolar_parser.cpp::opModeText()`; every other code honestly remains
 `"Unknown (<n>)"` until it has actually been observed (candidate: an error code during a


### PR DESCRIPTION
## Wat

Voegt een vijfde onafhankelijke dag/nacht-waarneming toe aan de `OP_MODE`-codetabel in [docs/eversolar-protocol.md](docs/eversolar-protocol.md), gereconstrueerd uit Home Assistant-historie (`sensor.heliograph_ever_solar_status`, volle resolutie).

Dageraad 2026-07-26 op de TL3000-20:

| Tijd | Status | AC Power |
|---|---|---|
| tot 06:20:42 | `unknown` (donker) | — |
| **06:20:42** | code 0 — `Standby (not feeding)` | 0 W |
| **06:25:46** | code 1 — `Grid-connected (normal)` | 7 W → oplopend |

Standby-venster ~5 min, in lijn met de al vastgelegde dageraad van 22 juli (~4 min).

## Waarom PR-worthy

Naast het versterken van de measured-facts tabel is dit een in-the-wild datapoint voor de **sunrise-registration fix**: de status ging direct van `unknown` naar code 0 op het moment dat de inverter zich herregistreerde — géén vastgelopen `poll: timeout` ertussen. Dat is precies de faalmodus die tegen 2026-07-21 in `eversolar_driver.h` staat gedocumenteerd. Firmware 0.12.0.

Bewust **niet** in de docs gezet: de `5/~7`-sunriseteller richting Stable — dat is project-tracking, geen protocol-fact, en hoort niet in de repo-docs.

## Verificatie

- Docs-only wijziging → de `firmware.yml`-gate (PR #14) hoort de firmware-matrix over te slaan; alleen `CI` (lint + native tests) draait. Meteen een praktijktest van die gate.
- Geen codewijziging; `opModeText()` mapt code 0/1 al, dit legt alleen een extra waarneming vast.
