### PR TITLE
build(relay-1ch): confirm N16R8 memory config on hardware

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -197,10 +197,11 @@ extends = esp32common
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
 board_build.partitions = partitions_16mb_ota.csv
-; UNVERIFIED: assumed N16R8 (octal PSRAM) by analogy with the RS485-CAN, never checked on
-; hardware -- nobody here owns this board. If a 1CH ever logs "octal_psram: PSRAM chip is
-; not connected" at boot, the module is a plain N16 and these two lines come out, exactly
-; as they did for the 6CH.
+; VERIFIED on hardware 2026-07-26 (board MAC 28:84:85:b2:e6:f0): the module IS an N16R8.
+; esptool reports 16MB flash + 8MB embedded octal PSRAM, and the firmware boots clean with
+; no "octal_psram: PSRAM chip is not connected" bailout -- which is exactly what the 6CH (a
+; plain N8, no PSRAM) logged on every boot before its config was corrected. So qio flash +
+; opi (octal) PSRAM is the right memory type here; these two lines stay.
 board_build.arduino.memory_type = qio_opi
 build_flags =
     ${esp32common.build_flags}


### PR DESCRIPTION
## Wat

De `waveshare-relay-1ch`-env droeg `qio_opi` + `BOARD_HAS_PSRAM` als **onbevestigde aanname** ("nobody here owns this board"). Er is nu een board binnen, en de aanname is gemeten en klopt — dus alleen de comment gaat van aanname → meting.

## Metingen (2026-07-26, board MAC `28:84:85:b2:e6:f0`)

- `esptool flash_id`: **16MB flash** + **Embedded PSRAM 8MB (octal)** → dit is een N16R8-klasse module
- Firmware boot **schoon**, **geen** `octal_psram: PSRAM chip is not connected`-bailout — precies de regel die de 6CH (een kale N8, géén PSRAM) elke boot logde vóór z'n config gestript werd
- 16MB matcht `partitions_16mb_ota.csv`; `qio` flash + `opi` (octal) PSRAM is dus correct

Config zelf wijzigt niet — `memory_type = qio_opi` en `-DBOARD_HAS_PSRAM` blijven staan, ze zijn nu geverifieerd i.p.v. aangenomen.

## Verificatie

- Geen firmware-wijziging; de env bouwt + flasht + boot bevestigd op hardware deze sessie (0.12.0, board-header `Waveshare ESP32-S3-Relay-1CH`, stabiel, geen reboot-loop/WDT/panic).
- `platformio.ini` is een build-input → de `firmware.yml`-matrix bouwt alle vier de boards op deze PR ter controle.
