### PR TITLE
Stop the boot log opening two hours in the past

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -901,6 +901,20 @@ void setup() {
     const auto loaded = g_store.load(g_config);
     // Apply the stored level before anything else logs, or the first lines ignore it.
     log::setLevel(g_config.logLevel);
+
+    // TZ before the FIRST log:: call, not merely before the RTC restore. formatLogTimestamp
+    // renders through localtime_r, so a stamped line written while TZ is unset comes out in
+    // UTC with nothing saying so. That is not hypothetical: a warm reset (OTA reboot, the
+    // reboot action) keeps the system clock across the restart, so the clock is already valid
+    // here and the config line below shipped an hour or two in the past on every OTA -- the
+    // exact boot whose log gets read. Seen on 0.13.0, 2026-07-26. A cold start hid it: the
+    // clock is not valid yet at this point, so the line carries an uptime stamp instead.
+    //
+    // This is as early as it can go. The zone comes out of the stored configuration, so the
+    // load above has to have happened -- which is fine, because nothing on that path logs.
+    setenv("TZ", g_config.ntp.timezone.c_str(), 1);
+    tzset();
+
     log::info("config: %s (log level %s)", loadResultName(loaded), logLevelName(g_config.logLevel));
     if (loaded == LoadResult::Corrupt || loaded == LoadResult::FutureVersion) {
         // Defaults, so the device lands in the setup portal. Better than running on values we
@@ -911,9 +925,7 @@ void setup() {
     // RTC restore, before anything else that logs at length: with a battery-backed
     // PCF85063 (board::kHasRtc) the system clock is valid from here on, so every log line
     // below carries a wall-clock timestamp even when the network never comes up -- which
-    // is exactly the boot you end up debugging. TZ first, so the timestamps render local.
-    setenv("TZ", g_config.ntp.timezone.c_str(), 1);
-    tzset();
+    // is exactly the boot you end up debugging.
     if (rtc::begin()) {
         time_t stored = 0;
         if (rtc::readUtc(stored)) {

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -74,6 +74,40 @@ else
     echo "OK"
 fi
 
+echo "==> 5. setup() applies TZ before it writes its first stamped log line"
+# formatLogTimestamp renders through localtime_r, so a log:: call made while TZ is still unset
+# comes out in UTC with nothing marking it as such. It shipped that way in 0.13.0: the config
+# line was written eleven lines above the tzset(), which nobody noticed because a COLD start
+# has no valid clock there and falls back to an uptime stamp. A warm reset (OTA reboot) keeps
+# the clock, so every OTA log opened with one line an hour or two in the past.
+#
+# Line order in setup() is the whole invariant, hence a positional check rather than a unit
+# test: main.cpp is not host-compilable, and the pure formatter is already covered in
+# test/test_logging.
+setup_start=$(grep -n '^void setup()' src/main.cpp | head -1 | cut -d: -f1)
+setup_end=$(grep -n '^void loop()' src/main.cpp | head -1 | cut -d: -f1)
+if [ -z "$setup_start" ] || [ -z "$setup_end" ]; then
+    echo "FAIL: could not locate setup()/loop() in src/main.cpp; this check needs updating"
+    status=1
+else
+    # Comment lines are stripped first: prose about log:: calls is not a log:: call.
+    tz_line=$(awk -v a="$setup_start" -v b="$setup_end" \
+        'NR>a && NR<b && $0 !~ /^[[:space:]]*\/\// && /tzset\(\)/ {print NR; exit}' src/main.cpp)
+    log_line=$(awk -v a="$setup_start" -v b="$setup_end" \
+        'NR>a && NR<b && $0 !~ /^[[:space:]]*\/\// && /log::(trace|debug|info|warn|error)\(/ {print NR; exit}' \
+        src/main.cpp)
+    if [ -z "$tz_line" ]; then
+        echo "FAIL: no tzset() in setup(); every stamped boot line would render in UTC"
+        status=1
+    elif [ -n "$log_line" ] && [ "$log_line" -lt "$tz_line" ]; then
+        echo "FAIL: src/main.cpp:$log_line logs before the tzset() on line $tz_line;"
+        echo "      that line renders in UTC after a warm reset, unmarked"
+        status=1
+    else
+        echo "OK"
+    fi
+fi
+
 echo
 if [ $status -eq 0 ]; then
     echo "RESULT: PASS"


### PR DESCRIPTION
Found while reading the boot log of 0.13.0 on the production bridge.

```
2026-07-26 10:26:51 [I] config: ok (log level info)
2026-07-26 12:26:51 [I] rtc: clock restored: 2026-07-26 12:26:51 (awaiting ntp for drift correction)
```

Same instant, two hours apart. `formatLogTimestamp` renders through
`localtime_r`, and `setup()` wrote that first line eleven lines before it
called `tzset()`, so it was formatted against an unset TZ and came out in UTC
with nothing saying so.

A cold start never showed it. The system clock is not valid at that point, so
the line falls back to an uptime stamp and the zone is irrelevant. A warm reset
keeps the clock across the restart, so it *is* valid there — which makes this
exactly the OTA-reboot log, the one you go and read after an update.

## The fix

Move `setenv("TZ")` / `tzset()` above the first `log::` call instead of merely
above the RTC restore. That is as early as it can go: the zone comes out of the
stored configuration, so the load has to have run first. Nothing on that load
path logs, so no line is left behind the move.

The comment that was already there said "TZ first, so the timestamps render
local" — it just sat below the line it was meant to protect.

## Guard

A positional check (`tools/check_layering.sh` rule 5) rather than a unit test:
line order inside `setup()` is the whole invariant, `main.cpp` is not
host-compilable, and the formatter's timezone handling is already covered by
`test/test_logging`. It strips comments first, so prose about `log::` calls is
not mistaken for one.

Mutation-tested against the previous commit's `main.cpp`:

```
==> 5. setup() applies TZ before it writes its first stamped log line
FAIL: src/main.cpp:904 logs before the tzset() on line 916;
      that line renders in UTC after a warm reset, unmarked
```

## Verification

- 622/622 native tests
- All five layering rules, profile schema, embedded JS, measurement ids
- `waveshare-rs485-can` builds

Not verified on hardware yet — that needs a flash and a warm reboot, and the
whole point of the bug is that only a warm reboot shows it.
