### PR TITLE
Give Modbus TCP and Prometheus a device dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,11 @@ own address before you connect them together.
 > took. It configures one device; the rest go in `additional_devices` as above. Quick discovery
 > is unchanged: each driver's default address only.
 >
-> One thing before wiring three: **Modbus TCP and Prometheus still carry the first device only**
-> — REST, `/api/v1/devices`, the bridge's own dashboard and Home Assistant have all of them.
-> That is next on the list, not a wiring fault. Note also that the units share one bus and one
-> poll interval, so each is read roughly every N intervals with N inverters.
+> **Every output carries all of them now.** Modbus TCP serves one **unit id per inverter**,
+> consecutively from `modbus.unit_id` — unit 1, 2, 3 with the default — and the register map is
+> the same at each. Prometheus labels every inverter series with `device="…"`, the same id REST
+> and Home Assistant use. Note that the units share one bus and one poll interval, so each is
+> read roughly every N intervals with N inverters.
 
 ### 2. Flash the firmware
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -678,21 +678,33 @@ unit, speak up" -- with no serial in the request, so two instances of the same P
 the same handshake and which physical unit each ends up owning is undefined. One PMU device per
 bus; mixing a PMU driver with Modbus drivers is fine.
 
-**Two of the outputs have not caught up.** `ModbusTcpServer::refresh` and `buildMetrics` each
-take a single `DeviceState`, so they are fed the first device only: the register map holds one
-device's worth of registers and the metric names have no device label. REST is device-keyed, and
-MQTT/Home Assistant became so — `MqttOutput` keeps one `Channel` per device (its own topics,
-throttle and discovery signature) and `buildDiscoveryEntities` takes a `uniqueBase` that scopes
-every `unique_id`, `object_id`, retained config topic and HA device identifier.
+**Every output is device-keyed, and each made its own back-compatibility call.** They are not
+the same call, deliberately:
 
-The first device deliberately keeps the bridge-scoped topics and unique ids it has always used,
-so an existing install's entities and recorder history survive the change; devices 2..N live
-under `<base>/<bridgeId>/device/<deviceId>/`. Availability, diagnostics and the relay/DRM topics
-stay bridge-scoped, because they describe the bridge.
+| Output | Device dimension | What happens to device 1 |
+|---|---|---|
+| REST | `/api/v1/devices/<id>` | unchanged; `/status` still describes it, plus a `devices` array |
+| MQTT / HA | topic subtree + `unique_id` prefix | **keeps** the bridge-scoped topics it always had |
+| Modbus TCP | one **unit id** per device, `modbus.unit_id + i` | **keeps** `modbus.unit_id`, map unchanged |
+| Prometheus | a `device` label on every inverter series | **gets the label too** — a breaking change |
 
-Until Modbus TCP and Prometheus follow, that limitation is stated in the README,
-`docs/rest-api.md`, `docs/mqtt.md` and next to the code in `main.cpp` rather than left to be
-discovered from a missing entity.
+MQTT and Modbus TCP could keep device 1 exactly where it was, so they did: an existing Home
+Assistant install keeps its entities and recorder history, and an existing Modbus client keeps
+reading unit 1. Prometheus could not do that without leaving one series unlabelled forever, and
+`sum by (device)` with a blank label is worse than a one-off dashboard edit. `docs/prometheus.md`
+says what to change.
+
+The Modbus mapping is the Unit Identifier doing the job the specification gives it — addressing
+a device on a serial sub-network behind a gateway — so a client needs no vendor-specific address
+arithmetic and the register map simply repeats at each unit. The run is consecutive and stops
+rather than skipping: a client derives device N by adding, so a hole would be inexpressible. The
+diagnostics unit still serves device 1's map, whose bridge block is identical at every unit.
+
+`MqttOutput` keeps one `Channel` per device (its own topics, throttle and discovery signature)
+and `buildDiscoveryEntities` takes a `uniqueBase` that scopes every `unique_id`, `object_id`,
+retained config topic and HA device identifier. Availability, diagnostics and the relay/DRM
+topics stay bridge-scoped, because they describe the bridge — as do the Prometheus counters,
+which live in one `Diagnostics` for the whole bus.
 
 ## Test strategy
 

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -217,10 +217,16 @@ address in turn and confirm exactly one answers, at the address you expect.
    > Quick discovery is unchanged: default address only.
    >
    > **All three units reach every output.** REST and Home Assistant key them by device id;
-   > Modbus TCP serves them at unit ids 1, 2 and 3 (`modbus.unit_id` plus the index, in the same
-   > order as `/api/v1/devices`); Prometheus labels each series `device="growatt_modbus-N"`.
-   > The Modbus register map is identical at each unit — point your client at a different unit
-   > id and everything is in the same place.
+   > Prometheus labels each series `device="growatt_modbus-<RS485 address>"`; Modbus TCP serves
+   > them at `modbus.unit_id` plus the **configuration row index** — units 1, 2, 3 with the
+   > defaults. The register map is identical at each unit, so point your client at a different
+   > unit id and everything is in the same place.
+   >
+   > Those two numbers are not the same thing, and they only coincide because this page has you
+   > assign 1/2/3. Put the units on 1, 2 and 5 and the third is `growatt_modbus-5` in Prometheus
+   > while Modbus TCP serves it at unit **3**. The mapping is in the boot log
+   > (`modbus: unit 3 -> growatt_modbus-5`) and in `modbus_unit_id` on each entry of the
+   > `devices` array in `/api/v1/status`.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.
 5. Check the dump against the inverter's own app: PV voltage, AC power, today's energy,

--- a/docs/growatt-mic-tl-x-protocol.md
+++ b/docs/growatt-mic-tl-x-protocol.md
@@ -216,9 +216,11 @@ address in turn and confirm exactly one answers, at the address you expect.
    > `additional_devices` as above, but you are copying addresses it found rather than guessing.
    > Quick discovery is unchanged: default address only.
    >
-   > **Modbus TCP and Prometheus still publish the first device only.** All three units appear
-   > in the REST API, in the device list and in Home Assistant, each as its own HA device; only
-   > one reaches those two outputs. Next piece of work.
+   > **All three units reach every output.** REST and Home Assistant key them by device id;
+   > Modbus TCP serves them at unit ids 1, 2 and 3 (`modbus.unit_id` plus the index, in the same
+   > order as `/api/v1/devices`); Prometheus labels each series `device="growatt_modbus-N"`.
+   > The Modbus register map is identical at each unit — point your client at a different unit
+   > id and everything is in the same place.
 4. Set log level to `trace` and read `/api/v1/logs`. The `GROWATT in <addr>: ...` lines are
    the raw block dump.
 5. Check the dump against the inverter's own app: PV voltage, AC power, today's energy,

--- a/docs/modbus-register-map.md
+++ b/docs/modbus-register-map.md
@@ -45,12 +45,29 @@ Two rules worth knowing:
   diagnostics unit or run past 247 (the last valid Modbus slave address), the devices beyond
   that point are simply not served, and the boot log says how many and why. A hole in the run
   would be inexpressible: a client derives device N's id by adding.
-- **Only devices that actually started get an id.** A unit id that answered with a map full of
-  NaN would be worse than one that does not answer at all — a client cannot tell those apart.
+- **The unit id follows the CONFIGURATION, not what started.** A device that fails to start
+  still owns its unit id; that unit answers `inverter_online = 0` with NaN readings. The
+  alternative — skipping it — would move every later inverter down one unit id, and a client
+  reading unit 2 would get inverter 3's watts with no way to notice. A unit id is a wire
+  contract; it must be a function of the settings page, not of how the last boot went.
+- **Units 0 and 255 read device 1.** The Modbus TCP specification calls the unit byte unused for
+  a server that is not a gateway, and clients that have no unit-id field send one of those two —
+  Home Assistant's Modbus integration defaults to 0. Answering them means a configuration copied
+  from a single-inverter example works rather than returning an exception.
+
+**Which unit is which inverter** is in the boot log (`modbus: unit 2 -> growatt_modbus-2`, one
+line per device) and in `/api/v1/status`, where every entry of the `devices` array carries
+`modbus_unit_id`. Do not count positions in the device list: that list omits devices that did
+not start, and the unit ids do not.
 
 The **diagnostics unit (250)** serves device 1's map. Its 800-899 block is bridge-wide and
 identical at every unit anyway; the same is true of the poll and RS485 counters, which the
 firmware keeps per bus rather than per device.
+
+That last point is worth spelling out, because those counters sit at registers **52, 54, 56 and
+58 — inside the per-device block**, where the layout suggests they are the unit's own. They are
+not: every unit reports the whole bus's totals. Registers 3 (`inverter_online`), 5
+(`data_stale`) and 50 (`seconds since poll`) *are* per device.
 
 FC3 (Read Holding Registers) mirrors the same content as FC4, so clients that can only do FC3
 (many PLCs, some EVCC configurations) also work. FC6/FC16 are disabled and

--- a/docs/modbus-register-map.md
+++ b/docs/modbus-register-map.md
@@ -18,8 +18,39 @@ Schema version: **1** (register 0-1). Increment on every breaking change.
 | Byte order | big-endian (Modbus standard) |
 | Measurements | **input registers** (FC4) |
 | Port | 502 (configurable) |
-| Unit ID inverter | 1 (configurable) |
+| Unit ID inverter | `modbus.unit_id` (default 1) for device 1, **+1 per further device** |
 | Unit ID diagnostics | 250 (configurable) |
+
+## Several inverters: one unit id each
+
+The bridge polls up to eight inverters on one RS485 bus. Each gets its **own Modbus unit id**,
+consecutively from `modbus.unit_id`, in the same order as `/api/v1/devices`:
+
+| Device | Unit ID (default config) |
+|---|---|
+| 1 (`driver`) | 1 |
+| 2 (`additional_devices[0]`) | 2 |
+| 3 (`additional_devices[1]`) | 3 |
+
+**The register map below is identical at every unit id.** Point a client at a different unit and
+everything is in the same place; there is no per-device offset and no address arithmetic. This is
+what the Modbus specification's Unit Identifier is for — addressing a device on a serial
+sub-network behind a gateway — so any client that can set a slave/unit id already supports it.
+
+A bridge with one inverter is unchanged: it is served at `modbus.unit_id` exactly as before.
+
+Two rules worth knowing:
+
+- **The run is consecutive and stops rather than skipping.** If the ids would reach the
+  diagnostics unit or run past 247 (the last valid Modbus slave address), the devices beyond
+  that point are simply not served, and the boot log says how many and why. A hole in the run
+  would be inexpressible: a client derives device N's id by adding.
+- **Only devices that actually started get an id.** A unit id that answered with a map full of
+  NaN would be worse than one that does not answer at all — a client cannot tell those apart.
+
+The **diagnostics unit (250)** serves device 1's map. Its 800-899 block is bridge-wide and
+identical at every unit anyway; the same is true of the poll and RS485 counters, which the
+firmware keeps per bus rather than per device.
 
 FC3 (Read Holding Registers) mirrors the same content as FC4, so clients that can only do FC3
 (many PLCs, some EVCC configurations) also work. FC6/FC16 are disabled and

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -53,8 +53,8 @@ control to do it for you. See [security.md](security.md).
 ## Several inverters: the `device` label
 
 Every inverter series carries a **`device`** label holding the device id — the same string
-`/api/v1/devices` serves and MQTT uses in its topics, e.g. `growatt_modbus-2`. So one bus of
-three inverters is three series per metric:
+`/api/v1/devices` serves, e.g. `growatt_modbus-2`. So one bus of three inverters is three series
+per metric:
 
 ```
 heliograph_inverter_ac_power_watts{device="growatt_modbus-1"} 1240.000
@@ -81,10 +81,22 @@ What actually breaks, and what does not:
 | `heliograph_inverter_ac_power_watts` | one series | one series **per inverter** — a graph gains lines |
 | `sum(heliograph_inverter_ac_power_watts)` | the one inverter | the whole bus — usually what you wanted |
 | a recording rule expecting a single series | fine | **fix it**: add `sum(...)` or `{device="…"}` |
+| `heliograph_build_info` | one series | one **per inverter**, and it gains `device` too — a `group_left` join on it now fans out |
 | any bridge-wide series | unchanged | unchanged |
 
-With one inverter nothing changes except that a label appears. Existing panels keep working;
-they just gain a legend entry.
+With one inverter the only visible change is that a label appears, and existing panels keep
+working. One thing to expect at the upgrade itself, on any number of inverters: adding a label
+**changes the series identity**, so Prometheus ends the old series and starts a new one. Gauges
+graph straight across the gap, but `rate()`, `increase()` or `resets()` over the boundary — and
+an alert with a long `for:` — will see a discontinuity once.
+
+### Matching it up with Home Assistant
+
+The `device` label matches `/api/v1/devices`, and matches the MQTT subtree for devices 2..N.
+It does **not** match what Home Assistant displays: device 1 keeps the bridge-scoped MQTT topics,
+so its id appears nowhere in MQTT, and HA names the devices after the model (`… - Growatt MIC
+TL-X`, `… #2`, `… #3`). Lining a Grafana panel up with an HA entity is a short lookup rather than
+a string match.
 
 ## What is exported
 
@@ -133,6 +145,14 @@ temperature sensor has no temperature series. That is not a fault.
 | `heliograph_wifi_reconnects_total` | counter | WiFi reconnections |
 | `heliograph_modbus_client_connections_total` | counter | Modbus TCP connections accepted |
 | `heliograph_modbus_clients` | gauge | Modbus TCP clients connected right now |
+
+**None of these carry a `device` label, and on a bus with several inverters that is a real
+limitation, not just a naming choice.** The counters live in one place for the whole bus, so
+when one of three inverters starts corrupting frames the checksum counter climbs and all three
+look equally guilty. What *is* per device is
+`heliograph_inverter_online{device="…"}` — so a unit that drops out entirely is identifiable; a
+unit with intermittent, sub-timeout faults is not. Per-device counters would mean changing the
+diagnostics model, which is tracked separately.
 
 The distinction matters when something is wrong, and it is three-way rather than two:
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -50,6 +50,42 @@ your board type. On a home LAN that is normally fine. If it is not, put the brid
 segregated VLAN and let only the scraper reach it — the firmware has no per-endpoint access
 control to do it for you. See [security.md](security.md).
 
+## Several inverters: the `device` label
+
+Every inverter series carries a **`device`** label holding the device id — the same string
+`/api/v1/devices` serves and MQTT uses in its topics, e.g. `growatt_modbus-2`. So one bus of
+three inverters is three series per metric:
+
+```
+heliograph_inverter_ac_power_watts{device="growatt_modbus-1"} 1240.000
+heliograph_inverter_ac_power_watts{device="growatt_modbus-2"} 980.500
+heliograph_inverter_ac_power_watts{device="growatt_modbus-3"} 1105.000
+```
+
+**Bridge-wide series carry no `device` label** — uptime, heap, WiFi, the RS485 and poll
+counters, the relay and DRM series. They are not per device: the counters live in one place for
+the whole bus, so labelling them would invent a distinction the firmware does not make.
+
+### If you already have a dashboard
+
+**The first device is labelled too.** That is a breaking change and it was chosen deliberately:
+leaving device 1 unlabelled would have been back-compatible, but `sum by (device)` would then
+produce a blank label forever, and an asymmetry that has to be explained every time is worse
+than a one-off edit. (MQTT made the opposite call for its topics, because there the cost of
+changing was a user's whole Home Assistant history.)
+
+What actually breaks, and what does not:
+
+| Query | Before | After |
+|---|---|---|
+| `heliograph_inverter_ac_power_watts` | one series | one series **per inverter** — a graph gains lines |
+| `sum(heliograph_inverter_ac_power_watts)` | the one inverter | the whole bus — usually what you wanted |
+| a recording rule expecting a single series | fine | **fix it**: add `sum(...)` or `{device="…"}` |
+| any bridge-wide series | unchanged | unchanged |
+
+With one inverter nothing changes except that a label appears. Existing panels keep working;
+they just gain a legend entry.
+
 ## What is exported
 
 Every series is prefixed `heliograph_`. Base units are in the names, counters end in `_total`.
@@ -58,14 +94,16 @@ Every series is prefixed `heliograph_`. Base units are in the names, counters en
 
 | Metric | Type | Notes |
 |---|---|---|
-| `heliograph_build_info` | gauge | Always `1`. Carries labels `version`, `driver`, `board` |
+| `heliograph_build_info` | gauge | Always `1`. One per inverter. Labels `device`, `version`, `driver`, `board` |
 | `heliograph_inverter_online` | gauge | `1` when the inverter is answering, `0` when it is not |
 | `heliograph_data_stale` | gauge | `1` when the last reading is too old to trust |
 
 ### Inverter readings
 
-All gauges, and all **omitted entirely when the value is unknown** (see
-[Missing values](#missing-values-are-missing-not-zero)).
+All gauges, all carrying `device`, and all **omitted entirely when the value is unknown** (see
+[Missing values](#missing-values-are-missing-not-zero)) — per device, so a bus where one
+inverter reports temperature and another does not gives one series, not two with a fabricated
+one. A metric no inverter reports is absent entirely, header included.
 
 | Metric | Unit |
 |---|---|

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -233,10 +233,11 @@ can never be filled.
 Adding, removing or retuning a device needs a restart: the drivers and their poll contexts are
 built once, at boot.
 
-**The outputs are not all there yet.** REST, the device list and MQTT/Home Assistant carry every
-configured device; **Modbus TCP and Prometheus carry the first one only**, because the register
-map holds one device's registers and the metric names have no device label. That is the next
-piece of work and is stated in `docs/architecture.md` too.
+**Every output carries every device**, each with its own dimension: REST keys them by device id,
+MQTT/Home Assistant by topic subtree, **Modbus TCP by unit id** (`modbus.unit_id` plus the index,
+same order as `/api/v1/devices`) and **Prometheus by a `device` label**. See
+`docs/modbus-register-map.md` and `docs/prometheus.md`; `docs/architecture.md` has the table of
+what each one did about backwards compatibility.
 
 ## Discovery: what each mode actually probes
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -802,13 +802,25 @@ void rs485Task(void* /*arg*/) {
                 }
             }
             const auto first = g_state->snapshot();
-            // Every device, one Modbus unit id each, in the same order as g_deviceIds and as
-            // the views above -- so unit 1 and the first Home Assistant device are the same
-            // inverter. `held` keeps the snapshots alive across the call (#36).
+            // Every device, one Modbus unit id each: index i is served at inverterUnitId + i,
+            // so unit 1 and the first Home Assistant device are the same inverter (#36).
+            //
+            // Built by POSITION in g_deviceIds, with a null for anything without a snapshot --
+            // not by walking `views`, which skips such a device and would shift every later
+            // one down an index. A Modbus unit id is a wire contract: a client that reads
+            // inverter 3's watts believing they are inverter 2's has no way to notice. Today
+            // the skip cannot happen (state() only returns null for an unregistered id, and
+            // nothing unregisters), so this is a positional guarantee rather than a fix -- but
+            // the alternative depends on a filter never filtering, and that is not a property
+            // worth resting a wire protocol on. refresh() leaves a null entry's map untouched.
             std::vector<const DeviceState*> modbusDevices;
-            modbusDevices.reserve(views.size());
-            for (const auto& v : views) {
-                modbusDevices.push_back(v.state);
+            modbusDevices.reserve(g_deviceIds.size());
+            for (const auto& id : g_deviceIds) {
+                const auto it = std::find_if(views.begin(), views.end(),
+                                             [&id](const mqtt::MqttOutput::DeviceView& v) {
+                                                 return v.id == id;
+                                             });
+                modbusDevices.push_back(it == views.end() ? nullptr : it->state);
             }
             g_modbus.refresh(modbusDevices, bridge, diag, nowMs());
             if (g_mqtt) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,10 +97,12 @@ std::unique_ptr<rest::RestApi>    g_rest;
 std::vector<std::unique_ptr<InverterDriver>> g_drivers;
 std::vector<std::unique_ptr<DeviceContext>>  g_contexts;
 
-/// The first device, or nullptr. Everything that still speaks about "the" inverter -- the
-/// status LED, the boot-confirm check, the outputs -- reads these. Naming them rather than
-/// indexing at each call site keeps the remaining single-device assumptions countable: every
-/// use of g_driver/g_context/g_state is a place that has not been taught about the others yet.
+/// The first device, or nullptr. What is left that still speaks about "the" inverter: the
+/// boot-confirm check, the REST /status device block, and the "is anything polling at all"
+/// guard in the poll loop. Naming them rather than indexing at each call site keeps the
+/// remaining single-device assumptions countable -- every use of g_driver/g_context/g_state is
+/// a place that has not been taught about the others. The outputs no longer belong on that
+/// list: MQTT, REST, Modbus TCP and Prometheus all carry every device.
 InverterDriver* g_driver  = nullptr;
 DeviceContext*  g_context = nullptr;
 StateStore*     g_state   = nullptr;
@@ -516,9 +518,28 @@ void startOutputs() {
         // Never from configuration: no driver in this build can write, so offering the switch
         // would advertise something untrue. validate() rejects it too.
         cfg.writeEnabled = false;
+        // One unit id per started device, consecutively from modbus.unit_id. Started, not
+        // configured: a unit id that answers with a map of NaN is worse than one that answers
+        // nothing, because a client cannot tell the two apart.
+        cfg.deviceCount = static_cast<uint8_t>(g_deviceIds.size());
         g_modbus.setConfig(cfg);
-        log::info("modbus: %s on :%u (unit %u)", g_modbus.begin() ? "listening" : "failed to start",
-                  cfg.port, cfg.inverterUnitId);
+        const bool listening = g_modbus.begin();
+        if (g_modbus.servedDevices() <= 1) {
+            log::info("modbus: %s on :%u (unit %u)", listening ? "listening" : "failed to start",
+                      cfg.port, cfg.inverterUnitId);
+        } else {
+            log::info("modbus: %s on :%u (units %u-%u, one per inverter)",
+                      listening ? "listening" : "failed to start", cfg.port, cfg.inverterUnitId,
+                      g_modbus.unitIdFor(g_modbus.servedDevices() - 1));
+        }
+        if (g_modbus.servedDevices() < g_deviceIds.size()) {
+            log::warn("modbus: only %u of %u devices are reachable over Modbus TCP -- the unit "
+                      "ids would run past 247 or into the diagnostics unit (%u). Lower "
+                      "modbus.unit_id.",
+                      static_cast<unsigned>(g_modbus.servedDevices()),
+                      static_cast<unsigned>(g_deviceIds.size()),
+                      static_cast<unsigned>(cfg.diagnosticsUnitId));
+        }
     }
 
     if (configSnapshot.mqtt.enabled && !configSnapshot.mqtt.host.empty()) {
@@ -781,10 +802,15 @@ void rs485Task(void* /*arg*/) {
                 }
             }
             const auto first = g_state->snapshot();
-            // Still first-device-only, and now the ONLY two that are: the Modbus TCP register
-            // map has one device's worth of registers and the metric names have no device
-            // label. Both are named in docs/architecture.md as the remaining gap.
-            g_modbus.refresh(*first, bridge, diag, nowMs());
+            // Every device, one Modbus unit id each, in the same order as g_deviceIds and as
+            // the views above -- so unit 1 and the first Home Assistant device are the same
+            // inverter. `held` keeps the snapshots alive across the call (#36).
+            std::vector<const DeviceState*> modbusDevices;
+            modbusDevices.reserve(views.size());
+            for (const auto& v : views) {
+                modbusDevices.push_back(v.state);
+            }
+            g_modbus.refresh(modbusDevices, bridge, diag, nowMs());
             if (g_mqtt) {
                 // Once, on the first connected pass -- before loop() below, so the clears are
                 // queued ahead of this boot's own discovery announcements.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,6 +134,16 @@ size_t g_devicesConfigured = 0;
 /// boot alongside the log lines, so the same facts reach a screen instead of only a ring buffer.
 std::vector<std::string> g_deviceProblems;
 
+/// The started device at each CONFIGURED position, empty where one did not start.
+///
+/// This is what the Modbus unit ids are keyed on, and it exists because g_deviceIds is
+/// compacted: a device that fails to start is simply absent from it, so keying unit ids on that
+/// list would silently move every later inverter down one unit id. A client reading unit 2
+/// would get inverter 3's watts with no way to notice, and unit ids are a wire contract nobody
+/// re-derives after bring-up. Keyed on the configuration instead, an unstarted device's unit id
+/// answers "offline, no data" -- which is the truth, and the same thing the Devices tab shows.
+std::vector<DeviceId> g_configSlotIds;
+
 bool g_outputsStarted = false;
 
 /// Guards g_config against the one cross-task hazard it has: the AsyncTCP task replacing
@@ -518,10 +528,11 @@ void startOutputs() {
         // Never from configuration: no driver in this build can write, so offering the switch
         // would advertise something untrue. validate() rejects it too.
         cfg.writeEnabled = false;
-        // One unit id per started device, consecutively from modbus.unit_id. Started, not
-        // configured: a unit id that answers with a map of NaN is worse than one that answers
-        // nothing, because a client cannot tell the two apart.
-        cfg.deviceCount = static_cast<uint8_t>(g_deviceIds.size());
+        // One unit id per CONFIGURED device, consecutively from modbus.unit_id. Configured, not
+        // started: the unit id has to be a function of the settings page, or a device that
+        // fails to start renumbers every inverter after it. A slot with no device answers
+        // offline with no readings, which is the truth and matches what the Devices tab shows.
+        cfg.deviceCount = static_cast<uint8_t>(g_devicesConfigured);
         g_modbus.setConfig(cfg);
         const bool listening = g_modbus.begin();
         if (g_modbus.servedDevices() <= 1) {
@@ -532,13 +543,28 @@ void startOutputs() {
                       listening ? "listening" : "failed to start", cfg.port, cfg.inverterUnitId,
                       g_modbus.unitIdFor(g_modbus.servedDevices() - 1));
         }
-        if (g_modbus.servedDevices() < g_deviceIds.size()) {
-            log::warn("modbus: only %u of %u devices are reachable over Modbus TCP -- the unit "
-                      "ids would run past 247 or into the diagnostics unit (%u). Lower "
-                      "modbus.unit_id.",
+        // Which unit is which inverter, once, at boot. Without it the only way to find out is
+        // to read modbus.unit_id, fetch /api/v1/devices and count positions -- and on a bus of
+        // identical inverters the per-device lines above are indistinguishable (review).
+        for (size_t i = 0; i < g_configSlotIds.size() && i < g_modbus.servedDevices(); ++i) {
+            log::info("modbus: unit %u -> %s", static_cast<unsigned>(g_modbus.unitIdFor(i)),
+                      g_configSlotIds[i].empty() ? "(configured device did not start)"
+                                                 : g_configSlotIds[i].c_str());
+        }
+        if (g_modbus.servedDevices() < g_devicesConfigured) {
+            // Which of the two limits was hit, because the fix differs: lowering the base is no
+            // help at all when the diagnostics unit is sitting inside the run (validate() only
+            // stops it equalling unit_id, not landing a few above it).
+            const int firstUnserved = cfg.inverterUnitId + g_modbus.servedDevices();
+            log::warn("modbus: only %u of %u configured devices are reachable over Modbus TCP -- "
+                      "unit %d is %s. %s",
                       static_cast<unsigned>(g_modbus.servedDevices()),
-                      static_cast<unsigned>(g_deviceIds.size()),
-                      static_cast<unsigned>(cfg.diagnosticsUnitId));
+                      static_cast<unsigned>(g_devicesConfigured), firstUnserved,
+                      firstUnserved == cfg.diagnosticsUnitId ? "the diagnostics unit"
+                                                             : "past 247, the last valid address",
+                      firstUnserved == cfg.diagnosticsUnitId
+                          ? "Move modbus.diagnostics_unit_id out of the range."
+                          : "Lower modbus.unit_id.");
         }
     }
 
@@ -607,6 +633,15 @@ void startRestApi() {
     };
     ctx.bridgeInfo  = bridgeInfo;
     ctx.clock       = nowMs;
+    // Configuration slot -> unit id, which is the mapping only this file knows.
+    ctx.modbusUnitIdFor = [](const DeviceId& id) -> uint8_t {
+        for (size_t i = 0; i < g_configSlotIds.size(); ++i) {
+            if (g_configSlotIds[i] == id) {
+                return g_modbus.running() ? g_modbus.unitIdFor(i) : 0;
+            }
+        }
+        return 0;
+    };
     ctx.saveConfig  = [](const Configuration& c) { return g_store.save(c); };
     // Request only -- the poll itself runs on rs485Task, exactly like discovery. Running
     // pollOnce() here executed a seconds-long bus transaction inside an AsyncTCP callback and
@@ -779,10 +814,9 @@ void rs485Task(void* /*arg*/) {
                 break;
             }
         }
-        // MQTT/Home Assistant take every device; Modbus TCP and Prometheus still take one --
-        // the register map holds a single device's registers and the metric names have no
-        // device label. Stated here, in docs/architecture.md, docs/rest-api.md, docs/mqtt.md
-        // and the README rather than left to be found from a missing entity.
+        // Every output takes every device: MQTT/Home Assistant by topic subtree, REST by device
+        // id, Modbus TCP by unit id, Prometheus by a `device` label. docs/architecture.md has
+        // the table of what each one did about backwards compatibility for device 1.
         if (g_state) {
             const auto bridge = bridgeInfo();
             const auto diag   = g_diagnostics.snapshot();
@@ -802,23 +836,22 @@ void rs485Task(void* /*arg*/) {
                 }
             }
             const auto first = g_state->snapshot();
-            // Every device, one Modbus unit id each: index i is served at inverterUnitId + i,
-            // so unit 1 and the first Home Assistant device are the same inverter (#36).
+            // Every device, one Modbus unit id each: configuration slot i is served at
+            // inverterUnitId + i (#36).
             //
-            // Built by POSITION in g_deviceIds, with a null for anything without a snapshot --
-            // not by walking `views`, which skips such a device and would shift every later
-            // one down an index. A Modbus unit id is a wire contract: a client that reads
-            // inverter 3's watts believing they are inverter 2's has no way to notice. Today
-            // the skip cannot happen (state() only returns null for an unregistered id, and
-            // nothing unregisters), so this is a positional guarantee rather than a fix -- but
-            // the alternative depends on a filter never filtering, and that is not a property
-            // worth resting a wire protocol on. refresh() leaves a null entry's map untouched.
+            // Keyed on g_configSlotIds -- the CONFIGURED positions -- not on g_deviceIds, which
+            // is compacted. A device that failed to start is absent from the latter, so keying
+            // on it moved every later inverter down a unit id: a client reading unit 2 would
+            // get inverter 3's watts with no way to notice, and a unit id is a wire contract
+            // nobody re-derives after bring-up. A slot with no device is passed as null;
+            // refresh() leaves its map at the constructed sentinels, so that unit answers
+            // offline with no readings rather than someone else's.
             std::vector<const DeviceState*> modbusDevices;
-            modbusDevices.reserve(g_deviceIds.size());
-            for (const auto& id : g_deviceIds) {
+            modbusDevices.reserve(g_configSlotIds.size());
+            for (const auto& slotId : g_configSlotIds) {
                 const auto it = std::find_if(views.begin(), views.end(),
-                                             [&id](const mqtt::MqttOutput::DeviceView& v) {
-                                                 return v.id == id;
+                                             [&slotId](const mqtt::MqttOutput::DeviceView& v) {
+                                                 return !slotId.empty() && v.id == slotId;
                                              });
                 modbusDevices.push_back(it == views.end() ? nullptr : it->state);
             }
@@ -967,6 +1000,9 @@ void setup() {
         planned.push_back({d.id, &d.options});
     }
     g_devicesConfigured = planned.size();
+    // One slot per CONFIGURED device, filled in as each one starts. The Modbus unit ids are
+    // keyed on this, not on the compacted g_deviceIds -- see the declaration.
+    g_configSlotIds.assign(planned.size(), DeviceId{});
     if (planned.empty()) {
         log::warn("no driver configured and none compiled in; nothing will be polled");
     }
@@ -1016,6 +1052,7 @@ void setup() {
         g_contexts.push_back(std::make_unique<DeviceContext>(*driver, *store, g_diagnostics,
                                                              nowMs, policy));
         g_deviceIds.push_back(id);
+        g_configSlotIds[plannedIndex] = id;
         // `planned` is in configuration order and `p` is the entry being started, so this is
         // true only for the first configured device -- never for a later one that starts first.
         if (&p == &planned.front()) {

--- a/src/outputs/modbus_tcp/modbus_tcp_server.cpp
+++ b/src/outputs/modbus_tcp/modbus_tcp_server.cpp
@@ -4,6 +4,59 @@
 
 #include "modbus_tcp_server.h"
 
+// Everything that is not eModbus lives here, once, for both builds: the unit-id mapping is the
+// part worth testing and the host build is where it gets tested.
+namespace heliograph::modbus {
+
+ModbusTcpServer::ModbusTcpServer(ModbusServerConfig config) { setConfig(config); }
+
+void ModbusTcpServer::refresh(const std::vector<const DeviceState*>& devices,
+                              const BridgeInfo& bridge, const DiagnosticsSnapshot& diagnostics,
+                              uint64_t nowMs) {
+    std::lock_guard<std::mutex> lock(mapMutex_);
+    for (size_t i = 0; i < maps_.size() && i < devices.size(); ++i) {
+        if (devices[i] != nullptr) {
+            maps_[i].update(*devices[i], bridge, diagnostics, nowMs);
+        }
+    }
+}
+
+bool ModbusTcpServer::setConfig(const ModbusServerConfig& config) {
+    if (started_) {
+        return false;  // workers are already registered against the old unit ids
+    }
+    config_        = config;
+    // Sized here rather than in begin() so the mapping is settled -- and host-testable --
+    // before any TCP stack is involved.
+    servedDevices_ = serveableDevices();
+    maps_.assign(servedDevices_, RegisterMap{});
+    return true;
+}
+
+uint8_t ModbusTcpServer::serveableDevices() const {
+    uint8_t served = 0;
+    for (uint8_t i = 0; i < config_.deviceCount; ++i) {
+        const int unit = static_cast<int>(config_.inverterUnitId) + i;
+        // Consecutive or not at all. Skipping a taken id and carrying on would leave a hole a
+        // client cannot derive: the whole point of unit-id-per-device is that a client works
+        // out device N's address by adding, so the run has to be unbroken.
+        if (unit > 247 || unit == static_cast<int>(config_.diagnosticsUnitId)) {
+            break;  // 247 is the last valid Modbus slave address
+        }
+        served = static_cast<uint8_t>(i + 1);
+    }
+    return served;
+}
+
+uint8_t ModbusTcpServer::unitIdFor(size_t index) const {
+    if (index >= servedDevices_) {
+        return 0;
+    }
+    return static_cast<uint8_t>(config_.inverterUnitId + index);
+}
+
+}  // namespace heliograph::modbus
+
 #if defined(ESP32)
 
 #include <ModbusServerTCPasync.h>
@@ -17,23 +70,7 @@ ModbusServerTCPasync g_server;
 
 }  // namespace
 
-ModbusTcpServer::ModbusTcpServer(ModbusServerConfig config) : config_(config) {}
-
 ModbusTcpServer::~ModbusTcpServer() { stop(); }
-
-void ModbusTcpServer::refresh(const DeviceState& state, const BridgeInfo& bridge,
-                              const DiagnosticsSnapshot& diagnostics, uint64_t nowMs) {
-    std::lock_guard<std::mutex> lock(mapMutex_);
-    map_.update(state, bridge, diagnostics, nowMs);
-}
-
-bool ModbusTcpServer::setConfig(const ModbusServerConfig& config) {
-    if (started_) {
-        return false;  // workers are already registered against the old unit ids
-    }
-    config_ = config;
-    return true;
-}
 
 uint16_t ModbusTcpServer::activeClients() const {
     return started_ ? g_server.activeClients() : 0;
@@ -61,11 +98,24 @@ bool ModbusTcpServer::begin() {
             return response;
         }
 
+        // Which inverter, from the unit id in the request. The diagnostics unit serves device
+        // 1's map, as it always has: its block is bridge-wide and identical at every unit.
+        const uint8_t unit = request.getServerID();
+        size_t        index = 0;
+        if (unit != config_.diagnosticsUnitId) {
+            if (unit < config_.inverterUnitId) {
+                ModbusMessage bad;
+                bad.setError(unit, request.getFunctionCode(), ILLEGAL_DATA_ADDRESS);
+                return bad;
+            }
+            index = static_cast<size_t>(unit - config_.inverterUnitId);
+        }
+
         uint16_t values[kMaxRegistersPerRead];
         bool     ok = false;
         {
             std::lock_guard<std::mutex> lock(mapMutex_);
-            ok = map_.read(address, words, values);
+            ok = index < maps_.size() && maps_[index].read(address, words, values);
         }
         if (!ok) {
             // Out of range. Note the official eModbus example sets this error and then falls
@@ -92,7 +142,14 @@ bool ModbusTcpServer::begin() {
         return response;
     };
 
-    for (const uint8_t unitId : {config_.inverterUnitId, config_.diagnosticsUnitId}) {
+    std::vector<uint8_t> units;
+    units.reserve(static_cast<size_t>(servedDevices_) + 1);
+    for (uint8_t i = 0; i < servedDevices_; ++i) {
+        units.push_back(static_cast<uint8_t>(config_.inverterUnitId + i));
+    }
+    units.push_back(config_.diagnosticsUnitId);
+
+    for (const uint8_t unitId : units) {
         g_server.registerWorker(unitId, READ_HOLD_REGISTER, readWorker);
         g_server.registerWorker(unitId, READ_INPUT_REGISTER, readWorker);
         if (!config_.writeEnabled) {
@@ -123,22 +180,8 @@ void ModbusTcpServer::stop() {
 
 namespace heliograph::modbus {
 
-ModbusTcpServer::ModbusTcpServer(ModbusServerConfig config) : config_(config) {}
 ModbusTcpServer::~ModbusTcpServer() = default;
 
-void ModbusTcpServer::refresh(const DeviceState& state, const BridgeInfo& bridge,
-                              const DiagnosticsSnapshot& diagnostics, uint64_t nowMs) {
-    std::lock_guard<std::mutex> lock(mapMutex_);
-    map_.update(state, bridge, diagnostics, nowMs);
-}
-
-bool ModbusTcpServer::setConfig(const ModbusServerConfig& config) {
-    if (started_) {
-        return false;
-    }
-    config_ = config;
-    return true;
-}
 uint16_t ModbusTcpServer::activeClients() const { return 0; }
 bool     ModbusTcpServer::running() const { return false; }
 bool     ModbusTcpServer::begin() { return false; }

--- a/src/outputs/modbus_tcp/modbus_tcp_server.cpp
+++ b/src/outputs/modbus_tcp/modbus_tcp_server.cpp
@@ -4,6 +4,8 @@
 
 #include "modbus_tcp_server.h"
 
+#include <algorithm>
+
 // Everything that is not eModbus lives here, once, for both builds: the unit-id mapping is the
 // part worth testing and the host build is where it gets tested.
 namespace heliograph::modbus {
@@ -25,16 +27,51 @@ bool ModbusTcpServer::setConfig(const ModbusServerConfig& config) {
     if (started_) {
         return false;  // workers are already registered against the old unit ids
     }
+    // Under the map lock, because this REALLOCATES. rs485Task is created in setup() and starts
+    // calling refresh() -- which writes maps_[i] -- before loop() ever reaches startOutputs()
+    // and this call. It preempts loop() too, being the higher priority of the two, so an
+    // unlocked assign() here frees a buffer another task may be writing into: a heap
+    // write-after-free that shows up once, as an unreproducible panic. On main this was a plain
+    // POD assignment and the hazard did not exist; the per-device maps created it (review).
+    std::lock_guard<std::mutex> lock(mapMutex_);
     config_        = config;
     // Sized here rather than in begin() so the mapping is settled -- and host-testable --
     // before any TCP stack is involved.
     //
-    // At least one map even when no inverter started: the diagnostics unit reads maps_[0], and
-    // a bridge with nothing polling is exactly when someone scrapes it. Before this change a
-    // single map always existed, so refusing that read now would be a quiet regression.
+    // One map per CONFIGURED device, not per started one, and at least one always: the
+    // diagnostics unit reads maps_[0], and a bridge with nothing polling is exactly when
+    // someone scrapes it for uptime and heap.
     servedDevices_ = serveableDevices();
     maps_.assign(servedDevices_ > 0 ? servedDevices_ : 1, RegisterMap{});
     return true;
+}
+
+bool ModbusTcpServer::readUnit(uint8_t unitId, uint16_t address, uint16_t count,
+                               uint16_t* out) const {
+    if (count == 0 || count > kMaxRegistersPerRead) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(mapMutex_);
+    const size_t index = mapIndexFor(unitId);
+    if (index >= maps_.size()) {
+        return false;
+    }
+    return maps_[index].read(address, count, out);
+}
+
+size_t ModbusTcpServer::mapIndexFor(uint8_t unitId) const {
+    // The diagnostics unit, and the two ids a client sends when it has no unit field to set,
+    // all read device 1's map. 0 and 255 are what the MB/TCP spec calls "unused" for a server
+    // that is not a gateway, and plenty of clients still send them -- Home Assistant's Modbus
+    // integration defaults to 0. Answering them with device 1 costs nothing and is the
+    // difference between a copied-in configuration working and returning an exception.
+    if (unitId == config_.diagnosticsUnitId || unitId == 0 || unitId == 255) {
+        return 0;
+    }
+    if (unitId < config_.inverterUnitId) {
+        return kNoMap;
+    }
+    return static_cast<size_t>(unitId - config_.inverterUnitId);
 }
 
 uint8_t ModbusTcpServer::serveableDevices() const {
@@ -102,26 +139,10 @@ bool ModbusTcpServer::begin() {
             return response;
         }
 
-        // Which inverter, from the unit id in the request. The diagnostics unit serves device
-        // 1's map, as it always has: its block is bridge-wide and identical at every unit.
-        const uint8_t unit = request.getServerID();
-        size_t        index = 0;
-        if (unit != config_.diagnosticsUnitId) {
-            if (unit < config_.inverterUnitId) {
-                ModbusMessage bad;
-                bad.setError(unit, request.getFunctionCode(), ILLEGAL_DATA_ADDRESS);
-                return bad;
-            }
-            index = static_cast<size_t>(unit - config_.inverterUnitId);
-        }
-
+        // Which inverter, and the read itself, both in readUnit() -- the same code path a host
+        // test exercises, rather than arithmetic that only runs on hardware.
         uint16_t values[kMaxRegistersPerRead];
-        bool     ok = false;
-        {
-            std::lock_guard<std::mutex> lock(mapMutex_);
-            ok = index < maps_.size() && maps_[index].read(address, words, values);
-        }
-        if (!ok) {
+        if (!readUnit(request.getServerID(), address, words, values)) {
             // Out of range. Note the official eModbus example sets this error and then falls
             // through into building a normal response anyway; returning here is deliberate.
             response.setError(request.getServerID(), request.getFunctionCode(),
@@ -147,11 +168,21 @@ bool ModbusTcpServer::begin() {
     };
 
     std::vector<uint8_t> units;
-    units.reserve(static_cast<size_t>(servedDevices_) + 1);
+    units.reserve(static_cast<size_t>(servedDevices_) + 3);
     for (uint8_t i = 0; i < servedDevices_; ++i) {
         units.push_back(static_cast<uint8_t>(config_.inverterUnitId + i));
     }
     units.push_back(config_.diagnosticsUnitId);
+    // A client with no unit-id field of its own sends 0 or 255 -- the MB/TCP spec calls the
+    // byte unused for a server that is not a gateway, and Home Assistant's Modbus integration
+    // defaults to 0. Both read device 1, so a configuration copied from a single-inverter
+    // example works instead of returning an exception. Skipped when they collide with a real
+    // unit, which cannot happen for 0 (validate() forbids unit_id 0) but can for 255.
+    for (const uint8_t alias : {static_cast<uint8_t>(0), static_cast<uint8_t>(255)}) {
+        if (std::find(units.begin(), units.end(), alias) == units.end()) {
+            units.push_back(alias);
+        }
+    }
 
     for (const uint8_t unitId : units) {
         g_server.registerWorker(unitId, READ_HOLD_REGISTER, readWorker);

--- a/src/outputs/modbus_tcp/modbus_tcp_server.cpp
+++ b/src/outputs/modbus_tcp/modbus_tcp_server.cpp
@@ -28,8 +28,12 @@ bool ModbusTcpServer::setConfig(const ModbusServerConfig& config) {
     config_        = config;
     // Sized here rather than in begin() so the mapping is settled -- and host-testable --
     // before any TCP stack is involved.
+    //
+    // At least one map even when no inverter started: the diagnostics unit reads maps_[0], and
+    // a bridge with nothing polling is exactly when someone scrapes it. Before this change a
+    // single map always existed, so refusing that read now would be a quiet regression.
     servedDevices_ = serveableDevices();
-    maps_.assign(servedDevices_, RegisterMap{});
+    maps_.assign(servedDevices_ > 0 ? servedDevices_ : 1, RegisterMap{});
     return true;
 }
 

--- a/src/outputs/modbus_tcp/modbus_tcp_server.h
+++ b/src/outputs/modbus_tcp/modbus_tcp_server.h
@@ -90,6 +90,19 @@ public:
     /// unit reads map 0, and a bridge with nothing polling is exactly when it gets scraped.
     size_t registerMapCount() const { return maps_.size(); }
 
+    /// Reads as a client would, by unit id. False when the unit has no map or the range falls
+    /// outside it -- the server turns that into an exception.
+    ///
+    /// Exists so the whole unit-id-to-device routing is reachable from a host test. The worker
+    /// that used to do this arithmetic is inside `#if defined(ESP32)`, which left the one thing
+    /// this feature is about -- unit `base+i` returning device `i` -- testable only by pointing
+    /// a real Modbus client at real hardware (review, 2026-07-26).
+    bool readUnit(uint8_t unitId, uint16_t address, uint16_t count, uint16_t* out) const;
+
+    /// Index into the maps for a unit id, or kNoMap. Public for the same reason as readUnit().
+    static constexpr size_t kNoMap = static_cast<size_t>(-1);
+    size_t                  mapIndexFor(uint8_t unitId) const;
+
     uint16_t activeClients() const;
 
     /// Optional: lets the server bump modbus client counters.

--- a/src/outputs/modbus_tcp/modbus_tcp_server.h
+++ b/src/outputs/modbus_tcp/modbus_tcp_server.h
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <mutex>
+#include <vector>
 
 #include "device/device_state.h"
 #include "diagnostics/diagnostics.h"
@@ -28,8 +29,18 @@ namespace heliograph::modbus {
 struct ModbusServerConfig {
     bool     enabled           = true;
     uint16_t port              = 502;
+    /// Device 1. Devices 2..N follow at inverterUnitId + 1, + 2, and so on.
+    ///
+    /// One unit id per inverter is what the Modbus specification's Unit Identifier is for --
+    /// addressing a device on a serial sub-network behind a gateway -- so a client needs no
+    /// vendor-specific address arithmetic, only the unit id field it already has. The register
+    /// map is identical at every unit; it simply repeats. Device 1 stays exactly where it has
+    /// always been, so an existing client keeps working untouched (#36).
     uint8_t  inverterUnitId    = 1;
     uint8_t  diagnosticsUnitId = 250;
+    /// How many inverters to serve, i.e. how many consecutive unit ids to claim. Set from the
+    /// number of devices that started, before begin().
+    uint8_t  deviceCount       = 1;
     uint8_t  maxClients        = 4;
     uint32_t idleTimeoutMs     = 20000;
     /// Never true in the MVP. Kept as config rather than as an absence of code so that the
@@ -60,9 +71,20 @@ public:
     void stop();
     bool running() const;
 
-    /// Re-renders the register map. Called from the poll task; takes the map lock briefly.
-    void refresh(const DeviceState& state, const BridgeInfo& bridge,
+    /// Re-renders the register maps, one per device, in configuration order: `devices[i]` is
+    /// served at `inverterUnitId + i`. Called from the poll task; takes the map lock briefly.
+    ///
+    /// Extra entries beyond servedDevices() are ignored rather than served at a unit id no
+    /// worker is registered for -- the workers are bound at begin() and cannot grow after.
+    void refresh(const std::vector<const DeviceState*>& devices, const BridgeInfo& bridge,
                  const DiagnosticsSnapshot& diagnostics, uint64_t nowMs);
+
+    /// How many inverters this server actually serves. Lower than the configured count when
+    /// the unit ids would run past 247 or collide with the diagnostics unit; begin() logs it.
+    uint8_t servedDevices() const { return servedDevices_; }
+
+    /// The unit id device `index` is served at, or 0 when it is not served.
+    uint8_t unitIdFor(size_t index) const;
 
     uint16_t activeClients() const;
 
@@ -72,12 +94,20 @@ public:
     const ModbusServerConfig& config() const { return config_; }
 
 private:
+    /// How many devices can be served without running past unit id 247 or over the diagnostics
+    /// unit. Pure, so the rule is host-testable; begin() applies it.
+    uint8_t serveableDevices() const;
+
     ModbusServerConfig config_;
-    RegisterMap        map_;
-    mutable std::mutex mapMutex_;
-    Diagnostics*       diagnostics_    = nullptr;
-    uint16_t           lastClientCount_ = 0;
-    bool               started_        = false;
+    /// One per served device, index i at unit id inverterUnitId + i. Allocated at begin(), when
+    /// the count is known: 900 registers is 1.8 KB apiece, and eight of those reserved up front
+    /// on a board with one inverter is 14 KB of heap for nothing.
+    std::vector<RegisterMap> maps_;
+    mutable std::mutex       mapMutex_;
+    Diagnostics*             diagnostics_     = nullptr;
+    uint16_t                 lastClientCount_ = 0;
+    uint8_t                  servedDevices_   = 0;
+    bool                     started_         = false;
 };
 
 }  // namespace heliograph::modbus

--- a/src/outputs/modbus_tcp/modbus_tcp_server.h
+++ b/src/outputs/modbus_tcp/modbus_tcp_server.h
@@ -86,6 +86,10 @@ public:
     /// The unit id device `index` is served at, or 0 when it is not served.
     uint8_t unitIdFor(size_t index) const;
 
+    /// How many register maps are allocated. Never zero, even with no inverter: the diagnostics
+    /// unit reads map 0, and a bridge with nothing polling is exactly when it gets scraped.
+    size_t registerMapCount() const { return maps_.size(); }
+
     uint16_t activeClients() const;
 
     /// Optional: lets the server bump modbus client counters.

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -40,17 +40,6 @@ void appendValue(std::string& out, const char* name, long value) {
     out += buf;
 }
 
-/// Exports a gauge from a measurement, or nothing at all if it is not a current reading.
-void appendGauge(std::string& out, const DeviceState& state, const char* id, const char* name,
-                 const char* help) {
-    const auto* m = state.measurements.find(id);
-    if (m == nullptr || !m->supported || !m->valid || m->stale) {
-        return;  // omit, do not zero
-    }
-    appendHelp(out, name, help, "gauge");
-    appendValue(out, name, m->value);
-}
-
 std::string escapeLabel(const std::string& value) {
     std::string out;
     out.reserve(value.size());
@@ -67,42 +56,89 @@ std::string escapeLabel(const std::string& value) {
     return out;
 }
 
+/// `<name>{device="<id>"} <value>`.
+void appendDeviceValue(std::string& out, const char* name, const std::string& deviceId,
+                       double value) {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), " %.3f\n", value);
+    out += name;
+    out += "{device=\"" + escapeLabel(deviceId) + "\"}";
+    out += buf;
+}
+
+void appendDeviceFlag(std::string& out, const char* name, const std::string& deviceId, bool set) {
+    out += name;
+    out += "{device=\"" + escapeLabel(deviceId) + "\"} ";
+    out += set ? "1\n" : "0\n";
+}
+
+/// One measurement, as one metric family across every device.
+struct GaugeSpec {
+    const char* measurementId;
+    const char* name;
+    const char* help;
+};
+
+constexpr GaugeSpec kInverterGauges[] = {
+    {measurement_id::kAcPowerTotal, "heliograph_inverter_ac_power_watts",
+     "Current AC output power"},
+    {measurement_id::kDcPowerTotal, "heliograph_inverter_dc_power_watts",
+     "Current DC input power (derived)"},
+    {measurement_id::kAcL1Voltage, "heliograph_inverter_ac_voltage_volts", "AC voltage on L1"},
+    {measurement_id::kAcL1Current, "heliograph_inverter_ac_current_amperes", "AC current on L1"},
+    {measurement_id::kAcFrequency, "heliograph_inverter_grid_frequency_hertz", "Grid frequency"},
+    {measurement_id::kEnergyToday, "heliograph_inverter_energy_today_kwh",
+     "Energy produced today"},
+    {measurement_id::kEnergyTotal, "heliograph_inverter_energy_total_kwh",
+     "Lifetime energy produced"},
+    {measurement_id::kTemperature, "heliograph_inverter_temperature_celsius",
+     "Inverter temperature"},
+};
+
 }  // namespace
 
-std::string buildMetrics(const DeviceState& state, const BridgeInfo& bridge,
+std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const BridgeInfo& bridge,
                          const DiagnosticsSnapshot& d) {
     std::string out;
-    out.reserve(2048);
+    out.reserve(2048 + devices.size() * 512);
 
+    // One build_info series per device: the firmware and board are the bridge's, the driver is
+    // the device's, and on a mixed bus those differ.
     appendHelp(out, "heliograph_build_info", "Firmware build information", "gauge");
-    out += "heliograph_build_info{version=\"" + escapeLabel(bridge.firmwareVersion) +
-           "\",driver=\"" + escapeLabel(state.identity.driverId) + "\",board=\"" +
-           escapeLabel(bridge.boardName) + "\"} 1\n";
+    for (const auto& dev : devices) {
+        out += "heliograph_build_info{device=\"" + escapeLabel(dev.id) + "\",version=\"" +
+               escapeLabel(bridge.firmwareVersion) + "\",driver=\"" +
+               escapeLabel(dev.state->identity.driverId) + "\",board=\"" +
+               escapeLabel(bridge.boardName) + "\"} 1\n";
+    }
 
     appendHelp(out, "heliograph_inverter_online", "1 if the inverter is responding", "gauge");
-    appendValue(out, "heliograph_inverter_online",
-                static_cast<unsigned long>(state.inverterOnline ? 1 : 0));
-
+    for (const auto& dev : devices) {
+        appendDeviceFlag(out, "heliograph_inverter_online", dev.id, dev.state->inverterOnline);
+    }
     appendHelp(out, "heliograph_data_stale", "1 if the last reading is too old to trust", "gauge");
-    appendValue(out, "heliograph_data_stale",
-                static_cast<unsigned long>(state.dataStale ? 1 : 0));
+    for (const auto& dev : devices) {
+        appendDeviceFlag(out, "heliograph_data_stale", dev.id, dev.state->dataStale);
+    }
 
-    appendGauge(out, state, measurement_id::kAcPowerTotal, "heliograph_inverter_ac_power_watts",
-                "Current AC output power");
-    appendGauge(out, state, measurement_id::kDcPowerTotal, "heliograph_inverter_dc_power_watts",
-                "Current DC input power (derived)");
-    appendGauge(out, state, measurement_id::kAcL1Voltage, "heliograph_inverter_ac_voltage_volts",
-                "AC voltage on L1");
-    appendGauge(out, state, measurement_id::kAcL1Current, "heliograph_inverter_ac_current_amperes",
-                "AC current on L1");
-    appendGauge(out, state, measurement_id::kAcFrequency, "heliograph_inverter_grid_frequency_hertz",
-                "Grid frequency");
-    appendGauge(out, state, measurement_id::kEnergyToday, "heliograph_inverter_energy_today_kwh",
-                "Energy produced today");
-    appendGauge(out, state, measurement_id::kEnergyTotal, "heliograph_inverter_energy_total_kwh",
-                "Lifetime energy produced");
-    appendGauge(out, state, measurement_id::kTemperature,
-                "heliograph_inverter_temperature_celsius", "Inverter temperature");
+    // HELP/TYPE once per family, then one line per device that actually has the channel. The
+    // header is written lazily so a family no device reports is absent entirely rather than
+    // present as a bare header -- which is a parse error in strict parsers, and is why the
+    // whole family loops here instead of each device rendering its own block.
+    for (const auto& gauge : kInverterGauges) {
+        bool headerWritten = false;
+        for (const auto& dev : devices) {
+            const auto* m = dev.state->measurements.find(gauge.measurementId);
+            if (m == nullptr || !m->supported || !m->valid || m->stale) {
+                continue;  // omit, do not zero
+            }
+            if (!headerWritten) {
+                appendHelp(out, gauge.name, gauge.help, "gauge");
+                headerWritten = true;
+            }
+            appendDeviceValue(out, gauge.name, dev.id, m->value);
+        }
+    }
 
     appendHelp(out, "heliograph_poll_success_total", "Successful inverter polls", "counter");
     appendValue(out, "heliograph_poll_success_total",

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -104,7 +104,9 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
 
     // One build_info series per device: the firmware and board are the bridge's, the driver is
     // the device's, and on a mixed bus those differ.
-    appendHelp(out, "heliograph_build_info", "Firmware build information", "gauge");
+    if (!devices.empty()) {
+        appendHelp(out, "heliograph_build_info", "Firmware build information", "gauge");
+    }
     for (const auto& dev : devices) {
         out += "heliograph_build_info{device=\"" + escapeLabel(dev.id) + "\",version=\"" +
                escapeLabel(bridge.firmwareVersion) + "\",driver=\"" +
@@ -112,13 +114,19 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
                escapeLabel(bridge.boardName) + "\"} 1\n";
     }
 
-    appendHelp(out, "heliograph_inverter_online", "1 if the inverter is responding", "gauge");
-    for (const auto& dev : devices) {
-        appendDeviceFlag(out, "heliograph_inverter_online", dev.id, dev.state->inverterOnline);
-    }
-    appendHelp(out, "heliograph_data_stale", "1 if the last reading is too old to trust", "gauge");
-    for (const auto& dev : devices) {
-        appendDeviceFlag(out, "heliograph_data_stale", dev.id, dev.state->dataStale);
+    // Headers only when there is a series to put under them -- the same rule as the gauges
+    // below. With an empty device list these three used to emit a bare HELP/TYPE pair and no
+    // samples, which is exactly the shape the lazy header exists to avoid (review).
+    if (!devices.empty()) {
+        appendHelp(out, "heliograph_inverter_online", "1 if the inverter is responding", "gauge");
+        for (const auto& dev : devices) {
+            appendDeviceFlag(out, "heliograph_inverter_online", dev.id, dev.state->inverterOnline);
+        }
+        appendHelp(out, "heliograph_data_stale", "1 if the last reading is too old to trust",
+                   "gauge");
+        for (const auto& dev : devices) {
+            appendDeviceFlag(out, "heliograph_data_stale", dev.id, dev.state->dataStale);
+        }
     }
 
     // HELP/TYPE once per family, then one line per device that actually has the channel. The

--- a/src/outputs/prometheus/prometheus_metrics.h
+++ b/src/outputs/prometheus/prometheus_metrics.h
@@ -20,9 +20,13 @@ namespace heliograph::prometheus {
 
 /// One inverter, as /metrics sees it.
 struct DeviceMetrics {
-    /// The registered device id -- the same string REST serves at /api/v1/devices and MQTT
-    /// uses in its topics. One id per inverter across every interface, so a Grafana panel and
-    /// a Home Assistant entity can be lined up without a lookup table.
+    /// The registered device id -- the same string REST serves at /api/v1/devices, and the same
+    /// one in the MQTT topic subtree for devices 2..N.
+    ///
+    /// Not for device 1: it keeps the bridge-scoped MQTT topics, so its device id appears
+    /// nowhere in MQTT, and the Home Assistant device is named after the model rather than the
+    /// id. Lining a Grafana panel up with an HA entity is therefore a short lookup, not a
+    /// string match -- an earlier version of this comment claimed otherwise (review).
     std::string        id;
     const DeviceState* state = nullptr;
 };

--- a/src/outputs/prometheus/prometheus_metrics.h
+++ b/src/outputs/prometheus/prometheus_metrics.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "device/bridge_info.h"
 #include "device/device_state.h"
@@ -17,11 +18,31 @@
 
 namespace heliograph::prometheus {
 
+/// One inverter, as /metrics sees it.
+struct DeviceMetrics {
+    /// The registered device id -- the same string REST serves at /api/v1/devices and MQTT
+    /// uses in its topics. One id per inverter across every interface, so a Grafana panel and
+    /// a Home Assistant entity can be lined up without a lookup table.
+    std::string        id;
+    const DeviceState* state = nullptr;
+};
+
 /// Renders the /metrics body.
+///
+/// Every inverter series carries a `device` label, including the first. That is a breaking
+/// change for a dashboard built when there was one inverter -- the query still matches, but it
+/// returns one series per device instead of one -- and it was chosen over leaving the first
+/// unlabelled: an asymmetry that has to be explained forever is worse than a one-off edit, and
+/// `sum by (device)` with a blank label is not something anyone should have to debug.
+/// docs/prometheus.md says exactly what to change.
+///
+/// Bridge-wide series (uptime, heap, WiFi, the RS485 and poll counters, relays) carry no device
+/// label, because they are not per device: the counters live in one Diagnostics for the whole
+/// bus.
 ///
 /// The serial number is deliberately not a label: it is high cardinality by definition and
 /// would multiply every series by the number of devices ever seen by a scraper.
-std::string buildMetrics(const DeviceState& state, const BridgeInfo& bridge,
+std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const BridgeInfo& bridge,
                          const DiagnosticsSnapshot& diagnostics);
 
 }  // namespace heliograph::prometheus

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -827,13 +827,26 @@ bool RestApi::begin() {
     });
 
 #if ENABLE_PROMETHEUS
-    g_server->on("/metrics", HTTP_GET, [this, firstDevice](AsyncWebServerRequest* request) {
-        const auto snapshot = firstDevice();
-        if (!snapshot) {
+    g_server->on("/metrics", HTTP_GET, [this](AsyncWebServerRequest* request) {
+        // Every polled device, each with its own `device` label -- not the first one. The
+        // handles are held for the whole render: DeviceMetrics keeps a raw pointer into each
+        // snapshot.
+        const auto                                ids = context_.devices->devices();
+        std::vector<StateHandle>                  held;
+        std::vector<prometheus::DeviceMetrics>    devices;
+        held.reserve(ids.size());
+        devices.reserve(ids.size());
+        for (const auto& id : ids) {
+            if (StateHandle h = context_.devices->state(id)) {
+                held.push_back(std::move(h));
+                devices.push_back({id, held.back().get()});
+            }
+        }
+        if (devices.empty()) {
             request->send(503, "text/plain", "# no device configured\n");
             return;
         }
-        const auto body = prometheus::buildMetrics(*snapshot, context_.bridgeInfo(),
+        const auto body = prometheus::buildMetrics(devices, context_.bridgeInfo(),
                                                    context_.diagnostics->snapshot());
         request->send(200, "text/plain; version=0.0.4", body.c_str());
     });

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -332,6 +332,11 @@ bool RestApi::begin() {
                 fleet.push_back(rest::summariseDevice(*snapshot, id, now));
             } else if (StateHandle h = context_.devices->state(id)) {
                 fleet.push_back(rest::summariseDevice(*h, id, now));
+            } else {
+                continue;
+            }
+            if (context_.modbusUnitIdFor) {
+                fleet.back().modbusUnitId = context_.modbusUnitIdFor(id);
             }
         }
         std::string body;

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -53,6 +53,10 @@ struct RestContext {
     std::function<void(const Configuration&)> applyConfig;
     std::function<BridgeInfo()>       bridgeInfo;
     std::function<uint64_t()>         clock;
+    /// The Modbus TCP unit id a device is served at, or 0 when it is not served. Injected
+    /// because only main knows the mapping from configuration slot to device, and because
+    /// otherwise the only way to learn it is to count positions in the device list.
+    std::function<uint8_t(const DeviceId&)> modbusUnitIdFor;
     /// Persist the configuration. Returns false if it could not be written.
     std::function<bool(const Configuration&)> saveConfig;
     /// Force an immediate poll. Returns false if the bus is busy.

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -209,6 +209,12 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
         o["online"]     = f.online;
         o["data_valid"] = f.dataValid;
         o["data_stale"] = f.dataStale;
+        // 0 means "not served over Modbus" -- Modbus disabled, or past the end of the run.
+        if (f.modbusUnitId != 0) {
+            o["modbus_unit_id"] = f.modbusUnitId;
+        } else {
+            o["modbus_unit_id"] = nullptr;
+        }
         if (f.everPolled) {
             o["last_successful_poll_seconds_ago"] = f.lastPollSecondsAgo;
         } else {

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -48,6 +48,11 @@ bool buildProvisionPayload(const std::string& hostname, std::string& out,
 /// report energy must not contribute a zero to a total.
 struct DeviceSummary {
     std::string id;
+    /// The Modbus TCP unit id this device is served at, or 0 when Modbus is off or this device
+    /// is past the end of the served run. Reported because otherwise the only way to learn it
+    /// is to read modbus.unit_id, fetch the device list and count positions -- and on a bus of
+    /// identical inverters that is exactly the sum nobody wants to do twice (review).
+    uint8_t     modbusUnitId = 0;
     bool        online    = false;
     bool        dataValid = false;
     bool        dataStale = false;

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1419,11 +1419,19 @@ static void test_oversized_response_is_refused() {
 
 // --- Prometheus ------------------------------------------------------------------------------
 
+/// One device, the way every test below used to call buildMetrics directly. The id is what
+/// lands in the `device` label, so the assertions read the same shape a scraper sees.
+static std::string metricsOf(const DeviceState& state, const BridgeInfo& bridge,
+                             const DiagnosticsSnapshot& diagnostics,
+                             const char* id = "eversolar_legacy") {
+    return prometheus::buildMetrics({{id, &state}}, bridge, diagnostics);
+}
+
 static void test_prometheus_stack_and_fragmentation_gauges() {
     Rig        r;
     const auto state = r.poll();
     // Unsampled stack marks: the gauges are omitted entirely, like the RSSI gauge.
-    auto text = prometheus::buildMetrics(state, makeBridge(), r.diagnostics.snapshot());
+    auto text = metricsOf(state, makeBridge(), r.diagnostics.snapshot());
     TEST_ASSERT_TRUE(text.find("rs485_stack_free_bytes") == std::string::npos);
     TEST_ASSERT_TRUE(text.find("loop_stack_free_bytes") == std::string::npos);
 
@@ -1431,7 +1439,7 @@ static void test_prometheus_stack_and_fragmentation_gauges() {
     r.diagnostics.recordLoopStackFree(4100);
     auto bridge              = makeBridge();
     bridge.maxAllocHeapBytes = 65536;
-    text = prometheus::buildMetrics(state, bridge, r.diagnostics.snapshot());
+    text = metricsOf(state, bridge, r.diagnostics.snapshot());
     TEST_ASSERT_TRUE(text.find("heliograph_rs485_stack_free_bytes 2500\n") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_loop_stack_free_bytes 4100\n") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_max_alloc_heap_bytes 65536\n") != std::string::npos);
@@ -1440,10 +1448,10 @@ static void test_prometheus_stack_and_fragmentation_gauges() {
 static void test_prometheus_exports_current_readings() {
     Rig        r;
     const auto state = r.poll();
-    const auto text  = prometheus::buildMetrics(state, makeBridge(), r.diagnostics.snapshot());
+    const auto text  = metricsOf(state, makeBridge(), r.diagnostics.snapshot());
 
-    TEST_ASSERT_TRUE(text.find("heliograph_inverter_online 1\n") != std::string::npos);
-    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_power_watts 1842.000\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_online{device=\"eversolar_legacy\"} 1\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_power_watts{device=\"eversolar_legacy\"} 1842.000\n") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_poll_success_total 1\n") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_wifi_rssi_dbm -57\n") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_uptime_seconds 86400\n") != std::string::npos);
@@ -1461,11 +1469,11 @@ static void test_prometheus_omits_unknown_rather_than_exporting_zero() {
         ctx.pollOnce();
     }
     const auto text =
-        prometheus::buildMetrics(*r.store.snapshot(), makeBridge(), r.diagnostics.snapshot());
+        metricsOf(*r.store.snapshot(), makeBridge(), r.diagnostics.snapshot());
 
     TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_power_watts") == std::string::npos);
-    TEST_ASSERT_TRUE(text.find("heliograph_inverter_online 0\n") != std::string::npos);
-    TEST_ASSERT_TRUE(text.find("heliograph_data_stale 1\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_online{device=\"eversolar_legacy\"} 0\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_data_stale{device=\"eversolar_legacy\"} 1\n") != std::string::npos);
     // Counters still work while the inverter is away.
     TEST_ASSERT_TRUE(text.find("heliograph_poll_failure_total 10\n") != std::string::npos);
 }
@@ -1478,7 +1486,7 @@ static void test_prometheus_omits_relays_on_a_board_without_them() {
     DeviceContext ctx(r.driver, r.store, r.diagnostics, clockFn);
     ctx.pollOnce();
     BridgeInfo b = makeBridge();  // relayCount stays 0
-    const auto text = prometheus::buildMetrics(*r.store.snapshot(), b, r.diagnostics.snapshot());
+    const auto text = metricsOf(*r.store.snapshot(), b, r.diagnostics.snapshot());
 
     TEST_ASSERT_TRUE(text.find("heliograph_relay_energised") == std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_relays_enabled") == std::string::npos);
@@ -1494,7 +1502,7 @@ static void test_prometheus_exports_relay_and_drm_state() {
     b.relaysEnabled = true;
     b.relayMask    = 0b010;  // only relay index 1 energised
     b.relayRoles   = {"drm0", "drm5", "none"};
-    const auto text = prometheus::buildMetrics(*r.store.snapshot(), b, r.diagnostics.snapshot());
+    const auto text = metricsOf(*r.store.snapshot(), b, r.diagnostics.snapshot());
 
     TEST_ASSERT_TRUE(text.find("heliograph_relays_enabled 1\n") != std::string::npos);
     // Labels carry the SAME 0-based index as the MQTT topic and the REST route.
@@ -1516,7 +1524,7 @@ static void test_prometheus_labelled_family_declares_help_once() {
     BridgeInfo b = makeBridge();
     b.relayCount = 6;
     b.relayMask  = 0b101010;
-    const auto text = prometheus::buildMetrics(*r.store.snapshot(), b, r.diagnostics.snapshot());
+    const auto text = metricsOf(*r.store.snapshot(), b, r.diagnostics.snapshot());
 
     auto count = [&text](const std::string& needle) {
         size_t n = 0;
@@ -1540,7 +1548,7 @@ static void test_prometheus_omits_drm_mode_without_roles() {
     BridgeInfo b = makeBridge();
     b.relayCount = 2;
     b.relayRoles = {"none", "none"};
-    const auto text = prometheus::buildMetrics(*r.store.snapshot(), b, r.diagnostics.snapshot());
+    const auto text = metricsOf(*r.store.snapshot(), b, r.diagnostics.snapshot());
 
     TEST_ASSERT_TRUE(text.find("heliograph_relay_energised{relay=\"0\"}") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_drm_mode") == std::string::npos);
@@ -1555,7 +1563,7 @@ static void test_prometheus_omits_ntp_timestamp_until_synced() {
 
     BridgeInfo unsynced = makeBridge();
     const auto before =
-        prometheus::buildMetrics(*r.store.snapshot(), unsynced, r.diagnostics.snapshot());
+        metricsOf(*r.store.snapshot(), unsynced, r.diagnostics.snapshot());
     TEST_ASSERT_TRUE(before.find("heliograph_time_synced 0\n") != std::string::npos);
     TEST_ASSERT_TRUE(before.find("heliograph_ntp_last_sync_timestamp_seconds") ==
                      std::string::npos);
@@ -1564,7 +1572,7 @@ static void test_prometheus_omits_ntp_timestamp_until_synced() {
     synced.timeSynced      = true;
     synced.lastNtpSyncEpoch = 1753000000;
     const auto after =
-        prometheus::buildMetrics(*r.store.snapshot(), synced, r.diagnostics.snapshot());
+        metricsOf(*r.store.snapshot(), synced, r.diagnostics.snapshot());
     TEST_ASSERT_TRUE(after.find("heliograph_time_synced 1\n") != std::string::npos);
     TEST_ASSERT_TRUE(after.find("heliograph_ntp_last_sync_timestamp_seconds 1753000000\n") !=
                      std::string::npos);
@@ -1573,7 +1581,7 @@ static void test_prometheus_omits_ntp_timestamp_until_synced() {
 static void test_prometheus_has_no_high_cardinality_labels() {
     Rig        r;
     const auto state = r.poll();
-    const auto text  = prometheus::buildMetrics(state, makeBridge(), r.diagnostics.snapshot());
+    const auto text  = metricsOf(state, makeBridge(), r.diagnostics.snapshot());
 
     // The serial number must never become a label: cardinality explodes across a fleet.
     TEST_ASSERT_TRUE(text.find(fx::kExpectedSerial) == std::string::npos);
@@ -1582,7 +1590,7 @@ static void test_prometheus_has_no_high_cardinality_labels() {
 static void test_prometheus_naming_conventions() {
     Rig        r;
     const auto state = r.poll();
-    const auto text  = prometheus::buildMetrics(state, makeBridge(), r.diagnostics.snapshot());
+    const auto text  = metricsOf(state, makeBridge(), r.diagnostics.snapshot());
 
     // Counters end in _total and are typed as counters; gauges are typed as gauges.
     TEST_ASSERT_TRUE(text.find("# TYPE heliograph_poll_success_total counter") != std::string::npos);
@@ -1600,11 +1608,117 @@ static void test_prometheus_naming_conventions() {
     }
 }
 
+// --- Prometheus with more than one inverter ---------------------------------------------
+//
+// Every inverter series carries a `device` label, the first one included. The alternative --
+// leaving device 1 unlabelled for back-compatibility, the way MQTT keeps its bridge-scoped
+// topics -- would have made `sum by (device)` produce a blank label forever (#36).
+
+static void test_every_inverter_series_carries_its_device_label() {
+    Rig r1;
+    Rig r2;
+    const auto a = r1.poll();
+    const auto b = r2.poll();
+    const auto text =
+        prometheus::buildMetrics({{"growatt_modbus-1", &a}, {"growatt_modbus-2", &b}},
+                                 makeBridge(), r1.diagnostics.snapshot());
+
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_power_watts{device=\"growatt_modbus-1\"} "
+                               "1842.000\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_power_watts{device=\"growatt_modbus-2\"} "
+                               "1842.000\n") != std::string::npos);
+    // Bridge-wide series stay unlabelled: the counters live in one Diagnostics for the bus.
+    TEST_ASSERT_TRUE(text.find("heliograph_uptime_seconds 86400\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_uptime_seconds{") == std::string::npos);
+}
+
+// HELP and TYPE appear once per metric family, whatever the device count. Repeating them per
+// series is a parse error in strict parsers -- the relay family already had a test for this,
+// and turning the inverter gauges into families made it apply to them too.
+static void test_help_and_type_appear_once_per_family_across_devices() {
+    Rig r1;
+    Rig r2;
+    const auto a = r1.poll();
+    const auto b = r2.poll();
+    const auto text =
+        prometheus::buildMetrics({{"growatt_modbus-1", &a}, {"growatt_modbus-2", &b}},
+                                 makeBridge(), r1.diagnostics.snapshot());
+
+    const std::string help = "# HELP heliograph_inverter_ac_power_watts";
+    size_t            count = 0;
+    for (size_t at = text.find(help); at != std::string::npos; at = text.find(help, at + 1)) {
+        ++count;
+    }
+    TEST_ASSERT_EQUAL_UINT32(1, count);
+}
+
+// A family no device reports is absent entirely -- not a bare HELP/TYPE header with no series
+// under it, which is what a lazily-written header exists to prevent.
+static void test_a_family_no_device_reports_has_no_header() {
+    Rig r;
+    DeviceContext ctx(r.driver, r.store, r.diagnostics, clockFn);
+    ctx.pollOnce();
+    r.device.offline = true;
+    for (int i = 0; i < 10; ++i) {
+        g_now += 10000;
+        ctx.pollOnce();
+    }
+    const auto text = metricsOf(*r.store.snapshot(), makeBridge(), r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("# HELP heliograph_inverter_ac_power_watts") == std::string::npos);
+    TEST_ASSERT_TRUE(text.find("# TYPE heliograph_inverter_ac_power_watts") == std::string::npos);
+}
+
+// --- Modbus TCP unit ids --------------------------------------------------------------------
+//
+// One unit id per inverter, consecutively from modbus.unit_id: the Modbus specification's Unit
+// Identifier is exactly the field for addressing a device behind a gateway, so a client needs
+// no vendor-specific arithmetic. Device 1 stays where it has always been.
+
+static modbus::ModbusServerConfig serverConfig(uint8_t base, uint8_t devices,
+                                               uint8_t diagnostics = 250) {
+    modbus::ModbusServerConfig cfg;
+    cfg.inverterUnitId    = base;
+    cfg.diagnosticsUnitId = diagnostics;
+    cfg.deviceCount       = devices;
+    return cfg;
+}
+
+static void test_each_device_gets_the_next_unit_id() {
+    modbus::ModbusTcpServer server(serverConfig(1, 3));
+    TEST_ASSERT_EQUAL_UINT8(3, server.servedDevices());
+    TEST_ASSERT_EQUAL_UINT8(1, server.unitIdFor(0));
+    TEST_ASSERT_EQUAL_UINT8(2, server.unitIdFor(1));
+    TEST_ASSERT_EQUAL_UINT8(3, server.unitIdFor(2));
+    TEST_ASSERT_EQUAL_UINT8(0, server.unitIdFor(3));  // not served
+}
+
+// A single-inverter bridge is served at exactly the unit id it always was, whatever the base.
+static void test_one_device_is_unchanged_at_the_configured_unit_id() {
+    modbus::ModbusTcpServer server(serverConfig(7, 1));
+    TEST_ASSERT_EQUAL_UINT8(1, server.servedDevices());
+    TEST_ASSERT_EQUAL_UINT8(7, server.unitIdFor(0));
+}
+
+// The run has to be unbroken: a client derives device N's unit id by adding, so skipping a
+// taken id and carrying on would leave a hole nothing can express. It stops instead, and
+// main() logs how many were dropped.
+static void test_the_run_stops_at_the_diagnostics_unit() {
+    modbus::ModbusTcpServer server(serverConfig(8, 4, 10));
+    TEST_ASSERT_EQUAL_UINT8(2, server.servedDevices());  // 8, 9; 10 is the diagnostics unit
+    TEST_ASSERT_EQUAL_UINT8(0, server.unitIdFor(2));
+}
+
+static void test_the_run_stops_at_the_last_valid_slave_address() {
+    // 247 is the last valid Modbus slave address; 248 and up are reserved.
+    modbus::ModbusTcpServer server(serverConfig(246, 4, 10));
+    TEST_ASSERT_EQUAL_UINT8(2, server.servedDevices());  // 246, 247
+}
+
 static void test_prometheus_build_info_carries_the_version() {
     Rig        r;
     const auto state = r.poll();
-    const auto text  = prometheus::buildMetrics(state, makeBridge(), r.diagnostics.snapshot());
-    TEST_ASSERT_TRUE(text.find("heliograph_build_info{version=\"0.1.0\",driver=\"eversolar_legacy\"") !=
+    const auto text  = metricsOf(state, makeBridge(), r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("heliograph_build_info{device=\"eversolar_legacy\",version=\"0.1.0\",driver=\"eversolar_legacy\"") !=
                      std::string::npos);
 }
 
@@ -1616,9 +1730,9 @@ static void test_the_mock_hybrid_also_exports() {
     DeviceContext ctx(driver, store, diag, clockFn);
     ctx.pollOnce();
 
-    const auto text = prometheus::buildMetrics(*store.snapshot(), makeBridge(), diag.snapshot());
+    const auto text = metricsOf(*store.snapshot(), makeBridge(), diag.snapshot());
     TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_power_watts") != std::string::npos);
-    TEST_ASSERT_TRUE(text.find("heliograph_build_info{version=\"0.1.0\",driver=\"mock_inverter\"") !=
+    TEST_ASSERT_TRUE(text.find("heliograph_build_info{device=\"eversolar_legacy\",version=\"0.1.0\",driver=\"mock_inverter\"") !=
                      std::string::npos);
 }
 
@@ -1712,6 +1826,13 @@ int main(int, char**) {
     RUN_TEST(test_prometheus_omits_ntp_timestamp_until_synced);
     RUN_TEST(test_prometheus_has_no_high_cardinality_labels);
     RUN_TEST(test_prometheus_naming_conventions);
+    RUN_TEST(test_every_inverter_series_carries_its_device_label);
+    RUN_TEST(test_help_and_type_appear_once_per_family_across_devices);
+    RUN_TEST(test_a_family_no_device_reports_has_no_header);
+    RUN_TEST(test_each_device_gets_the_next_unit_id);
+    RUN_TEST(test_one_device_is_unchanged_at_the_configured_unit_id);
+    RUN_TEST(test_the_run_stops_at_the_diagnostics_unit);
+    RUN_TEST(test_the_run_stops_at_the_last_valid_slave_address);
     RUN_TEST(test_prometheus_build_info_carries_the_version);
     RUN_TEST(test_the_mock_hybrid_also_exports);
     RUN_TEST(test_status_payload_reports_clock_sync_state);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1708,6 +1708,32 @@ static void test_the_run_stops_at_the_diagnostics_unit() {
     TEST_ASSERT_EQUAL_UINT8(0, server.unitIdFor(2));
 }
 
+// One map per served device -- not one per possible device. 900 registers is 1.8 KB apiece, so
+// reserving eight on a one-inverter bridge would be 14 KB of heap for nothing.
+static void test_maps_are_allocated_per_served_device() {
+    modbus::ModbusTcpServer three(serverConfig(1, 3));
+    TEST_ASSERT_EQUAL_UINT32(3, three.registerMapCount());
+    modbus::ModbusTcpServer one(serverConfig(1, 1));
+    TEST_ASSERT_EQUAL_UINT32(1, one.registerMapCount());
+}
+
+// ...but never zero. The diagnostics unit reads map 0, and a bridge with nothing polling is
+// exactly when someone scrapes it for uptime and heap. Before the per-device maps a single map
+// always existed, so refusing that read would be a quiet regression.
+static void test_the_diagnostics_unit_keeps_a_map_when_no_inverter_started() {
+    modbus::ModbusTcpServer server(serverConfig(1, 0));
+    TEST_ASSERT_EQUAL_UINT8(0, server.servedDevices());
+    TEST_ASSERT_EQUAL_UINT32(1, server.registerMapCount());
+}
+
+// Re-applying a configuration replaces the maps rather than accumulating them.
+static void test_reconfiguring_does_not_accumulate_maps() {
+    modbus::ModbusTcpServer server(serverConfig(1, 3));
+    TEST_ASSERT_TRUE(server.setConfig(serverConfig(1, 2)));
+    TEST_ASSERT_EQUAL_UINT32(2, server.registerMapCount());
+    TEST_ASSERT_EQUAL_UINT8(2, server.servedDevices());
+}
+
 static void test_the_run_stops_at_the_last_valid_slave_address() {
     // 247 is the last valid Modbus slave address; 248 and up are reserved.
     modbus::ModbusTcpServer server(serverConfig(246, 4, 10));
@@ -1833,6 +1859,9 @@ int main(int, char**) {
     RUN_TEST(test_one_device_is_unchanged_at_the_configured_unit_id);
     RUN_TEST(test_the_run_stops_at_the_diagnostics_unit);
     RUN_TEST(test_the_run_stops_at_the_last_valid_slave_address);
+    RUN_TEST(test_maps_are_allocated_per_served_device);
+    RUN_TEST(test_the_diagnostics_unit_keeps_a_map_when_no_inverter_started);
+    RUN_TEST(test_reconfiguring_does_not_accumulate_maps);
     RUN_TEST(test_prometheus_build_info_carries_the_version);
     RUN_TEST(test_the_mock_hybrid_also_exports);
     RUN_TEST(test_status_payload_reports_clock_sync_state);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -3,6 +3,9 @@
 
 #include <unity.h>
 
+#include <cmath>
+#include <cstring>
+
 #include <ArduinoJson.h>
 
 #include <string>
@@ -1710,6 +1713,79 @@ static void test_the_run_stops_at_the_diagnostics_unit() {
 
 // One map per served device -- not one per possible device. 900 registers is 1.8 KB apiece, so
 // reserving eight on a one-inverter bridge would be 14 KB of heap for nothing.
+// The routing itself, not just the arithmetic. Until readUnit() existed, "unit base+i returns
+// device i" lived in a worker inside #if defined(ESP32) -- so the one thing this feature is
+// about could only ever be checked by pointing a real Modbus client at real hardware (review).
+static void test_each_unit_id_reads_its_own_devices_registers() {
+    modbus::ModbusTcpServer server(serverConfig(1, 3));
+    Rig                     r;
+    DeviceState             a = r.poll();
+    DeviceState             b = a;
+    DeviceState             c = a;
+    // Distinct AC power per device, so a wrong map is visible rather than plausible.
+    b.measurements.set(measurement_id::kAcPowerTotal, 100.0, g_now);
+    c.measurements.set(measurement_id::kAcPowerTotal, 200.0, g_now);
+    server.refresh({&a, &b, &c}, makeBridge(), r.diagnostics.snapshot(), g_now);
+
+    const auto watts = [&server](uint8_t unit) {
+        uint16_t raw[2] = {0, 0};
+        TEST_ASSERT_TRUE(server.readUnit(unit, modbus::reg::kAcPowerTotal, 2, raw));
+        const uint32_t bits = (static_cast<uint32_t>(raw[0]) << 16) | raw[1];
+        float          f    = 0.0f;
+        std::memcpy(&f, &bits, sizeof(f));
+        return f;
+    };
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 1842.0f, watts(1));
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 100.0f, watts(2));
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 200.0f, watts(3));
+    // The diagnostics unit reads device 1, as it always has.
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 1842.0f, watts(250));
+}
+
+// A client with no unit-id field of its own sends 0 or 255. Both read device 1, so a
+// configuration copied from a single-inverter example works instead of erroring.
+static void test_unit_zero_and_255_read_the_first_device() {
+    modbus::ModbusTcpServer server(serverConfig(1, 2));
+    TEST_ASSERT_EQUAL_UINT32(0, server.mapIndexFor(0));
+    TEST_ASSERT_EQUAL_UINT32(0, server.mapIndexFor(255));
+    TEST_ASSERT_EQUAL_UINT32(0, server.mapIndexFor(250));  // diagnostics, unchanged
+    TEST_ASSERT_EQUAL_UINT32(1, server.mapIndexFor(2));
+}
+
+// A unit below the base has no map at all rather than falling back to device 1 -- silently
+// serving inverter 1 to a client that asked for something else is the failure to avoid.
+static void test_a_unit_below_the_base_has_no_map() {
+    modbus::ModbusTcpServer server(serverConfig(10, 2));
+    TEST_ASSERT_EQUAL_UINT32(modbus::ModbusTcpServer::kNoMap, server.mapIndexFor(9));
+    uint16_t raw[2] = {0, 0};
+    TEST_ASSERT_FALSE(server.readUnit(9, modbus::reg::kAcPowerTotal, 2, raw));
+    TEST_ASSERT_FALSE(server.readUnit(12, modbus::reg::kAcPowerTotal, 2, raw));  // past the run
+}
+
+// A configured device that did not start keeps its unit id, and that unit reports nothing
+// rather than the next inverter's readings. This is the whole reason the ids are keyed on the
+// configuration: skipping it would move every later inverter down one.
+static void test_a_slot_with_no_device_answers_with_no_readings() {
+    modbus::ModbusTcpServer server(serverConfig(1, 3));
+    Rig                     r;
+    const DeviceState       a = r.poll();
+    DeviceState             c = a;
+    c.measurements.set(measurement_id::kAcPowerTotal, 200.0, g_now);
+    // Device 2 did not start.
+    server.refresh({&a, nullptr, &c}, makeBridge(), r.diagnostics.snapshot(), g_now);
+
+    uint16_t raw[2] = {0, 0};
+    TEST_ASSERT_TRUE(server.readUnit(2, modbus::reg::kAcPowerTotal, 2, raw));
+    const uint32_t bits = (static_cast<uint32_t>(raw[0]) << 16) | raw[1];
+    float          f    = 0.0f;
+    std::memcpy(&f, &bits, sizeof(f));
+    TEST_ASSERT_TRUE_MESSAGE(std::isnan(f), "an unstarted slot must not serve a reading");
+    TEST_ASSERT_TRUE(server.readUnit(3, modbus::reg::kAcPowerTotal, 2, raw));
+    const uint32_t bits3 = (static_cast<uint32_t>(raw[0]) << 16) | raw[1];
+    std::memcpy(&f, &bits3, sizeof(f));
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 200.0f, f);  // device 3 did NOT move down to unit 2
+}
+
 static void test_maps_are_allocated_per_served_device() {
     modbus::ModbusTcpServer three(serverConfig(1, 3));
     TEST_ASSERT_EQUAL_UINT32(3, three.registerMapCount());
@@ -1859,6 +1935,10 @@ int main(int, char**) {
     RUN_TEST(test_one_device_is_unchanged_at_the_configured_unit_id);
     RUN_TEST(test_the_run_stops_at_the_diagnostics_unit);
     RUN_TEST(test_the_run_stops_at_the_last_valid_slave_address);
+    RUN_TEST(test_each_unit_id_reads_its_own_devices_registers);
+    RUN_TEST(test_unit_zero_and_255_read_the_first_device);
+    RUN_TEST(test_a_unit_below_the_base_has_no_map);
+    RUN_TEST(test_a_slot_with_no_device_answers_with_no_readings);
     RUN_TEST(test_maps_are_allocated_per_served_device);
     RUN_TEST(test_the_diagnostics_unit_keeps_a_map_when_no_inverter_started);
     RUN_TEST(test_reconfiguring_does_not_accumulate_maps);


### PR DESCRIPTION
Closes #36.

The bridge polls up to eight inverters and every other output carries all of them. These two still took a single `DeviceState`: a Modbus client saw inverter 1 and had no way to reach the rest, and `heliograph_inverter_ac_power_watts` was inverter 1's without saying so.

Both needed a dimension designed rather than a loop, and they did **not** make the same call about backwards compatibility. That is the point of the change, so it is spelled out below and in `docs/architecture.md`.

## Modbus TCP — one unit id per inverter

Device 1 at `modbus.unit_id`, device 2 at +1, and so on, in the same order as `/api/v1/devices`. With the defaults: units 1, 2, 3.

**The register map is unchanged and identical at every unit.** Point a client at a different unit id and everything is in the same place — no per-device offset, no address arithmetic.

That is what the specification's Unit Identifier is *for*: addressing a device on a serial sub-network behind a gateway. Any client that can set a slave/unit id already supports it, which is the whole requirement — nothing vendor-specific to teach it. The alternative in the issue, a register-block offset inside one unit id, would have made the map sparse and pushed arithmetic onto the client that no standard describes.

**Device 1 stays exactly where it was**, so an existing client keeps working untouched.

Three rules the mapping forces:

- **The run is consecutive and stops rather than skipping.** If the ids would reach the diagnostics unit or run past 247 — the last valid Modbus slave address — the devices beyond that are not served, and the boot log names which limit was hit, because the fix differs.
- **The unit id follows the CONFIGURATION, not what started.** A device that fails to start keeps its unit id and that unit answers `inverter_online = 0` with NaN readings. Skipping it would move every later inverter down one unit id — a client reading unit 2 would get inverter 3's watts with no way to notice.
- **Units 0 and 255 read device 1.** The MB/TCP specification calls the unit byte unused for a server that is not a gateway, and clients with no unit-id field send one of those two; Home Assistant's Modbus integration defaults to 0. Answering them is what makes a configuration copied from a single-inverter example work.

**Which unit is which inverter is discoverable**: one boot log line per device (`modbus: unit 2 -> growatt_modbus-2`) and `modbus_unit_id` on every entry of the `devices` array in `/api/v1/status`. Counting positions in the device list is wrong — that list omits devices that did not start, and the unit ids do not.

Maps are allocated per configured device at `setConfig`, under the map lock, and never fewer than one so the diagnostics unit always has something to serve.

## Prometheus — a `device` label on every inverter series

```
heliograph_inverter_ac_power_watts{device="growatt_modbus-1"} 1240.000
heliograph_inverter_ac_power_watts{device="growatt_modbus-2"} 980.500
```

The id is the same string `/api/v1/devices` serves, and the same one in the MQTT subtree for devices 2..N. Not for device 1, which keeps the bridge-scoped topics — so lining a Grafana panel up with a Home Assistant entity is a short lookup rather than a string match.

**The first device is labelled too, and that is a breaking change.** A query still matches, but it returns one series per inverter instead of one — a graph gains lines, and a recording rule expecting a single series needs `sum(...)` or `{device="…"}`. It was chosen over leaving device 1 unlabelled: MQTT made the opposite call for its topics, but there the cost of changing was a user's whole Home Assistant recorder history. Here it is one dashboard edit, weighed against an asymmetry that has to be explained forever and a `sum by (device)` with a blank label. `docs/prometheus.md` has a table of what breaks and what does not.

**Bridge-wide series stay unlabelled** — uptime, heap, WiFi, the poll and RS485 counters, relays and DRM. They are not per device: those counters live in one `Diagnostics` for the whole bus, and labelling them would invent a distinction the firmware does not make.

The inverter gauges became metric **families**, which changes how they render: HELP and TYPE are written once, lazily, before the first device that actually reports the channel. A header per device is a parse error in strict parsers; a header with no series under it is the same mistake in the other direction.

## Tests

**622 pass** (was 608). Fourteen new. Prometheus: every series carrying its label, bridge series not carrying one, HELP once per family across devices, a family no device reports having no header at all. Modbus: consecutive unit ids, one device unchanged at its configured unit id, the run stopping at the diagnostics unit and at 247, one map per configured device, never zero maps, reconfiguring replacing rather than accumulating, each unit id reading its **own** device's registers, units 0/255/250 reading device 1, a unit below the base having no map rather than falling back to device 1, and an unstarted slot answering NaN while the device after it stays put.

`readUnit()` exists so that last group is possible at all: the index arithmetic used to live in the eModbus worker, inside `#if defined(ESP32)`, so the one thing this feature is about was unreachable from a host test.

The `/metrics` text was also run through the real `prometheus_client` parser with three devices, one id containing a quote and a backslash: 28 families, 55 samples, no duplicate family, no duplicate series, labels round-trip, and the unlabelled set is exactly the bridge-wide metrics.

`check_layering.sh` PASS, all four boards build.

## What the reviews caught

Worth listing, because two of them were mine to have avoided:

- `setConfig` reallocated the map vector with **no lock** while `rs485Task` was already writing into it — a heap write-after-free on every boot with more than one device. The per-device maps created that hazard; on `main` it was a POD assignment.
- The unit ids were keyed on the compacted started-device list, so a device that failed to start renumbered every inverter after it. The second commit claimed to have closed this and had only made it positional *within* the compacted list.
- A second "first device only" comment in `main.cpp` survived the first commit, which claimed it was gone.
- The `device` label is **not** "the same string MQTT uses" — device 1 keeps the bridge-scoped topics, so lining Grafana up with Home Assistant is a lookup, not a string match. Corrected in the header and in `docs/prometheus.md`.

## Docs

The "first device only" notes are gone from the README, `docs/rest-api.md`, `docs/architecture.md`, `docs/growatt-mic-tl-x-protocol.md` and `main.cpp` — they were correct and would have become lies. `docs/architecture.md` gains a table of what each output did about device 1; `docs/modbus-register-map.md` and `docs/prometheus.md` document the two mappings, including the migration note.

## Not covered

- **Not verified against a real Modbus client on hardware.** The routing is host-tested through `readUnit()` now, which is the same call the worker makes, so what is left untested is eModbus's own unit dispatch. Still worth one pymodbus run against units 1, 2, 3 and 250 before trusting it in anger.
- **The poll and RS485 counters remain bridge-wide** in both outputs, because `Diagnostics` is. That is now said in both docs, including the awkward part: registers 52-58 sit *inside* the per-device block, where the layout suggests otherwise. Practical cost on a three-drop bus — when one inverter starts corrupting frames, the counter climbs and all three look equally guilty. A unit that drops out entirely is still identifiable. Per-device counters need a change to the diagnostics model.
- The diagnostics unit (250) serves device 1's map. Its own block is bridge-wide and identical at every unit, so nothing is lost, but it is not a fourth "device".
