### PR TITLE
Clear the warnings, the dead code and the duplication

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -58,7 +58,6 @@ build_flags =
     ; header between both builds by design. Genuinely dead fields still surface in review
     ; and cppcheck; this only silences the false positives on local macOS builds.
     -Wno-unused-private-field
-    -DUNIT_TEST
     ; Unity compiles without double support by default; the measurement model is all doubles.
     -DUNITY_INCLUDE_DOUBLE
     -DUNITY_DOUBLE_PRECISION=1e-12

--- a/src/device/capability.cpp
+++ b/src/device/capability.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+#include "capability.h"
+
+namespace heliograph {
+
+const char* capabilityName(InverterCapability capability) {
+    switch (capability) {
+        case InverterCapability::ReadAcPower:              return "read_ac_power";
+        case InverterCapability::ReadAcVoltage:            return "read_ac_voltage";
+        case InverterCapability::ReadAcCurrent:            return "read_ac_current";
+        case InverterCapability::ReadGridFrequency:        return "read_grid_frequency";
+        case InverterCapability::ReadDcPower:              return "read_dc_power";
+        case InverterCapability::ReadDcVoltage:            return "read_dc_voltage";
+        case InverterCapability::ReadDcCurrent:            return "read_dc_current";
+        case InverterCapability::ReadEnergyToday:          return "read_energy_today";
+        case InverterCapability::ReadEnergyTotal:          return "read_energy_total";
+        case InverterCapability::ReadTemperature:          return "read_temperature";
+        case InverterCapability::ReadOperatingHours:       return "read_operating_hours";
+        case InverterCapability::ReadStatus:               return "read_status";
+        case InverterCapability::ReadErrors:               return "read_errors";
+        case InverterCapability::ReadMultiplePhases:       return "read_multiple_phases";
+        case InverterCapability::ReadMultipleMppts:        return "read_multiple_mppts";
+        case InverterCapability::ReadBatteryState:         return "read_battery_state";
+        case InverterCapability::SetActivePowerLimit:      return "set_active_power_limit";
+        case InverterCapability::SetExportLimit:           return "set_export_limit";
+        case InverterCapability::StartStop:                return "start_stop";
+        case InverterCapability::SetReactivePower:         return "set_reactive_power";
+        case InverterCapability::SetBatteryChargeLimit:    return "set_battery_charge_limit";
+        case InverterCapability::SetBatteryDischargeLimit: return "set_battery_discharge_limit";
+        case InverterCapability::SetBatteryOperatingMode:  return "set_battery_operating_mode";
+        case InverterCapability::SetMinimumSoc:            return "set_minimum_soc";
+        case InverterCapability::SetMaximumSoc:            return "set_maximum_soc";
+        case InverterCapability::SynchronizeTime:          return "synchronize_time";
+        case InverterCapability::_Count:                   break;
+    }
+    return "unknown";
+}
+
+}  // namespace heliograph

--- a/src/device/capability.h
+++ b/src/device/capability.h
@@ -63,6 +63,14 @@ enum class InverterCommandType : uint8_t {
 
 inline constexpr size_t kCommandTypeCount = static_cast<size_t>(InverterCommandType::_Count);
 
+/// Stable snake_case name for a capability, used in the MQTT and REST capabilities payloads.
+///
+/// Lives here, next to the enum, rather than in one of the output adapters. It spent a while in
+/// heliograph::mqtt, which meant the REST payload builder included outputs/mqtt/mqtt_payloads.h
+/// for nothing else -- an output adapter reaching into a sibling adapter to name a value out of
+/// the device model. Its two siblings, commandTypeName and unitSymbol, were always here.
+const char* capabilityName(InverterCapability capability);
+
 /// Bounds for a writable numeric property. Validated centrally by the dispatcher so that
 /// every driver gets range checking without implementing it.
 struct NumericCapability {

--- a/src/device/device_context.cpp
+++ b/src/device/device_context.cpp
@@ -5,7 +5,7 @@
 namespace heliograph {
 
 DeviceContext::DeviceContext(InverterDriver& driver, StateStore& store, Diagnostics& diagnostics,
-                             ClockFn clock, PollPolicy policy)
+                             ClockFn clock, const PollPolicy& policy)
     : driver_(driver),
       store_(store),
       diagnostics_(diagnostics),

--- a/src/device/device_context.h
+++ b/src/device/device_context.h
@@ -29,7 +29,7 @@ struct PollPolicy {
 class DeviceContext {
 public:
     DeviceContext(InverterDriver& driver, StateStore& store, Diagnostics& diagnostics,
-                  ClockFn clock, PollPolicy policy = {});
+                  ClockFn clock, const PollPolicy& policy = {});
 
     /// One poll attempt. Publishes a new snapshot either way, so that consumers always see
     /// current liveness even while the device is unreachable.

--- a/src/diagnostics/logger.cpp
+++ b/src/diagnostics/logger.cpp
@@ -98,8 +98,12 @@ void traceHex(const char* prefix, const uint8_t* data, size_t len) {
     // output that itself takes the device down.
     constexpr size_t kMaxBytes = 64;
     const size_t     n         = len < kMaxBytes ? len : kMaxBytes;
-    char             line[3 * kMaxBytes + 1];
-    size_t           pos = 0;
+    // Initialised, not merely written by the loop below: at len == 0 that loop does not run and
+    // an uninitialised buffer would go to trace("%s"), printing stack bytes until it happened to
+    // hit a NUL. Two of the three callers guard with `received > 0`, but Rs485Transport::write
+    // passes the number of bytes it actually wrote -- which is 0 when the UART write fails.
+    char   line[3 * kMaxBytes + 1] = {};
+    size_t pos                     = 0;
     for (size_t i = 0; i < n; ++i) {
         pos += static_cast<size_t>(snprintf(line + pos, sizeof(line) - pos, "%02X ", data[i]));
     }

--- a/src/drivers/discovery_engine.cpp
+++ b/src/drivers/discovery_engine.cpp
@@ -39,15 +39,22 @@ std::vector<std::string> addressesFor(const DriverDescriptor& descriptor, Discov
     if (mode != DiscoveryMode::Extended || !descriptor.hasSweepableAddress()) {
         return {std::string{}};
     }
-    const std::string        def = descriptor.optionOr(DriverOptions{}, descriptor.addressOptionKey);
     const auto               bounds = descriptor.addressRange();
     std::vector<std::string> out;
     // The driver's own default first -- but only if the driver would accept it. A default
     // outside its own declared bounds would be probed, reported, offered by the wizard, and
     // then refused by the PATCH gate: a dead end on the confirm step.
+    //
+    // The PARSED value is pushed, not the declared string. Same thing for every driver today
+    // ("1", "10", "40000"), but a default written "007" would otherwise be offered verbatim --
+    // and the PATCH gate refuses a padded number precisely so a typed value is never silently
+    // rewritten, so the wizard would propose an address the confirm step then rejects. That is
+    // the dead end the paragraph above exists to prevent. It also keeps the dedupe below
+    // honest: the sweep compares against std::to_string(address), so "007" and "7" would have
+    // been probed as two separate candidates for one address.
     long parsedDefault = 0;
     if (descriptor.numericOption(DriverOptions{}, descriptor.addressOptionKey, parsedDefault)) {
-        out.push_back(def);
+        out.push_back(std::to_string(parsedDefault));
     }
     for (const int address : config.sweepAddresses) {
         // Outside what the driver declares is not a gap in the sweep, it is a value the driver

--- a/src/drivers/discovery_engine.cpp
+++ b/src/drivers/discovery_engine.cpp
@@ -45,8 +45,8 @@ std::vector<std::string> addressesFor(const DriverDescriptor& descriptor, Discov
     // The driver's own default first -- but only if the driver would accept it. A default
     // outside its own declared bounds would be probed, reported, offered by the wizard, and
     // then refused by the PATCH gate: a dead end on the confirm step.
-    const long parsedDefault = std::strtol(def.c_str(), nullptr, 10);
-    if (!def.empty() && parsedDefault >= bounds.first && parsedDefault <= bounds.second) {
+    long parsedDefault = 0;
+    if (descriptor.numericOption(DriverOptions{}, descriptor.addressOptionKey, parsedDefault)) {
         out.push_back(def);
     }
     for (const int address : config.sweepAddresses) {

--- a/src/drivers/driver_descriptor.h
+++ b/src/drivers/driver_descriptor.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdlib>
 #include <map>
 #include <string>
 #include <utility>
@@ -108,29 +110,29 @@ struct DriverDescriptor {
     /// Extended discovery sweeps this option; nothing else reads it.
     std::string addressOptionKey;
 
+    /// The option declared under this key, or nullptr. Every other lookup below goes through
+    /// here; four separate hand-rolled searches over the same vector is three too many.
+    const DriverOption* findOption(const std::string& key) const {
+        const auto it = std::find_if(options.begin(), options.end(),
+                                     [&](const DriverOption& o) { return o.key == key; });
+        return it == options.end() ? nullptr : &*it;
+    }
+
     /// True when addressOptionKey names a declared, numeric option -- the only shape a sweep can
     /// use. A key naming nothing, or naming an enum, would otherwise be swept over values the
     /// driver never accepts.
     bool hasSweepableAddress() const {
-        if (addressOptionKey.empty()) {
-            return false;
-        }
-        for (const auto& o : options) {
-            if (o.key == addressOptionKey) {
-                return o.isNumeric() && !o.defaultValue.empty();
-            }
-        }
-        return false;
+        const DriverOption* o = addressOptionKey.empty() ? nullptr : findOption(addressOptionKey);
+        return o != nullptr && o->isNumeric() && !o->defaultValue.empty();
     }
 
     /// The declared bounds of addressOptionKey. Only meaningful when hasSweepableAddress().
     std::pair<long, long> addressRange() const {
-        for (const auto& o : options) {
-            if (o.key == addressOptionKey && o.isNumeric()) {
-                return {o.minValue, o.maxValue};
-            }
+        const DriverOption* o = findOption(addressOptionKey);
+        if (o == nullptr || !o->isNumeric()) {
+            return {0, 0};
         }
-        return {0, 0};
+        return {o->minValue, o->maxValue};
     }
 
     /// Looks up an option value, falling back to the declared default.
@@ -138,12 +140,47 @@ struct DriverDescriptor {
         if (const auto it = values.find(key); it != values.end()) {
             return it->second;
         }
-        for (const auto& o : options) {
-            if (o.key == key) {
-                return o.defaultValue;
-            }
+        const DriverOption* o = findOption(key);
+        return o == nullptr ? std::string{} : o->defaultValue;
+    }
+
+    /// Reads a numeric option and checks it against the bounds the option ITSELF declares.
+    ///
+    /// This is the whole point: every driver factory used to re-state its own option's range as
+    /// a literal (`parsed >= 1 && parsed <= 247` beside a DriverOption{…, 1, 247}), so each
+    /// bound lived in two places and three of the four pairs had already drifted -- SunSpec's
+    /// base_address accepted 65535 that the descriptor refused, and the mock's day length had
+    /// no upper bound at all despite declaring one. A driver now writes its range once, in the
+    /// descriptor, where the REST gate and the settings page read it too.
+    ///
+    /// True with `out` filled when the stored value -- or, absent that, the declared default --
+    /// is a whole decimal number inside the declared range. False with `out` untouched when the
+    /// option is unknown, not numeric, empty, not a number, or out of range.
+    ///
+    /// Deliberately NOT the stricter parse validateDriverOptions applies: that one also refuses
+    /// " 7", "+7" and "007" so a typed value is never silently rewritten. That is a rule about
+    /// what a user may SUBMIT. This is a rule about what the firmware may READ back out of a
+    /// config written by an older build, and refusing to boot a driver over a leading zero
+    /// would be the wrong trade.
+    bool numericOption(const DriverOptions& values, const std::string& key, long& out) const {
+        const DriverOption* option = findOption(key);
+        if (option == nullptr || !option->isNumeric()) {
+            return false;
         }
-        return {};
+        const std::string value = optionOr(values, key);
+        if (value.empty()) {
+            return false;
+        }
+        char*      end    = nullptr;
+        const long parsed = std::strtol(value.c_str(), &end, 10);  // base 10: "010" is ten
+        if (end == value.c_str() || *end != '\0') {
+            return false;
+        }
+        if (parsed < option->minValue || parsed > option->maxValue) {
+            return false;
+        }
+        out = parsed;
+        return true;
     }
 };
 

--- a/src/drivers/driver_registry.cpp
+++ b/src/drivers/driver_registry.cpp
@@ -49,13 +49,7 @@ const char* pollResultName(PollResult result) {
 bool validateDriverOptions(const DriverDescriptor& descriptor, const DriverOptions& values,
                            DriverOptionError& error) {
     for (const auto& [key, value] : values) {
-        const DriverOption* option = nullptr;
-        for (const auto& o : descriptor.options) {
-            if (o.key == key) {
-                option = &o;
-                break;
-            }
-        }
+        const DriverOption* option = descriptor.findOption(key);
         if (option == nullptr) {
             error = {key, "unknown option for driver '" + descriptor.id + "'"};
             return false;

--- a/src/drivers/eversolar_legacy/eversolar_parser.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_parser.cpp
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#include "protocols/byte_order.h"
 #include "protocols/pmu/pmu_protocol.h"  // kRegisterAck
 
 namespace heliograph::eversolar {
@@ -71,15 +72,16 @@ std::string toTrimmedString(const uint8_t* data, size_t len) {
 
 }  // namespace
 
-uint16_t readWord(const uint8_t* data, size_t index) {
-    const size_t o = index * 2;
-    return static_cast<uint16_t>((data[o] << 8) | data[o + 1]);
-}
+// Word-indexed, unlike bytes::be16 -- this protocol numbers its payload in 16-bit registers,
+// and every call site below reads better as a register number than as a byte offset.
+uint16_t readWord(const uint8_t* data, size_t index) { return bytes::be16(data, index * 2); }
 
 int16_t readSignedWord(const uint8_t* data, size_t index) {
-    return static_cast<int16_t>(readWord(data, index));
+    return bytes::be16s(data, index * 2);
 }
 
+// Not bytes::be32: the two halves are not adjacent. Several layouts put the high and low words
+// at unrelated register numbers, which is why this takes two indices.
 uint32_t readDoubleWord(const uint8_t* data, size_t highIndex, size_t lowIndex) {
     return (static_cast<uint32_t>(readWord(data, highIndex)) << 16) | readWord(data, lowIndex);
 }

--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -4,7 +4,6 @@
 #include "growatt_driver.h"
 
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 
 #include "diagnostics/logger.h"
@@ -46,17 +45,15 @@ void traceBlock(uint8_t unitId, RegSpace space, uint16_t start, uint16_t count,
 
 GrowattOptions optionsFrom(const heliograph::DriverOptions& values) {
     GrowattOptions o;
-    const std::string unit = descriptor().optionOr(values, "unit_id");
-    if (!unit.empty()) {
-        const long parsed = strtol(unit.c_str(), nullptr, 10);
-        if (parsed >= 1 && parsed <= 247) {  // valid Modbus unit id range
-            o.unitId = static_cast<uint8_t>(parsed);
-        } else {
-            // Config validation only length-checks option strings, so a typo lands here.
-            // Falling back silently would poll the wrong slave with no clue why it is silent.
-            log::warn("GROWATT unit_id '%s' invalid (want 1-247), using %u", unit.c_str(),
-                      static_cast<unsigned>(o.unitId));
-        }
+    // Range comes from the descriptor's own DriverOption, not from a literal repeated here.
+    long unit = 0;
+    if (descriptor().numericOption(values, "unit_id", unit)) {
+        o.unitId = static_cast<uint8_t>(unit);
+    } else {
+        // Falling back silently would poll the wrong slave with no clue why it is silent.
+        log::warn("GROWATT unit_id '%s' invalid, using %u",
+                  descriptor().optionOr(values, "unit_id").c_str(),
+                  static_cast<unsigned>(o.unitId));
     }
     const std::string profileId = descriptor().optionOr(values, "profile");
     if (!profileId.empty()) {

--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -4,8 +4,9 @@
 
 #include <chrono>
 #include <cmath>
-#include <cstdlib>
 #include <string>
+
+#include "diagnostics/logger.h"
 
 namespace heliograph::mock {
 namespace {
@@ -93,11 +94,17 @@ const DriverDescriptor& writableDescriptor() {
 MockOptions optionsFrom(const heliograph::DriverOptions& values, bool writable) {
     MockOptions out;
     out.writable = writable;
-    const std::string minutes =
-        (writable ? writableDescriptor() : readOnlyDescriptor()).optionOr(values, "day_length_minutes");
-    const long parsed = std::strtol(minutes.c_str(), nullptr, 10);
-    if (parsed > 0) {
-        out.dayLengthMs = static_cast<uint64_t>(parsed) * 60ULL * 1000ULL;
+    // The 1-1440 range comes from the descriptor row, which is where it was declared and never
+    // enforced: this parser only checked `> 0`, so the one driver everybody has compiled in was
+    // the one whose declared bound meant nothing.
+    const DriverDescriptor& d = writable ? writableDescriptor() : readOnlyDescriptor();
+    long minutes = 0;
+    if (d.numericOption(values, "day_length_minutes", minutes)) {
+        out.dayLengthMs = static_cast<uint64_t>(minutes) * 60ULL * 1000ULL;
+    } else {
+        log::warn("MOCK day_length_minutes '%s' invalid, using %llu minutes",
+                  d.optionOr(values, "day_length_minutes").c_str(),
+                  static_cast<unsigned long long>(out.dayLengthMs / 60000ULL));
     }
     return out;
 }

--- a/src/drivers/mock/mock_driver.h
+++ b/src/drivers/mock/mock_driver.h
@@ -65,9 +65,6 @@ public:
     /// untestable without hardware.
     BusErrorCounts       busErrors() const override { return busErrors_; }
 
-    void setOptions(const MockOptions& options) { options_ = options; }
-    const MockOptions& options() const { return options_; }
-
     /// Last value accepted by execute(), so tests can prove a command reached the driver
     /// instead of only that it was not rejected.
     double lastAcceptedValue() const { return lastAcceptedValue_; }

--- a/src/drivers/solax_x1/solax_driver.cpp
+++ b/src/drivers/solax_x1/solax_driver.cpp
@@ -3,7 +3,6 @@
 
 #include "solax_driver.h"
 
-#include <cstdlib>
 #include <cstring>
 #include <string>
 
@@ -25,17 +24,13 @@ constexpr uint8_t kTimeoutsBeforeRecoveryProbe = 3;
 
 SolaxOptions optionsFrom(const heliograph::DriverOptions& values) {
     SolaxOptions out;
-    const std::string addr = solax::descriptor().optionOr(values, "address");
-    if (!addr.empty()) {
-        // Base 10, not 0: auto-detection would silently read "010" as octal 8 (a valid
-        // address, so no warning would fire). Same pattern as the growatt unit_id parse.
-        const long parsed = strtol(addr.c_str(), nullptr, 10);
-        if (parsed >= 0x01 && parsed <= 0xFE) {
-            out.assignedAddress = static_cast<uint8_t>(parsed);
-        } else {
-            log::warn("SOLAX address '%s' invalid (want 1-254), using 0x%02X", addr.c_str(),
-                      out.assignedAddress);
-        }
+    // Range comes from the descriptor's own DriverOption, not from a literal repeated here.
+    long addr = 0;
+    if (solax::descriptor().numericOption(values, "address", addr)) {
+        out.assignedAddress = static_cast<uint8_t>(addr);
+    } else {
+        log::warn("SOLAX address '%s' invalid, using 0x%02X",
+                  solax::descriptor().optionOr(values, "address").c_str(), out.assignedAddress);
     }
     return out;
 }

--- a/src/drivers/solax_x1/solax_parser.cpp
+++ b/src/drivers/solax_x1/solax_parser.cpp
@@ -3,30 +3,15 @@
 
 #include "solax_parser.h"
 
+#include "protocols/byte_order.h"
+
 namespace heliograph::solax {
 namespace {
 
-uint16_t u16At(const uint8_t* data, size_t offset) {
-    return static_cast<uint16_t>((data[offset] << 8) | data[offset + 1]);
-}
-
-int16_t s16At(const uint8_t* data, size_t offset) {
-    return static_cast<int16_t>(u16At(data, offset));
-}
-
-uint32_t u32BigAt(const uint8_t* data, size_t offset) {
-    return (static_cast<uint32_t>(data[offset]) << 24) |
-           (static_cast<uint32_t>(data[offset + 1]) << 16) |
-           (static_cast<uint32_t>(data[offset + 2]) << 8) |
-           static_cast<uint32_t>(data[offset + 3]);
-}
-
-uint32_t u32LittleAt(const uint8_t* data, size_t offset) {
-    return static_cast<uint32_t>(data[offset]) |
-           (static_cast<uint32_t>(data[offset + 1]) << 8) |
-           (static_cast<uint32_t>(data[offset + 2]) << 16) |
-           (static_cast<uint32_t>(data[offset + 3]) << 24);
-}
+using bytes::be16;
+using bytes::be16s;
+using bytes::be32;
+using bytes::le32;
 
 /// Fixed-width space/NUL-padded ASCII field -> trimmed string. Non-printable bytes are
 /// dropped rather than copied, so a corrupt field cannot smuggle control characters into
@@ -54,22 +39,22 @@ DecodeResult decodeStatusReport(const uint8_t* data, size_t len, StatusReport& o
         return DecodeResult::TooShort;
     }
     out                = StatusReport{};
-    out.temperatureC   = static_cast<double>(s16At(data, 0));
-    out.energyTodayKwh = u16At(data, 2) * 0.1;
-    out.pv1Voltage     = u16At(data, 4) * 0.1;
-    out.pv2Voltage     = u16At(data, 6) * 0.1;
-    out.pv1Current     = u16At(data, 8) * 0.1;
-    out.pv2Current     = u16At(data, 10) * 0.1;
-    out.acCurrent      = u16At(data, 12) * 0.1;
-    out.acVoltage      = u16At(data, 14) * 0.1;
-    out.frequencyHz    = u16At(data, 16) * 0.01;
-    out.acPowerW       = static_cast<double>(u16At(data, 18));
+    out.temperatureC   = static_cast<double>(be16s(data, 0));
+    out.energyTodayKwh = be16(data, 2) * 0.1;
+    out.pv1Voltage     = be16(data, 4) * 0.1;
+    out.pv2Voltage     = be16(data, 6) * 0.1;
+    out.pv1Current     = be16(data, 8) * 0.1;
+    out.pv2Current     = be16(data, 10) * 0.1;
+    out.acCurrent      = be16(data, 12) * 0.1;
+    out.acVoltage      = be16(data, 14) * 0.1;
+    out.frequencyHz    = be16(data, 16) * 0.01;
+    out.acPowerW       = static_cast<double>(be16(data, 18));
     // offset 20 unused per the reference.
-    out.energyTotalKwh = u32BigAt(data, 22) * 0.1;
-    out.runtimeHours   = u32BigAt(data, 26);
-    out.mode           = u16At(data, 30);
+    out.energyTotalKwh = be32(data, 22) * 0.1;
+    out.runtimeHours   = be32(data, 26);
+    out.mode           = be16(data, 30);
     // offsets 32-44: protection thresholds, deliberately not decoded (see header).
-    out.errorBits = u32LittleAt(data, 46);
+    out.errorBits = le32(data, 46);
     return DecodeResult::Ok;
 }
 

--- a/src/drivers/sunspec/descriptor.cpp
+++ b/src/drivers/sunspec/descriptor.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-#include <cstdlib>
-
+#include "diagnostics/logger.h"
 #include "sunspec_driver.h"
 
 namespace heliograph::sunspec {
@@ -61,15 +60,23 @@ std::unique_ptr<InverterDriver> factory(Transport& transport, const DriverOption
     const DriverDescriptor& d = descriptor();
     SunspecOptions          o;
 
-    // Base 10 explicitly on both: strtol with base 0 reads a leading zero as octal, which
-    // turned a driver option into a different number once already in this project.
-    const long unit = std::strtol(d.optionOr(options, "unit_id").c_str(), nullptr, 10);
-    if (unit >= 1 && unit <= 247) {
+    // Both ranges come from the descriptor's own DriverOption rows. They used to be restated
+    // here as literals, and had already drifted: base_address was accepted up to 0xFFFF here
+    // while the declaration says 65534, for the documented reason that the 'SunS' marker is
+    // two registers wide. The declaration wins.
+    long unit = 0;
+    if (d.numericOption(options, "unit_id", unit)) {
         o.unitId = static_cast<uint8_t>(unit);
+    } else {
+        log::warn("SUNSPEC unit_id '%s' invalid, using %u",
+                  d.optionOr(options, "unit_id").c_str(), static_cast<unsigned>(o.unitId));
     }
-    const long base = std::strtol(d.optionOr(options, "base_address").c_str(), nullptr, 10);
-    if (base >= 0 && base <= 0xFFFF) {
+    long base = 0;
+    if (d.numericOption(options, "base_address", base)) {
         o.baseAddress = static_cast<uint16_t>(base);
+    } else {
+        log::warn("SUNSPEC base_address '%s' invalid, using %u",
+                  d.optionOr(options, "base_address").c_str(), static_cast<unsigned>(o.baseAddress));
     }
     return std::make_unique<SunspecDriver>(o);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,14 +219,16 @@ void applySerialOverride() {
     const auto& p = g_config.serial.profile;
     if (g_transport.configure(p)) {
         Serial.printf("[serial] override: %u baud, %u data bits, %s parity, %u stop\n",
-                      p.baudRate, p.dataBits, parityName(p.parity), p.stopBits);
+                      static_cast<unsigned>(p.baudRate), static_cast<unsigned>(p.dataBits),
+                      parityName(p.parity), static_cast<unsigned>(p.stopBits));
     } else {
         // configure() opens the UART before the direction-pin setup that is the only thing
         // that can fail, so on this path the line IS at the override's speed and framing --
         // what is missing is half-duplex direction control. Saying "the line is still at the
         // driver's setting" would have sent the reader to the wrong hypothesis entirely.
         Serial.printf("[serial] override applied at %u baud, but RS485 direction control "
-                      "failed to configure; transmissions may collide\n", p.baudRate);
+                      "failed to configure; transmissions may collide\n",
+                      static_cast<unsigned>(p.baudRate));
     }
 }
 
@@ -398,7 +400,7 @@ void initOnboardIndicators() {
         digitalWrite(board::kBuzzerPin, LOW);
     }
     if (board::kHasStatusLed) {
-        neopixelWrite(board::kStatusLedPin, 0, 0, 0);  // dark until the first health reading
+        rgbLedWrite(board::kStatusLedPin, 0, 0, 0);  // dark until the first health reading
     }
 }
 
@@ -439,11 +441,14 @@ void driveStatusLed(const status::LedIndication& ind) {
         case status::LedColor::Blue:  b = 40; break;
         case status::LedColor::Off:   break;
     }
-    // Channel order: this WS2812 lights the RED element from neopixelWrite's SECOND argument,
+    // Channel order: this WS2812 lights the RED element from rgbLedWrite's SECOND argument,
     // not the first -- a plain "green" (0,40,0) came out red on the first 6CH hardware run
-    // (2026-07-23). So swap red and green here; blue is unaffected. neopixelWrite's own GRB
+    // (2026-07-23). So swap red and green here; blue is unaffected. rgbLedWrite's own GRB
     // timing conversion is fine, it is the element mapping on this board that is transposed.
-    neopixelWrite(board::kStatusLedPin, g, r, b);
+    //
+    // rgbLedWrite, not neopixelWrite: the latter is [[deprecated]] in Arduino core 3.x and is
+    // now a thin forwarder to this one. Same signature, same behaviour.
+    rgbLedWrite(board::kStatusLedPin, g, r, b);
 }
 
 /// One call per loop pass: sample BOOT, act on a completed hold, and refresh the LED.

--- a/src/network/wifi_manager.cpp
+++ b/src/network/wifi_manager.cpp
@@ -13,7 +13,7 @@
 
 namespace heliograph {
 
-WifiManager::WifiManager(ProvisioningPolicy policy) : policy_(policy) {}
+WifiManager::WifiManager(const ProvisioningPolicy& policy) : policy_(policy) {}
 
 namespace {
 
@@ -243,7 +243,7 @@ void WifiManager::loop(uint64_t nowMs) {
 
 namespace heliograph {
 
-WifiManager::WifiManager(ProvisioningPolicy policy) : policy_(policy) {}
+WifiManager::WifiManager(const ProvisioningPolicy& policy) : policy_(policy) {}
 void        WifiManager::begin(const Configuration& config) { config_ = config; }
 void        WifiManager::loop(uint64_t) {}
 bool        WifiManager::connected() const { return false; }

--- a/src/network/wifi_manager.h
+++ b/src/network/wifi_manager.h
@@ -25,7 +25,7 @@ namespace heliograph {
 
 class WifiManager {
 public:
-    WifiManager(ProvisioningPolicy policy = {});
+    explicit WifiManager(const ProvisioningPolicy& policy = {});
 
     void setDiagnostics(Diagnostics* diagnostics) { diagnostics_ = diagnostics; }
 

--- a/src/outputs/json_util.h
+++ b/src/outputs/json_util.h
@@ -10,6 +10,9 @@
 #include <string>
 
 #include "device/bridge_info.h"
+#include "device/capability.h"
+#include "device/command.h"
+#include "device/device_state.h"
 #include "diagnostics/log_timestamp.h"
 
 namespace heliograph::json_util {
@@ -70,6 +73,95 @@ inline void addClockFields(JsonObject obj, const BridgeInfo& bridge) {
         obj["ntp_server"]        = nullptr;
         obj["ntp_server_source"] = nullptr;
     }
+}
+
+/// One measurement entry: `{"value": …, "unit": …, "valid": …, "stale": …[, "derived": true]}`.
+///
+/// null, never 0, for anything not currently usable. Home Assistant maps null to "unknown" and
+/// keeps it out of the statistics; a zero is recorded as a genuine reading, so a dead inverter
+/// would drag an energy average down all night. The rule is identical in MQTT and REST because
+/// it is the same promise to the same consumer -- it lived in both files until this became one.
+inline void writeMeasurement(JsonObject entry, const Measurement& m) {
+    if (m.valid && !m.stale) {
+        entry["value"] = m.value;
+    } else {
+        entry["value"] = nullptr;
+    }
+    entry["unit"]  = unitSymbol(m.unit);
+    entry["valid"] = m.valid;
+    entry["stale"] = m.stale;
+    if (m.derived) {
+        entry["derived"] = true;
+    }
+}
+
+/// The `status_code` / `status_text` / `error_code` triplet, under the same absent-as-null rule.
+///
+/// A protocol with no error-code field must not report 0: that reads as "no fault". A driver
+/// with no status text must not report "": the UI renders that as a blank tile rather than as
+/// "this protocol does not say".
+inline void writeDeviceStatus(JsonObject obj, const DeviceState& state) {
+    const bool usable = state.dataValid && !state.dataStale;
+    if (state.statusCodeSupported && usable) {
+        obj["status_code"] = state.statusCode;
+        if (state.statusText.empty()) {
+            obj["status_text"] = nullptr;
+        } else {
+            obj["status_text"] = state.statusText;
+        }
+    } else {
+        obj["status_code"] = nullptr;
+        obj["status_text"] = nullptr;
+    }
+    if (state.errorCodeSupported && usable) {
+        obj["error_code"] = state.errorCode;
+    } else {
+        obj["error_code"] = nullptr;
+    }
+}
+
+/// The capabilities document, byte-for-byte the same over MQTT and REST.
+///
+/// `maxBytes` has no default on purpose: the two outputs cap their payloads differently
+/// (mqtt::kMaxPayloadBytes vs rest::kMaxResponseBytes) and that difference is deliberate, so
+/// each caller states its own ceiling rather than inheriting whichever one was written first.
+inline bool buildCapabilitiesPayload(const InverterCapabilities& capabilities, std::string& out,
+                                     size_t maxBytes) {
+    JsonDocument doc;
+    doc["read_only"]   = capabilities.isReadOnly();
+    doc["phase_count"] = capabilities.phaseCount;
+    doc["mppt_count"]  = capabilities.mpptCount;
+    doc["has_battery"] = capabilities.hasBattery;
+
+    JsonArray read = doc["read"].to<JsonArray>();
+    for (size_t i = 0; i < kCapabilityCount; ++i) {
+        if (capabilities.read.test(i)) {
+            read.add(capabilityName(static_cast<InverterCapability>(i)));
+        }
+    }
+    JsonArray write = doc["write"].to<JsonArray>();
+    for (size_t i = 0; i < kCapabilityCount; ++i) {
+        if (capabilities.write.test(i)) {
+            write.add(capabilityName(static_cast<InverterCapability>(i)));
+        }
+    }
+    // Numeric bounds, so a client can render a writable driver's min/max/step for bring-up
+    // rather than only discover that the command exists.
+    JsonObject numeric = doc["numeric"].to<JsonObject>();
+    for (size_t i = 0; i < kCommandTypeCount; ++i) {
+        const NumericCapability& cap = capabilities.numeric[i];
+        if (!cap.supported) {
+            continue;
+        }
+        JsonObject entry = numeric[commandTypeName(static_cast<InverterCommandType>(i))]
+                               .to<JsonObject>();
+        entry["writable"] = cap.writable;
+        entry["minimum"]  = cap.minimum;
+        entry["maximum"]  = cap.maximum;
+        entry["step"]     = cap.step;
+        entry["unit"]     = unitSymbol(cap.unit);
+    }
+    return finish(doc, out, maxBytes);
 }
 
 }  // namespace heliograph::json_util

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -73,7 +73,6 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
                 std::string("mqtt disconnected: ") +
                 espMqttClientTypes::disconnectReasonToString(reason));
         }
-        lastDisconnectReason_ = static_cast<uint8_t>(reason);
     });
 
     relayCount_ = bridge.relayCount;

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -7,6 +7,7 @@
 
 #include "home_assistant_discovery.h"
 #include "mqtt_payloads.h"
+#include "outputs/json_util.h"
 #include "relays/drm.h"
 
 #include <cstring>
@@ -202,7 +203,7 @@ void MqttOutput::onConnected(Channel& channel, const DeviceState& state,
     if (buildIdentityPayload(state.identity, payload)) {
         g_client.publish(channel.topics.identity().c_str(), 1, true, payload.c_str());
     }
-    if (buildCapabilitiesPayload(state.capabilities, payload)) {
+    if (json_util::buildCapabilitiesPayload(state.capabilities, payload, kMaxPayloadBytes)) {
         g_client.publish(channel.topics.capabilities().c_str(), 1, true, payload.c_str());
     }
     publishDiscovery(channel, state, bridge);

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -49,7 +49,7 @@ struct MqttConfig {
 
 class MqttOutput {
 public:
-    MqttOutput(MqttConfig config, PublishPolicy publishPolicy = {});
+    explicit MqttOutput(MqttConfig config, PublishPolicy publishPolicy = {});
 
     /// Sets up the client and starts connecting. Non-blocking.
     bool begin(const BridgeInfo& bridge);

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -165,9 +165,6 @@ private:
     uint64_t nextReconnectMs_    = 0;
     /// Exponential back-off, capped. An unreachable broker must not turn into a busy loop.
     uint32_t reconnectDelayMs_ = 1000;
-    /// espMqttClientTypes::DisconnectReason of the last drop, for diagnostics. Atomic:
-    /// written by onDisconnect on the library's task, read from the caller's task.
-    std::atomic<uint8_t> lastDisconnectReason_{0};
     /// Set by onDisconnect (library task), consumed by loop() (caller's task): forces a
     /// throttle reset and a discovery republish after a reconnect, because retained
     /// messages may not have survived the broker outage. The disconnect callback itself
@@ -198,9 +195,6 @@ private:
     /// re-announce discovery and re-ack state -- "applied immediately" would otherwise
     /// only be true after the next reconnect (self-review of PR #3).
     uint64_t lastRelayRolesSig_ = 0;
-
-public:
-    uint8_t lastDisconnectReason() const { return lastDisconnectReason_; }
 };
 
 inline constexpr uint32_t kMaxReconnectDelayMs = 60000;

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -39,7 +39,11 @@ bool buildStatePayload(const DeviceState& state, std::string& out, size_t maxByt
         }
         writeMeasurement(measurements[m.id].to<JsonObject>(), m);
     }
-    writeDeviceStatus(root, state);
+    // Re-taken rather than reusing `root` from above: `root` was captured before the whole
+    // measurements object was built, and whether a JsonObject handle survives the document
+    // growing is an ArduinoJson internal nobody should have to be sure about to read this.
+    // Re-taking costs nothing and matches what the REST builder does.
+    writeDeviceStatus(doc.as<JsonObject>(), state);
 
     return finish(doc, out, maxBytes);
 }

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -12,41 +12,10 @@ namespace {
 
 using json_util::addOptional;
 using json_util::finish;
+using json_util::writeDeviceStatus;
+using json_util::writeMeasurement;
 
 }  // namespace
-
-const char* capabilityName(InverterCapability capability) {
-    switch (capability) {
-        case InverterCapability::ReadAcPower:              return "read_ac_power";
-        case InverterCapability::ReadAcVoltage:            return "read_ac_voltage";
-        case InverterCapability::ReadAcCurrent:            return "read_ac_current";
-        case InverterCapability::ReadGridFrequency:        return "read_grid_frequency";
-        case InverterCapability::ReadDcPower:              return "read_dc_power";
-        case InverterCapability::ReadDcVoltage:            return "read_dc_voltage";
-        case InverterCapability::ReadDcCurrent:            return "read_dc_current";
-        case InverterCapability::ReadEnergyToday:          return "read_energy_today";
-        case InverterCapability::ReadEnergyTotal:          return "read_energy_total";
-        case InverterCapability::ReadTemperature:          return "read_temperature";
-        case InverterCapability::ReadOperatingHours:       return "read_operating_hours";
-        case InverterCapability::ReadStatus:               return "read_status";
-        case InverterCapability::ReadErrors:               return "read_errors";
-        case InverterCapability::ReadMultiplePhases:       return "read_multiple_phases";
-        case InverterCapability::ReadMultipleMppts:        return "read_multiple_mppts";
-        case InverterCapability::ReadBatteryState:         return "read_battery_state";
-        case InverterCapability::SetActivePowerLimit:      return "set_active_power_limit";
-        case InverterCapability::SetExportLimit:           return "set_export_limit";
-        case InverterCapability::StartStop:                return "start_stop";
-        case InverterCapability::SetReactivePower:         return "set_reactive_power";
-        case InverterCapability::SetBatteryChargeLimit:    return "set_battery_charge_limit";
-        case InverterCapability::SetBatteryDischargeLimit: return "set_battery_discharge_limit";
-        case InverterCapability::SetBatteryOperatingMode:  return "set_battery_operating_mode";
-        case InverterCapability::SetMinimumSoc:            return "set_minimum_soc";
-        case InverterCapability::SetMaximumSoc:            return "set_maximum_soc";
-        case InverterCapability::SynchronizeTime:          return "synchronize_time";
-        case InverterCapability::_Count:                   break;
-    }
-    return "unknown";
-}
 
 bool buildStatePayload(const DeviceState& state, std::string& out, size_t maxBytes) {
     JsonDocument doc;
@@ -68,44 +37,9 @@ bool buildStatePayload(const DeviceState& state, std::string& out, size_t maxByt
         if (!m.supported) {
             continue;  // the driver never provides this; do not mention it at all
         }
-        JsonObject entry = measurements[m.id].to<JsonObject>();
-        const bool usable = m.valid && !m.stale;
-        if (usable) {
-            entry["value"] = m.value;
-        } else {
-            // null, never 0. Home Assistant maps this to "unknown" and keeps it out of the
-            // statistics; a zero would be recorded as a genuine reading.
-            entry["value"] = nullptr;
-        }
-        entry["unit"]  = unitSymbol(m.unit);
-        entry["valid"] = m.valid;
-        entry["stale"] = m.stale;
-        if (m.derived) {
-            entry["derived"] = true;
-        }
+        writeMeasurement(measurements[m.id].to<JsonObject>(), m);
     }
-
-    const bool statusUsable = state.dataValid && !state.dataStale;
-    if (state.statusCodeSupported && statusUsable) {
-        doc["status_code"] = state.statusCode;
-        // Absent-as-null, mirroring the REST payload: a driver with no status text for its
-        // protocol must not surface as an empty string in Home Assistant.
-        if (state.statusText.empty()) {
-            doc["status_text"] = nullptr;
-        } else {
-            doc["status_text"] = state.statusText;
-        }
-    } else {
-        doc["status_code"] = nullptr;
-        doc["status_text"] = nullptr;
-    }
-
-    if (state.errorCodeSupported && statusUsable) {
-        doc["error_code"] = state.errorCode;
-    } else {
-        // A protocol with no error code field must not report 0: that asserts "no fault".
-        doc["error_code"] = nullptr;
-    }
+    writeDeviceStatus(root, state);
 
     return finish(doc, out, maxBytes);
 }
@@ -167,44 +101,6 @@ bool buildIdentityPayload(const DeviceIdentity& identity, std::string& out, size
     addOptional(root, "protocol_version", identity.protocolVersion);
     addOptional(root, "driver_id", identity.driverId);
     root["device_id"] = identity.deviceId();
-    return finish(doc, out, maxBytes);
-}
-
-bool buildCapabilitiesPayload(const InverterCapabilities& capabilities, std::string& out,
-                              size_t maxBytes) {
-    JsonDocument doc;
-    doc["read_only"]   = capabilities.isReadOnly();
-    doc["phase_count"] = capabilities.phaseCount;
-    doc["mppt_count"]  = capabilities.mpptCount;
-    doc["has_battery"] = capabilities.hasBattery;
-
-    JsonArray read = doc["read"].to<JsonArray>();
-    for (size_t i = 0; i < kCapabilityCount; ++i) {
-        if (capabilities.read.test(i)) {
-            read.add(capabilityName(static_cast<InverterCapability>(i)));
-        }
-    }
-    JsonArray write = doc["write"].to<JsonArray>();
-    for (size_t i = 0; i < kCapabilityCount; ++i) {
-        if (capabilities.write.test(i)) {
-            write.add(capabilityName(static_cast<InverterCapability>(i)));
-        }
-    }
-
-    JsonObject numeric = doc["numeric"].to<JsonObject>();
-    for (size_t i = 0; i < kCommandTypeCount; ++i) {
-        const NumericCapability& cap = capabilities.numeric[i];
-        if (!cap.supported) {
-            continue;
-        }
-        const auto type  = static_cast<InverterCommandType>(i);
-        JsonObject entry = numeric[commandTypeName(type)].to<JsonObject>();
-        entry["writable"] = cap.writable;
-        entry["minimum"]  = cap.minimum;
-        entry["maximum"]  = cap.maximum;
-        entry["step"]     = cap.step;
-        entry["unit"]     = unitSymbol(cap.unit);
-    }
     return finish(doc, out, maxBytes);
 }
 

--- a/src/outputs/mqtt/mqtt_payloads.h
+++ b/src/outputs/mqtt/mqtt_payloads.h
@@ -41,10 +41,4 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& diagnostics, const Bridg
 bool buildIdentityPayload(const DeviceIdentity& identity, std::string& out,
                           size_t maxBytes = kMaxPayloadBytes);
 
-bool buildCapabilitiesPayload(const InverterCapabilities& capabilities, std::string& out,
-                              size_t maxBytes = kMaxPayloadBytes);
-
-/// Stable snake_case name for a capability, used in the capabilities payload and the REST API.
-const char* capabilityName(InverterCapability capability);
-
 }  // namespace heliograph::mqtt

--- a/src/outputs/mqtt/publish_policy.cpp
+++ b/src/outputs/mqtt/publish_policy.cpp
@@ -6,7 +6,7 @@
 
 namespace heliograph::mqtt {
 
-PublishThrottle::PublishThrottle(PublishPolicy policy) : policy_(policy) {}
+PublishThrottle::PublishThrottle(const PublishPolicy& policy) : policy_(policy) {}
 
 double PublishThrottle::deadbandFor(MeasurementType type) const {
     switch (type) {

--- a/src/outputs/mqtt/publish_policy.h
+++ b/src/outputs/mqtt/publish_policy.h
@@ -32,7 +32,7 @@ struct PublishPolicy {
 /// Tracks what was last published and answers whether the current state differs enough.
 class PublishThrottle {
 public:
-    explicit PublishThrottle(PublishPolicy policy = {});
+    explicit PublishThrottle(const PublishPolicy& policy = {});
 
     /// True when `state` should be published now.
     ///

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -22,12 +22,10 @@ void appendHelp(std::string& out, const char* name, const char* help, const char
     out += '\n';
 }
 
-void appendValue(std::string& out, const char* name, double value) {
-    char buf[64];
-    std::snprintf(buf, sizeof(buf), "%s %.3f\n", name, value);
-    out += buf;
-}
-
+// Only the integral overloads exist. Every bridge-level metric is a counter, a gauge of bytes
+// or a 0/1 flag; the one place a double would be wanted -- a measurement -- goes through
+// appendDeviceValue below, which formats its own. A `double` overload shipped here unused and
+// unnoticed until -Wunused-function caught it; add one back the day something needs it.
 void appendValue(std::string& out, const char* name, unsigned long value) {
     char buf[64];
     std::snprintf(buf, sizeof(buf), "%s %lu\n", name, value);

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -14,6 +14,7 @@
 
 #include "diagnostics/log_buffer.h"
 #include "diagnostics/logger.h"
+#include "outputs/json_util.h"
 #include "outputs/prometheus/prometheus_metrics.h"
 #include "outputs/rest/rest_payloads.h"
 #include "config/configuration_store.h"
@@ -398,7 +399,8 @@ bool RestApi::begin() {
         } else if (sub == "measurements") {
             ok = buildMeasurementsPayload(*snapshot, body);
         } else if (sub == "capabilities") {
-            ok = buildCapabilitiesPayload(snapshot->capabilities, body);
+            ok = json_util::buildCapabilitiesPayload(snapshot->capabilities, body,
+                                                     kMaxResponseBytes);
         } else {
             sendError(request, {404, "not_found", "no such endpoint"});
             return;

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -86,7 +86,7 @@ struct RestContext {
 
 class RestApi {
 public:
-    RestApi(RestContext context, uint16_t port = 80);
+    explicit RestApi(RestContext context, uint16_t port = 80);
     ~RestApi();
 
     RestApi(const RestApi&)            = delete;

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -6,29 +6,14 @@
 
 #include "outputs/json_util.h"
 #include "relays/drm.h"
-#include "outputs/mqtt/mqtt_payloads.h"  // capabilityName, shared vocabulary
 
 namespace heliograph::rest {
 namespace {
 
 using json_util::addOptional;
 using json_util::finish;
-
-/// One measurement, with the same null-not-zero rule the MQTT payload uses.
-void writeMeasurement(JsonObject entry, const Measurement& m) {
-    const bool usable = m.valid && !m.stale;
-    if (usable) {
-        entry["value"] = m.value;
-    } else {
-        entry["value"] = nullptr;
-    }
-    entry["unit"]  = unitSymbol(m.unit);
-    entry["valid"] = m.valid;
-    entry["stale"] = m.stale;
-    if (m.derived) {
-        entry["derived"] = true;
-    }
-}
+using json_util::writeDeviceStatus;
+using json_util::writeMeasurement;
 
 }  // namespace
 
@@ -176,25 +161,7 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
         writeMeasurement(measurements[m.id].to<JsonObject>(), m);
     }
 
-    const bool statusUsable = state.dataValid && !state.dataStale;
-    if (state.statusCodeSupported && statusUsable) {
-        doc["status_code"] = state.statusCode;
-        // Empty means the driver has no text for this protocol -- same rule as identity
-        // fields: absent-as-null, never an empty string the UI would render as a blank tile.
-        if (state.statusText.empty()) {
-            doc["status_text"] = nullptr;
-        } else {
-            doc["status_text"] = state.statusText;
-        }
-    } else {
-        doc["status_code"] = nullptr;
-        doc["status_text"] = nullptr;
-    }
-    if (state.errorCodeSupported && statusUsable) {
-        doc["error_code"] = state.errorCode;
-    } else {
-        doc["error_code"] = nullptr;
-    }
+    writeDeviceStatus(doc.as<JsonObject>(), state);
 
     // Every polled device, and the totals over them. The `device` block above is the first
     // device and stays that way for compatibility, but nothing that presents itself as the
@@ -331,44 +298,6 @@ bool buildMeasurementsPayload(const DeviceState& state, std::string& out, size_t
         entry["display_name"] = m.displayName;
         writeMeasurement(entry, m);
         entry["timestamp_ms"] = m.timestampMs;
-    }
-    return finish(doc, out, maxBytes);
-}
-
-bool buildCapabilitiesPayload(const InverterCapabilities& capabilities, std::string& out,
-                              size_t maxBytes) {
-    JsonDocument doc;
-    doc["read_only"]   = capabilities.isReadOnly();
-    doc["phase_count"] = capabilities.phaseCount;
-    doc["mppt_count"]  = capabilities.mpptCount;
-    doc["has_battery"] = capabilities.hasBattery;
-
-    JsonArray read = doc["read"].to<JsonArray>();
-    for (size_t i = 0; i < kCapabilityCount; ++i) {
-        if (capabilities.read.test(i)) {
-            read.add(mqtt::capabilityName(static_cast<InverterCapability>(i)));
-        }
-    }
-    JsonArray write = doc["write"].to<JsonArray>();
-    for (size_t i = 0; i < kCapabilityCount; ++i) {
-        if (capabilities.write.test(i)) {
-            write.add(mqtt::capabilityName(static_cast<InverterCapability>(i)));
-        }
-    }
-    // Numeric bounds, matching the MQTT capabilities payload -- so a REST/web client can render
-    // a writable driver's min/max/step for bring-up, not just discover the command exists.
-    JsonObject numeric = doc["numeric"].to<JsonObject>();
-    for (size_t i = 0; i < kCommandTypeCount; ++i) {
-        const NumericCapability& cap = capabilities.numeric[i];
-        if (!cap.supported) {
-            continue;
-        }
-        JsonObject entry  = numeric[commandTypeName(static_cast<InverterCommandType>(i))].to<JsonObject>();
-        entry["writable"] = cap.writable;
-        entry["minimum"]  = cap.minimum;
-        entry["maximum"]  = cap.maximum;
-        entry["step"]     = cap.step;
-        entry["unit"]     = unitSymbol(cap.unit);
     }
     return finish(doc, out, maxBytes);
 }

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -104,9 +104,6 @@ bool buildDevicePayload(const DeviceState& state, const std::string& deviceId,
 bool buildMeasurementsPayload(const DeviceState& state, std::string& out,
                               size_t maxBytes = kMaxResponseBytes);
 
-bool buildCapabilitiesPayload(const InverterCapabilities& capabilities, std::string& out,
-                              size_t maxBytes = kMaxResponseBytes);
-
 bool buildDiagnosticsPayload(const DiagnosticsSnapshot& diagnostics, const BridgeInfo& bridge,
                              std::string& out, size_t maxBytes = kMaxResponseBytes);
 

--- a/src/protocols/byte_order.h
+++ b/src/protocols/byte_order.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+//
+// Reading and writing multi-byte integers out of a wire buffer.
+//
+// Every protocol here packs its numbers big-endian on the wire, and four separate places had
+// written their own shifts to unpack them: two vendor payload parsers, the Modbus RTU codec
+// (getBe16/putBe16, plus a hand-inlined little-endian read for the CRC field) and the PMU
+// framing (a shift expression spelled out at the checksum). Identical arithmetic, four
+// vocabularies, and a name like `u16At` that does not say which end comes first.
+//
+// Host-compilable and brand-free by construction: no Arduino, no ESP-IDF, no driver knowledge.
+// It sits in src/protocols/ because that is the one place both the drivers and the codecs
+// already depend on.
+//
+// Offsets are in BYTES. A protocol that indexes by 16-bit register multiplies by two at its own
+// call site, where the register number is the meaningful unit.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace heliograph::bytes {
+
+/// Unsigned 16-bit, most significant byte first.
+inline uint16_t be16(const uint8_t* data, size_t offset = 0) {
+    return static_cast<uint16_t>((static_cast<uint16_t>(data[offset]) << 8) | data[offset + 1]);
+}
+
+/// Signed 16-bit, most significant byte first. Two's complement, which every protocol here uses.
+inline int16_t be16s(const uint8_t* data, size_t offset = 0) {
+    return static_cast<int16_t>(be16(data, offset));
+}
+
+/// Unsigned 16-bit, least significant byte first. Rare: Modbus RTU frames are big-endian
+/// throughout EXCEPT their trailing CRC, which goes out low byte first.
+inline uint16_t le16(const uint8_t* data, size_t offset = 0) {
+    return static_cast<uint16_t>(static_cast<uint16_t>(data[offset + 1]) << 8 | data[offset]);
+}
+
+/// Unsigned 32-bit, most significant byte first.
+inline uint32_t be32(const uint8_t* data, size_t offset = 0) {
+    return (static_cast<uint32_t>(be16(data, offset)) << 16) | be16(data, offset + 2);
+}
+
+/// Unsigned 32-bit, least significant byte first.
+inline uint32_t le32(const uint8_t* data, size_t offset = 0) {
+    return (static_cast<uint32_t>(le16(data, offset + 2)) << 16) | le16(data, offset);
+}
+
+/// Writes an unsigned 16-bit value most significant byte first. Caller guarantees two bytes.
+inline void putBe16(uint8_t* out, uint16_t value) {
+    out[0] = static_cast<uint8_t>((value >> 8) & 0xFF);
+    out[1] = static_cast<uint8_t>(value & 0xFF);
+}
+
+/// Writes an unsigned 16-bit value least significant byte first. Caller guarantees two bytes.
+inline void putLe16(uint8_t* out, uint16_t value) {
+    out[0] = static_cast<uint8_t>(value & 0xFF);
+    out[1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+}
+
+}  // namespace heliograph::bytes

--- a/src/protocols/modbus/modbus_rtu.cpp
+++ b/src/protocols/modbus/modbus_rtu.cpp
@@ -2,32 +2,25 @@
 
 #include "modbus_rtu.h"
 
+#include "protocols/byte_order.h"
+
 namespace heliograph::modbus {
 namespace {
 
 /// Appends the CRC of the first `len` bytes at out[len], low byte first (Modbus wire order),
 /// and returns the new length. Caller guarantees room for two more bytes.
 size_t appendCrc(uint8_t* out, size_t len) {
-    const uint16_t crc = crc16(out, len);
-    out[len]     = static_cast<uint8_t>(crc & 0xFF);
-    out[len + 1] = static_cast<uint8_t>((crc >> 8) & 0xFF);
+    bytes::putLe16(out + len, crc16(out, len));  // Modbus sends the CRC low byte first
     return len + 2;
 }
 
-void putBe16(uint8_t* out, uint16_t v) {
-    out[0] = static_cast<uint8_t>((v >> 8) & 0xFF);
-    out[1] = static_cast<uint8_t>(v & 0xFF);
-}
-
-uint16_t getBe16(const uint8_t* in) {
-    return static_cast<uint16_t>((static_cast<uint16_t>(in[0]) << 8) | in[1]);
-}
+using bytes::be16;
+using bytes::putBe16;
 
 bool crcOk(const uint8_t* buf, size_t len) {
-    // len includes the trailing two CRC bytes.
-    const uint16_t expected = crc16(buf, len - 2);
-    const uint16_t actual   = static_cast<uint16_t>(buf[len - 2] | (buf[len - 1] << 8));
-    return expected == actual;
+    // len includes the trailing two CRC bytes. The CRC is the one little-endian field in an
+    // otherwise big-endian frame -- hence le16 here and be16 everywhere else.
+    return crc16(buf, len - 2) == bytes::le16(buf, len - 2);
 }
 
 }  // namespace
@@ -160,7 +153,7 @@ ParseResult parseReadResponse(const uint8_t* buf, size_t len, uint8_t expectedUn
         return ParseResult::Malformed;
     }
     for (size_t i = 0; i < registers; ++i) {
-        regsOut[i] = getBe16(buf + 3 + i * 2);
+        regsOut[i] = be16(buf + 3 + i * 2);
     }
     out.unitId        = buf[0];
     out.functionCode  = buf[1];
@@ -207,8 +200,8 @@ ParseResult parseWriteResponse(const uint8_t* buf, size_t len, uint8_t expectedU
     }
     out.unitId       = buf[0];
     out.functionCode = buf[1];
-    out.address      = getBe16(buf + 2);
-    out.value        = getBe16(buf + 4);
+    out.address      = be16(buf + 2);
+    out.value        = be16(buf + 4);
     return ParseResult::Ok;
 }
 

--- a/src/protocols/pmu/pmu_protocol.cpp
+++ b/src/protocols/pmu/pmu_protocol.cpp
@@ -3,6 +3,8 @@
 
 #include "pmu_protocol.h"
 
+#include "protocols/byte_order.h"
+
 namespace heliograph::pmu {
 
 uint16_t checksum(const uint8_t* data, size_t len) {
@@ -55,9 +57,7 @@ BuildResult buildRequestFrom(Address     source,
     }
 
     // Checksum covers every byte up to and including the payload, header included.
-    const uint16_t sum = checksum(out, kOffsetData + dataLen);
-    out[kOffsetData + dataLen]     = static_cast<uint8_t>(sum >> 8);
-    out[kOffsetData + dataLen + 1] = static_cast<uint8_t>(sum & 0xFF);
+    bytes::putBe16(out + kOffsetData + dataLen, checksum(out, kOffsetData + dataLen));
 
     outLength = frameLen;
     return BuildResult::Ok;
@@ -89,8 +89,7 @@ ParseResult parseFrame(const uint8_t* buf, size_t len, Frame& out) {
     }
 
     const uint16_t calculated = checksum(buf, kOffsetData + dataLen);
-    const uint16_t received =
-        static_cast<uint16_t>((buf[kOffsetData + dataLen] << 8) | buf[kOffsetData + dataLen + 1]);
+    const uint16_t received = bytes::be16(buf, kOffsetData + dataLen);
     if (calculated != received) {
         // Header and length byte were consistent up to this point, so the length is good
         // enough for resync: report it so the caller can skip the whole corrupt frame

--- a/src/transport/transport.cpp
+++ b/src/transport/transport.cpp
@@ -4,17 +4,6 @@
 
 namespace heliograph {
 
-const char* transportTypeName(TransportType type) {
-    switch (type) {
-        case TransportType::Rs485: return "rs485";
-        case TransportType::Rs232: return "rs232";
-        case TransportType::Can:   return "can";
-        case TransportType::Tcp:   return "tcp";
-        case TransportType::Mock:  return "mock";
-    }
-    return "unknown";
-}
-
 const char* parityName(SerialParity parity) {
     switch (parity) {
         case SerialParity::None: return "none";

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -17,8 +17,6 @@ namespace heliograph {
 
 enum class TransportType : uint8_t { Rs485, Rs232, Can, Tcp, Mock };
 
-const char* transportTypeName(TransportType type);
-
 struct TransportStats {
     uint32_t bytesWritten   = 0;
     uint32_t bytesRead      = 0;

--- a/test/test_commands/test_main.cpp
+++ b/test/test_commands/test_main.cpp
@@ -545,6 +545,7 @@ int main(int, char**) {
     RUN_TEST(test_a_mode_command_without_a_selection_is_refused);
     RUN_TEST(test_a_mode_command_with_a_selection_reaches_the_driver);
 
+    RUN_TEST(test_start_is_never_throttled);
     RUN_TEST(test_a_limit_at_its_maximum_still_pays_for_a_token);
     RUN_TEST(test_run_state_commands_are_spaced_but_never_starved);
     RUN_TEST(test_stop_is_not_starved_by_restricting_traffic);

--- a/test/test_driver_registry/test_main.cpp
+++ b/test/test_driver_registry/test_main.cpp
@@ -331,6 +331,89 @@ static void test_a_range_starting_at_zero_is_still_numeric() {
     TEST_ASSERT_FALSE(validateDriverOptions(d, {{"base_address", "65535"}}, e));
 }
 
+// --- numericOption: the read-back path, deliberately not the same rule as the gate above -----
+
+// The gate refuses what a user TYPES. This is what the firmware READS back out of a stored
+// config, and the two must not be confused: refusing to start a driver over a leading zero
+// written by an older build would be the wrong answer.
+static void test_numeric_option_reads_a_value_inside_the_declared_range() {
+    const auto d = boundedDescriptor();
+    long       out = 0;
+    TEST_ASSERT_TRUE(d.numericOption({{"unit_id", "7"}}, "unit_id", out));
+    TEST_ASSERT_EQUAL_INT32(7, out);
+    TEST_ASSERT_TRUE(d.numericOption({{"unit_id", "1"}}, "unit_id", out));
+    TEST_ASSERT_EQUAL_INT32(1, out);
+    TEST_ASSERT_TRUE(d.numericOption({{"unit_id", "247"}}, "unit_id", out));
+    TEST_ASSERT_EQUAL_INT32(247, out);
+}
+
+// The whole point of the change: the range comes from the DriverOption row, so a factory can
+// no longer disagree with its own declaration.
+static void test_numeric_option_refuses_what_the_declaration_refuses() {
+    const auto d = boundedDescriptor();
+    long       out = 99;
+    TEST_ASSERT_FALSE(d.numericOption({{"unit_id", "0"}}, "unit_id", out));
+    TEST_ASSERT_FALSE(d.numericOption({{"unit_id", "248"}}, "unit_id", out));
+    TEST_ASSERT_EQUAL_INT32(99, out);  // untouched on refusal, so the caller keeps its default
+}
+
+// strtol alone reads "12abc" as 12 and stops. That is how a typo becomes a plausible unit id.
+static void test_numeric_option_refuses_trailing_garbage_and_non_numbers() {
+    const auto d = boundedDescriptor();
+    long       out = 99;
+    TEST_ASSERT_FALSE(d.numericOption({{"unit_id", "12abc"}}, "unit_id", out));
+    TEST_ASSERT_FALSE(d.numericOption({{"unit_id", "one"}}, "unit_id", out));
+    TEST_ASSERT_FALSE(d.numericOption({{"unit_id", ""}}, "unit_id", out));
+    TEST_ASSERT_EQUAL_INT32(99, out);
+}
+
+// Accepted here and refused by the gate, on purpose. Also base 10 explicitly: "010" is ten,
+// not eight -- strtol with base 0 would read it as octal.
+static void test_numeric_option_accepts_a_padded_number_the_gate_would_refuse() {
+    const auto        d = boundedDescriptor();
+    DriverOptionError e;
+    TEST_ASSERT_FALSE(validateDriverOptions(d, {{"unit_id", "010"}}, e));
+
+    long out = 0;
+    TEST_ASSERT_TRUE(d.numericOption({{"unit_id", "010"}}, "unit_id", out));
+    TEST_ASSERT_EQUAL_INT32(10, out);
+}
+
+// Absent means "use what the driver declared", which is how every factory gets its default.
+static void test_numeric_option_falls_back_to_the_declared_default() {
+    const auto d = boundedDescriptor();
+    long       out = 0;
+    TEST_ASSERT_TRUE(d.numericOption({}, "unit_id", out));
+    TEST_ASSERT_EQUAL_INT32(1, out);  // boundedDescriptor declares "1"
+}
+
+// A key that names nothing, and a key that names a free-form option, are both refusals rather
+// than a lenient parse of whatever string happens to be stored there.
+static void test_numeric_option_refuses_unknown_and_non_numeric_keys() {
+    DriverDescriptor d;
+    d.id      = "mixed";
+    d.options = {DriverOption{"note", "Note", "", "42", {}}};  // no bounds -> free-form
+    long out  = 99;
+    TEST_ASSERT_FALSE(d.numericOption({{"note", "42"}}, "note", out));
+    TEST_ASSERT_FALSE(d.numericOption({{"nope", "1"}}, "nope", out));
+    TEST_ASSERT_EQUAL_INT32(99, out);
+}
+
+// A range that legitimately starts at zero must read back too, not just validate -- this is
+// the SunSpec base register, and it is the pair that had drifted.
+static void test_numeric_option_handles_a_range_starting_at_zero() {
+    DriverDescriptor d;
+    d.id      = "based";
+    d.options = {DriverOption{"base_address", "Base", "", "40000", {}, 0, 65534}};
+    long out  = 99;
+    TEST_ASSERT_TRUE(d.numericOption({{"base_address", "0"}}, "base_address", out));
+    TEST_ASSERT_EQUAL_INT32(0, out);
+    TEST_ASSERT_TRUE(d.numericOption({{"base_address", "65534"}}, "base_address", out));
+    TEST_ASSERT_EQUAL_INT32(65534, out);
+    TEST_ASSERT_FALSE(d.numericOption({{"base_address", "65535"}}, "base_address", out));
+    TEST_ASSERT_EQUAL_INT32(65534, out);
+}
+
 static void test_an_unbounded_option_stays_free_form() {
     DriverDescriptor d;
     d.id      = "free";
@@ -362,5 +445,12 @@ int main(int, char**) {
     RUN_TEST(test_a_factory_built_mock_has_a_running_clock);
     RUN_TEST(test_driver_ids_are_stable_strings);
     RUN_TEST(test_configured_options_reach_the_created_driver);
+    RUN_TEST(test_numeric_option_reads_a_value_inside_the_declared_range);
+    RUN_TEST(test_numeric_option_refuses_what_the_declaration_refuses);
+    RUN_TEST(test_numeric_option_refuses_trailing_garbage_and_non_numbers);
+    RUN_TEST(test_numeric_option_accepts_a_padded_number_the_gate_would_refuse);
+    RUN_TEST(test_numeric_option_falls_back_to_the_declared_default);
+    RUN_TEST(test_numeric_option_refuses_unknown_and_non_numeric_keys);
+    RUN_TEST(test_numeric_option_handles_a_range_starting_at_zero);
     return UNITY_END();
 }

--- a/test/test_logging/test_main.cpp
+++ b/test/test_logging/test_main.cpp
@@ -11,6 +11,7 @@
 
 #include "diagnostics/log_buffer.h"
 #include "diagnostics/log_timestamp.h"
+#include "diagnostics/logger.h"
 
 using heliograph::log::formatIsoLocalTime;
 using heliograph::log::formatLogTimestamp;
@@ -158,6 +159,50 @@ static void test_a_null_line_is_ignored() {
     TEST_ASSERT_EQUAL_size_t(0, heliograph::log::recentLines(10).size());
 }
 
+// A hex dump of nothing is the empty dump, not whatever was on the stack. Rs485Transport::write
+// hands traceHex the byte count it actually wrote, which is 0 when the UART write fails -- so
+// the one caller that does not pre-check for emptiness is also the one that reaches it on a
+// fault. The buffer used to be filled only by the formatting loop, which at len == 0 never
+// runs.
+static void test_trace_hex_of_zero_bytes_prints_no_bytes() {
+    const auto previous = heliograph::log::level();
+    heliograph::log::setLevel(heliograph::LogLevel::Trace);
+    heliograph::log::clearLines();
+
+    const uint8_t data[1] = {0xAB};
+    heliograph::log::traceHex("EMPTY", data, 0);
+
+    const auto lines = heliograph::log::recentLines(1);
+    TEST_ASSERT_EQUAL_size_t(1, lines.size());
+    TEST_ASSERT_EQUAL_STRING("[T] EMPTY ", lines[0].c_str());
+
+    heliograph::log::setLevel(previous);
+}
+
+static void test_trace_hex_is_bounded_and_marks_truncation() {
+    const auto previous = heliograph::log::level();
+    heliograph::log::setLevel(heliograph::LogLevel::Trace);
+    heliograph::log::clearLines();
+
+    // One byte past the 64-byte cap: a corrupted length must not turn into unbounded output,
+    // and the reader has to be told the dump is partial.
+    uint8_t data[65];
+    for (size_t i = 0; i < sizeof(data); ++i) {
+        data[i] = static_cast<uint8_t>(i);
+    }
+    heliograph::log::traceHex("LONG", data, sizeof(data));
+
+    const auto lines = heliograph::log::recentLines(1);
+    TEST_ASSERT_EQUAL_size_t(1, lines.size());
+    // "[T] LONG " + 64 * "XX " + "..."
+    TEST_ASSERT_EQUAL_size_t(9 + 64 * 3 + 3, lines[0].size());
+    TEST_ASSERT_TRUE(lines[0].rfind("...") == lines[0].size() - 3);
+    TEST_ASSERT_TRUE(lines[0].find("3F ") != std::string::npos);   // byte 63, the last kept one
+    TEST_ASSERT_TRUE(lines[0].find(" 40 ") == std::string::npos);  // byte 64, dropped
+
+    heliograph::log::setLevel(previous);
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_lines_come_back_oldest_first);
@@ -166,6 +211,8 @@ int main(int, char**) {
     RUN_TEST(test_total_counts_overwritten_lines_too);
     RUN_TEST(test_an_overlong_line_is_truncated_not_overflowing);
     RUN_TEST(test_a_null_line_is_ignored);
+    RUN_TEST(test_trace_hex_of_zero_bytes_prints_no_bytes);
+    RUN_TEST(test_trace_hex_is_bounded_and_marks_truncation);
     RUN_TEST(test_iso_local_time_formats_in_the_configured_zone);
     RUN_TEST(test_synced_formats_local_wallclock);
     RUN_TEST(test_synced_honours_timezone_and_dst);

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -13,6 +13,7 @@
 #include "device/device_context.h"
 #include "drivers/eversolar_legacy/eversolar_driver.h"
 #include "drivers/mock/mock_driver.h"
+#include "outputs/json_util.h"
 #include "outputs/mqtt/announced_devices.h"
 #include "outputs/mqtt/home_assistant_discovery.h"
 #include "outputs/mqtt/mqtt_payloads.h"
@@ -408,7 +409,8 @@ static void test_capabilities_payload_reports_read_only() {
     Rig r;
     const auto  state = r.poll();
     std::string json;
-    TEST_ASSERT_TRUE(buildCapabilitiesPayload(state.capabilities, json));
+    TEST_ASSERT_TRUE(json_util::buildCapabilitiesPayload(state.capabilities, json,
+                                                     kMaxPayloadBytes));
     auto doc = parse(json);
 
     TEST_ASSERT_TRUE(doc["read_only"].as<bool>());
@@ -423,7 +425,8 @@ static void test_writable_driver_lists_its_bounds() {
     o.writable = true;
     mock::MockDriver driver(clockFn, o);
     std::string      json;
-    TEST_ASSERT_TRUE(buildCapabilitiesPayload(driver.capabilities(), json));
+    TEST_ASSERT_TRUE(json_util::buildCapabilitiesPayload(driver.capabilities(), json,
+                                                     kMaxPayloadBytes));
     auto doc = parse(json);
 
     TEST_ASSERT_FALSE(doc["read_only"].as<bool>());

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1342,16 +1342,6 @@ static void test_measurements_payload_omits_unsupported() {
     TEST_ASSERT_TRUE(doc["measurements"]["dc.power.total"]["derived"].as<bool>());
 }
 
-static void test_capabilities_payload() {
-    Rig        r;
-    const auto state = r.poll();
-    std::string json;
-    TEST_ASSERT_TRUE(rest::buildCapabilitiesPayload(state.capabilities, json));
-    auto doc = parse(json);
-    TEST_ASSERT_TRUE(doc["read_only"].as<bool>());
-    TEST_ASSERT_EQUAL_size_t(0, doc["write"].as<JsonArray>().size());
-}
-
 static void test_drivers_payload_drives_the_wizard() {
     DriverRegistry reg;
     registerBuiltinDrivers(reg);
@@ -1912,7 +1902,6 @@ int main(int, char**) {
     RUN_TEST(test_provision_payload_escapes_the_hostname);
     RUN_TEST(test_devices_payload);
     RUN_TEST(test_measurements_payload_omits_unsupported);
-    RUN_TEST(test_capabilities_payload);
     RUN_TEST(test_drivers_payload_drives_the_wizard);
     RUN_TEST(test_diagnostics_payload_has_no_secrets);
     RUN_TEST(test_diagnostics_report_stack_marks_and_fragmentation);

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -108,6 +108,31 @@ else
     fi
 fi
 
+echo "==> 6. Every test that is written is also registered"
+# A `static void test_x()` with no matching RUN_TEST compiles, reads as coverage, and never
+# runs. test_start_is_never_throttled sat that way for a while -- and it is the test asserting
+# that the rate limiter can never be the reason a curtailed inverter stays curtailed, which is
+# a safety property, not a nicety. Clang says "unused function" only on a fresh compile of that
+# one file, so a normal incremental run never shows it.
+unregistered=""
+for f in test/*/test_main.cpp; do
+    for fn in $(grep -oE '^static void (test_[A-Za-z0-9_]+)\(\)' "$f" | awk '{print $3}' |
+                sed 's/()$//'); do
+        if ! grep -q "RUN_TEST($fn)" "$f"; then
+            unregistered="$unregistered $f:$fn"
+        fi
+    done
+done
+if [ -n "$unregistered" ]; then
+    echo "FAIL: tests defined but never run:"
+    for hit in $unregistered; do
+        echo "      $hit"
+    done
+    status=1
+else
+    echo "OK"
+fi
+
 echo
 if [ $status -eq 0 ]; then
     echo "RESULT: PASS"

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -25,6 +25,9 @@ echo "==> 2. The host-testable core must not depend on Arduino or ESP-IDF"
 # break the build, it means protocol logic has drifted into something untestable.
 core_paths=(
     src/device
+    src/protocols/byte_order.h
+    src/protocols/modbus/modbus_rtu.h
+    src/protocols/modbus/modbus_rtu.cpp
     src/protocols/pmu/pmu_protocol.h
     src/protocols/pmu/pmu_protocol.cpp
     src/network/rtc_time.h

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -22,23 +22,35 @@ ASSETS = [
 def main() -> int:
     root = pathlib.Path(__file__).resolve().parent.parent
     status = 0
-    for name in ASSETS:
-        source = (root / name).read_text()
-        scripts = re.findall(r"<script>(.*?)</script>", source, re.S)
-        if not scripts:
-            print(f"{name}: FAIL (no <script> blocks found)")
-            status = 1
-            continue
-        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as handle:
-            handle.write("\n".join(scripts))
-            path = handle.name
-        result = subprocess.run(
-            ["node", "--check", path], capture_output=True, text=True
-        )
-        print(f"{name}: {'OK' if result.returncode == 0 else 'FAIL'}")
-        if result.returncode != 0:
-            print(result.stderr)
-            status = 1
+    # One scratch directory for the whole run, removed on the way out. The previous form used
+    # NamedTemporaryFile(delete=False) and never unlinked, so every local run and every CI run
+    # left a .js file behind in the system temp directory.
+    with tempfile.TemporaryDirectory(prefix="heliograph-js-") as scratch:
+        for name in ASSETS:
+            source = (root / name).read_text()
+            scripts = re.findall(r"<script>(.*?)</script>", source, re.S)
+            if not scripts:
+                print(f"{name}: FAIL (no <script> blocks found)")
+                status = 1
+                continue
+            path = pathlib.Path(scratch) / (pathlib.Path(name).stem + ".js")
+            path.write_text("\n".join(scripts))
+            try:
+                result = subprocess.run(
+                    ["node", "--check", str(path)], capture_output=True, text=True
+                )
+            except FileNotFoundError:
+                # Without this the script dies on a bare traceback that names no cause. The
+                # check is genuinely unrunnable, so say which tool is missing and fail --
+                # skipping silently would report a clean tree that was never parsed.
+                print(
+                    "FAIL: node is not on PATH; install Node.js to syntax-check the web assets"
+                )
+                return 1
+            print(f"{name}: {'OK' if result.returncode == 0 else 'FAIL'}")
+            if result.returncode != 0:
+                print(result.stderr)
+                status = 1
     return status
 
 


### PR DESCRIPTION
Audit-driven cleanup: every warning our own code emitted, the dead symbols, and the
duplication that had a single point of truth to move to. Eight commits, one category
each, each independently revertable.

Net **−123 lines** of source, **+9 tests**, and one real bug fixed.

## What was actually wrong

**A latent defect.** `traceHex()` filled its line buffer only inside the formatting
loop, so at `len == 0` an uninitialised stack buffer went to `trace("%s")`. Two of the
three callers pre-check for emptiness; the third is `Rs485Transport::write`, which
passes the number of bytes it *actually wrote* — zero when the UART write fails. The
one caller that can reach it is the one that reaches it during a bus fault, at TRACE
level, while somebody is diagnosing that fault. Two tests now pin it.

**A test that never ran.** `test_start_is_never_throttled` had no `RUN_TEST` line. It
asserts that the rate limiter can never be the reason a curtailed inverter stays
curtailed — a safety property, and a deliberate one given this project's failsafe
direction. It passes. It had simply never executed.

**Bounds declared twice, drifted twice.** Every numeric driver option was bounded once
in its `DriverOption` row and again as literals in the factory. Two of the four pairs
disagreed: SunSpec's `base_address` accepted 65535 that its declaration refused, and
the mock's day length had no upper bound despite declaring 1–1440.

## Commits

| | |
|---|---|
| `1a7e357` | Five compiler warnings from `src/`, plus the `traceHex` defect |
| `e457610` | Four dead symbols, verified by grep across src/, test/, tools/ and the web assets |
| `a6755c9` | MQTT/REST payload duplication → `json_util.h`; `capabilityName` → `device/capability.h` |
| `47f4529` | `DriverDescriptor::numericOption()`: a driver declares its range once |
| `a5cce51` | Register the unrun test; `check_layering.sh` rule 6 so it cannot recur |
| `411f0e6` | `protocols/byte_order.h`: one place that knows which byte comes first |
| `5a0358a` | `check_web_js.py` stops leaving temp files; says so when `node` is missing |
| `22e17ed` | Three implicit constructors made explicit, three policy structs by const ref |
| `9f1de2a` | Self-review: seven tests for the new API, two rough edges in my own diff |

## Behaviour changes

None in the payloads. `buildStatePayload`, `buildMeasurementsPayload`,
`buildDevicePayload`, `buildStatusPayload` and the capabilities document were compared
**byte-for-byte** against `main` with a throwaway dumper built at both revisions —
6224 bytes each side, diff clean. Re-run against the final head, not an intermediate
commit.

Four narrowings in driver-option handling, all toward the range the descriptor already
declared:

- `sunspec base_address` 65535 is refused (falls back to 40000)
- `mock day_length_minutes` outside 1–1440 is refused (falls back to 10)
- a value with trailing garbage (`"12abc"`) is refused rather than read as `12`
- SunSpec and the mock now log a warning on a refused value; Growatt and SolaX already did

Reading a stored value stays deliberately more permissive than the REST PATCH gate: that
gate also refuses `" 7"`, `"+7"` and `"007"` so a typed value is never silently rewritten,
but refusing to start a driver over a leading zero in a config written by an older build
would be the wrong trade.

## Verification

- **631 native tests** (622 + 9 new − 1 duplicate + 1 that now runs)
- Firmware grew **+476 bytes** of flash (1555115 → 1555591), RAM unchanged. Fewer source
  lines but slightly more image: the new warning strings are rodata, and the shared
  capabilities builder is `inline` in a header now used from two translation units.
- Clean rebuild of all four boards: **zero warnings from `src/`**, down from five. The 48
  that remain are all eModbus and the Arduino core.
- `check_layering.sh` 6/6, `pio check --severity=high` clean, ruff clean, profile/JS/
  measurement-id checks clean
- cppcheck at `--severity=low`: **308 → 211**. What is left is the per-translation-unit
  blind spot already documented in `platformio.ini`, plus five genuine false positives
  (four `std::lock_guard` "unused variable", one value-flow `i<n`). Not suppressed — CI
  runs `--severity=high`, so a suppression would buy nothing and cost the next reader.

## Deliberately not done

- **AsyncTCP 3.4.10 → 3.5.0** is available. A dependency bump is not a cleanup, and
  `docs/decisions.md` says it must be hardware-tested; the monthly `dependency-check`
  workflow already tracks it.
- **The hand-written Modbus CRC16.** eModbus has one, but it is Arduino-only and
  `modbus_rtu.cpp` must stay host-compilable. Current choice is correct.
- **`kCanTx`/`kCanRx`** are unused but stay: the comment above them says they are recorded
  so a future CAN driver starts from verified facts. That is documentation.
- **Merging the four drivers' identical `kResponseTimeoutMs`/`kTransactionDeadlineMs`.**
  They agree today at 1000/3000, but protocol timing belongs to the protocol; equal values
  are a coincidence, not a contract. Say the word if you want them shared.

## Risk to the running bridge: effectively none

Worth stating plainly, since this branch is going onto a production EverSolar bridge. The
option-bounds change cannot touch it: `eversolar_legacy` declares exactly one option,
`layout`, which is an enum and not numeric, so `numericOption` is never reached on that
path. The payloads are byte-identical. `rgbLedWrite` is behind `kHasStatusLed`, which the
RS485-CAN sets to false. The MQTT disconnect reason still reaches diagnostics as the
human-readable string the UI already shows.

The narrowings land on SunSpec and the mock, neither of which has run on hardware.

No version bump here — that belongs to the release commit on main, following 0.13.1.

## Housekeeping outside the repo

There is a stale git worktree on the merged branch `hw/relay-1ch-psram-verified`, holding
a full `.pio` build tree:

```bash
git worktree remove .claude/worktrees/elegant-hopper-19b881
```

Left for you to run — it is your working copy, not repo content.
