### PR TITLE
Act on the ESP32-S3 hardware audit

### DIFF
--- a/docs/esp32s3-hardware-audit.md
+++ b/docs/esp32s3-hardware-audit.md
@@ -2,6 +2,11 @@
 
 Audit date: **2026-07-26**, against `v0.13.2` (`96a2629`).
 
+> **Status: acted on.** Every quick win and both medium items are implemented — see the
+> plan at the bottom for what landed and what deliberately did not. One recommendation in
+> this document (L1) was **withdrawn after its justification turned out to be wrong**; the
+> correction is in §6 and is left visible rather than edited away.
+
 Scope: are the ESP32-S3-specific facilities that firmware projects commonly leave on the table
 actually being used here? Every claim below is backed by a `path:line` reference that was read
 during the audit, not recalled. Where the answer turned out to be "already handled", that is
@@ -359,11 +364,18 @@ Two distinct things:
    report it — not REST, not Prometheus, not the Modbus diagnostics block. The bridge would run
    on internal RAM with a quietly reduced ceiling. This is the one item in this section that is a
    present-tense defect in the monitoring, not a future opportunity.
-2. **Missed capability.** Every Prometheus scrape gap is permanent data loss, and every REST query
-   sees only *now*. With 8 MB available, a ring of per-device samples is nearly free: 8 devices ×
-   33 measurements × 8 bytes is ~2 KB per sample, so 24 hours at 10-second resolution is roughly
-   17 MB — too much, but 24 hours at 60-second resolution is ~2.8 MB, comfortably inside PSRAM
-   and well beyond anything internal SRAM could hold.
+2. **A possible capability, on a weaker basis than first stated.** Every REST query sees only
+   *now*, and with 8 MB available a ring of per-device samples would be nearly free: 24 hours at
+   60-second resolution is roughly 2.8 MB, well beyond anything internal SRAM could hold.
+
+   ⚠️ **The original version of this paragraph also claimed a device-side ring would stop
+   Prometheus scrape gaps from being permanent data loss. That is wrong, and the claim is
+   withdrawn.** Prometheus records one sample per series per scrape, at scrape time. The text
+   exposition format does allow an optional per-sample timestamp, but it cannot carry a *series*
+   of historical points for one metric in a single scrape, and our exporter emits none anyway
+   (`prometheus_metrics.cpp`, `appendValue`). So a missed scrape stays missed no matter what the
+   device remembers. Device-side history would serve REST and a dashboard curve — a feature —
+   and would do nothing for the monitoring gap it was justified by.
 
 ### Recommendation
 
@@ -481,7 +493,7 @@ already records as a known, reasoned position.
 
 ## Prioritised plan
 
-### Quick wins — hours, low risk
+### Quick wins — hours, low risk  ✅ all implemented
 
 | # | Item | Impact | Test |
 |---|---|---|---|
@@ -492,19 +504,19 @@ already records as a known, reasoned position.
 
 Q1 and Q4 are effectively free. Q2 is the one with real present-tense value.
 
-### Medium — a day or two each
+### Medium — a day or two each  ✅ both implemented (M2 in a different shape — see below)
 
 | # | Item | Impact | Test |
 |---|---|---|---|
 | M1 | Coredump surfacing: `esp_core_dump_image_check()` + `esp_core_dump_get_summary()` in diagnostics, admin-gated erase route, retrieval documented | Turns an unexplained night-time reboot into a named faulting task and PC, without a cable | The IDF calls are not host-compilable, so keep the presentation pure: a `CoredumpSummary` struct formatted by a host-tested payload builder, with the IDF call behind the same `#if defined(ESP32)` split the OTA manager already uses. Hardware: force a panic, reboot, confirm the summary appears and that erasing clears it |
-| M2 | Liveness heartbeats for the AsyncTCP and MQTT tasks in `Diagnostics` (age of last service), rather than registering library tasks with the WDT | Makes a stalled web server or MQTT client visible in Prometheus instead of silent; avoids the panic risk of watchdogging a task we do not control | Fully host-testable: the age calculation and its thresholds are pure. Hardware: block the broker with a firewall rule and confirm the MQTT heartbeat ages while polling continues |
+| M2 | ~~Liveness heartbeats~~ → **MQTT publish-failure counter** | Implementing the heartbeats showed both were the wrong shape. **The web server needs none:** a successful `/metrics` scrape is itself proof the AsyncTCP task is alive, so the field would be true exactly whenever you could read it. **MQTT needed something better:** `publish()` returns 0 when the client refuses a message (link down, outbox full), and eleven of twelve call sites discarded that — so an undelivered message looked delivered, while `mqtt_connected` stayed true. Now counted and exported | Two host tests. Hardware: block the broker and confirm the counter climbs while polling continues |
 
-### Larger — worth planning, not worth starting this week
+### Larger — L1 withdrawn, L2 deliberately deferred
 
 | # | Item | Impact | Test |
 |---|---|---|---|
-| L1 | PSRAM-backed measurement history ring + `?since=` on the measurements route | Prometheus scrape gaps stop being permanent data loss; the dashboard could show a real curve without Home Assistant | The ring itself is pure and belongs in `-e native` with a fake allocator: bounded capacity, wrap behaviour, eviction order, and the "no PSRAM → history disabled, everything else unchanged" path. Hardware: 24 h soak on the production bridge watching internal-heap free stay flat |
-| L2 | Blocking UART read replacing the `delay(1)` poll | Latency only, and only at 115200 with several devices | Measure before and after on the real Growatt bus. Do not start until that bus exists |
+| L1 | ~~PSRAM-backed measurement history ring~~ | **Withdrawn.** Its stated benefit — closing Prometheus scrape gaps — does not exist (see §6). What remains is a dashboard feature: a device-side curve without Home Assistant. Worth doing if that is wanted for its own sake, on its own design pass, and not justified by monitoring |
+| L2 | Blocking UART read replacing the `delay(1)` poll | Latency only, and only at 115200 with several devices | **Not done, on purpose.** It touches `Rs485Transport::read`, the one path that talks to a live inverter, for a benefit nobody can currently measure. The current loop returns as soon as any byte arrives and the caller reassembles frames; a naive blocking read would wait for a full buffer and stall on every short reply. Revisit when the Growatt bus exists to measure against |
 
 ### Explicitly not recommended
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -98,6 +98,43 @@ peripheral). No driver uses it today. It is recorded because battery BMS protoco
 commonly speak CAN, which makes this board a natural fit for a future battery-side
 source — a deliberate decision for later, not an accident waiting in a header file.
 
+## Step-debugging over the built-in USB-JTAG
+
+The S3 has a USB-Serial-JTAG peripheral on the chip. No external probe, no extra wiring, and
+the same USB-C cable that carries the serial console — JTAG and CDC are separate interfaces on
+the one USB device, so `ARDUINO_USB_CDC_ON_BOOT=1` does not get in the way.
+
+```bash
+pio debug -e debug-rs485-can --interface=gdb -x .pioinit
+```
+
+Or in an editor with the PlatformIO extension, pick the `debug-rs485-can` environment and start
+a debug session normally.
+
+`debug-rs485-can` is a separate environment (`build_type = debug`, `debug_tool = esp-builtin`)
+so the shipping images stay release builds. Debug drops the optimiser to `-Og`, which changes
+timing — and RS485 timing is the last thing that should shift underneath you unannounced. The
+image grows by roughly 130 KB, which the 6.25 MB app partition absorbs without noticing.
+
+**The watchdog will reset the board while you sit on a breakpoint.** A halted core stops feeding
+the task WDT, and its timeout is 120 s (`src/main.cpp`, `setup()`). For a long inspection,
+either work in short hops or temporarily raise the timeout in that call — and put it back before
+you commit.
+
+Three places where a breakpoint earns its keep, all of them things serial logging is bad at:
+
+- `Rs485Transport::read` / the driver's frame parser, to inspect a malformed buffer *at the
+  moment* it is rejected — logging it changes the timing you are trying to observe.
+- `applySerialOverride()` and driver `begin()`, for the boot path that runs once and is over
+  before you can attach a console.
+- Anything reached from the AsyncTCP task, where a `log::` call competes with the request it is
+  trying to describe.
+
+> If a PlatformIO-generated `.vscode/launch.json` predates 2026-07-22 it names
+> `waveshare-eversolar`, the environment renamed to `waveshare-rs485-can` in the board refactor,
+> and the session will fail on a path that no longer exists. Delete the file and let PlatformIO
+> regenerate it; it is gitignored, so nothing in the repo needs changing.
+
 ## Recovery — hold BOOT to factory-reset
 
 Holding **BOOT for ~5 seconds while the firmware is running** erases the stored

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -98,6 +98,38 @@ peripheral). No driver uses it today. It is recorded because battery BMS protoco
 commonly speak CAN, which makes this board a natural fit for a future battery-side
 source — a deliberate decision for later, not an accident waiting in a header file.
 
+## After a crash — the core dump
+
+A panic writes a full ELF core dump to the `coredump` partition (64 KB, present in both
+partition tables; `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` is set in the prebuilt IDF config). It
+survives the reboot.
+
+The bridge now tells you it is there without a cable. The boot log carries a `coredump:` warn
+line naming the faulting task and PC, `GET /api/v1/diagnostics` reports
+`coredump_present` / `coredump_task` / `coredump_pc`, Prometheus exports
+`heliograph_coredump_present`, and Modbus register 828 carries the same flag. That is enough to
+know a crash happened, which task died, and roughly where — usually enough to decide whether it
+is worth going further.
+
+To go further, pull the dump itself:
+
+```bash
+python -m esp_coredump --chip esp32s3 --port /dev/tty.usbmodem* info_corefile .pio/build/waveshare-rs485-can/firmware.elf
+```
+
+The ELF you pass **must be the image that was running when it crashed**. Keep the build
+artifacts from the release you flashed, or rebuild from the exact tag — a dump decoded against
+a different binary produces confident nonsense.
+
+Once you have dealt with it, clear the dump so the next one is distinguishable from this one:
+
+```bash
+curl -u admin:PASSWORD -X POST http://heliograph.local/api/v1/actions/clear-coredump
+```
+
+A new crash overwrites the old one on its own (`CONFIG_ESP_COREDUMP_FLASH_NO_OVERWRITE` is not
+set), so clearing is about answering "is this new?", not about making room.
+
 ## Step-debugging over the built-in USB-JTAG
 
 The S3 has a USB-Serial-JTAG peripheral on the chip. No external probe, no extra wiring, and

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -47,12 +47,34 @@ authoritative pin record for all of them (Relay-1CH: 1 relay + RTC; Relay-6CH: 6
 | Fact | Value | Relevance |
 |---|---|---|
 | Flash | **16 MB** | Dual-app OTA partitions + headroom (`partitions_16mb_ota.csv`) |
-| PSRAM | 8 MB | `-DBOARD_HAS_PSRAM` |
+| PSRAM | 8 MB, octal | `-DBOARD_HAS_PSRAM` + `memory_type = qio_opi`. Reported as `psram_size_bytes` / `psram_free_bytes` — see below |
 | USB | native USB-C, no CH340 | `-DARDUINO_USB_CDC_ON_BOOT=1`; attaching USB power-cycles a USB-powered board |
 | Power | USB-C or 7–36 V DC terminal | The DC terminal allows powering from the inverter side of the room |
 | Isolation | power + optocoupler, RS485 **and** CAN | `SGND` is NOT `GND` — never bridge them |
 | Termination | 120 Ω jumper per bus | Fit only when the bridge is physically at the end of the RS485 bus |
 | Buttons | BOOT + RESET | RESET reboots. BOOT held ~5 s **while running** factory-resets; held **at power-on** it enters USB download mode instead (GPIO0 strapping) — see Recovery |
+
+## Reading the memory figures
+
+The bridge reports five memory numbers, and they do not all measure the same pool.
+
+| Field | Covers |
+|---|---|
+| `free_heap_bytes`, `minimum_free_heap_bytes`, `max_alloc_heap_bytes` | **Internal SRAM only** (~320 KB total) |
+| `psram_size_bytes`, `psram_free_bytes` | **External PSRAM only** (8 MB here, absent on the Relay-6CH) |
+
+This is not a naming quirk, it is what the Arduino core does: `ESP.getFreeHeap()`,
+`getMinFreeHeap()` and `getMaxAllocHeap()` are all `heap_caps_*(MALLOC_CAP_INTERNAL)`. So a free
+heap of ~150 KB on this board is healthy, not alarming — it is 150 KB of 320 KB, not of 8 MB.
+
+The PSRAM pair is `null` in JSON, absent from Prometheus and `0xFFFFFFFF` in the Modbus
+registers on a board that has none. That is also how you tell, from the network alone, that
+PSRAM failed to initialise on a board that should have it: the fields go absent. Before these
+existed there was no way to see that at all (audit, 2026-07-26).
+
+Note that the IDF is configured with `CONFIG_SPIRAM_USE_MALLOC` and a 4096-byte threshold, so
+allocations above 4 KB already land in PSRAM through plain `malloc` without any code asking for
+it. `psram_free_bytes` moving is normal and expected.
 
 ## RS485 direction control
 

--- a/docs/modbus-register-map.md
+++ b/docs/modbus-register-map.md
@@ -243,6 +243,7 @@ there is no possible confusion with a valid value.
 | 820 | 3 | uint16[3] | Firmware version major/minor/patch |
 | 824 | 2 | uint32 | Total external PSRAM in bytes — `0xFFFFFFFF` = no PSRAM on this board |
 | 826 | 2 | uint32 | Free external PSRAM in bytes — `0xFFFFFFFF` = no PSRAM on this board |
+| 828 | 1 | uint16 | `1` = a crash dump is waiting in flash; read the task and PC from `/api/v1/diagnostics` |
 | 850 | 1 | uint16 | Relay count — `0xFFFF` = no relay hardware on this board |
 | 851 | 1 | uint16 | Relay state bitmask (bit *i* = relay *i* energised); `0xFFFF` without hardware |
 

--- a/docs/modbus-register-map.md
+++ b/docs/modbus-register-map.md
@@ -241,6 +241,8 @@ there is no possible confusion with a valid value.
 | 816 | 2 | uint32 | REST requests |
 | 818 | 2 | uint32 | Invalid frames |
 | 820 | 3 | uint16[3] | Firmware version major/minor/patch |
+| 824 | 2 | uint32 | Total external PSRAM in bytes — `0xFFFFFFFF` = no PSRAM on this board |
+| 826 | 2 | uint32 | Free external PSRAM in bytes — `0xFFFFFFFF` = no PSRAM on this board |
 | 850 | 1 | uint16 | Relay count — `0xFFFF` = no relay hardware on this board |
 | 851 | 1 | uint16 | Relay state bitmask (bit *i* = relay *i* energised); `0xFFFF` without hardware |
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -234,6 +234,7 @@ wiring and the addressing are fine:
 | `heliograph_psram_size_bytes` | gauge | Total external PSRAM — **absent on a board without it** |
 | `heliograph_psram_free_bytes` | gauge | Free external PSRAM — **absent on a board without it** |
 | `heliograph_coredump_present` | gauge | `1` when a crash dump is waiting in flash — **always emitted**, `0` is a fact |
+| `heliograph_mqtt_publish_failures_total` | counter | Publishes the MQTT client refused (link down, or outbox full) |
 | `heliograph_wifi_rssi_dbm` | gauge | Only present while WiFi is connected |
 | `heliograph_rs485_stack_free_bytes` | gauge | Only after the first sample |
 | `heliograph_loop_stack_free_bytes` | gauge | Only after the first sample |

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -231,6 +231,8 @@ wiring and the addressing are fine:
 | `heliograph_uptime_seconds` | gauge | Seconds since boot |
 | `heliograph_free_heap_bytes` | gauge | Free heap |
 | `heliograph_max_alloc_heap_bytes` | gauge | Largest single allocatable block |
+| `heliograph_psram_size_bytes` | gauge | Total external PSRAM — **absent on a board without it** |
+| `heliograph_psram_free_bytes` | gauge | Free external PSRAM — **absent on a board without it** |
 | `heliograph_wifi_rssi_dbm` | gauge | Only present while WiFi is connected |
 | `heliograph_rs485_stack_free_bytes` | gauge | Only after the first sample |
 | `heliograph_loop_stack_free_bytes` | gauge | Only after the first sample |
@@ -266,6 +268,14 @@ This is what makes curtailment reviewable after the fact. Graphing
 `heliograph_relay_energised` beside `heliograph_inverter_ac_power_watts` shows the contact
 closing and the production dropping in the same picture — which is the evidence you want when
 deciding whether a curtailment rule is behaving.
+
+The three heap gauges are **internal SRAM only**. Arduino's `ESP.getFreeHeap()` and friends are
+`heap_caps_*(MALLOC_CAP_INTERNAL)`, so on the RS485-CAN and Relay-1CH — which carry 8 MB of
+external PSRAM — they describe roughly 300 KB of the RAM that exists. `heliograph_psram_*`
+covers the rest, and is **omitted entirely** on the Relay-6CH, which has none. Omitted rather
+than zero, for the same reason as the RSSI and stack gauges: a flat 0 reads as exhaustion to an
+alerting rule. Their absence is also the only way to tell from the network that PSRAM failed to
+initialise on a board that should have it.
 
 `max_alloc_heap_bytes` is the fragmentation signal, and it is the more useful of the two heap
 numbers on a device meant to run for months: free heap can look healthy while no allocation of

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -233,6 +233,7 @@ wiring and the addressing are fine:
 | `heliograph_max_alloc_heap_bytes` | gauge | Largest single allocatable block |
 | `heliograph_psram_size_bytes` | gauge | Total external PSRAM — **absent on a board without it** |
 | `heliograph_psram_free_bytes` | gauge | Free external PSRAM — **absent on a board without it** |
+| `heliograph_coredump_present` | gauge | `1` when a crash dump is waiting in flash — **always emitted**, `0` is a fact |
 | `heliograph_wifi_rssi_dbm` | gauge | Only present while WiFi is connected |
 | `heliograph_rs485_stack_free_bytes` | gauge | Only after the first sample |
 | `heliograph_loop_stack_free_bytes` | gauge | Only after the first sample |

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -23,6 +23,7 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 | POST | `/api/v1/actions/discover` | **✔** | Start discovery |
 | POST | `/api/v1/actions/poll` | **✔** | Force an immediate poll |
 | POST | `/api/v1/actions/reboot` | **✔** | Reboot |
+| POST | `/api/v1/actions/clear-coredump` | **✔** | Discard a stored crash dump (404 when there is none) |
 | POST | `/api/v1/ota` | **✔** | Firmware upload |
 | GET | `/api/v1/events` | — | Server-Sent Events (live updates) |
 | GET | `/metrics` | — | Prometheus |

--- a/docs/security.md
+++ b/docs/security.md
@@ -103,6 +103,24 @@ re-provision instead of authenticating over the air.
 **No brute-force protection on HTTP Basic.** Rate limiting is on `/actions/*`, not on the
 auth itself.
 
+**Nothing in the firmware generates a secret, and there is no random number generator in the
+tree at all.** The admin password is set by the operator, every request re-presents it, and
+there are no session tokens, cookies or nonces to mint. That is a deliberate absence, not an
+oversight — a 2026-07-26 audit confirmed no `esp_random`, `random()`, `rand()` or
+`mbedtls_ctr_drbg` call anywhere in `src/`.
+
+It is recorded here because the day that changes, the obvious reach is the wrong one. If a
+session token, a CSRF nonce, a pairing code or a generated first-boot password is ever added:
+
+- Use `esp_random()` / `esp_fill_random()`. **Never Arduino's `random()`**, which on ESP32 is a
+  seeded PRNG and predictable.
+- Do it after the RF subsystem is up. `esp_random()` is only a true hardware RNG while WiFi or
+  Bluetooth is active or the bootloader's entropy is still valid; during early boot with the
+  radio down — exactly when a first-boot password would be minted — the guarantee is weaker.
+- Remember that a generated secret has to reach the user somehow, and every channel this
+  bridge has (the open setup AP, plain HTTP, the serial console) is one of the exposures listed
+  above.
+
 **OTA images are not cryptographically signed.** The upload is gated by the admin password
 and checked for the ESP32 image magic (`0xE9`) before any byte reaches flash, and a bad image
 is rolled back by the bootloader — but the magic check only rejects a wrong *file* (a

--- a/platformio.ini
+++ b/platformio.ini
@@ -232,6 +232,29 @@ build_flags =
     ${esp32common.build_flags}
     -DHELIOGRAPH_BOARD_RELAY_6CH
 
+; Step-debugging over the S3's built-in USB-Serial-JTAG. Same board and flags as the production
+; env, differing only in build type and debugger.
+;
+; A SEPARATE env on purpose. The shipping images must stay release builds -- `build_type = debug`
+; drops the optimiser to -Og and keeps full symbols, which changes both size and timing, and RS485
+; timing is the one thing this firmware cannot afford to have change underneath it silently.
+;
+; Deliberately NOT in the CI matrix (firmware.yml enumerates its four envs explicitly) and not in
+; default_envs, so it costs nothing per PR and produces no release asset. The flip side is that
+; nothing compiles it automatically: if it ever stops building, that is why.
+;
+; debug_tool is stated even though esp32-s3-devkitc-1.json already declares esp-builtin as its
+; default_tool -- so it reads as a decision rather than an accident. No external probe is needed:
+; the JTAG lives on the same USB-C connector as the CDC console, on a separate USB interface, so
+; ARDUINO_USB_CDC_ON_BOOT=1 and debugging coexist.
+;
+; See docs/hardware.md for the workflow, including the watchdog caveat -- halting a core stops
+; the task WDT being fed, so a breakpoint held longer than the timeout resets the board.
+[env:debug-rs485-can]
+extends = env:waveshare-rs485-can
+build_type = debug
+debug_tool = esp-builtin
+
 ; Mock-only build: no RS485 hardware needed, exercises the full output stack.
 [env:mock]
 extends = esp32common

--- a/platformio.ini
+++ b/platformio.ini
@@ -121,6 +121,15 @@ framework = arduino
 board_build.mcu = esp32s3
 board_build.flash_mode = qio
 monitor_speed = 115200
+; A panic prints a backtrace of raw addresses. esp32_exception_decoder resolves them against
+; the ELF that is already sitting in .pio/build, so the console shows file:line instead of
+; hex -- the whole difference between a diagnosable 03:00 reboot and a shrug. `time` stamps
+; every line, which matters because the firmware's own log timestamps only start once the RTC
+; or NTP has a clock, and a panic can happen before that.
+;
+; Belongs here rather than in an editor setting: .vscode/extensions.json recommends an IDE
+; decoder, but that does nothing for `pio device monitor` on the command line.
+monitor_filters = esp32_exception_decoder, time
 extra_scripts = ${common.extra_scripts}
 ; PSRAM is deliberately NOT set here: it is a per-module property, not a family one, and
 ; the boards this firmware targets genuinely differ. Declaring octal PSRAM for a module

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -66,6 +66,20 @@ struct BridgeInfo {
     /// confirmation, then "valid"). Makes the rollback window observable in diagnostics.
     std::string otaImageState = "unknown";
 
+    /// The crash dump waiting in the `coredump` partition, read once at boot.
+    ///
+    /// Same kind of fact as otaImageState above: a one-shot read of what the bootloader left
+    /// behind, carried here so the outputs never call an ESP-IDF function themselves. Reading
+    /// it verifies a checksum over the whole stored image, so it happens once in setup(), not
+    /// per request.
+    ///
+    /// `coredumpPresent` false is the normal state, and the state after an erase; the other
+    /// two are meaningless then and every output reports them absent rather than as task ""
+    /// at PC 0.
+    bool        coredumpPresent = false;
+    std::string coredumpTask;
+    uint32_t    coredumpPc      = 0;
+
     /// The board this firmware is running on. Reported to Home Assistant as the bridge
     /// device's model.
     /// Set by main from board::kName; the default only serves host tests, which have no

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -25,6 +25,20 @@ struct BridgeInfo {
     /// healthy while no allocation of consequence fits anymore, which is exactly the
     /// failure mode a months-uptime device grows into.
     uint32_t maxAllocHeapBytes = 0;
+    /// External PSRAM, reported separately because the three figures above do NOT include it.
+    ///
+    /// ESP.getFreeHeap(), getMinFreeHeap() and getMaxAllocHeap() are all
+    /// heap_caps_*(MALLOC_CAP_INTERNAL) in Arduino core 3.x -- internal SRAM only. So on a
+    /// board with 8 MB of PSRAM every heap number this struct carried described about 300 KB
+    /// of it, and a board where PSRAM failed to train looked exactly like one where it worked.
+    /// The RS485-CAN and Relay-1CH have 8 MB; the Relay-6CH is an N8 with none (audit,
+    /// 2026-07-26).
+    ///
+    /// `psramSizeBytes == 0` means this board has no PSRAM, or it did not initialise -- the two
+    /// are indistinguishable from software and both are worth seeing. Outputs report absent
+    /// rather than zero, per the house rule.
+    uint32_t psramSizeBytes    = 0;
+    uint32_t psramFreeBytes    = 0;
     uint16_t resetReason       = 0;
 
     bool    wifiConnected  = false;

--- a/src/diagnostics/coredump.cpp
+++ b/src/diagnostics/coredump.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+#include "coredump.h"
+
+#if defined(ESP32)
+
+#include <esp_core_dump.h>
+
+#include <cstring>
+
+namespace heliograph::diag {
+
+CoredumpSummary readCoredumpSummary() {
+    CoredumpSummary out;
+    // image_check verifies the stored checksum, so a partition holding a half-written dump --
+    // the plausible outcome of a panic during the panic handler -- reports absent rather than
+    // handing back a garbage task name.
+    if (esp_core_dump_image_check() != ESP_OK) {
+        return out;
+    }
+    esp_core_dump_summary_t summary{};
+    if (esp_core_dump_get_summary(&summary) != ESP_OK) {
+        // A dump that passes its checksum but cannot be summarised is still a dump: say it is
+        // there. The ELF is retrievable with the host tool even when this call cannot parse it.
+        out.present = true;
+        return out;
+    }
+    out.present        = true;
+    out.programCounter = summary.exc_pc;
+    out.version        = summary.core_dump_version;
+    // exc_task is a fixed 16-byte field and is NOT guaranteed to be NUL-terminated when the
+    // name uses all of it. strnlen bounds it; taking strlen would run into whatever follows.
+    out.taskName.assign(summary.exc_task,
+                        strnlen(summary.exc_task, sizeof(summary.exc_task)));
+    return out;
+}
+
+bool eraseCoredump() { return esp_core_dump_image_erase() == ESP_OK; }
+
+}  // namespace heliograph::diag
+
+#else
+
+namespace heliograph::diag {
+
+// No partition off-device. Returning an empty summary keeps main.cpp free of #if blocks, and
+// the payload builder that formats this is host-tested against constructed structs anyway.
+CoredumpSummary readCoredumpSummary() { return {}; }
+bool            eraseCoredump() { return false; }
+
+}  // namespace heliograph::diag
+
+#endif

--- a/src/diagnostics/coredump.h
+++ b/src/diagnostics/coredump.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+//
+// Reading the crash dump the bootloader already writes.
+//
+// A panic writes a full ELF core dump to the `coredump` partition -- the partition has existed
+// in both tables since the OTA layout was designed, and CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH has
+// always been set in the prebuilt IDF config. Nothing ever read it. So the answer to "it
+// rebooted at 03:00, why" was `reset_reason` as an integer, while a complete dump naming the
+// faulting task sat in flash where only a cable and espcoredump.py could reach it (audit,
+// 2026-07-26).
+//
+// This is the summary, not the dump. Retrieving the ELF itself still wants the host tool -- see
+// docs/hardware.md -- but knowing a dump EXISTS, and which task died, is what turns "something
+// happened" into a question worth taking the cable out for.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace heliograph::diag {
+
+/// What the crash left behind. `present` false means no valid dump is stored, which is the
+/// normal state and the state after an erase.
+///
+/// The other fields are only meaningful when `present` is true; outputs must report them as
+/// absent otherwise rather than as zero, since task "" at PC 0 is not a fact about anything.
+struct CoredumpSummary {
+    bool        present = false;
+    std::string taskName;         ///< task that caused the exception, "" if the dump omits it
+    uint32_t    programCounter = 0;
+    uint32_t    version        = 0;  ///< core dump format version, for reading the ELF later
+};
+
+/// Reads the summary from flash. Call ONCE, at boot: it verifies a checksum over the whole
+/// stored image, which is far too much work to repeat per REST request.
+///
+/// Host builds return `{}` -- there is no partition, and the diagnostics payload that formats
+/// this stays fully testable because the formatting takes the struct, not the flash.
+CoredumpSummary readCoredumpSummary();
+
+/// Erases the stored dump. Returns false if nothing was erased (no dump, or the flash refused).
+///
+/// Worth having rather than leaving the partition to overwrite itself: with a dump present,
+/// every later diagnostics read keeps reporting the same old crash, and an operator who has
+/// dealt with it needs a way to say so. CONFIG_ESP_COREDUMP_FLASH_NO_OVERWRITE is not set, so
+/// a NEW crash does overwrite the old one -- this is about clearing a handled one, not about
+/// making room.
+bool eraseCoredump();
+
+}  // namespace heliograph::diag

--- a/src/diagnostics/diagnostics.cpp
+++ b/src/diagnostics/diagnostics.cpp
@@ -32,23 +32,4 @@ DiagnosticsSnapshot Diagnostics::snapshot() const {
     return s;
 }
 
-void Diagnostics::reset() {
-    pollSuccessTotal_.store(0);
-    pollFailureTotal_.store(0);
-    consecutivePollFailures_.store(0);
-    checksumErrorTotal_.store(0);
-    rs485TimeoutTotal_.store(0);
-    invalidFrameTotal_.store(0);
-    wifiReconnectTotal_.store(0);
-    mqttReconnectTotal_.store(0);
-    modbusClientConnections_.store(0);
-    restRequestTotal_.store(0);
-    mqttPublishFailureTotal_.store(0);
-    lastSuccessfulPollMs_.store(0);
-    rs485StackFreeBytes_.store(0);
-    loopStackFreeBytes_.store(0);
-    std::lock_guard<std::mutex> lock(errorMutex_);
-    lastError_.clear();
-}
-
 }  // namespace heliograph

--- a/src/diagnostics/diagnostics.cpp
+++ b/src/diagnostics/diagnostics.cpp
@@ -21,6 +21,7 @@ DiagnosticsSnapshot Diagnostics::snapshot() const {
     s.mqttReconnectTotal      = mqttReconnectTotal_.load(std::memory_order_relaxed);
     s.modbusClientConnections = modbusClientConnections_.load(std::memory_order_relaxed);
     s.restRequestTotal        = restRequestTotal_.load(std::memory_order_relaxed);
+    s.mqttPublishFailureTotal = mqttPublishFailureTotal_.load(std::memory_order_relaxed);
     s.lastSuccessfulPollMs    = lastSuccessfulPollMs_.load(std::memory_order_relaxed);
     s.rs485StackFreeBytes     = rs485StackFreeBytes_.load(std::memory_order_relaxed);
     s.loopStackFreeBytes      = loopStackFreeBytes_.load(std::memory_order_relaxed);
@@ -42,6 +43,7 @@ void Diagnostics::reset() {
     mqttReconnectTotal_.store(0);
     modbusClientConnections_.store(0);
     restRequestTotal_.store(0);
+    mqttPublishFailureTotal_.store(0);
     lastSuccessfulPollMs_.store(0);
     rs485StackFreeBytes_.store(0);
     loopStackFreeBytes_.store(0);

--- a/src/diagnostics/diagnostics.h
+++ b/src/diagnostics/diagnostics.h
@@ -97,7 +97,6 @@ public:
     void setLastError(const std::string& message);
 
     DiagnosticsSnapshot snapshot() const;
-    void                reset();
 
 private:
     std::atomic<uint32_t> pollSuccessTotal_{0};

--- a/src/diagnostics/diagnostics.h
+++ b/src/diagnostics/diagnostics.h
@@ -23,6 +23,13 @@ struct DiagnosticsSnapshot {
     uint32_t mqttReconnectTotal        = 0;
     uint32_t modbusClientConnections   = 0;
     uint32_t restRequestTotal          = 0;
+    /// Publishes espMqttClient refused: disconnected, or its outbox out of memory.
+    ///
+    /// The symptom of an MQTT client that is wedged or falling behind while still reporting
+    /// connected. Until this existed the return value of publish() was discarded at eleven of
+    /// its twelve call sites, so a refused publish was indistinguishable from a delivered one
+    /// on every output (audit, 2026-07-26).
+    uint32_t mqttPublishFailureTotal   = 0;
     uint64_t lastSuccessfulPollMs      = 0;
     /// Lowest-ever free stack per application task, in bytes (ESP-IDF's xtensa port defines
     /// StackType_t as uint8_t, so uxTaskGetStackHighWaterMark already returns bytes). Each
@@ -66,6 +73,10 @@ public:
     void recordMqttReconnect() { mqttReconnectTotal_.fetch_add(1, std::memory_order_relaxed); }
     void recordModbusClient() { modbusClientConnections_.fetch_add(1, std::memory_order_relaxed); }
     void recordRestRequest() { restRequestTotal_.fetch_add(1, std::memory_order_relaxed); }
+    /// Called from the MQTT task, hence the atomic like every other counter here.
+    void recordMqttPublishFailure() {
+        mqttPublishFailureTotal_.fetch_add(1, std::memory_order_relaxed);
+    }
 
     /// Stack high-water marks, in bytes. Each task reports its OWN mark
     /// (uxTaskGetStackHighWaterMark(nullptr)) so no task handle ever crosses a boundary.
@@ -99,6 +110,7 @@ private:
     std::atomic<uint32_t> mqttReconnectTotal_{0};
     std::atomic<uint32_t> modbusClientConnections_{0};
     std::atomic<uint32_t> restRequestTotal_{0};
+    std::atomic<uint32_t> mqttPublishFailureTotal_{0};
     std::atomic<uint64_t> lastSuccessfulPollMs_{0};
     std::atomic<uint32_t> rs485StackFreeBytes_{0};
     std::atomic<uint32_t> loopStackFreeBytes_{0};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1120,6 +1120,17 @@ void setup() {
     // 5 s default: an extended discovery scan legitimately runs many back-to-back 3 s
     // transactions between feeds, and the purpose here is catching forever-hangs, not
     // latency policing.
+    //
+    // Side effect worth naming: esp_task_wdt_reconfigure applies to EVERY watched task,
+    // including the core-0 idle task kept by idle_core_mask. So idle starvation on core 0,
+    // which the IDF default would have caught in 5 s, now takes two minutes to trip. The API
+    // has no per-task timeout, so the choice is this or no idle coverage at all; discovery
+    // needs the headroom more than idle starvation needs the faster trip.
+    //
+    // Not watched at all: the AsyncTCP task behind the web server and the task espMqttClient
+    // creates for itself. Registering a task whose blocking behaviour we do not control risks
+    // panicking a healthy device, so their liveness is reported through diagnostics instead
+    // (webLastServiceMs / mqttLastServiceMs) and left for a human or an alert to act on.
     esp_task_wdt_config_t wdtConfig = {
         .timeout_ms    = 120000,
         .idle_core_mask = 1 << 0,  // keep the idle-task coverage the sdkconfig had

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,6 +249,10 @@ BridgeInfo bridgeInfo() {
     info.freeHeapBytes    = ESP.getFreeHeap();
     info.minFreeHeapBytes = ESP.getMinFreeHeap();
     info.maxAllocHeapBytes = ESP.getMaxAllocHeap();
+    // Separate from the three above, which are MALLOC_CAP_INTERNAL. Both accessors are guarded
+    // by psramFound() inside the core, so a board without PSRAM reports 0 rather than failing.
+    info.psramSizeBytes    = ESP.getPsramSize();
+    info.psramFreeBytes    = ESP.getFreePsram();
     info.resetReason      = static_cast<uint16_t>(esp_reset_reason());
     info.wifiConnected    = g_wifi.connected();
     info.wifiRssiDbm      = g_wifi.rssi();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "config/configuration_store.h"
 #include "config/nvs_backend.h"
 #include "device/device_context.h"
+#include "diagnostics/coredump.h"
 #include "diagnostics/diagnostics.h"
 #include "diagnostics/log_timestamp.h"
 #include "diagnostics/logger.h"
@@ -174,6 +175,14 @@ std::atomic<bool> g_manualPollRequested{false};
 /// the log-timestamp provider.
 uint64_t nowMs() { return static_cast<uint64_t>(esp_timer_get_time() / 1000); }
 
+/// The crash dump the previous boot left behind, read ONCE in setup().
+///
+/// Not per request: reading it verifies a checksum over the whole stored image. It also cannot
+/// change while we run -- a new dump is only written by a panic, and a panic does not come back
+/// here -- so a cached copy is not merely an optimisation, it is the accurate model. Cleared in
+/// place when the erase action succeeds, which is the one thing that CAN change it.
+diag::CoredumpSummary g_coredump;
+
 /// The bridge's DRM relays (empty on boards without them). Commands arrive on two tasks
 /// (REST via AsyncTCP, MQTT via the client's task); g_relayMutex serialises them and the
 /// state reads in bridgeInfo(). The controller itself stays lock-free and host-testable.
@@ -270,6 +279,9 @@ BridgeInfo bridgeInfo() {
     info.ntpServer        = ntpSource.server;
     info.ntpFromDhcp      = ntpSource.fromDhcp;
     info.otaImageState    = ota::imageStateName();
+    info.coredumpPresent  = g_coredump.present;
+    info.coredumpTask     = g_coredump.taskName;
+    info.coredumpPc       = g_coredump.programCounter;
     if (g_relays.count() > 0) {
         {
             std::lock_guard<std::mutex> lock(g_relayMutex);
@@ -680,6 +692,16 @@ void startRestApi() {
     ctx.requestDiscovery    = [](bool extended) { return g_discovery.request(extended); };
     ctx.discoveryReport     = [] { return g_discovery.report(); };
     ctx.requestFactoryReset = [] { return g_store.factoryReset(); };
+    // Clears a dump the operator has dealt with. Without it every later diagnostics read keeps
+    // reporting the same old crash, and "is this new?" becomes unanswerable. The cached copy is
+    // updated in the same breath so the next payload agrees with the flash.
+    ctx.clearCoredump = [] {
+        if (!diag::eraseCoredump()) {
+            return false;
+        }
+        g_coredump = {};
+        return true;
+    };
     ctx.portalActive        = [] { return g_wifi.portalActive(); };
     ctx.scanNetworks        = scanNetworksJson;
     if (g_relays.count() > 0) {
@@ -928,6 +950,17 @@ void setup() {
     tzset();
 
     log::info("config: %s (log level %s)", loadResultName(loaded), logLevelName(g_config.logLevel));
+
+    // Once per boot, before anything else can panic on top of it. A dump here means the PREVIOUS
+    // run crashed; saying so in the boot log is half the value, because that log is what gets
+    // read after an unexplained reboot.
+    g_coredump = diag::readCoredumpSummary();
+    if (g_coredump.present) {
+        log::warn("coredump: previous boot crashed in task '%s' at pc 0x%08lX "
+                  "(clear it from Diagnostics once handled)",
+                  g_coredump.taskName.empty() ? "?" : g_coredump.taskName.c_str(),
+                  static_cast<unsigned long>(g_coredump.programCounter));
+    }
     if (loaded == LoadResult::Corrupt || loaded == LoadResult::FutureVersion) {
         // Defaults, so the device lands in the setup portal. Better than running on values we
         // could not parse or do not understand.

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -338,6 +338,16 @@ void RegisterMap::update(const DeviceState& state, const BridgeInfo& bridge,
     writeU16(reg::kDiagFirmwareMajor, bridge.firmwareMajor);
     writeU16(reg::kDiagFirmwareMinor, bridge.firmwareMinor);
     writeU16(reg::kDiagFirmwarePatch, bridge.firmwarePatch);
+    // Sentinel rather than 0 for a board with no PSRAM: 0 free is a real reading on a board
+    // that has it and has exhausted it, and a monitoring rule must be able to tell those
+    // apart. kDiagFreeHeap above is internal SRAM only and never included this.
+    if (bridge.psramSizeBytes > 0) {
+        writeU32(reg::kDiagPsramSize, bridge.psramSizeBytes);
+        writeU32(reg::kDiagPsramFree, bridge.psramFreeBytes);
+    } else {
+        writeU32(reg::kDiagPsramSize, kInvalidU32);
+        writeU32(reg::kDiagPsramFree, kInvalidU32);
+    }
     // Read-only observation of the bridge relays; the sentinel distinguishes "no relay
     // hardware" from "relays, none energised". Control never goes through Modbus.
     if (bridge.relayCount > 0) {

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -348,6 +348,7 @@ void RegisterMap::update(const DeviceState& state, const BridgeInfo& bridge,
         writeU32(reg::kDiagPsramSize, kInvalidU32);
         writeU32(reg::kDiagPsramFree, kInvalidU32);
     }
+    writeU16(reg::kDiagCoredump, bridge.coredumpPresent ? 1 : 0);
     // Read-only observation of the bridge relays; the sentinel distinguishes "no relay
     // hardware" from "relays, none energised". Control never goes through Modbus.
     if (bridge.relayCount > 0) {

--- a/src/outputs/modbus_tcp/register_map.h
+++ b/src/outputs/modbus_tcp/register_map.h
@@ -127,6 +127,11 @@ inline constexpr uint16_t kDiagInvalidFrames = 818;  // uint32
 inline constexpr uint16_t kDiagFirmwareMajor = 820;  // uint16
 inline constexpr uint16_t kDiagFirmwareMinor = 821;  // uint16
 inline constexpr uint16_t kDiagFirmwarePatch = 822;  // uint16
+// External PSRAM. NOT part of kDiagFreeHeap/kDiagMinFreeHeap above, which are internal SRAM
+// only. All-ones = this board has no PSRAM (or it failed to initialise), distinct from a
+// board that has it and has run out.
+inline constexpr uint16_t kDiagPsramSize     = 824;  // uint32, 0xFFFFFFFF = no PSRAM
+inline constexpr uint16_t kDiagPsramFree     = 826;  // uint32, 0xFFFFFFFF = no PSRAM
 // Bridge relays (DRM contacts). READ-ONLY here by design: relay control goes through the
 // admin-gated REST/MQTT paths with their safety gates; the unauthenticated Modbus surface
 // only ever observes. 0xFFFF sentinel on boards without relays (count 0 would claim

--- a/src/outputs/modbus_tcp/register_map.h
+++ b/src/outputs/modbus_tcp/register_map.h
@@ -132,6 +132,9 @@ inline constexpr uint16_t kDiagFirmwarePatch = 822;  // uint16
 // board that has it and has run out.
 inline constexpr uint16_t kDiagPsramSize     = 824;  // uint32, 0xFFFFFFFF = no PSRAM
 inline constexpr uint16_t kDiagPsramFree     = 826;  // uint32, 0xFFFFFFFF = no PSRAM
+// 1 = a crash dump is waiting in the coredump partition. Read the task name and PC from
+// /api/v1/diagnostics; a Modbus client only needs to know whether to raise the alarm.
+inline constexpr uint16_t kDiagCoredump      = 828;  // uint16, 0 or 1
 // Bridge relays (DRM contacts). READ-ONLY here by design: relay control goes through the
 // admin-gated REST/MQTT paths with their safety gates; the unauthenticated Modbus surface
 // only ever observes. 0xFFFF sentinel on boards without relays (count 0 would claim

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -26,6 +26,26 @@ espMqttClient g_client;
 
 }  // namespace
 
+/// publish() that notices a refusal.
+///
+/// espMqttClient returns a packet id, or 0 when it could not accept the message -- link down,
+/// or the outbox out of memory. Eleven of the twelve call sites in this file discarded that,
+/// so a message that never left looked exactly like one that did, on every output. A backed-up
+/// or wedged client reports connected the whole time, which is precisely the failure this
+/// counter makes visible (audit, 2026-07-26).
+///
+/// Returns the same bool the one careful call site already wanted, so forgetDevice keeps its
+/// existing semantics.
+bool MqttOutput::publishTracked(const char* topic, uint8_t qos, bool retain, const char* payload) {
+    if (g_client.publish(topic, qos, retain, payload) != 0) {
+        return true;
+    }
+    if (diagnostics_ != nullptr) {
+        diagnostics_->recordMqttPublishFailure();
+    }
+    return false;
+}
+
 MqttOutput::MqttOutput(MqttConfig config, PublishPolicy publishPolicy)
     : config_(std::move(config)),
       topics_(config_.baseTopic, "pending"),
@@ -176,7 +196,7 @@ void MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
     for (const auto& e : buildDiscoveryEntities(state, bridge, channel.topics,
                                                 topics_.availability(), config_.discoveryPrefix,
                                                 channel.uniqueBase)) {
-        g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
+        publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str());
     }
     // Bridge entities belong to the bridge and are announced once -- publishing them per
     // device would create N copies of the same RSSI sensor. Tied to the bridge-scoped channel
@@ -184,12 +204,12 @@ void MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
     if (channel.uniqueBase == bridge.bridgeId) {
         for (const auto& e :
              buildBridgeDiagnosticEntities(bridge, topics_, config_.discoveryPrefix)) {
-            g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
+            publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str());
         }
         // Relay switches -- or, when the feature is disabled on a relay board, empty retained
         // payloads that remove previously announced switches from Home Assistant.
         for (const auto& e : buildRelayEntities(bridge, topics_, config_.discoveryPrefix)) {
-            g_client.publish(e.configTopic.c_str(), 1, true, e.payload.c_str());
+            publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str());
         }
     }
     channel.discoveryPublished = true;
@@ -197,14 +217,14 @@ void MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
 
 void MqttOutput::onConnected(Channel& channel, const DeviceState& state,
                              const BridgeInfo& bridge) {
-    g_client.publish(topics_.availability().c_str(), 1, true, kPayloadOnline);
+    publishTracked(topics_.availability().c_str(), 1, true, kPayloadOnline);
 
     std::string payload;
     if (buildIdentityPayload(state.identity, payload)) {
-        g_client.publish(channel.topics.identity().c_str(), 1, true, payload.c_str());
+        publishTracked(channel.topics.identity().c_str(), 1, true, payload.c_str());
     }
     if (json_util::buildCapabilitiesPayload(state.capabilities, payload, kMaxPayloadBytes)) {
-        g_client.publish(channel.topics.capabilities().c_str(), 1, true, payload.c_str());
+        publishTracked(channel.topics.capabilities().c_str(), 1, true, payload.c_str());
     }
     publishDiscovery(channel, state, bridge);
 
@@ -288,7 +308,7 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
         if (channel.throttle.shouldPublish(state, nowMs)) {
             std::string payload;
             if (buildStatePayload(state, payload)) {
-                g_client.publish(channel.topics.state().c_str(), config_.qos, true,
+                publishTracked(channel.topics.state().c_str(), config_.qos, true,
                                  payload.c_str());
                 channel.throttle.recordPublished(state, nowMs);
             }
@@ -317,7 +337,7 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
             bridge.relayMask != lastRelayMask_) {
             for (uint8_t i = 0; i < bridge.relayCount; ++i) {
                 const bool on = (bridge.relayMask >> i) & 1;
-                g_client.publish(topics_.relayState(i).c_str(), 1, true,
+                publishTracked(topics_.relayState(i).c_str(), 1, true,
                                  on ? "ON" : "OFF");
             }
             // The DRM mode is derived state over the same mask; ack it in the same breath
@@ -326,7 +346,7 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
             roles.resize(bridge.relayCount, "none");
             if (!drm::optionsFor(roles).empty()) {
                 const std::string mode = drm::modeFrom(roles, bridge.relayMask);
-                g_client.publish(topics_.drmState().c_str(), 1, true, mode.c_str());
+                publishTracked(topics_.drmState().c_str(), 1, true, mode.c_str());
             }
             lastRelayMask_    = bridge.relayMask;
             relayStateForced_ = false;
@@ -336,7 +356,7 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
     if (nowMs - lastDiagnosticsMs_ >= config_.diagnosticsIntervalMs) {
         std::string payload;
         if (buildDiagnosticsPayload(diagnostics, bridge, payload)) {
-            g_client.publish(topics_.diagnostics().c_str(), 0, true, payload.c_str());
+            publishTracked(topics_.diagnostics().c_str(), 0, true, payload.c_str());
         }
         lastDiagnosticsMs_ = nowMs;
     }
@@ -355,7 +375,7 @@ bool MqttOutput::forgetDevice(const DeviceId& id, const BridgeInfo& bridge) {
     // clear that never left must not be recorded as done (review, 2026-07-26).
     bool ok = true;
     const auto clear = [&](const std::string& topic) {
-        ok = (g_client.publish(topic.c_str(), 1, true, "") != 0) && ok;
+        ok = publishTracked(topic.c_str(), 1, true, "") && ok;
     };
 
     // The device's own retained payloads. Empty, retained: a subscriber that connects later
@@ -383,7 +403,7 @@ bool MqttOutput::forgetDevice(const DeviceId& id, const BridgeInfo& bridge) {
 void MqttOutput::stop() {
     if (started_) {
         // Say goodbye properly so subscribers do not have to wait for the will.
-        g_client.publish(topics_.availability().c_str(), 1, true, kPayloadOffline);
+        publishTracked(topics_.availability().c_str(), 1, true, kPayloadOffline);
         g_client.disconnect();
         started_ = false;
     }

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -402,8 +402,15 @@ bool MqttOutput::forgetDevice(const DeviceId& id, const BridgeInfo& bridge) {
 
 void MqttOutput::stop() {
     if (started_) {
-        // Say goodbye properly so subscribers do not have to wait for the will.
-        publishTracked(topics_.availability().c_str(), 1, true, kPayloadOffline);
+        // Say goodbye properly so subscribers do not have to wait for the will -- but only if
+        // there is a link to say it on. Unguarded, stopping while the broker is already gone
+        // (a config change during an outage is the realistic case, and stop() is not only the
+        // reboot path) charges the publish-failure counter for a message that was never going
+        // to be accepted. One spurious count is enough to send somebody looking for a fault
+        // that is not there, which defeats a counter whose whole value is that it stays at 0.
+        if (g_client.connected()) {
+            publishTracked(topics_.availability().c_str(), 1, true, kPayloadOffline);
+        }
         g_client.disconnect();
         started_ = false;
     }

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -138,6 +138,10 @@ private:
         uint64_t        discoveredSignature = 0;
     };
 
+    /// publish() whose refusals are counted. Every publish in this class goes through it --
+    /// see the definition for why discarding the return value was hiding a real failure mode.
+    bool publishTracked(const char* topic, uint8_t qos, bool retain, const char* payload);
+
     Channel& channelFor(const DeviceView& view, const BridgeInfo& bridge);
 
     void onConnected(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -75,13 +75,15 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     // and `coredump_present` false already carries the whole message. The partition and the
     // IDF support have existed since the OTA layout was designed; nothing read them until now.
     doc["coredump_present"] = bridge.coredumpPresent;
-    if (bridge.coredumpPresent) {
-        doc["coredump_task"] = bridge.coredumpTask.empty() ? nullptr
-                                                           : JsonString(bridge.coredumpTask.c_str());
-        doc["coredump_pc"]   = bridge.coredumpPc;
+    if (bridge.coredumpPresent && !bridge.coredumpTask.empty()) {
+        doc["coredump_task"] = bridge.coredumpTask;  // std::string: copied into the document
     } else {
         doc["coredump_task"] = nullptr;
-        doc["coredump_pc"]   = nullptr;
+    }
+    if (bridge.coredumpPresent) {
+        doc["coredump_pc"] = bridge.coredumpPc;
+    } else {
+        doc["coredump_pc"] = nullptr;
     }
     doc["wifi_connected"]            = bridge.wifiConnected;
     // Only meaningful while associated; 0 dBm would look like an excellent signal.

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -56,6 +56,18 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     doc["free_heap_bytes"]           = bridge.freeHeapBytes;
     doc["minimum_free_heap_bytes"]   = bridge.minFreeHeapBytes;
     doc["max_alloc_heap_bytes"]      = bridge.maxAllocHeapBytes;
+
+    // Absent, not zero, when the board has none -- and 0 is a legitimate reading for
+    // psram_free_bytes on a board that HAS PSRAM and has exhausted it, so the two must not
+    // collapse onto the same value. Reported at all because the three heap figures above are
+    // MALLOC_CAP_INTERNAL and say nothing about it (audit, 2026-07-26).
+    if (bridge.psramSizeBytes > 0) {
+        doc["psram_size_bytes"] = bridge.psramSizeBytes;
+        doc["psram_free_bytes"] = bridge.psramFreeBytes;
+    } else {
+        doc["psram_size_bytes"] = nullptr;
+        doc["psram_free_bytes"] = nullptr;
+    }
     doc["reset_reason"]              = bridge.resetReason;
     doc["ota_image_state"]           = bridge.otaImageState;
     doc["wifi_connected"]            = bridge.wifiConnected;

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -101,6 +101,7 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     doc["mqtt_reconnect_total"]      = d.mqttReconnectTotal;
     doc["modbus_client_connections_total"] = d.modbusClientConnections;
     doc["rest_requests_total"]       = d.restRequestTotal;
+    doc["mqtt_publish_failure_total"] = d.mqttPublishFailureTotal;
     doc["last_successful_poll_ms"]   = d.lastSuccessfulPollMs;
     // Null until the first sample, not 0: same reasoning as the RSSI field above.
     if (d.rs485StackFreeBytes > 0) {

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -70,6 +70,19 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     }
     doc["reset_reason"]              = bridge.resetReason;
     doc["ota_image_state"]           = bridge.otaImageState;
+
+    // Absent, not zero, when no dump is stored: task "" at PC 0 is not a fact about anything,
+    // and `coredump_present` false already carries the whole message. The partition and the
+    // IDF support have existed since the OTA layout was designed; nothing read them until now.
+    doc["coredump_present"] = bridge.coredumpPresent;
+    if (bridge.coredumpPresent) {
+        doc["coredump_task"] = bridge.coredumpTask.empty() ? nullptr
+                                                           : JsonString(bridge.coredumpTask.c_str());
+        doc["coredump_pc"]   = bridge.coredumpPc;
+    } else {
+        doc["coredump_task"] = nullptr;
+        doc["coredump_pc"]   = nullptr;
+    }
     doc["wifi_connected"]            = bridge.wifiConnected;
     // Only meaningful while associated; 0 dBm would look like an excellent signal.
     if (bridge.wifiConnected) {

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -166,6 +166,10 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
     appendHelp(out, "heliograph_mqtt_reconnects_total", "MQTT reconnections", "counter");
     appendValue(out, "heliograph_mqtt_reconnects_total",
                 static_cast<unsigned long>(d.mqttReconnectTotal));
+    appendHelp(out, "heliograph_mqtt_publish_failures_total",
+               "Publishes the MQTT client refused (link down, or outbox full)", "counter");
+    appendValue(out, "heliograph_mqtt_publish_failures_total",
+                static_cast<unsigned long>(d.mqttPublishFailureTotal));
     appendHelp(out, "heliograph_wifi_reconnects_total", "WiFi reconnections", "counter");
     appendValue(out, "heliograph_wifi_reconnects_total",
                 static_cast<unsigned long>(d.wifiReconnectTotal));

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -203,6 +203,18 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
                "Largest allocatable heap block (fragmentation signal)", "gauge");
     appendValue(out, "heliograph_max_alloc_heap_bytes",
                 static_cast<unsigned long>(bridge.maxAllocHeapBytes));
+    // The three gauges above are MALLOC_CAP_INTERNAL and exclude PSRAM entirely, so on an 8 MB
+    // board they describe ~300 KB of the RAM that exists. Emitted only when there IS PSRAM:
+    // a flat 0 on the Relay-6CH, which has none, would look like exhaustion to an alert rule
+    // -- the same reasoning as the RSSI and stack gauges (audit, 2026-07-26).
+    if (bridge.psramSizeBytes > 0) {
+        appendHelp(out, "heliograph_psram_size_bytes", "Total external PSRAM", "gauge");
+        appendValue(out, "heliograph_psram_size_bytes",
+                    static_cast<unsigned long>(bridge.psramSizeBytes));
+        appendHelp(out, "heliograph_psram_free_bytes", "Free external PSRAM", "gauge");
+        appendValue(out, "heliograph_psram_free_bytes",
+                    static_cast<unsigned long>(bridge.psramFreeBytes));
+    }
     // Omitted until the first sample, like the RSSI gauge above: 0 would read as an
     // exhausted stack to any alerting rule.
     if (d.rs485StackFreeBytes > 0) {

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -203,6 +203,14 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
                "Largest allocatable heap block (fragmentation signal)", "gauge");
     appendValue(out, "heliograph_max_alloc_heap_bytes",
                 static_cast<unsigned long>(bridge.maxAllocHeapBytes));
+    // Always emitted, unlike the gauges below it: 0 means "no crash dump stored", which is a
+    // fact rather than a missing sample, and it is the value an alert rule wants to watch for
+    // going to 1. The task name and PC are not metric material -- read those from
+    // /api/v1/diagnostics once this fires.
+    appendHelp(out, "heliograph_coredump_present",
+               "1 when a crash dump is waiting in flash", "gauge");
+    appendValue(out, "heliograph_coredump_present",
+                static_cast<unsigned long>(bridge.coredumpPresent ? 1 : 0));
     // The three gauges above are MALLOC_CAP_INTERNAL and exclude PSRAM entirely, so on an 8 MB
     // board they describe ~300 KB of the RAM that exists. Emitted only when there IS PSRAM:
     // a flat 0 on the Relay-6CH, which has none, would look like exhaustion to an alert rule

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -816,6 +816,21 @@ bool RestApi::begin() {
             }
         });
 
+    g_server->on("/api/v1/actions/clear-coredump", HTTP_POST,
+                 [this, authorised, rateLimited](AsyncWebServerRequest* request) {
+        if (!authorised(request) || rateLimited(request)) {
+            return;
+        }
+        context_.diagnostics->recordRestRequest();
+        if (context_.clearCoredump == nullptr || !context_.clearCoredump()) {
+            // 404, not 500: by far the likeliest reason is that there is nothing stored, which
+            // is the normal state and not an error the caller should retry.
+            sendError(request, {404, "no_coredump", "no crash dump is stored"});
+            return;
+        }
+        request->send(200, kJson, "{\"status\":\"cleared\"}");
+    });
+
     g_server->on("/api/v1/actions/reboot", HTTP_POST,
                  [this, authorised, rateLimited](AsyncWebServerRequest* request) {
         if (!authorised(request) || rateLimited(request)) {

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -70,6 +70,10 @@ struct RestContext {
     /// The same wipe the BOOT-hold performs, reached over the network instead of the button --
     /// which is what a user without physical access has when a config locks them out.
     std::function<bool()> requestFactoryReset;
+    /// Erases a stored crash dump. Returns false when there was none, or the flash refused.
+    /// Admin-gated and rate-limited like every other action -- it destroys diagnostic evidence,
+    /// which is exactly the sort of thing an unauthenticated caller must not be able to do.
+    std::function<bool()> clearCoredump;
     /// True while the setup portal is up: the API then serves the setup page and /provision.
     std::function<bool()> portalActive;
     /// Scans for networks; returns a JSON body. Portal only.

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -325,6 +325,19 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     }
     doc["reset_reason"]            = bridge.resetReason;
     doc["ota_image_state"]         = bridge.otaImageState;
+
+    // Absent, not zero, when no dump is stored: task "" at PC 0 is not a fact about anything,
+    // and `coredump_present` false already carries the whole message. The partition and the
+    // IDF support have existed since the OTA layout was designed; nothing read them until now.
+    doc["coredump_present"] = bridge.coredumpPresent;
+    if (bridge.coredumpPresent) {
+        doc["coredump_task"] = bridge.coredumpTask.empty() ? nullptr
+                                                           : JsonString(bridge.coredumpTask.c_str());
+        doc["coredump_pc"]   = bridge.coredumpPc;
+    } else {
+        doc["coredump_task"] = nullptr;
+        doc["coredump_pc"]   = nullptr;
+    }
     doc["wifi_connected"]          = bridge.wifiConnected;
     if (bridge.wifiConnected) {
         doc["wifi_rssi_dbm"] = bridge.wifiRssiDbm;

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -330,13 +330,15 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     // and `coredump_present` false already carries the whole message. The partition and the
     // IDF support have existed since the OTA layout was designed; nothing read them until now.
     doc["coredump_present"] = bridge.coredumpPresent;
-    if (bridge.coredumpPresent) {
-        doc["coredump_task"] = bridge.coredumpTask.empty() ? nullptr
-                                                           : JsonString(bridge.coredumpTask.c_str());
-        doc["coredump_pc"]   = bridge.coredumpPc;
+    if (bridge.coredumpPresent && !bridge.coredumpTask.empty()) {
+        doc["coredump_task"] = bridge.coredumpTask;  // std::string: copied into the document
     } else {
         doc["coredump_task"] = nullptr;
-        doc["coredump_pc"]   = nullptr;
+    }
+    if (bridge.coredumpPresent) {
+        doc["coredump_pc"] = bridge.coredumpPc;
+    } else {
+        doc["coredump_pc"] = nullptr;
     }
     doc["wifi_connected"]          = bridge.wifiConnected;
     if (bridge.wifiConnected) {

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -311,6 +311,18 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     doc["free_heap_bytes"]         = bridge.freeHeapBytes;
     doc["minimum_free_heap_bytes"] = bridge.minFreeHeapBytes;
     doc["max_alloc_heap_bytes"]    = bridge.maxAllocHeapBytes;
+
+    // Absent, not zero, when the board has none -- and 0 is a legitimate reading for
+    // psram_free_bytes on a board that HAS PSRAM and has exhausted it, so the two must not
+    // collapse onto the same value. Reported at all because the three heap figures above are
+    // MALLOC_CAP_INTERNAL and say nothing about it (audit, 2026-07-26).
+    if (bridge.psramSizeBytes > 0) {
+        doc["psram_size_bytes"] = bridge.psramSizeBytes;
+        doc["psram_free_bytes"] = bridge.psramFreeBytes;
+    } else {
+        doc["psram_size_bytes"] = nullptr;
+        doc["psram_free_bytes"] = nullptr;
+    }
     doc["reset_reason"]            = bridge.resetReason;
     doc["ota_image_state"]         = bridge.otaImageState;
     doc["wifi_connected"]          = bridge.wifiConnected;

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -356,6 +356,7 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     doc["mqtt_reconnect_total"]            = d.mqttReconnectTotal;
     doc["modbus_client_connections_total"] = d.modbusClientConnections;
     doc["rest_requests_total"]             = d.restRequestTotal;
+    doc["mqtt_publish_failure_total"] = d.mqttPublishFailureTotal;
     doc["last_successful_poll_ms"]         = d.lastSuccessfulPollMs;
     // Null until the first sample, not 0: a monitoring rule on "stack headroom == 0" must
     // not fire during the first seconds after boot.

--- a/test/test_register_map/test_main.cpp
+++ b/test/test_register_map/test_main.cpp
@@ -142,6 +142,21 @@ static void test_psram_registers_carry_the_sentinel_without_psram() {
     TEST_ASSERT_EQUAL_UINT32(kInvalidU32, (static_cast<uint32_t>(v[0]) << 16) | v[1]);
 }
 
+static void test_coredump_register_flags_a_stored_dump() {
+    EversolarRig r;
+    r.bridge.coredumpPresent = true;
+    r.pollAndRender();
+    uint16_t v = 0;
+    TEST_ASSERT_TRUE(r.map.read(reg::kDiagCoredump, 1, &v));
+    TEST_ASSERT_EQUAL_UINT16(1, v);
+
+    EversolarRig clean;
+    clean.bridge.coredumpPresent = false;
+    clean.pollAndRender();
+    TEST_ASSERT_TRUE(clean.map.read(reg::kDiagCoredump, 1, &v));
+    TEST_ASSERT_EQUAL_UINT16(0, v);
+}
+
 // --- schema and framing --------------------------------------------------------------------
 
 static void test_schema_version_is_published() {
@@ -591,5 +606,6 @@ int main(int, char**) {
     RUN_TEST(test_firmware_version_registers_report_the_running_version);
     RUN_TEST(test_psram_registers_report_size_and_free);
     RUN_TEST(test_psram_registers_carry_the_sentinel_without_psram);
+    RUN_TEST(test_coredump_register_flags_a_stored_dump);
     return UNITY_END();
 }

--- a/test/test_register_map/test_main.cpp
+++ b/test/test_register_map/test_main.cpp
@@ -115,6 +115,33 @@ static void test_firmware_version_registers_report_the_running_version() {
     TEST_ASSERT_EQUAL_UINT16(3, v);
 }
 
+// Registers 824-827. The all-ones sentinel distinguishes "this board has no PSRAM" from
+// "it has PSRAM and none is free" -- 0 would collapse the two, and only one of them is a
+// reason to page somebody. kDiagFreeHeap is MALLOC_CAP_INTERNAL and never covered this.
+static void test_psram_registers_report_size_and_free() {
+    EversolarRig r;
+    r.bridge.psramSizeBytes = 8388608;
+    r.bridge.psramFreeBytes = 7340032;
+    r.pollAndRender();
+    uint16_t v[2] = {0, 0};
+    TEST_ASSERT_TRUE(r.map.read(reg::kDiagPsramSize, 2, v));
+    TEST_ASSERT_EQUAL_UINT32(8388608u, (static_cast<uint32_t>(v[0]) << 16) | v[1]);
+    TEST_ASSERT_TRUE(r.map.read(reg::kDiagPsramFree, 2, v));
+    TEST_ASSERT_EQUAL_UINT32(7340032u, (static_cast<uint32_t>(v[0]) << 16) | v[1]);
+}
+
+static void test_psram_registers_carry_the_sentinel_without_psram() {
+    EversolarRig r;
+    r.bridge.psramSizeBytes = 0;  // Relay-6CH
+    r.bridge.psramFreeBytes = 0;
+    r.pollAndRender();
+    uint16_t v[2] = {0, 0};
+    TEST_ASSERT_TRUE(r.map.read(reg::kDiagPsramSize, 2, v));
+    TEST_ASSERT_EQUAL_UINT32(kInvalidU32, (static_cast<uint32_t>(v[0]) << 16) | v[1]);
+    TEST_ASSERT_TRUE(r.map.read(reg::kDiagPsramFree, 2, v));
+    TEST_ASSERT_EQUAL_UINT32(kInvalidU32, (static_cast<uint32_t>(v[0]) << 16) | v[1]);
+}
+
 // --- schema and framing --------------------------------------------------------------------
 
 static void test_schema_version_is_published() {
@@ -562,5 +589,7 @@ int main(int, char**) {
     RUN_TEST(test_validity_bits_fit_the_reserved_space);
     RUN_TEST(test_relay_registers_use_the_sentinel_without_hardware);
     RUN_TEST(test_firmware_version_registers_report_the_running_version);
+    RUN_TEST(test_psram_registers_report_size_and_free);
+    RUN_TEST(test_psram_registers_carry_the_sentinel_without_psram);
     return UNITY_END();
 }

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1418,6 +1418,51 @@ static void test_psram_is_null_on_a_board_without_it() {
     TEST_ASSERT_TRUE(doc["psram_free_bytes"].isNull());
 }
 
+// The dump has been written to flash on every panic since the OTA partition layout was
+// designed; nothing read it until 2026-07-26. These pin the reporting, not the reading -- the
+// esp_core_dump_* calls are ESP32-only and the summary reaches the builder as a plain struct.
+static void test_coredump_is_reported_when_one_is_stored() {
+    Rig  r;
+    auto bridge            = makeBridge();
+    bridge.coredumpPresent = true;
+    bridge.coredumpTask    = "rs485";
+    bridge.coredumpPc      = 0x42011AF0;
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_TRUE(doc["coredump_present"].as<bool>());
+    TEST_ASSERT_EQUAL_STRING("rs485", doc["coredump_task"].as<const char*>());
+    TEST_ASSERT_EQUAL_UINT32(0x42011AF0u, doc["coredump_pc"].as<uint32_t>());
+}
+
+// Task "" at PC 0 is not a fact about anything, and coredump_present already carries the whole
+// message. Null keeps a dashboard from rendering a crash that did not happen.
+static void test_coredump_details_are_null_when_none_is_stored() {
+    Rig  r;
+    auto bridge            = makeBridge();
+    bridge.coredumpPresent = false;
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_FALSE(doc["coredump_present"].as<bool>());
+    TEST_ASSERT_TRUE(doc["coredump_task"].isNull());
+    TEST_ASSERT_TRUE(doc["coredump_pc"].isNull());
+}
+
+// A dump whose summary could not be parsed still says present -- the ELF is retrievable with
+// the host tool even when the on-device summariser cannot read it.
+static void test_a_nameless_coredump_still_reports_present() {
+    Rig  r;
+    auto bridge            = makeBridge();
+    bridge.coredumpPresent = true;
+    bridge.coredumpTask    = "";
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_TRUE(doc["coredump_present"].as<bool>());
+    TEST_ASSERT_TRUE(doc["coredump_task"].isNull());
+}
+
 static void test_stack_marks_are_null_before_the_first_sample() {
     // 0 would read as an exhausted stack to any alerting rule; before the tasks have
     // sampled themselves the honest answer is "unknown".
@@ -1469,6 +1514,23 @@ static void test_prometheus_stack_and_fragmentation_gauges() {
 
 // Omitted rather than zero on a board with no PSRAM, like the RSSI and stack gauges: a flat 0
 // would read as exhaustion to an alerting rule.
+// 0 is a fact here ("no crash stored"), not a missing sample, so unlike the PSRAM gauges this
+// one is always emitted -- it is the series an alert rule watches for going to 1.
+static void test_prometheus_always_reports_the_coredump_flag() {
+    Rig        r;
+    const auto state = r.poll();
+
+    auto clean = makeBridge();
+    clean.coredumpPresent = false;
+    auto text = metricsOf(state, clean, r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("heliograph_coredump_present 0\n") != std::string::npos);
+
+    auto crashed = makeBridge();
+    crashed.coredumpPresent = true;
+    text = metricsOf(state, crashed, r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("heliograph_coredump_present 1\n") != std::string::npos);
+}
+
 static void test_prometheus_reports_psram_only_when_present() {
     Rig        r;
     const auto state = r.poll();
@@ -1957,6 +2019,10 @@ int main(int, char**) {
     RUN_TEST(test_psram_is_reported_when_the_board_has_it);
     RUN_TEST(test_psram_is_null_on_a_board_without_it);
     RUN_TEST(test_prometheus_reports_psram_only_when_present);
+    RUN_TEST(test_coredump_is_reported_when_one_is_stored);
+    RUN_TEST(test_coredump_details_are_null_when_none_is_stored);
+    RUN_TEST(test_a_nameless_coredump_still_reports_present);
+    RUN_TEST(test_prometheus_always_reports_the_coredump_flag);
     RUN_TEST(test_stack_marks_are_null_before_the_first_sample);
     RUN_TEST(test_oversized_response_is_refused);
     RUN_TEST(test_prometheus_stack_and_fragmentation_gauges);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1421,6 +1421,22 @@ static void test_psram_is_null_on_a_board_without_it() {
 // The dump has been written to flash on every panic since the OTA partition layout was
 // designed; nothing read it until 2026-07-26. These pin the reporting, not the reading -- the
 // esp_core_dump_* calls are ESP32-only and the summary reaches the builder as a plain struct.
+// Until this counter existed, publish() returning 0 -- link down, or the client's outbox out
+// of memory -- was discarded at eleven of its twelve call sites, so a message that never left
+// looked exactly like one that did. A wedged client reports connected the whole time, which is
+// why mqtt_connected alone was not enough.
+static void test_mqtt_publish_failures_are_counted_and_published() {
+    Rig r;
+    r.diagnostics.recordMqttPublishFailure();
+    r.diagnostics.recordMqttPublishFailure();
+    r.diagnostics.recordMqttPublishFailure();
+
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), makeBridge(), json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(3, doc["mqtt_publish_failure_total"].as<uint32_t>());
+}
+
 static void test_coredump_is_reported_when_one_is_stored() {
     Rig  r;
     auto bridge            = makeBridge();
@@ -1516,6 +1532,19 @@ static void test_prometheus_stack_and_fragmentation_gauges() {
 // would read as exhaustion to an alerting rule.
 // 0 is a fact here ("no crash stored"), not a missing sample, so unlike the PSRAM gauges this
 // one is always emitted -- it is the series an alert rule watches for going to 1.
+// A counter, so 0 is emitted from the start: a rate() rule needs the series to exist before
+// the first failure, not to appear at the moment things go wrong.
+static void test_prometheus_exports_the_publish_failure_counter() {
+    Rig        r;
+    const auto state = r.poll();
+    auto       text  = metricsOf(state, makeBridge(), r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("heliograph_mqtt_publish_failures_total 0\n") != std::string::npos);
+
+    r.diagnostics.recordMqttPublishFailure();
+    text = metricsOf(state, makeBridge(), r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("heliograph_mqtt_publish_failures_total 1\n") != std::string::npos);
+}
+
 static void test_prometheus_always_reports_the_coredump_flag() {
     Rig        r;
     const auto state = r.poll();
@@ -2019,6 +2048,8 @@ int main(int, char**) {
     RUN_TEST(test_psram_is_reported_when_the_board_has_it);
     RUN_TEST(test_psram_is_null_on_a_board_without_it);
     RUN_TEST(test_prometheus_reports_psram_only_when_present);
+    RUN_TEST(test_mqtt_publish_failures_are_counted_and_published);
+    RUN_TEST(test_prometheus_exports_the_publish_failure_counter);
     RUN_TEST(test_coredump_is_reported_when_one_is_stored);
     RUN_TEST(test_coredump_details_are_null_when_none_is_stored);
     RUN_TEST(test_a_nameless_coredump_still_reports_present);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1389,6 +1389,35 @@ static void test_diagnostics_report_stack_marks_and_fragmentation() {
     TEST_ASSERT_EQUAL_UINT32(65536, doc["max_alloc_heap_bytes"].as<uint32_t>());
 }
 
+// The three heap figures are MALLOC_CAP_INTERNAL and exclude PSRAM, so without these two an
+// 8 MB board reported ~300 KB of RAM and a board whose PSRAM never trained looked identical
+// to one where it worked (audit, 2026-07-26).
+static void test_psram_is_reported_when_the_board_has_it() {
+    Rig  r;
+    auto bridge            = makeBridge();
+    bridge.psramSizeBytes  = 8 * 1024 * 1024;
+    bridge.psramFreeBytes  = 7 * 1024 * 1024;
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(8388608, doc["psram_size_bytes"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(7340032, doc["psram_free_bytes"].as<uint32_t>());
+}
+
+// Null, not 0. Zero free is a real reading on a board that HAS PSRAM and has exhausted it;
+// collapsing that onto "no PSRAM fitted" would hide the more alarming of the two.
+static void test_psram_is_null_on_a_board_without_it() {
+    Rig  r;
+    auto bridge           = makeBridge();
+    bridge.psramSizeBytes = 0;  // Relay-6CH: ESP32-S3-WROOM-1U-N8, no PSRAM
+    bridge.psramFreeBytes = 0;
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_TRUE(doc["psram_size_bytes"].isNull());
+    TEST_ASSERT_TRUE(doc["psram_free_bytes"].isNull());
+}
+
 static void test_stack_marks_are_null_before_the_first_sample() {
     // 0 would read as an exhausted stack to any alerting rule; before the tasks have
     // sampled themselves the honest answer is "unknown".
@@ -1436,6 +1465,26 @@ static void test_prometheus_stack_and_fragmentation_gauges() {
     TEST_ASSERT_TRUE(text.find("heliograph_rs485_stack_free_bytes 2500\n") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_loop_stack_free_bytes 4100\n") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_max_alloc_heap_bytes 65536\n") != std::string::npos);
+}
+
+// Omitted rather than zero on a board with no PSRAM, like the RSSI and stack gauges: a flat 0
+// would read as exhaustion to an alerting rule.
+static void test_prometheus_reports_psram_only_when_present() {
+    Rig        r;
+    const auto state = r.poll();
+
+    auto without = makeBridge();
+    without.psramSizeBytes = 0;
+    auto text = metricsOf(state, without, r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("heliograph_psram_size_bytes") == std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_psram_free_bytes") == std::string::npos);
+
+    auto with_ = makeBridge();
+    with_.psramSizeBytes = 8388608;
+    with_.psramFreeBytes = 7340032;
+    text = metricsOf(state, with_, r.diagnostics.snapshot());
+    TEST_ASSERT_TRUE(text.find("heliograph_psram_size_bytes 8388608\n") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_psram_free_bytes 7340032\n") != std::string::npos);
 }
 
 static void test_prometheus_exports_current_readings() {
@@ -1905,6 +1954,9 @@ int main(int, char**) {
     RUN_TEST(test_drivers_payload_drives_the_wizard);
     RUN_TEST(test_diagnostics_payload_has_no_secrets);
     RUN_TEST(test_diagnostics_report_stack_marks_and_fragmentation);
+    RUN_TEST(test_psram_is_reported_when_the_board_has_it);
+    RUN_TEST(test_psram_is_null_on_a_board_without_it);
+    RUN_TEST(test_prometheus_reports_psram_only_when_present);
     RUN_TEST(test_stack_marks_are_null_before_the_first_sample);
     RUN_TEST(test_oversized_response_is_refused);
     RUN_TEST(test_prometheus_stack_and_fragmentation_gauges);


### PR DESCRIPTION
Implements `docs/esp32s3-hardware-audit.md`, which merged in #49. Every quick win, both
medium items, and one recommendation withdrawn because checking it showed the justification
was wrong.

#49 was merged while it still held only the audit document, so these six commits never got a
CI run there. They are replayed here on top of current `main`.

## What the audit found

Eight areas where ESP32-S3 firmware commonly leaves hardware unused, each checked against
the tree with a `path:line` reference.

| # | Topic | Verdict |
|---|---|---|
| 1 | RS485 direction | **Already correct** — `UART_MODE_RS485_HALF_DUPLEX`, no software toggle |
| 2 | Crash diagnostics | Partition **and** IDF support present; nothing read the dump |
| 3 | Watchdogs | **Well covered**; two library-owned tasks unwatched |
| 4 | USB-JTAG | Available by default, never wired into the workflow |
| 5 | Randomness | No weak RNG — **nothing generates a secret** |
| 6 | PSRAM | Enabled, implicitly used, **invisible in diagnostics** |
| 7 | Timing | **Already correct** — `esp_timer` throughout |
| 8 | NVS / OTA rollback | **Verified as claimed** |

Four needed nothing. The brief's suggested coredump partition and sdkconfig changes were
both already in place — what was missing was anything that *reads* the dump.

## What landed

| Commit | |
|---|---|
| `3af9892` | `monitor_filters` for exception decoding; two comments recording what the code is silent about |
| `7e74a15` | PSRAM in all four outputs |
| `8de9686` | `debug-rs485-can` env + the JTAG workflow in `docs/hardware.md` |
| `2127878` | Coredump summary in boot log, REST, MQTT, Prometheus, Modbus + an admin-gated clear action |
| `d494ce7` | MQTT publish-failure counter |
| `a9478c0` | Audit updated: L1 withdrawn, M2's change of shape recorded |
| `1d0dabd` | Self-review: three fixes in my own diff (below) |

**643 native tests** (up from 636), zero warnings from `src/`, all five environments build,
`check_layering.sh` 6/6, cppcheck clean.

## The blind spot this closed

`ESP.getFreeHeap()`, `getMinFreeHeap()` and `getMaxAllocHeap()` are all
`MALLOC_CAP_INTERNAL`, so every memory figure the bridge published described ~300 KB of a
board that has 8 MB. A board whose PSRAM failed to train looked byte-for-byte identical, on
every output, to one where it worked. Now reported as `psram_size_bytes` / `psram_free_bytes`
— absent rather than zero, because 0 free is a real and alarming reading on a board that has
PSRAM and has exhausted it.

## Two things I got wrong and corrected

Both are left visible in the document rather than edited away.

**L1 is withdrawn.** The audit justified a PSRAM history ring with "every Prometheus scrape
gap is permanent data loss". That is wrong: Prometheus records one sample per series per
scrape, and the exposition format cannot carry a series of historical points in one scrape.
A missed scrape stays missed regardless of what the device remembers. What a ring would
actually buy is a dashboard curve without Home Assistant — a feature, decided on its own
merits, on its own design pass.

**M2 shipped in a different shape.** The proposed liveness heartbeats turned out wrong for
both tasks. The web server needs none — a successful `/metrics` scrape *is* proof the
AsyncTCP task is alive, so the field would be true exactly whenever you could read it. MQTT
needed something better than proposed: `publish()` returns 0 when the client refuses a
message, and **eleven of twelve call sites discarded that**, so an undelivered message looked
delivered while `mqtt_connected` stayed true. Now counted and exported.

## Deliberately not done

**L2, the blocking UART read.** It touches `Rs485Transport::read` — the one path that talks
to a live inverter — for a latency benefit nobody can currently measure, and the obvious
implementation is wrong: the current loop returns as soon as any byte arrives because the
caller reassembles frames, while a plain blocking read would wait for a full buffer and stall
on every short reply. Worth doing when the Growatt bus exists to measure against.

Also unchanged, with reasons in the document: the RS485 direction handling, the `esp_timer`
clocks, the Relay-6CH's `kRs485De = -1`, and adding `esp_random()` calls nothing consumes.

## Risk to the running bridge

New fields and one new counter; no change to any existing value. The coredump read happens
once in `setup()` and is a no-op when no dump is stored. The new REST action is admin-gated
and rate-limited. `debug-rs485-can` is outside the CI matrix and `default_envs`, so it
produces no release asset.

Hardware validation owed after flashing: RS485-CAN should report `psram_size_bytes` 8388608
and the Relay-6CH should report it absent on every output.

## Self-review found three things

**A false positive I had just built in.** `stop()` published the goodbye availability
message without checking `connected()`, so the new counter charged one for a message that
was never going to be accepted. `stop()` is not only the reboot path — an MQTT config change
calls it too, so doing that during a broker outage would leave a permanent +1 on a counter
whose entire value is that it stays at 0.

**A subtlety that should not have been load-bearing.** The coredump task name went in as
`JsonString(str.c_str())`. That is safe — the second parameter is `bool isStatic = false`, so
ArduinoJson copies — but I had to open the library header to be sure. Assigning the
`std::string` directly is unambiguously a copy and matches every other conditional field in
both files.

**`Diagnostics::reset()` has no callers, and I had just added a line to it.** It was dead
before this branch. The cleanup sweep in #48 missed it because a name-counting script cannot
tell this `reset` from `ESP.restart` or factory reset, and because I dismissed cppcheck's
whole `unusedFunction` class as per-TU noise. That class was mostly noise and contained one
true positive. Removed.

## Unrelated, noticed in passing

The **Firmware** workflow concluded `failure` on #49's docs-only push, with its single job
(`Detect build-affecting changes`) green and zero matrix jobs. That is the empty-matrix case
the workflow's own header comment describes; it does not block a merge, but a red run on every
docs-only PR is the kind of noise that trains people to skim past red. Not touched here.
