### PR TITLE
Sweep bus addresses during extended discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,15 @@ own address before you connect them together.
 >   -d '{"additional_devices":[{"driver_id":"growatt_modbus","options":{"unit_id":"2"}}]}'
 > ```
 >
-> Three more things before wiring three: discovery probes only the default address, so the
-> others must be added by hand; **Modbus TCP and Prometheus still carry the first device only**
-> — REST, `/api/v1/devices` and Home Assistant have all of them; and **the bridge's own
-> dashboard shows the first device only** too. All three are next on the list, not wiring
-> faults. Note also that the units share one bus and one poll interval, so each is read roughly
-> every N intervals with N inverters.
+> **Extended discovery sweeps addresses 1–8**, so the wizard reports one candidate per inverter
+> with the address each answered at — use it to check that the addresses you assigned actually
+> took. It configures one device; the rest go in `additional_devices` as above. Quick discovery
+> is unchanged: each driver's default address only.
+>
+> One thing before wiring three: **Modbus TCP and Prometheus still carry the first device only**
+> — REST, `/api/v1/devices`, the bridge's own dashboard and Home Assistant have all of them.
+> That is next on the list, not a wiring fault. Note also that the units share one bus and one
+> poll interval, so each is read roughly every N intervals with N inverters.
 
 ### 2. Flash the firmware
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,9 @@ preempt the higher-priority `rs485Task`; the MQTT payload building that runs on 
 itself is microseconds of pure CPU against a protocol with second-scale timeouts.
 
 Watchdog: `esp_task_wdt` with a 120 s timeout (an extended discovery scan legitimately runs
-many back-to-back 3 s transactions between feeds); `rs485Task` and `loopTask` register with
+many back-to-back 3 s transactions between feeds — since the address sweep it is fed **per
+probe** rather than once per cycle, because a full sweep is dozens of them inside one
+iteration); `rs485Task` and `loopTask` register with
 it, the library tasks do not. `rs485Task` calls `esp_task_wdt_reset()` every cycle, even when
 the poll fails — an unreachable inverter must never cause a reset.
 
@@ -250,7 +252,11 @@ EverSolar:
 Only **one** serial profile for this driver: 9600 8N1 is hardcoded in the reference. We do not
 try other combinations — that would be blind brute-forcing. Drivers whose protocol genuinely
 allows more list them, and extended discovery tries each in turn (quick discovery only tries the
-first).
+first). The same distinction governs bus addresses: a driver names the option that selects
+*which* device on the bus it talks to (`addressOptionKey`), and extended discovery sweeps it
+over 1–8 plus the driver's own default. Nothing is inferred — a driver that names no such
+option is probed once, and a range the driver does not declare is never tried. See
+`docs/rest-api.md`.
 
 The driver's list is not the last word at runtime. `config.serial` stores an optional line
 override: off by default, and set by the discovery wizard when a device answers at a profile the

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -207,10 +207,14 @@ address in turn and confirm exactly one answers, at the address you expect.
    > ```
    >
    > Note `driver_id` here where the `driver` section uses `id`. Sending the array replaces it,
-   > so send all the extra units at once. Restart afterwards. Discovery probes only the default
-   > address, so it finds the unit at address 1 and not the others — a known gap, not a wiring
-   > fault. Check `/api/v1/devices` after the restart: you should see one entry per unit, named
-   > `growatt_modbus-1`, `-2`, `-3`.
+   > so send all the extra units at once. Restart afterwards. Check `/api/v1/devices` after the
+   > restart: you should see one entry per unit, named `growatt_modbus-1`, `-2`, `-3`.
+   >
+   > **Or let the wizard find them.** Extended discovery sweeps addresses 1–8, so it reports one
+   > candidate per unit with the address each answered at — which is also how you confirm that
+   > the addresses you wrote actually took. It still configures one device; the others go in
+   > `additional_devices` as above, but you are copying addresses it found rather than guessing.
+   > Quick discovery is unchanged: default address only.
    >
    > **Modbus TCP and Prometheus still publish the first device only.** All three units appear
    > in the REST API, in the device list and in Home Assistant, each as its own HA device; only

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -238,6 +238,42 @@ configured device; **Modbus TCP and Prometheus carry the first one only**, becau
 map holds one device's registers and the metric names have no device label. That is the next
 piece of work and is stated in `docs/architecture.md` too.
 
+## Discovery: what each mode actually probes
+
+| | Serial profiles | Bus addresses |
+|---|---|---|
+| **Quick** | the driver's first recommended profile | the driver's own default only |
+| **Extended** | all of them, in order, stopping at the first that answers | the driver's default, then **1–8** |
+
+Quick mode's cost is unchanged — one probe per driver — because it is the mode that runs by
+default, sometimes on a bus that is already in service.
+
+Extended sweeps addresses because a chain of identical inverters is the case the wizard was
+worst at: only the unit at the default address could ever be a candidate, and the address is
+exactly the field a typo makes invisible. Each candidate carries the `options` it answered at
+and an `address`, and the report carries `swept_addresses` — so "nothing else answered" can be
+told apart from "nothing else was asked". A device parked outside 1–8 is still configured by
+hand; the wizard says which addresses it tried rather than implying the bus is empty.
+
+Why 1–8 and not 1–247: the bridge polls at most eight devices, and probing 247 addresses across
+every driver and profile is hours of traffic for addresses nothing could use. A driver's own
+default is always included even when it falls outside the range — SolaX registers at 10.
+
+Two consequences worth knowing:
+
+- **One driver can now produce several candidates**, one per device. The "too close to call"
+  rule only compares *different* drivers: three inverters of the same make are not ambiguous
+  about which protocol they speak, and treating them as such would have made the sweep defeat
+  auto-selection on exactly the bus it was built for. The wizard still configures one device and
+  says how many answered.
+- **The same serial number at two addresses is reported once**, at the lower address, with the
+  other recorded in its evidence. That is one inverter mid-reconfiguration, and configuring it
+  twice would collide at boot.
+
+A full extended sweep on a silent bus is dozens of response timeouts back to back, all with
+polling stopped. It is a user-requested operation and it is slow; the task watchdog is fed per
+probe rather than per run.
+
 ## `serial` — overriding the line the driver picks
 
 Every driver advertises the serial profiles plausible for its protocol and configures the first

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -240,13 +240,22 @@ piece of work and is stated in `docs/architecture.md` too.
 
 ## Discovery: what each mode actually probes
 
-| | Serial profiles | Bus addresses |
-|---|---|---|
-| **Quick** | the driver's first recommended profile | the driver's own default only |
-| **Extended** | all of them, in order, stopping at the first that answers | the driver's default, then **1–8** |
+| | Serial profiles | Bus addresses | Probes, drivers in this build |
+|---|---|---|---|
+| **Quick** | the driver's first recommended profile | none — the driver's own default, with no option set | 4, ≈ 8 s |
+| **Extended** | all of them, stopping at the first profile that answers | the driver's default, then **1–8** | up to 33, ≈ 35 s |
 
 Quick mode's cost is unchanged — one probe per driver — because it is the mode that runs by
-default, sometimes on a bus that is already in service.
+default, sometimes on a bus that is already in service. It also passes **no options at all**, so
+a quick candidate never claims an address it did not discover: the wizard prefers a discovered
+address over the stored configuration, and a candidate carrying the driver's default would have
+quietly proposed unit id 1 to a bridge configured at 7.
+
+The extended numbers are the worst case, on a bus where nothing answers: 16 probes each for the
+two Modbus drivers (2 profiles × 8 addresses), one for the PMU driver, at roughly a second of
+response timeout apiece. Polling is stopped for the whole run. On a bus with devices it is much
+faster — the profile is settled at the first address that answers and the rest are probed at
+known-good line settings.
 
 Extended sweeps addresses because a chain of identical inverters is the case the wizard was
 worst at: only the unit at the default address could ever be a candidate, and the address is
@@ -257,7 +266,24 @@ hand; the wizard says which addresses it tried rather than implying the bus is e
 
 Why 1–8 and not 1–247: the bridge polls at most eight devices, and probing 247 addresses across
 every driver and profile is hours of traffic for addresses nothing could use. A driver's own
-default is always included even when it falls outside the range — SolaX registers at 10.
+default is included on top of the range, as long as the driver would accept it.
+
+**Only an address the device already has is swept.** A driver names it (`addressOptionKey`), and
+naming it is a claim about what the option means, not just where it lives. SolaX's `address` is
+the address the bridge *hands out* at registration, so it is deliberately not named: sweeping it
+would assign nine addresses in a row and leave the inverter on the last one while the report
+described the first. A driver that names nothing, or names an option that is not a declared
+numeric one, is probed once.
+
+**Traffic without a device is reported, not discarded.** `unidentified_addresses` lists any
+address where bytes came back that identified nothing — which on a chain of identical inverters
+is what two units left on the same unit id look like: their replies collide into a failed
+checksum. That is the one fault a sweep can diagnose that nothing else can, and when it is all
+there is, the report says so instead of blaming the wiring.
+
+`candidates` is capped at ten, lowest scores dropped first, with `candidates_omitted` saying how
+many. Sixteen candidates at half a kilobyte each would exceed the 8 KB response bound, and a
+refused body reads to the wizard as "nothing answered" after a minute of probing.
 
 Two consequences worth knowing:
 
@@ -272,7 +298,9 @@ Two consequences worth knowing:
 
 A full extended sweep on a silent bus is dozens of response timeouts back to back, all with
 polling stopped. It is a user-requested operation and it is slow; the task watchdog is fed per
-probe rather than per run.
+probe rather than per run. Note that the "stop at the first profile that answers" saving only
+applies to a driver that *does* answer — for every driver that finds nothing, profiles and
+addresses multiply in full, and that is where the bulk of the time on a mixed bus goes.
 
 ## `serial` — overriding the line the driver picks
 

--- a/src/app/discovery_runner.cpp
+++ b/src/app/discovery_runner.cpp
@@ -39,7 +39,8 @@ bool DiscoveryRunner::request(bool extended) {
     return true;
 }
 
-bool DiscoveryRunner::runIfRequested(Transport& transport) {
+bool DiscoveryRunner::runIfRequested(Transport& transport,
+                                     const std::function<void()>& onProbe) {
     DiscoveryMode mode;
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -53,8 +54,8 @@ bool DiscoveryRunner::runIfRequested(Transport& transport) {
 
     // The engine runs outside the lock: it takes seconds, and report() must stay answerable
     // for the web UI polling for progress the whole time.
-    DiscoveryEngine engine(registry_, transport);
-    DiscoveryOutcome outcome = engine.run(mode);
+    DiscoveryEngine  engine(registry_, transport);
+    DiscoveryOutcome outcome = engine.run(mode, DiscoveryConfig{}, onProbe);
 
     {
         std::lock_guard<std::mutex> lock(mutex_);

--- a/src/app/discovery_runner.h
+++ b/src/app/discovery_runner.h
@@ -57,7 +57,12 @@ public:
     /// Called from rs485Task. Runs a pending request, if any, and returns true if it ran.
     /// Polling must be paused around this by the caller: probing re-registers every inverter
     /// on the bus.
-    bool runIfRequested(Transport& transport);
+    ///
+    /// `onProbe` is called before each probe, on the caller's task. An extended sweep is now
+    /// dozens of probes -- every address on a silent bus is a response timeout -- and they all
+    /// happen inside one rs485Task iteration, so the task watchdog has to be fed from in here
+    /// rather than once around the whole run.
+    bool runIfRequested(Transport& transport, const std::function<void()>& onProbe = {});
 
     DiscoveryReport report() const;
     bool            busy() const;

--- a/src/drivers/discovery_engine.cpp
+++ b/src/drivers/discovery_engine.cpp
@@ -3,6 +3,7 @@
 #include "discovery_engine.h"
 
 #include <algorithm>
+#include <cstdlib>
 
 namespace heliograph {
 namespace {
@@ -30,19 +31,28 @@ bool probesAgree(const ProbeResult& a, const ProbeResult& b) {
 /// itself in any mode.
 std::vector<std::string> addressesFor(const DriverDescriptor& descriptor, DiscoveryMode mode,
                                       const DiscoveryConfig& config) {
-    if (descriptor.addressOptionKey.empty()) {
+    // Quick mode probes with NO options at all, exactly as it always has. Passing the driver's
+    // own default looks equivalent -- same value, same probe -- but it makes every quick
+    // candidate claim an address it did not discover, and the wizard prefers a discovered
+    // address over the stored configuration. A bridge configured at unit id 7 would have had
+    // quick discovery quietly propose 1 (review, 2026-07-26).
+    if (mode != DiscoveryMode::Extended || !descriptor.hasSweepableAddress()) {
         return {std::string{}};
     }
-    const std::string def = descriptor.optionOr(DriverOptions{}, descriptor.addressOptionKey);
-    std::vector<std::string> out{def};
-    if (mode != DiscoveryMode::Extended) {
-        return out;
+    const std::string        def = descriptor.optionOr(DriverOptions{}, descriptor.addressOptionKey);
+    const auto               bounds = descriptor.addressRange();
+    std::vector<std::string> out;
+    // The driver's own default first -- but only if the driver would accept it. A default
+    // outside its own declared bounds would be probed, reported, offered by the wizard, and
+    // then refused by the PATCH gate: a dead end on the confirm step.
+    const long parsedDefault = std::strtol(def.c_str(), nullptr, 10);
+    if (!def.empty() && parsedDefault >= bounds.first && parsedDefault <= bounds.second) {
+        out.push_back(def);
     }
-    const auto bounds = descriptor.addressRange();
     for (const int address : config.sweepAddresses) {
         // Outside what the driver declares is not a gap in the sweep, it is a value the driver
         // would refuse anyway -- the option bounds are the protocol's.
-        if (bounds.second != 0 && (address < bounds.first || address > bounds.second)) {
+        if (address < bounds.first || address > bounds.second) {
             continue;
         }
         const std::string value = std::to_string(address);
@@ -50,28 +60,43 @@ std::vector<std::string> addressesFor(const DriverDescriptor& descriptor, Discov
             out.push_back(value);
         }
     }
+    if (out.empty()) {
+        out.push_back(std::string{});  // nothing sweepable after all; probe once, as before
+    }
     return out;
 }
 
 /// Same driver, same non-empty serial number, two addresses: one inverter mid-reconfiguration,
-/// or one still answering on an address it was moved off. Reported once, at the lower address,
+/// or one still answering on an address it was moved off. Reported once, at the lowest address,
 /// with the fact recorded -- two entries for one device would have the owner configure it
 /// twice, and two configured devices that resolve to one physical inverter is the collision the
 /// boot loop exists to refuse.
+///
+/// "Lowest", numerically, and not "the first one probed": the driver's own default is probed
+/// first and is not necessarily the lowest, so keeping the first would report a device at the
+/// higher of the two addresses while claiming the lower (review, 2026-07-26).
 void mergeDuplicateSerials(std::vector<DiscoveryCandidate>& candidates) {
+    const auto lower = [](const std::string& a, const std::string& b) {
+        return std::strtol(a.c_str(), nullptr, 10) < std::strtol(b.c_str(), nullptr, 10);
+    };
     for (auto it = candidates.begin(); it != candidates.end(); ++it) {
         if (it->probe.serialNumber.empty()) {
             continue;  // no serial: nothing to match on, and two silent units are two units
         }
         for (auto other = it + 1; other != candidates.end();) {
-            if (other->descriptor.id == it->descriptor.id &&
-                other->probe.serialNumber == it->probe.serialNumber) {
-                it->probe.evidence.push_back("the same serial number also answered at address " +
-                                             other->address());
-                other = candidates.erase(other);
-            } else {
+            if (other->descriptor.id != it->descriptor.id ||
+                other->probe.serialNumber != it->probe.serialNumber) {
                 ++other;
+                continue;
             }
+            if (lower(other->address(), it->address())) {
+                // Keep the lower address, and with it the options the wizard will configure.
+                std::swap(it->matchedOptions, other->matchedOptions);
+                std::swap(it->matchedProfile, other->matchedProfile);
+            }
+            it->probe.evidence.push_back("the same serial number also answered at address " +
+                                         other->address());
+            other = candidates.erase(other);
         }
     }
 }
@@ -146,6 +171,16 @@ DiscoveryOutcome DiscoveryEngine::run(DiscoveryMode mode, const DiscoveryConfig&
                 tick();
                 ProbeResult first = driver->probe();
                 if (!first.responded) {
+                    // Bytes that identified nothing are the duplicate-address signal, and the
+                    // only one there is: two units on one id answer together and collide. Kept
+                    // rather than discarded with the probe -- but only when an address was
+                    // actually selected, since at the wrong baud rate the same garbage is
+                    // routine and says nothing about addressing.
+                    if (first.sawTraffic && !address.empty()) {
+                        outcome.unidentified.push_back(
+                            {descriptor.id, address,
+                             first.evidence.empty() ? std::string{} : first.evidence.back()});
+                    }
                     continue;
                 }
 
@@ -192,6 +227,15 @@ DiscoveryOutcome DiscoveryEngine::run(DiscoveryMode mode, const DiscoveryConfig&
                      });
 
     if (outcome.candidates.empty()) {
+        // Traffic without an identification is a different fault from silence, and pointing at
+        // the wiring when the bus is demonstrably alive sends someone to re-crimp a cable that
+        // is fine. Two units left on one address is what this usually is.
+        if (!outcome.unidentified.empty()) {
+            outcome.reason = "no device could be identified, but address " +
+                             outcome.unidentified.front().address +
+                             " produced traffic: " + outcome.unidentified.front().note;
+            return outcome;
+        }
         outcome.reason = "no device answered; check wiring, termination and the RS485 A/B order";
         // Which addresses were asked, so silence at 1..8 is not mistaken for silence
         // everywhere: an inverter parked outside the swept range is configured by hand.

--- a/src/drivers/discovery_engine.cpp
+++ b/src/drivers/discovery_engine.cpp
@@ -19,13 +19,79 @@ bool probesAgree(const ProbeResult& a, const ProbeResult& b) {
     return a.detectedModel == b.detectedModel;
 }
 
+/// The bus addresses one driver is probed at, in order, as option values.
+///
+/// The driver's own default always comes first and is always included, whatever the sweep set
+/// says: SolaX assigns 10 by default, which is outside 1..8, and a wizard that stopped finding
+/// the device it used to find would be a regression dressed as a feature.
+///
+/// A single empty string means "no address option": probe once, with no options, exactly as
+/// before. That is every driver in Quick mode, and drivers whose protocol addresses devices
+/// itself in any mode.
+std::vector<std::string> addressesFor(const DriverDescriptor& descriptor, DiscoveryMode mode,
+                                      const DiscoveryConfig& config) {
+    if (descriptor.addressOptionKey.empty()) {
+        return {std::string{}};
+    }
+    const std::string def = descriptor.optionOr(DriverOptions{}, descriptor.addressOptionKey);
+    std::vector<std::string> out{def};
+    if (mode != DiscoveryMode::Extended) {
+        return out;
+    }
+    const auto bounds = descriptor.addressRange();
+    for (const int address : config.sweepAddresses) {
+        // Outside what the driver declares is not a gap in the sweep, it is a value the driver
+        // would refuse anyway -- the option bounds are the protocol's.
+        if (bounds.second != 0 && (address < bounds.first || address > bounds.second)) {
+            continue;
+        }
+        const std::string value = std::to_string(address);
+        if (std::find(out.begin(), out.end(), value) == out.end()) {
+            out.push_back(value);
+        }
+    }
+    return out;
+}
+
+/// Same driver, same non-empty serial number, two addresses: one inverter mid-reconfiguration,
+/// or one still answering on an address it was moved off. Reported once, at the lower address,
+/// with the fact recorded -- two entries for one device would have the owner configure it
+/// twice, and two configured devices that resolve to one physical inverter is the collision the
+/// boot loop exists to refuse.
+void mergeDuplicateSerials(std::vector<DiscoveryCandidate>& candidates) {
+    for (auto it = candidates.begin(); it != candidates.end(); ++it) {
+        if (it->probe.serialNumber.empty()) {
+            continue;  // no serial: nothing to match on, and two silent units are two units
+        }
+        for (auto other = it + 1; other != candidates.end();) {
+            if (other->descriptor.id == it->descriptor.id &&
+                other->probe.serialNumber == it->probe.serialNumber) {
+                it->probe.evidence.push_back("the same serial number also answered at address " +
+                                             other->address());
+                other = candidates.erase(other);
+            } else {
+                ++other;
+            }
+        }
+    }
+}
+
 }  // namespace
 
 DiscoveryEngine::DiscoveryEngine(const DriverRegistry& registry, Transport& transport)
     : registry_(registry), transport_(transport) {}
 
-DiscoveryOutcome DiscoveryEngine::run(DiscoveryMode mode, const DiscoveryConfig& config) {
+DiscoveryOutcome DiscoveryEngine::run(DiscoveryMode mode, const DiscoveryConfig& config,
+                                      const std::function<void()>& onProbe) {
     DiscoveryOutcome outcome;
+    if (mode == DiscoveryMode::Extended) {
+        outcome.sweptAddresses = config.sweepAddresses;
+    }
+    const auto tick = [&onProbe]() {
+        if (onProbe) {
+            onProbe();
+        }
+    };
 
     for (const auto& descriptor : registry_.availableDrivers()) {
         if (!descriptor.supportsAutoDetection) {
@@ -46,58 +112,94 @@ DiscoveryOutcome DiscoveryEngine::run(DiscoveryMode mode, const DiscoveryConfig&
             profiles.resize(1);
         }
 
+        // Every address the driver could be answering at, not just its default. On a chain of
+        // identical inverters only the one at the default address was ever a candidate, and the
+        // wizard's answer to "which inverters are on this bus" was "there is one at address 1"
+        // (#37). The address is also the field a typo makes invisible, which is the failure this
+        // is meant to head off.
+        const std::vector<std::string> addresses = addressesFor(descriptor, mode, config);
+
         for (const auto& profile : profiles) {
-            auto driver = registry_.create(descriptor.id, transport_);
-            if (!driver) {
-                continue;
-            }
-            transport_.configure(profile);
-            if (!driver->begin(transport_)) {
-                continue;
-            }
-            // Re-applied, because begin() configures the line to the driver's OWN first choice.
-            // That is correct at boot -- a driver started straight from config must not depend
-            // on a discovery run having configured the UART, which was a real bug -- but here it
-            // silently undid the sweep: every iteration probed at the driver's default, so the
-            // second and later profiles were never actually tried. A device shipped at the
-            // family's other baud rate could not be found, and the failure looked exactly like
-            // bad wiring (review, 2026-07-25).
-            transport_.configure(profile);
-
-            ProbeResult first = driver->probe();
-            if (!first.responded) {
-                continue;
-            }
-
-            DiscoveryCandidate candidate;
-            candidate.descriptor    = descriptor;
-            candidate.probe         = first;
-            candidate.matchedProfile = profile;
-
-            if (config.requireConsistentProbes) {
-                const ProbeResult second = driver->probe();
-                candidate.consistent     = probesAgree(first, second);
-                if (!candidate.consistent) {
-                    candidate.probe.confidenceScore /= 2;
-                    candidate.probe.evidence.push_back(
-                        "second probe disagreed with the first; confidence halved");
-                } else {
-                    candidate.probe.evidence.push_back("second probe gave the same result");
+            bool answeredAtThisProfile = false;
+            for (const auto& address : addresses) {
+                DriverOptions options;
+                if (!address.empty()) {
+                    options[descriptor.addressOptionKey] = address;
                 }
-            }
+                auto driver = registry_.create(descriptor.id, transport_, options);
+                if (!driver) {
+                    continue;
+                }
+                transport_.configure(profile);
+                if (!driver->begin(transport_)) {
+                    continue;
+                }
+                // Re-applied, because begin() configures the line to the driver's OWN first
+                // choice. That is correct at boot -- a driver started straight from config must
+                // not depend on a discovery run having configured the UART, which was a real
+                // bug -- but here it silently undid the sweep: every iteration probed at the
+                // driver's default, so the second and later profiles were never actually tried.
+                // A device shipped at the family's other baud rate could not be found, and the
+                // failure looked exactly like bad wiring (review, 2026-07-25).
+                transport_.configure(profile);
 
-            outcome.candidates.push_back(std::move(candidate));
-            break;  // a profile answered; no reason to keep poking the bus
+                tick();
+                ProbeResult first = driver->probe();
+                if (!first.responded) {
+                    continue;
+                }
+
+                DiscoveryCandidate candidate;
+                candidate.descriptor     = descriptor;
+                candidate.probe          = first;
+                candidate.matchedProfile = profile;
+                candidate.matchedOptions = options;
+
+                if (config.requireConsistentProbes) {
+                    tick();
+                    const ProbeResult second = driver->probe();
+                    candidate.consistent     = probesAgree(first, second);
+                    if (!candidate.consistent) {
+                        candidate.probe.confidenceScore /= 2;
+                        candidate.probe.evidence.push_back(
+                            "second probe disagreed with the first; confidence halved");
+                    } else {
+                        candidate.probe.evidence.push_back("second probe gave the same result");
+                    }
+                }
+                if (!address.empty()) {
+                    candidate.probe.evidence.push_back("answered at address " + address);
+                }
+
+                outcome.candidates.push_back(std::move(candidate));
+                answeredAtThisProfile = true;
+            }
+            if (answeredAtThisProfile) {
+                // One bus, one set of line settings: if something answered at this profile,
+                // every other device on the wire is at this profile too. Trying the driver's
+                // remaining baud rates would be silence by construction, at a response timeout
+                // per address.
+                break;
+            }
         }
     }
 
-    std::sort(outcome.candidates.begin(), outcome.candidates.end(),
-              [](const DiscoveryCandidate& a, const DiscoveryCandidate& b) {
-                  return a.probe.confidenceScore > b.probe.confidenceScore;
-              });
+    mergeDuplicateSerials(outcome.candidates);
+
+    std::stable_sort(outcome.candidates.begin(), outcome.candidates.end(),
+                     [](const DiscoveryCandidate& a, const DiscoveryCandidate& b) {
+                         return a.probe.confidenceScore > b.probe.confidenceScore;
+                     });
 
     if (outcome.candidates.empty()) {
         outcome.reason = "no device answered; check wiring, termination and the RS485 A/B order";
+        // Which addresses were asked, so silence at 1..8 is not mistaken for silence
+        // everywhere: an inverter parked outside the swept range is configured by hand.
+        if (!outcome.sweptAddresses.empty()) {
+            outcome.reason += " (addresses " + std::to_string(outcome.sweptAddresses.front()) +
+                              "-" + std::to_string(outcome.sweptAddresses.back()) +
+                              " and each driver's own default were tried)";
+        }
         return outcome;
     }
 
@@ -118,23 +220,48 @@ DiscoveryOutcome DiscoveryEngine::run(DiscoveryMode mode, const DiscoveryConfig&
                          "' disagreed; confirm manually";
         return outcome;
     }
-    if (outcome.candidates.size() > 1) {
-        const int margin =
-            best.probe.confidenceScore - outcome.candidates[1].probe.confidenceScore;
+    // The runner-up has to be a DIFFERENT driver. Three identical inverters on one bus are now
+    // three candidates with the same driver id and near-identical scores, and reading that as
+    // "too close to call" would have made the sweep defeat auto-selection exactly on the bus it
+    // was built for -- the ambiguity this rule guards against is which PROTOCOL a device speaks,
+    // never how many devices answered it.
+    const auto runnerUp =
+        std::find_if(outcome.candidates.begin(), outcome.candidates.end(),
+                     [&best](const DiscoveryCandidate& c) {
+                         return c.descriptor.id != best.descriptor.id;
+                     });
+    if (runnerUp != outcome.candidates.end()) {
+        const int margin = best.probe.confidenceScore - runnerUp->probe.confidenceScore;
         if (margin < config.minMargin) {
             outcome.reason = "'" + best.descriptor.id + "' (" +
                              std::to_string(best.probe.confidenceScore) + ") and '" +
-                             outcome.candidates[1].descriptor.id + "' (" +
-                             std::to_string(outcome.candidates[1].probe.confidenceScore) +
+                             runnerUp->descriptor.id + "' (" +
+                             std::to_string(runnerUp->probe.confidenceScore) +
                              ") are too close to call; confirm manually";
             return outcome;
         }
     }
 
+    const size_t sameDriver =
+        static_cast<size_t>(std::count_if(outcome.candidates.begin(), outcome.candidates.end(),
+                                          [&best](const DiscoveryCandidate& c) {
+                                              return c.descriptor.id == best.descriptor.id;
+                                          }));
+
     outcome.autoSelected     = true;
     outcome.selectedDriverId = best.descriptor.id;
+    outcome.selectedOptions  = best.matchedOptions;
     outcome.reason           = "'" + best.descriptor.id + "' matched convincingly (" +
                      std::to_string(best.probe.confidenceScore) + "/100)";
+    if (!best.address().empty()) {
+        outcome.reason += " at address " + best.address();
+    }
+    // Said here rather than left to be counted off the candidate list: the wizard configures
+    // ONE device, and on a bus of three the other two are the ones the owner has to remember.
+    if (sameDriver > 1) {
+        outcome.reason += "; " + std::to_string(sameDriver) +
+                          " devices answered it -- add the others under Settings, Extra devices";
+    }
     return outcome;
 }
 

--- a/src/drivers/discovery_engine.h
+++ b/src/drivers/discovery_engine.h
@@ -4,8 +4,13 @@
 //
 // Discovery only ever calls InverterDriver::probe(), never execute(). Everything a probe is
 // forbidden from doing -- writes, function codes 5/6/15/16, broadcast writes, start/stop,
-// power limits, address changes, clock setting, factory reset, firmware updates, brute-force
-// scanning -- is therefore unreachable from here by construction, not by discipline.
+// power limits, clock setting, factory reset, firmware updates, brute-force scanning -- is
+// therefore unreachable from here by construction, not by discipline.
+//
+// One honest exception, and it predates the address sweep: a driver for a protocol that
+// REGISTERS devices (the AA55/PMU family) hands the inverter a bus address as part of probing
+// it at all -- there is no read-only way to discover such a device. That is why those drivers
+// name no addressOptionKey: the sweep must not turn one address assignment into nine.
 
 #pragma once
 
@@ -69,9 +74,24 @@ struct DiscoveryCandidate {
     }
 };
 
+/// An address where bytes came back that identified nothing.
+///
+/// The reason the sweep is worth having at all: two inverters left on one unit id answer
+/// together, their replies collide, and the result is a failed checksum -- not silence. Reported
+/// separately from the candidates because it is not a device, and thrown away before this
+/// existed, so the wizard blamed the wiring for the one fault it could actually name.
+struct UnidentifiedAddress {
+    std::string driverId;
+    std::string address;
+    /// The probe's own words, shown verbatim.
+    std::string note;
+};
+
 struct DiscoveryOutcome {
     /// Highest score first.
     std::vector<DiscoveryCandidate> candidates;
+    /// Addresses that produced traffic without a usable reply. Never a device.
+    std::vector<UnidentifiedAddress> unidentified;
     bool                            autoSelected = false;
     std::string                     selectedDriverId;
     /// The options the selected candidate answered at, so the wizard configures the device it

--- a/src/drivers/discovery_engine.h
+++ b/src/drivers/discovery_engine.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -32,6 +33,17 @@ struct DiscoveryConfig {
     int minMargin = 20;
     /// Probes run twice and must agree. A single lucky reply is not identification.
     bool requireConsistentProbes = true;
+
+    /// Bus addresses Extended mode tries, on top of each driver's own default. Quick mode
+    /// ignores this entirely.
+    ///
+    /// 1..8 rather than the protocol's full range: Modbus allows 1-247, and probing 247
+    /// addresses across every driver and profile is hours of traffic on someone's live bus for
+    /// a bridge that will poll at most kMaxDevices of them anyway. Eight is the number the
+    /// firmware can actually use. An inverter parked at 30 is still configurable by hand -- the
+    /// wizard just does not promise to find it, and reports which addresses it tried so that
+    /// silence at 1-8 is not read as silence everywhere. See docs/rest-api.md.
+    std::vector<int> sweepAddresses{1, 2, 3, 4, 5, 6, 7, 8};
 };
 
 struct DiscoveryCandidate {
@@ -42,8 +54,19 @@ struct DiscoveryCandidate {
     /// so every probe really did happen at the driver default. Now that the sweep works, the
     /// two can differ, and reporting the recommendation would be an active lie in the wizard.
     SerialProfile matchedProfile{};
+    /// The options this candidate answered at -- in practice the bus address, when the driver
+    /// has one. Empty means the driver's own defaults, which is every candidate Quick mode can
+    /// produce. Handed to the wizard as-is, so what gets configured is what answered rather
+    /// than a default that happened to be right the first time.
+    DriverOptions matchedOptions;
     /// False when a repeat probe contradicted the first; the score is halved in that case.
     bool consistent = true;
+
+    /// The bus address this answered at, or empty when the driver has no address option.
+    std::string address() const {
+        const auto it = matchedOptions.find(descriptor.addressOptionKey);
+        return it == matchedOptions.end() ? std::string{} : it->second;
+    }
 };
 
 struct DiscoveryOutcome {
@@ -51,6 +74,12 @@ struct DiscoveryOutcome {
     std::vector<DiscoveryCandidate> candidates;
     bool                            autoSelected = false;
     std::string                     selectedDriverId;
+    /// The options the selected candidate answered at, so the wizard configures the device it
+    /// found rather than the one at the driver's default address.
+    DriverOptions selectedOptions;
+    /// Addresses that were tried beyond each driver's default. Empty in Quick mode. Reported so
+    /// "nothing else answered" can be told apart from "nothing else was asked".
+    std::vector<int> sweptAddresses;
     /// Why it was or was not auto-selected, shown to the user verbatim.
     std::string reason;
 };
@@ -59,7 +88,12 @@ class DiscoveryEngine {
 public:
     DiscoveryEngine(const DriverRegistry& registry, Transport& transport);
 
-    DiscoveryOutcome run(DiscoveryMode mode, const DiscoveryConfig& config = {});
+    /// `onProbe` runs immediately before every probe. It exists for one reason: an extended
+    /// sweep on a silent bus is dozens of response timeouts back to back, all inside a single
+    /// rs485Task iteration, and the task watchdog does not care that the delay is legitimate.
+    /// The caller feeds it here. Host tests pass nothing.
+    DiscoveryOutcome run(DiscoveryMode mode, const DiscoveryConfig& config = {},
+                         const std::function<void()>& onProbe = {});
 
 private:
     const DriverRegistry& registry_;

--- a/src/drivers/driver_descriptor.h
+++ b/src/drivers/driver_descriptor.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "transport/serial_profile.h"
@@ -91,6 +92,28 @@ struct DriverDescriptor {
 
     /// Settings this driver understands. See DriverOption.
     std::vector<DriverOption> options;
+
+    /// The option that selects WHICH device on a shared bus this driver talks to, if the user
+    /// picks it: "unit_id" for Modbus, "address" for a protocol that assigns one.
+    ///
+    /// Named rather than inferred, because there is no safe convention to infer from: a driver
+    /// may have several numeric options (SunSpec has a base register too) and probing the wrong
+    /// one at eight values is eight pointless transactions on someone's live bus. Empty means
+    /// the driver has no such option -- a protocol where the bridge registers devices itself
+    /// addresses them itself, and there is nothing to sweep.
+    ///
+    /// Extended discovery sweeps this option; nothing else reads it.
+    std::string addressOptionKey;
+
+    /// The declared bounds of addressOptionKey, or {0,0} when there is no such option.
+    std::pair<long, long> addressRange() const {
+        for (const auto& o : options) {
+            if (o.key == addressOptionKey && o.isNumeric()) {
+                return {o.minValue, o.maxValue};
+            }
+        }
+        return {0, 0};
+    }
 
     /// Looks up an option value, falling back to the declared default.
     std::string optionOr(const DriverOptions& values, const std::string& key) const {

--- a/src/drivers/driver_descriptor.h
+++ b/src/drivers/driver_descriptor.h
@@ -93,19 +93,37 @@ struct DriverDescriptor {
     /// Settings this driver understands. See DriverOption.
     std::vector<DriverOption> options;
 
-    /// The option that selects WHICH device on a shared bus this driver talks to, if the user
-    /// picks it: "unit_id" for Modbus, "address" for a protocol that assigns one.
+    /// The option naming an address the device ALREADY answers at, which a probe can therefore
+    /// select: "unit_id" for Modbus.
     ///
-    /// Named rather than inferred, because there is no safe convention to infer from: a driver
-    /// may have several numeric options (SunSpec has a base register too) and probing the wrong
-    /// one at eight values is eight pointless transactions on someone's live bus. Empty means
-    /// the driver has no such option -- a protocol where the bridge registers devices itself
-    /// addresses them itself, and there is nothing to sweep.
+    /// Named rather than inferred, because there is no safe convention to infer from. Two
+    /// distinctions matter and neither is visible from an option's name or type:
+    ///   - a driver may have several numeric options (SunSpec has a base register too), and
+    ///     probing the wrong one at eight values is eight pointless transactions on a live bus;
+    ///   - an option may be an address the bridge HANDS OUT rather than one the device has.
+    ///     The registration protocols work that way, and sweeping such an option would assign
+    ///     nine addresses in a row rather than discover anything.
     ///
+    /// Empty means there is nothing to sweep, and that is the safe default for a new driver.
     /// Extended discovery sweeps this option; nothing else reads it.
     std::string addressOptionKey;
 
-    /// The declared bounds of addressOptionKey, or {0,0} when there is no such option.
+    /// True when addressOptionKey names a declared, numeric option -- the only shape a sweep can
+    /// use. A key naming nothing, or naming an enum, would otherwise be swept over values the
+    /// driver never accepts.
+    bool hasSweepableAddress() const {
+        if (addressOptionKey.empty()) {
+            return false;
+        }
+        for (const auto& o : options) {
+            if (o.key == addressOptionKey) {
+                return o.isNumeric() && !o.defaultValue.empty();
+            }
+        }
+        return false;
+    }
+
+    /// The declared bounds of addressOptionKey. Only meaningful when hasSweepableAddress().
     std::pair<long, long> addressRange() const {
         for (const auto& o : options) {
             if (o.key == addressOptionKey && o.isNumeric()) {

--- a/src/drivers/growatt_modbus/descriptor.cpp
+++ b/src/drivers/growatt_modbus/descriptor.cpp
@@ -53,6 +53,7 @@ const DriverDescriptor& descriptor() {
         // No write path is wired yet. This is the read-only bring-up build; battery control is
         // the deliberate next step, gated on the map being confirmed.
         x.supportsWrite = false;
+        x.addressOptionKey = "unit_id";
         x.options       = {
             // Bounded here, not only in optionsFrom(): the parser's fallback is silent by the
             // time it runs, and on a bus of identical inverters the value it falls back to is

--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -264,9 +264,10 @@ ProbeResult GrowattDriver::probe() {
         // is entirely normal at the wrong line speed -- claiming a device here would abort the
         // sweep before the right baud rate is ever tried. Only the wording changes, and that
         // wording is shown to the user verbatim in the wizard.
+        result.sawTraffic = true;
         result.evidence.push_back(
-            "replies arrived but failed their checksum: wrong line speed, or a noisy bus "
-            "(check ground, termination and cable routing)");
+            "replies arrived but failed their checksum: wrong line speed, two devices sharing "
+            "this address, or a noisy bus (check ground, termination and cable routing)");
     } else {
         result.evidence.push_back("no Modbus reply at this unit id and line speed");
     }

--- a/src/drivers/inverter_driver.h
+++ b/src/drivers/inverter_driver.h
@@ -20,6 +20,15 @@ namespace heliograph {
 struct ProbeResult {
     bool responded      = false;
     bool checksumValid  = false;
+    /// Bytes came back but did not identify anything -- a reply that failed its checksum, or a
+    /// frame that made no sense. Deliberately separate from `responded`, which stops the profile
+    /// sweep: garbage at the wrong line speed must not claim a device.
+    ///
+    /// It exists because on an ADDRESS sweep the same signal means something quite different.
+    /// Two inverters left on one unit id answer together and their replies collide into a bad
+    /// checksum, so "traffic here, no device" is precisely the duplicate-address diagnosis --
+    /// and it was being thrown away with the failed probe (review, 2026-07-26).
+    bool sawTraffic = false;
     /// 0-100. Only meaningful relative to other drivers probed on the same bus.
     int  confidenceScore = 0;
 

--- a/src/drivers/solax_x1/descriptor.cpp
+++ b/src/drivers/solax_x1/descriptor.cpp
@@ -31,7 +31,11 @@ const DriverDescriptor& descriptor() {
         x.supportsMultipleDevices = false;
         x.supportsRead            = true;
         x.supportsWrite           = false;
-        x.addressOptionKey        = "address";
+        // Deliberately NOT addressOptionKey. This option is the address the bridge HANDS the
+        // inverter at registration, not one the inverter already answers at -- sweeping it would
+        // not discover anything, it would assign nine different addresses in a row and leave the
+        // device on the last one, while the report named the first (review, 2026-07-26). A PMU
+        // device is found by its broadcast offline query, which needs no address at all.
         x.options                 = {DriverOption{
             "address", "Assigned bus address",
             "Address handed to the inverter at registration (reference default 10 = 0x0A). "

--- a/src/drivers/solax_x1/descriptor.cpp
+++ b/src/drivers/solax_x1/descriptor.cpp
@@ -31,6 +31,7 @@ const DriverDescriptor& descriptor() {
         x.supportsMultipleDevices = false;
         x.supportsRead            = true;
         x.supportsWrite           = false;
+        x.addressOptionKey        = "address";
         x.options                 = {DriverOption{
             "address", "Assigned bus address",
             "Address handed to the inverter at registration (reference default 10 = 0x0A). "

--- a/src/drivers/sunspec/descriptor.cpp
+++ b/src/drivers/sunspec/descriptor.cpp
@@ -34,6 +34,7 @@ const DriverDescriptor& descriptor() {
         x.supportsMultipleDevices = false;
         x.supportsRead            = true;
         x.supportsWrite           = false;
+        x.addressOptionKey        = "unit_id";
         x.options                 = {
             DriverOption{"unit_id", "Modbus unit id",
                                          "Slave address of the inverter on the RS485 bus. Range 1-247.", "1", {},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -695,7 +695,10 @@ void rs485Task(void* /*arg*/) {
         // Discovery first, and instead of polling this cycle: probing re-registers every
         // inverter on the bus, so the two must never interleave. This task owns the bus, which
         // is why the web handler only ever *requests* a run.
-        if (g_discovery.runIfRequested(g_transport)) {
+        // The watchdog is fed per PROBE, not once per iteration: an extended run now sweeps
+        // eight addresses per driver per profile, and on a silent bus every one of those is a
+        // response timeout. The one feed above covered a run that was a handful of probes long.
+        if (g_discovery.runIfRequested(g_transport, [] { esp_task_wdt_reset(); })) {
             Serial.printf("[discovery] %s\n", g_discovery.report().outcome.reason.c_str());
             // The probe left the bus re-registered; make the driver pick that up rather than
             // poll a stale address.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -683,8 +683,9 @@ void reconcileAnnouncedDevices(const BridgeInfo& bridge) {
 
 void rs485Task(void* /*arg*/) {
     for (;;) {
-        // One feed per iteration; the 120 s budget covers the longest legitimate iteration
-        // (an extended discovery run). See the watchdog setup in setup().
+        // One feed per iteration. The 120 s budget covers a normal iteration; an extended
+        // discovery run no longer fits inside one feed and provides its own, per probe -- see
+        // the call below and the watchdog setup in setup().
         esp_task_wdt_reset();
         // Own stack headroom into diagnostics: the 8192 sizing rests on one measured crash
         // (2026-07-19); this keeps creeping growth visible in the API instead of leaving

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -468,10 +468,32 @@ bool buildDiscoveryPayload(const DiscoveryReport& report, uint64_t nowMs, std::s
                 profile["stop_bits"] = p.stopBits;
                 profile["response_timeout_ms"] = p.responseTimeoutMs;
             }
+            // The options it answered at -- the bus address, in practice. Handed over as a map
+            // so the wizard can apply them verbatim rather than re-deriving an address from a
+            // driver id, and `address` separately because that is the one the UI shows.
+            JsonObject options = e["options"].to<JsonObject>();
+            for (const auto& [key, value] : c.matchedOptions) {
+                options[key] = value;
+            }
+            if (c.address().empty()) {
+                e["address"] = nullptr;  // this protocol has no address the user picks
+            } else {
+                e["address"] = c.address();
+            }
             JsonArray evidence = e["evidence"].to<JsonArray>();
             for (const auto& line : c.probe.evidence) {
                 evidence.add(line);
             }
+        }
+        JsonObject selectedOptions = doc["selected_options"].to<JsonObject>();
+        for (const auto& [key, value] : report.outcome.selectedOptions) {
+            selectedOptions[key] = value;
+        }
+        // Always present, empty in Quick mode: "nothing else answered" and "nothing else was
+        // asked" are different results and a client must be able to tell them apart.
+        JsonArray swept = doc["swept_addresses"].to<JsonArray>();
+        for (const int address : report.outcome.sweptAddresses) {
+            swept.add(address);
         }
     }
     return finish(doc, out, maxBytes);

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -441,8 +441,24 @@ bool buildDiscoveryPayload(const DiscoveryReport& report, uint64_t nowMs, std::s
             doc["selected_driver_id"] = nullptr;
         }
 
+        // Bounded. A sweep of eight addresses across two Modbus drivers can produce sixteen
+        // candidates at roughly half a kilobyte each, and the response bound is 8 KB -- past
+        // which finish() refuses the whole body and the wizard shows "nothing answered" after a
+        // minute of probing. Ten is well inside the bound and more than a bridge can poll.
+        constexpr size_t kMaxCandidates = 10;
+        size_t           omitted        = 0;
+        if (report.outcome.candidates.size() > kMaxCandidates) {
+            omitted = report.outcome.candidates.size() - kMaxCandidates;
+        }
+        // Never silently: the lowest-scoring ones are dropped, and the client is told how many.
+        doc["candidates_omitted"] = static_cast<unsigned>(omitted);
+
         JsonArray candidates = doc["candidates"].to<JsonArray>();
+        size_t    written    = 0;
         for (const auto& c : report.outcome.candidates) {
+            if (++written > kMaxCandidates) {
+                break;
+            }
             JsonObject e            = candidates.add<JsonObject>();
             e["driver_id"]          = c.descriptor.id;
             e["display_name"]       = c.descriptor.displayName;
@@ -484,6 +500,15 @@ bool buildDiscoveryPayload(const DiscoveryReport& report, uint64_t nowMs, std::s
             for (const auto& line : c.probe.evidence) {
                 evidence.add(line);
             }
+        }
+        // Addresses that produced traffic without identifying anything -- two devices sharing
+        // one unit id, in practice. Not candidates: they are not devices.
+        JsonArray unidentified = doc["unidentified_addresses"].to<JsonArray>();
+        for (const auto& u : report.outcome.unidentified) {
+            JsonObject e  = unidentified.add<JsonObject>();
+            e["driver_id"] = u.driverId;
+            e["address"]   = u.address;
+            e["note"]      = u.note;
         }
         JsonObject selectedOptions = doc["selected_options"].to<JsonObject>();
         for (const auto& [key, value] : report.outcome.selectedOptions) {

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -567,10 +567,14 @@ function renderWizard(){
   } else if(wizStep===2){
     h+=`<div class="card"><b>Step 2 — Automatic or manual</b>
     <p class="dim">Quick tries each auto-detectable driver once, on its own recommended serial
-    profile. Extended tries every profile and repeats — slower and noisier on the bus, so it is
-    opt-in.</p>
-    <p class="dim">Probing is read-only. It never writes a register, never starts or stops the
-    inverter, and never changes an address permanently.</p>
+    profile and its own default address — a few seconds. Extended also tries every profile and
+    <b>sweeps bus addresses 1–8</b>, which is what finds a chain of inverters rather than just
+    the one at the default address. Budget up to a minute, and note that polling stops for the
+    whole run.</p>
+    <p class="dim">Probing never writes a register and never starts or stops the inverter.
+    Modbus drivers only ever read. One exception, and it is not new: on protocols where the
+    bridge <i>registers</i> devices, being discovered means being handed a bus address — there
+    is no read-only way to find such a device at all.</p>
     <button onclick="startDiscovery(false)">Run quick discovery</button>
     <button onclick="startDiscovery(true)" style="background:none;border:1px solid var(--line);color:var(--fg)">Run extended discovery</button>
     <button onclick="wizStep=5;renderWizard()" style="background:none;border:1px solid var(--line);color:var(--fg)">Skip — select a driver manually</button></div>`;
@@ -582,13 +586,29 @@ function renderWizard(){
     const c=(wizReport&&wizReport.candidates)||[];
     h+=`<div class="card"><b>Step 4 — Candidates</b>
     <p class="dim">${esc(wizReport?wizReport.reason:'')}</p>`;
-    if(!c.length){h+='<p class="dim">Nothing answered. The quick scan only tries each driver’s default line speed and default address — run the <b>extended scan</b> to try all of them, and addresses 1–8. Also check the wiring: A/B swapped is the most common cause, then termination.</p>'}
-    // One card per DEVICE now, not per driver: an extended scan sweeps addresses, so three
-    // identical inverters are three candidates sharing a driver id. Saying how many answered
-    // is the difference between "here is your inverter" and "here is your bus" (#37).
-    if(c.length>1){
-      const swept=(wizReport&&wizReport.swept_addresses)||[];
-      h+=`<p class="dim">${c.length} devices answered${swept.length?` (addresses ${esc(swept[0])}–${esc(swept[swept.length-1])} and each driver’s own default were tried)`:''}. The wizard configures one — add the rest afterwards under <b>Settings → Extra devices</b>, using the addresses below.</p>`;
+    const swept=(wizReport&&wizReport.swept_addresses)||[];
+    const sweptText=swept.length?`Addresses ${esc(swept[0])}–${esc(swept[swept.length-1])} and each driver’s own default were tried.`:'';
+    if(!c.length){h+=`<p class="dim">Nothing was identified. ${sweptText||'The quick scan only tries each driver’s default line speed and default address — run the <b>extended scan</b> to try all of them, and addresses 1–8.'} Check the wiring too: A/B swapped is the most common cause, then termination.</p>`}
+    // Traffic without an identification is the one fault a sweep can name that nothing else
+    // can: two inverters left on the same unit id answer together and their replies collide.
+    // Shown before the candidates, because it explains a device that is missing from them.
+    const unk=(wizReport&&wizReport.unidentified_addresses)||[];
+    if(unk.length){
+      h+=`<div class="msg err" style="display:block"><b>Traffic at ${unk.length===1?'an address':'addresses'} with no device identified.</b>
+      <ul style="margin:6px 0 0 18px">${unk.map(u=>`<li>Address <b>${esc(u.address)}</b> (${esc(u.driver_id)}): ${esc(u.note)}</li>`).join('')}</ul>
+      <div style="margin-top:6px">On a chain of identical inverters this usually means two of them
+      are still on the same address — their replies collide. Put one unit on the bus at a time to
+      confirm, then reassign.</div></div>`;
+    }
+    // Devices, not cards: two drivers can both claim one physical inverter, and telling the
+    // owner to add "3 devices" when two of the cards are one unit produces exactly the
+    // duplicate-id collision the boot loop refuses.
+    const deviceCount=new Set(c.map(x=>x.driver_id+'@'+(x.address??''))).size;
+    if(deviceCount>1){
+      h+=`<p class="dim">${deviceCount} devices answered. ${sweptText} The wizard configures one — add the rest afterwards under <b>Settings → Extra devices</b>, using the addresses below.</p>`;
+    }
+    if(wizReport&&wizReport.candidates_omitted>0){
+      h+=`<p class="dim">${esc(wizReport.candidates_omitted)} further lower-scoring candidate(s) are not shown.</p>`;
     }
     c.forEach(x=>{
       h+=`<div style="border:1px solid var(--line);border-radius:8px;padding:12px;margin-top:10px">
@@ -596,7 +616,12 @@ function renderWizard(){
         <b>${esc(x.display_name)}</b><span class="tag">${x.confidence}/100</span></div>
       <table style="margin-top:8px">
       <tr><td class="dim">Driver</td><td>${esc(x.driver_id)} <span class="tag">${esc(x.support_level)}</span></td></tr>
-      <tr><td class="dim">Bus address</td><td>${x.address==null?'<span class="dim">assigned by the protocol</span>':'<b>'+esc(x.address)+'</b>'}</td></tr>
+      <!-- Absent means two different things and they must not read the same: in a quick scan
+           no address was selected at all, so this device is wherever its driver defaults to;
+           in a swept scan it means the protocol hands out addresses itself. -->
+      <tr><td class="dim">Bus address</td><td>${x.address!=null?'<b>'+esc(x.address)+'</b>'
+        :(swept.length?'<span class="dim">assigned by the protocol</span>'
+                      :'<span class="dim">not probed — the quick scan does not sweep addresses</span>')}</td></tr>
       <tr><td class="dim">Serial profile tried</td><td>${x.serial_profile?`${x.serial_profile.baud_rate} ${x.serial_profile.data_bits}${esc(x.serial_profile.parity[0].toUpperCase())}${x.serial_profile.stop_bits}, timeout ${x.serial_profile.response_timeout_ms} ms`:'—'}</td></tr>
       <tr><td class="dim">Response found</td><td>${x.responded?'yes':'no'}</td></tr>
       <tr><td class="dim">Checksum valid</td><td>${x.checksum_valid?'yes':'no'}</td></tr>
@@ -675,7 +700,10 @@ function renderWizard(){
 }
 
 async function startDiscovery(extended){
-  wizStep=3;wizReport=null;renderWizard();
+  // wizFound is cleared here and not only reassigned on the next pick: it outranks the stored
+  // configuration in step 5, so an address left over from a previous run -- or from a run the
+  // user then skipped past -- would silently propose a device they did not choose this time.
+  wizStep=3;wizReport=null;wizChosen=null;wizFound={};renderWizard();
   const r=await authFetch('/api/v1/actions/discover'+(extended?'?extended=true':''),{method:'POST'});
   if(r.cancelled){wizStep=2;renderWizard();return}
   if(r.status===401){wizStep=2;renderWizard();alert('Admin password required.');return}
@@ -685,7 +713,13 @@ async function startDiscovery(extended){
     wizReport=await (await fetch('/api/v1/discovery')).json();
     if(wizReport.busy){renderWizard();return}
     clearInterval(wizPoll);
-    if(wizReport.auto_selected)wizChosen=wizReport.selected_driver_id;
+    // The options come with the selection. Without them the auto-select path landed on step 5
+    // with the driver filled in and the address left at its default -- the one thing the sweep
+    // exists to get right.
+    if(wizReport.auto_selected){
+      wizChosen=wizReport.selected_driver_id;
+      wizFound=wizReport.selected_options||{};
+    }
     wizStep=4;renderWizard();
   },1000);
 }

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -546,6 +546,8 @@ let wizStep=1, wizPoll=null, wizChosen=null, wizReport=null, wizSavedSerial=null
     wizOptions={};
 // What the bridge already has configured, so step 5 can offer it back instead of overwriting it.
 let wizStoredDriverId=null, wizStoredOptions={};
+/// The options the chosen candidate actually answered at, carried from step 4 into step 5.
+let wizFound={};
 const STEPS=['Interface','Mode','Probing','Candidates','Confirm','Test poll','Save'];
 
 function stepBar(){
@@ -580,13 +582,21 @@ function renderWizard(){
     const c=(wizReport&&wizReport.candidates)||[];
     h+=`<div class="card"><b>Step 4 — Candidates</b>
     <p class="dim">${esc(wizReport?wizReport.reason:'')}</p>`;
-    if(!c.length){h+='<p class="dim">Nothing answered. The quick scan only tries each driver’s default line speed — run the <b>extended scan</b> to try all of them. Also check the wiring: A/B swapped is the most common cause, then termination.</p>'}
+    if(!c.length){h+='<p class="dim">Nothing answered. The quick scan only tries each driver’s default line speed and default address — run the <b>extended scan</b> to try all of them, and addresses 1–8. Also check the wiring: A/B swapped is the most common cause, then termination.</p>'}
+    // One card per DEVICE now, not per driver: an extended scan sweeps addresses, so three
+    // identical inverters are three candidates sharing a driver id. Saying how many answered
+    // is the difference between "here is your inverter" and "here is your bus" (#37).
+    if(c.length>1){
+      const swept=(wizReport&&wizReport.swept_addresses)||[];
+      h+=`<p class="dim">${c.length} devices answered${swept.length?` (addresses ${esc(swept[0])}–${esc(swept[swept.length-1])} and each driver’s own default were tried)`:''}. The wizard configures one — add the rest afterwards under <b>Settings → Extra devices</b>, using the addresses below.</p>`;
+    }
     c.forEach(x=>{
       h+=`<div style="border:1px solid var(--line);border-radius:8px;padding:12px;margin-top:10px">
       <div style="display:flex;justify-content:space-between;align-items:baseline">
         <b>${esc(x.display_name)}</b><span class="tag">${x.confidence}/100</span></div>
       <table style="margin-top:8px">
       <tr><td class="dim">Driver</td><td>${esc(x.driver_id)} <span class="tag">${esc(x.support_level)}</span></td></tr>
+      <tr><td class="dim">Bus address</td><td>${x.address==null?'<span class="dim">assigned by the protocol</span>':'<b>'+esc(x.address)+'</b>'}</td></tr>
       <tr><td class="dim">Serial profile tried</td><td>${x.serial_profile?`${x.serial_profile.baud_rate} ${x.serial_profile.data_bits}${esc(x.serial_profile.parity[0].toUpperCase())}${x.serial_profile.stop_bits}, timeout ${x.serial_profile.response_timeout_ms} ms`:'—'}</td></tr>
       <tr><td class="dim">Response found</td><td>${x.responded?'yes':'no'}</td></tr>
       <tr><td class="dim">Checksum valid</td><td>${x.checksum_valid?'yes':'no'}</td></tr>
@@ -595,7 +605,9 @@ function renderWizard(){
       <tr><td class="dim">Serial number</td><td>${esc(x.serial_number||'—')}</td></tr>
       <tr><td class="dim">Evidence</td><td>${(x.evidence||[]).map(e=>'· '+esc(e)).join('<br>')||'—'}</td></tr>
       </table>
-      <button onclick="wizChosen='${esc(x.driver_id)}';wizStep=5;renderWizard()">Choose this driver</button>
+      <!-- The options travel as JSON through esc(), not as a hand-built string: they come from
+           the device, and every other value on this page goes through the same escape. -->
+      <button onclick="wizChosen=${esc(JSON.stringify(x.driver_id))};wizFound=${esc(JSON.stringify(x.options||{}))};wizStep=5;renderWizard()">Choose this device</button>
       </div>`;
     });
     h+=`<button onclick="wizStep=2;renderWizard()" style="background:none;border:1px solid var(--line);color:var(--fg)">Back</button></div>`;
@@ -764,7 +776,12 @@ function wizRenderOpts(){
     // rewrote a working {profile:"mic_tl_x", unit_id:"3"} back to the defaults and reported
     // success. Every rendered key is asserted in the PATCH, so nothing survives by omission.
     const stored=(id===wizStoredDriverId)?(wizStoredOptions||{})[o.key]:undefined;
-    const cur=stored??o.default_value??'';
+    // What the device ANSWERED at wins over both. Only ever the bus address -- discovery
+    // reports the options it probed with, and it only ever varies that one -- and it is the
+    // whole point of sweeping: finding an inverter at address 3 and then offering to configure
+    // address 1 would be a worse answer than not looking (#37).
+    const found=(id===wizChosen)?(wizFound||{})[o.key]:undefined;
+    const cur=found??stored??o.default_value??'';
     const hint=o.description?`<div class="dim" style="font-size:12px">${esc(o.description)}</div>`:'';
     if(o.allowed_values&&o.allowed_values.length){
       // An empty entry among the allowed values is the driver saying "unset means my own

--- a/test/test_discovery/test_main.cpp
+++ b/test/test_discovery/test_main.cpp
@@ -112,6 +112,231 @@ static void addDriver(DriverRegistry& r, const DriverDescriptor& d, FakeDriver::
                      });
 }
 
+// --- a bus with several devices on it --------------------------------------------------------
+//
+// Discovery created every candidate driver with no options, so every Modbus driver probed at
+// its declared default unit id and nothing else. On a chain of identical inverters the wizard's
+// answer to "which inverters are on this bus" was "there is one at address 1" (#37).
+
+/// A bus where devices sit at fixed addresses. The driver is built with the options the engine
+/// probed with, so a probe only answers when something is actually at that address.
+struct AddressBus {
+    std::vector<std::string> occupied;
+    /// Every address probed, in order. The cost of a sweep is a property worth pinning: this
+    /// runs on a live RS485 bus with the poll loop stopped.
+    std::vector<std::string> probed;
+    /// Same serial at every address, for the one-device-two-addresses case.
+    bool sharedSerial = false;
+};
+
+class AddressedDriver : public InverterDriver {
+public:
+    AddressedDriver(DriverDescriptor d, AddressBus* bus, std::string address)
+        : descriptor_(std::move(d)), bus_(bus), address_(std::move(address)) {}
+
+    const DriverDescriptor& descriptor() const override { return descriptor_; }
+    bool                    begin(Transport&) override { return true; }
+
+    ProbeResult probe() override {
+        if (!counted_) {
+            bus_->probed.push_back(address_);
+            counted_ = true;  // the consistency re-probe is the same address, not a new one
+        }
+        ProbeResult r;
+        r.responded = std::find(bus_->occupied.begin(), bus_->occupied.end(), address_) !=
+                      bus_->occupied.end();
+        if (!r.responded) {
+            return r;
+        }
+        r.checksumValid   = true;
+        r.confidenceScore = 95;
+        r.detectedModel   = "MIC-TL-X";
+        r.serialNumber    = bus_->sharedSerial ? "SHARED" : "SER-" + address_;
+        return r;
+    }
+
+    PollResult           poll(DeviceState&) override { return PollResult::Ok; }
+    DeviceIdentity       identity() const override { return {}; }
+    InverterCapabilities capabilities() const override { return {}; }
+    BusErrorCounts       busErrors() const override { return {}; }
+    CommandResult        execute(const InverterCommand&) override { return CommandResult::Ok; }
+
+private:
+    DriverDescriptor descriptor_;
+    AddressBus*      bus_;
+    std::string      address_;
+    bool             counted_ = false;
+};
+
+static DriverDescriptor addressedDesc(const std::string& id, const std::string& defaultAddress,
+                                      long minValue = 1, long maxValue = 247) {
+    DriverDescriptor d      = desc(id, 10);
+    d.addressOptionKey      = "unit_id";
+    d.options               = {DriverOption{"unit_id", "Unit id", "", defaultAddress, {},
+                                            minValue, maxValue}};
+    return d;
+}
+
+static void addAddressedDriver(DriverRegistry& r, const DriverDescriptor& d, AddressBus* bus) {
+    r.registerDriver(d, [d, bus](Transport&,
+                                 const DriverOptions& options) -> std::unique_ptr<InverterDriver> {
+        const auto it = options.find("unit_id");
+        return std::make_unique<AddressedDriver>(d, bus,
+                                                 it == options.end() ? std::string{} : it->second);
+    });
+}
+
+static void test_extended_discovery_finds_devices_at_other_addresses() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied = {"1", "2", "3"};  // three identical inverters, the bus this exists for
+    addAddressedDriver(reg, addressedDesc("growatt_like", "1"), &bus);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(3, out.candidates.size());
+    std::vector<std::string> found;
+    for (const auto& c : out.candidates) {
+        found.push_back(c.address());
+    }
+    std::sort(found.begin(), found.end());
+    TEST_ASSERT_EQUAL_STRING("1", found[0].c_str());
+    TEST_ASSERT_EQUAL_STRING("2", found[1].c_str());
+    TEST_ASSERT_EQUAL_STRING("3", found[2].c_str());
+    // And the option map is what the wizard configures, so it has to carry the address.
+    TEST_ASSERT_EQUAL_STRING("1", out.selectedOptions.at("unit_id").c_str());
+}
+
+// Quick mode is the one that runs by default and on a bus that may already be in service.
+// Its cost must not change: one probe per driver, at the driver's own default.
+static void test_quick_discovery_still_probes_only_the_default_address() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied = {"1", "2", "3"};
+    addAddressedDriver(reg, addressedDesc("growatt_like", "1"), &bus);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Quick);
+
+    TEST_ASSERT_EQUAL_size_t(1, out.candidates.size());
+    TEST_ASSERT_EQUAL_size_t(1, bus.probed.size());
+    TEST_ASSERT_EQUAL_STRING("1", bus.probed[0].c_str());
+    TEST_ASSERT_TRUE(out.sweptAddresses.empty());
+}
+
+// The driver's own default is always tried, whatever the sweep set says. SolaX registers at 10,
+// which is outside 1..8 -- a wizard that stopped finding the device it used to find would be a
+// regression dressed as a feature.
+static void test_the_drivers_own_default_is_probed_even_outside_the_sweep() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied = {"10"};
+    addAddressedDriver(reg, addressedDesc("solax_like", "10"), &bus);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(1, out.candidates.size());
+    TEST_ASSERT_EQUAL_STRING("10", out.candidates[0].address().c_str());
+    TEST_ASSERT_EQUAL_STRING("10", bus.probed[0].c_str());  // its own default first
+}
+
+// The option bounds are the protocol's. Probing outside them is transactions the driver would
+// refuse anyway, on someone's live bus.
+static void test_the_sweep_stays_inside_the_declared_bounds() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied = {"2"};
+    addAddressedDriver(reg, addressedDesc("small_range", "1", 1, 3), &bus);
+
+    DiscoveryEngine e(reg, t);
+    e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(3, bus.probed.size());  // 1, 2, 3 -- not 1..8
+    TEST_ASSERT_EQUAL_STRING("3", bus.probed.back().c_str());
+}
+
+// A protocol that addresses devices itself has nothing to sweep, and must not be probed eight
+// times to establish that.
+static void test_a_driver_without_an_address_option_is_probed_once() {
+    DriverRegistry     reg;
+    MockTransport      t;
+    FakeDriver::Script s;
+    s.score = 97;
+    addDriver(reg, desc("eversolar_like", 10), &s);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(1, out.candidates.size());
+    TEST_ASSERT_TRUE(out.candidates[0].address().empty());
+    TEST_ASSERT_TRUE(out.candidates[0].matchedOptions.empty());
+}
+
+// The margin rule guards against ambiguity about which PROTOCOL a device speaks. Three
+// inverters of the same make are not ambiguous -- and reading them as "too close to call" would
+// have made the sweep defeat auto-selection on exactly the bus it was built for.
+static void test_identical_inverters_do_not_block_auto_selection() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied = {"1", "2", "3"};
+    addAddressedDriver(reg, addressedDesc("growatt_like", "1"), &bus);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_TRUE(out.autoSelected);
+    TEST_ASSERT_EQUAL_STRING("growatt_like", out.selectedDriverId.c_str());
+    // ...and the owner is told the other two exist, because the wizard configures one device.
+    TEST_ASSERT_TRUE(out.reason.find("3 devices answered") != std::string::npos);
+}
+
+// Two addresses, one serial number: an inverter mid-reconfiguration, or one still answering on
+// an address it was moved off. Two entries would have the owner configure it twice, and two
+// configured devices resolving to one physical inverter is the collision the boot loop refuses.
+static void test_one_device_answering_at_two_addresses_is_reported_once() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied     = {"1", "5"};
+    bus.sharedSerial = true;
+    addAddressedDriver(reg, addressedDesc("growatt_like", "1"), &bus);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(1, out.candidates.size());
+    TEST_ASSERT_EQUAL_STRING("1", out.candidates[0].address().c_str());
+    bool mentioned = false;
+    for (const auto& line : out.candidates[0].probe.evidence) {
+        mentioned = mentioned || line.find("also answered at address 5") != std::string::npos;
+    }
+    TEST_ASSERT_TRUE_MESSAGE(mentioned, "the second address has to be reported, not dropped");
+}
+
+// The watchdog reason for the callback: an extended sweep is dozens of response timeouts inside
+// one rs485Task iteration, and the task watchdog does not care that the delay is legitimate.
+static void test_every_probe_ticks_the_caller() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied = {"4"};
+    addAddressedDriver(reg, addressedDesc("growatt_like", "1"), &bus);
+
+    int             ticks = 0;
+    DiscoveryEngine e(reg, t);
+    e.run(DiscoveryMode::Extended, DiscoveryConfig{}, [&ticks] { ++ticks; });
+
+    // Eight addresses, plus the consistency re-probe of the one that answered.
+    TEST_ASSERT_EQUAL_INT(9, ticks);
+}
+
 // --- the happy path ------------------------------------------------------------------------
 
 static void test_single_convincing_match_is_auto_selected() {
@@ -492,6 +717,14 @@ int main(int, char**) {
     RUN_TEST(test_extended_mode_is_carried_through);
     RUN_TEST(test_timings_are_recorded_for_the_wizard);
     RUN_TEST(test_the_runner_never_executes_a_command);
+    RUN_TEST(test_extended_discovery_finds_devices_at_other_addresses);
+    RUN_TEST(test_quick_discovery_still_probes_only_the_default_address);
+    RUN_TEST(test_the_drivers_own_default_is_probed_even_outside_the_sweep);
+    RUN_TEST(test_the_sweep_stays_inside_the_declared_bounds);
+    RUN_TEST(test_a_driver_without_an_address_option_is_probed_once);
+    RUN_TEST(test_identical_inverters_do_not_block_auto_selection);
+    RUN_TEST(test_one_device_answering_at_two_addresses_is_reported_once);
+    RUN_TEST(test_every_probe_ticks_the_caller);
     RUN_TEST(test_single_convincing_match_is_auto_selected);
     RUN_TEST(test_clear_winner_over_a_weak_match_is_auto_selected);
     RUN_TEST(test_two_close_candidates_are_never_auto_selected);

--- a/test/test_discovery/test_main.cpp
+++ b/test/test_discovery/test_main.cpp
@@ -180,9 +180,10 @@ static DriverDescriptor addressedDesc(const std::string& id, const std::string& 
 static void addAddressedDriver(DriverRegistry& r, const DriverDescriptor& d, AddressBus* bus) {
     r.registerDriver(d, [d, bus](Transport&,
                                  const DriverOptions& options) -> std::unique_ptr<InverterDriver> {
-        const auto it = options.find("unit_id");
-        return std::make_unique<AddressedDriver>(d, bus,
-                                                 it == options.end() ? std::string{} : it->second);
+        // Falls back to the declared default exactly as every real driver's optionsFrom() does.
+        // Without that, "probed with no options" would look like "probed at no address", and
+        // the quick-mode test below would be asserting the fake rather than the engine.
+        return std::make_unique<AddressedDriver>(d, bus, d.optionOr(options, "unit_id"));
     });
 }
 
@@ -211,7 +212,12 @@ static void test_extended_discovery_finds_devices_at_other_addresses() {
 
 // Quick mode is the one that runs by default and on a bus that may already be in service.
 // Its cost must not change: one probe per driver, at the driver's own default.
-static void test_quick_discovery_still_probes_only_the_default_address() {
+//
+// And it must carry NO options. Passing the driver's default looks equivalent -- same value,
+// same probe -- but the wizard prefers a discovered address over the stored configuration, so a
+// quick candidate claiming an address it never discovered would propose the default to a bridge
+// configured at unit id 7 (review, 2026-07-26).
+static void test_quick_discovery_probes_the_default_address_and_claims_nothing() {
     DriverRegistry reg;
     MockTransport  t;
     AddressBus     bus;
@@ -223,7 +229,11 @@ static void test_quick_discovery_still_probes_only_the_default_address() {
 
     TEST_ASSERT_EQUAL_size_t(1, out.candidates.size());
     TEST_ASSERT_EQUAL_size_t(1, bus.probed.size());
-    TEST_ASSERT_EQUAL_STRING("1", bus.probed[0].c_str());
+    TEST_ASSERT_EQUAL_STRING("1", bus.probed[0].c_str());  // its own default, internally
+    TEST_ASSERT_TRUE_MESSAGE(out.candidates[0].matchedOptions.empty(),
+                             "a quick candidate must not claim an address it did not discover");
+    TEST_ASSERT_TRUE(out.candidates[0].address().empty());
+    TEST_ASSERT_TRUE(out.selectedOptions.empty());
     TEST_ASSERT_TRUE(out.sweptAddresses.empty());
 }
 
@@ -318,6 +328,142 @@ static void test_one_device_answering_at_two_addresses_is_reported_once() {
         mentioned = mentioned || line.find("also answered at address 5") != std::string::npos;
     }
     TEST_ASSERT_TRUE_MESSAGE(mentioned, "the second address has to be reported, not dropped");
+}
+
+// Two units left on one address answer together and their replies collide into a bad checksum.
+// The probe reports that as "did not respond" -- deliberately, so garbage at the wrong baud rate
+// cannot abort the profile sweep -- and it used to be discarded with the failed probe. It is the
+// one fault a sweep can name that nothing else can, and it is the likeliest mistake on a chain
+// of identical inverters.
+class NoisyDriver : public InverterDriver {
+public:
+    NoisyDriver(DriverDescriptor d, std::string address)
+        : descriptor_(std::move(d)), address_(std::move(address)) {}
+    const DriverDescriptor& descriptor() const override { return descriptor_; }
+    bool                    begin(Transport&) override { return true; }
+    ProbeResult             probe() override {
+        ProbeResult r;
+        if (address_ == "1") {
+            r.sawTraffic = true;  // two devices on this id; nothing usable came back
+            r.evidence.push_back("replies arrived but failed their checksum");
+            return r;
+        }
+        if (address_ == "2") {
+            r.responded       = true;
+            r.checksumValid   = true;
+            r.confidenceScore = 95;
+        }
+        return r;
+    }
+    PollResult           poll(DeviceState&) override { return PollResult::Ok; }
+    DeviceIdentity       identity() const override { return {}; }
+    InverterCapabilities capabilities() const override { return {}; }
+    BusErrorCounts       busErrors() const override { return {}; }
+    CommandResult        execute(const InverterCommand&) override { return CommandResult::Ok; }
+
+private:
+    DriverDescriptor descriptor_;
+    std::string      address_;
+};
+
+static void test_an_address_with_traffic_but_no_device_is_reported() {
+    DriverRegistry reg;
+    MockTransport  t;
+    const auto     d = addressedDesc("growatt_like", "1");
+    reg.registerDriver(d, [d](Transport&, const DriverOptions& o) {
+        return std::make_unique<NoisyDriver>(d, d.optionOr(o, "unit_id"));
+    });
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(1, out.candidates.size());  // only the clean one at 2
+    TEST_ASSERT_EQUAL_size_t(1, out.unidentified.size());
+    TEST_ASSERT_EQUAL_STRING("1", out.unidentified[0].address.c_str());
+    TEST_ASSERT_TRUE(out.unidentified[0].note.find("checksum") != std::string::npos);
+}
+
+// ...and when that is ALL there is, the reason must not send someone to re-crimp a cable that
+// is fine. A bus producing traffic is demonstrably wired.
+static void test_traffic_without_an_identification_is_not_reported_as_bad_wiring() {
+    DriverRegistry reg;
+    MockTransport  t;
+    const auto     d = addressedDesc("growatt_like", "1");
+    reg.registerDriver(d, [d](Transport&, const DriverOptions& o) {
+        // Only address 1 exists, and it is the noisy one.
+        const std::string addr = d.optionOr(o, "unit_id");
+        return std::make_unique<NoisyDriver>(d, addr == "2" ? "9" : addr);
+    });
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_TRUE(out.candidates.empty());
+    TEST_ASSERT_EQUAL_size_t(1, out.unidentified.size());
+    TEST_ASSERT_TRUE(out.reason.find("produced traffic") != std::string::npos);
+    TEST_ASSERT_TRUE_MESSAGE(out.reason.find("check wiring") == std::string::npos,
+                             "the bus answered; blaming the cable sends someone the wrong way");
+}
+
+// One bus, one set of line settings. Once something answers at a profile, the driver's other
+// baud rates are silence by construction -- and at eight addresses each, trying them anyway is
+// the difference between a slow sweep and an unusable one. Nothing pinned this.
+static void test_the_remaining_profiles_are_not_swept_once_one_answers() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied            = {"3"};
+    DriverDescriptor d      = addressedDesc("two_speed", "1");
+    d.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3},
+                                   SerialProfile{115200, SerialParity::None, 8, 1, 1000, 3}};
+    addAddressedDriver(reg, d, &bus);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(1, out.candidates.size());
+    // Eight addresses at the first profile, and no second pass over them.
+    TEST_ASSERT_EQUAL_size_t(8, bus.probed.size());
+}
+
+// The driver's default is probed first and is not necessarily the lowest address, so keeping
+// "the first one probed" would report a device at the higher of the two while claiming the
+// lower. Only reachable for a driver whose default sits above the sweep range.
+static void test_a_duplicate_is_kept_at_the_lowest_address_not_the_first_probed() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied     = {"8", "3"};
+    bus.sharedSerial = true;
+    addAddressedDriver(reg, addressedDesc("high_default", "8"), &bus);
+
+    DiscoveryEngine e(reg, t);
+    const auto      out = e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(1, out.candidates.size());
+    TEST_ASSERT_EQUAL_STRING("3", out.candidates[0].address().c_str());
+}
+
+// A driver naming an option that is not numeric, or not declared at all, has nothing a sweep
+// can use. Probing it over 1..8 is eight transactions the driver would refuse.
+static void test_an_unsweepable_address_option_is_not_swept() {
+    DriverRegistry reg;
+    MockTransport  t;
+    AddressBus     bus;
+    bus.occupied = {"left"};
+    DriverDescriptor enumerated = desc("enum_option", 10);
+    enumerated.addressOptionKey = "side";
+    enumerated.options = {DriverOption{"side", "Side", "", "left", {"left", "right"}}};
+    addAddressedDriver(reg, enumerated, &bus);
+
+    DriverDescriptor undeclared = desc("undeclared_option", 9);
+    undeclared.addressOptionKey = "unit_id";  // names an option it never declares
+    addAddressedDriver(reg, undeclared, &bus);
+
+    DiscoveryEngine e(reg, t);
+    e.run(DiscoveryMode::Extended);
+
+    TEST_ASSERT_EQUAL_size_t(2, bus.probed.size());  // one probe each, not nine
 }
 
 // The watchdog reason for the callback: an extended sweep is dozens of response timeouts inside
@@ -718,12 +864,17 @@ int main(int, char**) {
     RUN_TEST(test_timings_are_recorded_for_the_wizard);
     RUN_TEST(test_the_runner_never_executes_a_command);
     RUN_TEST(test_extended_discovery_finds_devices_at_other_addresses);
-    RUN_TEST(test_quick_discovery_still_probes_only_the_default_address);
+    RUN_TEST(test_quick_discovery_probes_the_default_address_and_claims_nothing);
     RUN_TEST(test_the_drivers_own_default_is_probed_even_outside_the_sweep);
     RUN_TEST(test_the_sweep_stays_inside_the_declared_bounds);
     RUN_TEST(test_a_driver_without_an_address_option_is_probed_once);
     RUN_TEST(test_identical_inverters_do_not_block_auto_selection);
     RUN_TEST(test_one_device_answering_at_two_addresses_is_reported_once);
+    RUN_TEST(test_an_address_with_traffic_but_no_device_is_reported);
+    RUN_TEST(test_traffic_without_an_identification_is_not_reported_as_bad_wiring);
+    RUN_TEST(test_the_remaining_profiles_are_not_swept_once_one_answers);
+    RUN_TEST(test_a_duplicate_is_kept_at_the_lowest_address_not_the_first_probed);
+    RUN_TEST(test_an_unsweepable_address_option_is_not_swept);
     RUN_TEST(test_every_probe_ticks_the_caller);
     RUN_TEST(test_single_convincing_match_is_auto_selected);
     RUN_TEST(test_clear_winner_over_a_weak_match_is_auto_selected);


### PR DESCRIPTION
Closes #37.

## The failure

`DiscoveryEngine::run()` created every candidate driver with **no options**, so every Modbus driver probed at its declared default unit id and nothing else. On a chain of identical inverters only the one at address 1 could ever be a candidate — the wizard answered "is there an inverter at address 1", not "which inverters are on this bus".

The address is also exactly the field a typo makes invisible, which is why it has since needed bounds (#35) and a duplicate check in the settings card. Finding it is better than reporting it afterwards.

## What it does now

Extended discovery sweeps addresses **1–8** on top of each driver's own default. Each candidate carries the `options` it answered at and an `address`; the wizard shows one card per device with its bus address, and **Choose this device** carries that address into the confirm step. Finding an inverter at address 3 and then offering to configure address 1 would be a worse answer than not looking.

**Traffic without a device is reported too**, and that is the part that earns the sweep. Two inverters left on the same unit id answer together and their replies collide into a failed checksum — which the probe correctly reports as "did not respond", so that garbage at the wrong baud rate cannot abort the profile sweep. That evidence used to be discarded along with the failed probe, so on the likeliest bring-up mistake the wizard showed one device at address 2 and blamed the wiring. `unidentified_addresses` carries it now, and when it is all there is, the report says the bus is alive and which address is noisy.

Quick mode probes exactly as before — one probe per driver, at its own default — and passes **no options at all**. That distinction is not cosmetic: the wizard prefers a discovered address over the stored configuration, so a quick candidate carrying the driver's default would have proposed unit id 1 to a bridge configured at 7, and 1 is usually already in `additional_devices`.

## The trade-offs the issue asked to decide

**Which option is the address** is named by the driver (`addressOptionKey`), never inferred, and naming it is a claim about what the option *means*. Two distinctions matter and neither is visible from a name or a type: a driver may have several numeric options (SunSpec has a base register too), and an option may be an address the bridge **hands out** rather than one the device has. The registration protocols are the second kind — being discovered *is* being assigned an address — so they name nothing and are probed once, as before. Sweeping such an option would have assigned nine addresses in a row and left the inverter on the last one while the report named the first.

**1–8, not 1–247.** Modbus allows 247 addresses; the bridge polls at most eight. The driver's own default is included on top of the range, provided the driver would accept it — a default outside its own declared bounds is skipped rather than offered and then refused by the PATCH gate. When nothing answers, the report says which addresses were tried.

**Profiles × addresses does not multiply — for a driver that answers.** One bus has one set of line settings, so once anything answers at a profile the remaining baud rates are silence by construction and are not tried. For a driver that finds nothing it multiplies in full, and that is where the time goes.

**A device answering at two addresses** is reported once, at the **lowest** address, with the other in its evidence. Lowest, not first probed: the driver's default is probed first and is not necessarily the lowest.

## Two consequences the sweep forces

- **One driver can now produce several candidates.** The "too close to call" rule compared the best candidate against the next in the list, which after this is usually *the same driver at another address* — so three identical inverters would have blocked auto-selection on exactly the bus this was built for. It compares against the best candidate with a **different driver id** now. That rule guards against ambiguity about which protocol a device speaks, never about how many answered it.
- **The task watchdog is fed per probe**, not once per `rs485Task` cycle. The 120 s budget was sized for a run that was a handful of probes long.

## Cost, in numbers

| | probes | silent bus |
|---|---|---|
| Quick | 4 | ≈ 8 s |
| Extended | up to 33 | ≈ 35 s |

Polling stops for the whole run. Step 2 of the wizard now says to budget a minute and that polling stops; it previously said only "slower and noisier". On a bus with devices it is faster — the profile settles at the first address that answers.

The candidate list is capped at ten with `candidates_omitted`: sixteen candidates at roughly half a kilobyte each exceed the 8 KB response bound, and a refused body reads to the wizard as "nothing answered" after a minute of probing.

## Tests

**608 pass** (was 595 on main), against a fake bus whose devices sit at fixed addresses and whose probes are counted. Devices found at other addresses; quick mode probing exactly one and claiming nothing; the driver's own default swept even when outside the sweep range; the sweep staying inside the declared bounds; a driver without an address option probed once; an unsweepable option (enum, or naming nothing) not swept; identical inverters not blocking auto-selection; one device at two addresses kept at the lowest; an address with traffic but no device reported; that case not read as bad wiring; the profile break; and every probe ticking the caller.

The profile break had **no coverage at all** in the first version of this branch — muting it left every test green. It and the lowest-address rule were both mutation-checked.

The wizard has no behavioural coverage — `tools/check_web_js.py` is `node --check` — so step 4 was rendered under Node against four reports: three devices at 1/2/3, the address-collision case, nothing answering, and a quick-mode candidate. The last one confirms the stored `unit_id` survives into step 5.

`check_layering.sh` PASS, all four boards build.

## Not covered

- **The wizard still configures one device.** It tells you how many answered and at which addresses; the other two go into `additional_devices` by hand, and the register-map profile is not discoverable so you repeat that yourself.
- An inverter parked outside 1–8 and off its driver's default is not found. The report says which addresses were tried.
- **Any Modbus device that answers a register read is reported as a candidate** — an energy meter on the same pair will show up. It scores 40, below the auto-select threshold, and the card shows the score; nothing else distinguishes it. Pre-existing, but eight addresses give it eight more chances than one did.
- **Modbus TCP and Prometheus still carry the first device only** — #36.

## Docs

`docs/rest-api.md` gains a table of what each mode probes, the real probe counts, and the rules above; `docs/architecture.md` covers `addressOptionKey` and the changed watchdog feed; the README and `docs/growatt-mic-tl-x-protocol.md` no longer say only the unit at the default address can be found.
