### PR TITLE
Make the configuration something you can carry off the board

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -402,7 +402,7 @@ open WiFi network), not a redaction, and the two are told apart by whether the k
               "exported_at": "2026-07-26T12:00:00Z", "includes_secrets": false },
   "change_count": 2,
   "reboot_required": true,
-  "rollback_available": true,
+  "rollback_exists": true,
   "changes": [
     { "field": "mqtt.host", "before": "old.broker", "after": "new.broker" },
     { "field": "polling.interval_seconds", "before": "10", "after": "30" }
@@ -419,6 +419,12 @@ added later is redacted before anyone has to remember it should be.
 Nothing is staged on the bridge between the two calls. The apply re-sends the file rather than
 confirming a token, so there is no server-side session to expire, to be raced by a second
 browser tab, or to apply something other than what was on screen.
+
+`rollback_exists` says whether an undo point is stored **right now**, from an earlier restore —
+applying replaces it, so the way back becomes the configuration the bridge has at this moment
+rather than the older one. It deliberately does *not* claim that an undo will exist afterwards:
+that cannot be known before the copy is attempted, because attempting it is the only thing that
+discovers whether it fits. `rollback_stored` in the result answers that, after the fact.
 
 Dropping `?dry_run=true` applies it and reboots when `reboot_required`:
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -20,6 +20,9 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 | GET | `/api/v1/drivers` | — | Registered drivers + descriptors |
 | GET | `/api/v1/config` | — | Config **without secrets** |
 | PATCH | `/api/v1/config` | **✔** | Change config |
+| GET | `/api/v1/config/backup` | **✔** | Download the whole configuration as a file (`?secrets=true` to include passwords) |
+| POST | `/api/v1/config/restore` | **✔** | Apply a backup file (`?dry_run=true` to preview only) |
+| POST | `/api/v1/actions/undo-restore` | **✔** | Swap back to the configuration from before the last restore |
 | POST | `/api/v1/actions/discover` | **✔** | Start discovery |
 | POST | `/api/v1/actions/poll` | **✔** | Force an immediate poll |
 | POST | `/api/v1/actions/reboot` | **✔** | Reboot |
@@ -155,7 +158,7 @@ Uniform, for every error:
 | 401 | Auth missing/incorrect on a secured endpoint |
 | 404 | Unknown device or path |
 | 409 | Discovery already in progress; RS485 bus busy |
-| 413 | Body > 4 KB |
+| 413 | Body > 4 KB (8 KB on `/config/restore`, which carries a whole configuration) |
 | 429 | Rate limit (1 req/s on `/actions/*`) |
 | 503 | No valid data yet (cold start) |
 
@@ -349,6 +352,107 @@ a client knows whether to call `POST /api/v1/actions/reboot`:
 ```
 
 `GET` does not include the field (nothing was changed).
+
+## Backup and restore
+
+The backup file is a thin envelope around the exact document the bridge stores in NVS. That
+matters more than it sounds: the field list has one point of truth, so a setting added in a
+later firmware lands in the backup without anyone remembering to add it, and reading a file
+back reuses the same parser the bootloader uses — including its migration chain, so a backup
+taken on an older firmware is upgraded on the way in.
+
+```json
+{
+  "format": "heliograph-config-backup",
+  "format_version": 1,
+  "firmware_version": "0.13.2",
+  "exported_at": "2026-07-26T12:00:00Z",
+  "includes_secrets": false,
+  "bridge_name": "Shed bridge",
+  "config": { "version": 1, "wifi": { "ssid": "HomeNet", "hostname": "shed" }, "...": "..." }
+}
+```
+
+`format_version` versions the envelope; `config.version` versions the configuration inside it,
+and the two are checked separately. A file from a newer firmware is **refused**, not
+reinterpreted — the same rule NVS loading follows, and for the same reason: a half-understood
+configuration looks plausible.
+
+### Secrets are opt-out by default
+
+`GET /api/v1/config/backup` omits every password. `?secrets=true` includes them, in plain text.
+
+What makes the redacted file usable rather than merely safe is the merge rule: **an absent
+password means "keep the one the bridge already has"**. So a redacted backup restored onto a
+running bridge is complete. Only a factory-fresh board has nothing to inherit — and a restore
+that would leave such a board with no admin password is refused outright (`password_required`),
+because the alternative is a bridge on your WiFi that nobody can change and only a five-second
+BOOT hold can recover.
+
+A password that is *present but empty* is applied. That is a deliberately empty credential (an
+open WiFi network), not a redaction, and the two are told apart by whether the key exists.
+
+### Preview, then apply
+
+`POST /api/v1/config/restore?dry_run=true` returns what would change and applies nothing:
+
+```json
+{
+  "backup": { "format_version": 1, "firmware_version": "0.13.2",
+              "exported_at": "2026-07-26T12:00:00Z", "includes_secrets": false },
+  "change_count": 2,
+  "reboot_required": true,
+  "rollback_available": true,
+  "changes": [
+    { "field": "mqtt.host", "before": "old.broker", "after": "new.broker" },
+    { "field": "polling.interval_seconds", "before": "10", "after": "30" }
+  ]
+}
+```
+
+The diff is computed against the **merged result**, not against the file, so it tells the truth
+about a redacted backup: those credentials show as unchanged, because leaving them alone is
+what applying it will do. Password values never appear — any key named `password` or ending in
+`_password` renders as `(set)` / `(not set)`, as a rule rather than a list, so a credential
+added later is redacted before anyone has to remember it should be.
+
+Nothing is staged on the bridge between the two calls. The apply re-sends the file rather than
+confirming a token, so there is no server-side session to expire, to be raced by a second
+browser tab, or to apply something other than what was on screen.
+
+Dropping `?dry_run=true` applies it and reboots when `reboot_required`:
+
+```json
+{ "status": "restored", "changed_fields": 2, "reboot_required": true, "rollback_stored": true }
+```
+
+### The undo
+
+Immediately before a restore overwrites it, the current configuration is copied to a second NVS
+key. `POST /api/v1/actions/undo-restore` **swaps** the two back — pressing it twice returns to
+the restored configuration, which is what makes the button honest rather than silently doing
+nothing the second time.
+
+Only a restore creates a restore point; an ordinary `PATCH` does not. Writing one on every save
+would double the flash wear and, worse, make "the configuration from before the restore" mean
+nothing in particular.
+
+`rollback_stored: false` means the copy did not fit. NVS here is 20 KB shared with the WiFi
+stack's own calibration data, so a second copy of the configuration is the first thing that will
+not fit — and the restore still goes ahead, because losing the safety net is a smaller harm than
+refusing the operation the safety net was for.
+
+### Restoring during setup
+
+The setup portal offers the same restore, which is the context that makes the feature worth
+having: a factory-reset or replacement board takes a file instead of twenty fields typed by
+hand.
+
+It carries the same gate as `/api/v1/provision`, and for the same reason — the portal is **not**
+exclusive to first boot. It returns on an already-configured bridge after repeated WiFi failures
+(a router reboot reaches that in about two minutes) and its AP is open. So the gate is "does an
+admin password exist yet", not "is the portal up": open on a factory-fresh board, authenticated
+afterwards.
 
 ## Auth
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,6 +15,7 @@ the same LAN", not "someone holding the PCB in their hands".
 | OTA | Same auth + firmware magic check (0xE9) before the first byte hits flash |
 | Completing setup | Refuses without an admin password |
 | Secrets in logs/REST/MQTT/Prometheus | Never. `serializeConfig()` omits every password **and both usernames** — the MQTT one and `security.admin_username` (not masked, absent); `serializeConfigForStorage()` is the only one that writes them |
+| Configuration backup | Passwords omitted unless the operator ticks a box. Admin-gated even redacted. See below |
 | Rate limiting | 1 req/s on `/actions/*` |
 | Request size | 4096 bytes, rejected with 413 |
 | String lengths | Bounded in `validate()`; SSID 32 and PSK 64 are the 802.11/WPA2 limits |
@@ -120,6 +121,28 @@ session token, a CSRF nonce, a pairing code or a generated first-boot password i
 - Remember that a generated secret has to reach the user somehow, and every channel this
   bridge has (the open setup AP, plain HTTP, the serial console) is one of the exposures listed
   above.
+
+**A configuration backup with `?secrets=true` is a plaintext credential file.** It holds the
+WiFi password, the MQTT password and the admin password exactly as NVS stores them. This is the
+one place the firmware will hand a password back to anyone, which is why it is opt-in, off by
+default, admin-gated, and labelled in the UI with what actually happens to such a file: it lands
+in a downloads folder, syncs to whatever cloud drive is watching that folder, and is the obvious
+thing to attach to a bug report. Treat it like a copy of the flash, because that is what it is.
+
+The redacted form — the default — carries no password at all, and the keys are removed rather
+than emptied, so nothing round-trips back in as a deliberate "clear this password". It is still
+admin-gated: it contains no secret, but it does put every other setting in one convenient
+document, and unlike `GET /api/v1/config` nothing needs it except a human who is already signed
+in.
+
+Restoring cannot leave the bridge without an admin password. A redacted backup keeps whatever
+the bridge already has; on a factory-fresh board there is nothing to keep, and that restore is
+refused rather than producing a bridge on your WiFi that nobody can reconfigure.
+
+**The rollback copy holds credentials too.** `config.prev` is a full copy of the previous
+configuration, secrets included, in the same unencrypted NVS. A factory reset clears the whole
+namespace and takes it along — which is what keeps "erases everything, including passwords"
+true.
 
 **OTA images are not cryptographically signed.** The upload is gated by the admin password
 and checked for the ESP32 image magic (`0xE9`) before any byte reaches flash, and a bad image

--- a/platformio.ini
+++ b/platformio.ini
@@ -94,6 +94,7 @@ build_src_filter =
     +<outputs/prometheus/prometheus_metrics.cpp>
     +<config/configuration.cpp>
     +<config/configuration_store.cpp>
+    +<config/config_backup.cpp>
     +<network/provisioning_policy.cpp>
     +<network/rtc_time.cpp>
     +<network/wifi_manager.cpp>

--- a/src/config/config_backup.cpp
+++ b/src/config/config_backup.cpp
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: MIT
+
+#include "config_backup.h"
+
+#include <ArduinoJson.h>
+
+#include <cstdio>
+#include <cstring>
+
+#include "configuration_store.h"
+
+namespace heliograph {
+namespace {
+
+/// Keys whose value must never be rendered or exported. A rule, not a list: a credential
+/// added to the config model later is covered without anyone having to remember this file.
+bool isSecretKey(const char* key) {
+    if (key == nullptr) return false;
+    const size_t n = std::strlen(key);
+    if (std::strcmp(key, "password") == 0) return true;
+    const char* suffix = "_password";
+    const size_t m     = std::strlen(suffix);
+    return n > m && std::strcmp(key + n - m, suffix) == 0;
+}
+
+/// The storage document, as a parsed tree. Goes through serializeConfigForStorage rather than
+/// rebuilding the field list, which is the whole point -- see the header. The extra
+/// serialise/parse round trip costs a millisecond on a path a human triggers by hand.
+bool storageDocument(const Configuration& config, JsonDocument& out) {
+    std::string blob;
+    if (!serializeConfigForStorage(config, blob)) {
+        return false;
+    }
+    return deserializeJson(out, blob) == DeserializationError::Ok;
+}
+
+/// Removes every secret-named key, at any depth. Recursive because the config document is
+/// nested and a top-level sweep would miss wifi.password.
+void stripSecrets(JsonVariant node) {
+    if (node.is<JsonObject>()) {
+        JsonObject           obj = node.as<JsonObject>();
+        std::vector<std::string> doomed;
+        for (JsonPair kv : obj) {
+            if (isSecretKey(kv.key().c_str())) {
+                // Collected first: removing while iterating invalidates the iterator.
+                doomed.emplace_back(kv.key().c_str());
+            } else {
+                stripSecrets(kv.value());
+            }
+        }
+        for (const auto& key : doomed) {
+            obj.remove(key);
+        }
+    } else if (node.is<JsonArray>()) {
+        for (JsonVariant v : node.as<JsonArray>()) {
+            stripSecrets(v);
+        }
+    }
+}
+
+/// Renders a leaf for the diff. Bool as true/false rather than 1/0 -- this is read by a person
+/// deciding whether a restore does what they expect.
+std::string renderValue(JsonVariantConst v) {
+    if (v.isNull()) return "(absent)";
+    if (v.is<bool>()) return v.as<bool>() ? "true" : "false";
+    if (v.is<const char*>()) {
+        const char* s = v.as<const char*>();
+        return (s == nullptr || s[0] == '\0') ? "(empty)" : std::string(s);
+    }
+    if (v.is<JsonArrayConst>() || v.is<JsonObjectConst>()) {
+        std::string compact;
+        serializeJson(v, compact);
+        // Bounded: additional_devices with eight entries would otherwise dominate the table.
+        if (compact.size() > 120) {
+            compact.resize(117);
+            compact += "...";
+        }
+        return compact;
+    }
+    std::string number;
+    serializeJson(v, number);
+    return number;
+}
+
+void walkDiff(JsonObjectConst before, JsonObjectConst after, const std::string& prefix,
+              std::vector<ConfigDiffEntry>& out) {
+    // Driven by `after`, then swept for keys only `before` had. Iterating one side alone would
+    // miss a setting the restore REMOVES, which is a change like any other.
+    for (JsonPairConst kv : after) {
+        const std::string path = prefix.empty() ? kv.key().c_str()
+                                                : prefix + "." + kv.key().c_str();
+        JsonVariantConst  old  = before[kv.key()];
+        if (isSecretKey(kv.key().c_str())) {
+            const auto flag = [](JsonVariantConst v) {
+                if (!v.is<const char*>()) return "(not set)";
+                const char* s = v.as<const char*>();
+                return (s != nullptr && s[0] != '\0') ? "(set)" : "(not set)";
+            };
+            if (std::strcmp(flag(old), flag(kv.value())) != 0) {
+                out.push_back({path, flag(old), flag(kv.value())});
+            }
+            continue;
+        }
+        if (kv.value().is<JsonObjectConst>() && old.is<JsonObjectConst>()) {
+            walkDiff(old.as<JsonObjectConst>(), kv.value().as<JsonObjectConst>(), path, out);
+            continue;
+        }
+        const std::string a = renderValue(old);
+        const std::string b = renderValue(kv.value());
+        if (a != b) {
+            out.push_back({path, a, b});
+        }
+    }
+    for (JsonPairConst kv : before) {
+        if (!after[kv.key()].isNull()) continue;
+        const std::string path = prefix.empty() ? kv.key().c_str()
+                                                : prefix + "." + kv.key().c_str();
+        if (isSecretKey(kv.key().c_str())) {
+            out.push_back({path, "(set)", "(not set)"});
+        } else {
+            out.push_back({path, renderValue(kv.value()), "(absent)"});
+        }
+    }
+}
+
+}  // namespace
+
+const char* backupResultName(BackupResult result) {
+    switch (result) {
+        case BackupResult::Ok:           return "ok";
+        case BackupResult::NotJson:      return "not_json";
+        case BackupResult::NotABackup:   return "not_a_backup";
+        case BackupResult::FutureFormat: return "future_format";
+        case BackupResult::FutureConfig: return "future_config";
+        case BackupResult::Corrupt:      return "corrupt";
+    }
+    return "unknown";
+}
+
+std::string isoUtcTimestamp(time_t epoch) {
+    // 2020-01-01. Below this the clock has not been set, and stamping a file "1970-01-01"
+    // would put a plausible-looking date on a backup whose age is actually unknown.
+    if (epoch < 1577836800) {
+        return {};
+    }
+    std::tm tm{};
+#if defined(_WIN32)
+    gmtime_s(&tm, &epoch);
+#else
+    gmtime_r(&epoch, &tm);
+#endif
+    char buf[32];
+    if (std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm) == 0) {
+        return {};
+    }
+    return buf;
+}
+
+bool buildConfigBackup(const Configuration& config, const BackupOptions& options,
+                       std::string& out) {
+    JsonDocument inner;
+    if (!storageDocument(config, inner)) {
+        return false;
+    }
+    if (!options.includeSecrets) {
+        stripSecrets(inner.as<JsonVariant>());
+    }
+
+    JsonDocument doc;
+    doc["format"]         = kBackupFormat;
+    doc["format_version"] = kBackupFormatVersion;
+    if (!options.firmwareVersion.empty()) doc["firmware_version"] = options.firmwareVersion;
+    if (!options.exportedAt.empty()) doc["exported_at"] = options.exportedAt;
+    // Recorded so the restore preview can say "this file carries no passwords" before the
+    // operator commits, rather than leaving them to discover it from the diff.
+    doc["includes_secrets"] = options.includeSecrets;
+    // A name for the human sorting through a downloads folder. Not read back on restore.
+    doc["bridge_name"]      = config.bridgeName;
+    doc["config"]           = inner;
+
+    if (doc.overflowed()) {
+        return false;
+    }
+    // Pretty-printed on purpose. This file is meant to be opened, read and occasionally
+    // hand-edited; the compact form the device stores is not.
+    out.resize(measureJsonPretty(doc) + 1);
+    out.resize(serializeJsonPretty(doc, out.data(), out.size()));
+    return true;
+}
+
+BackupResult parseConfigBackup(const std::string& json, BackupContents& out,
+                               std::string& detail) {
+    detail.clear();
+    if (json.size() > kMaxBackupBytes) {
+        detail = "the file is larger than a configuration backup can be";
+        return BackupResult::NotJson;
+    }
+    JsonDocument doc;
+    if (deserializeJson(doc, json) != DeserializationError::Ok || !doc.is<JsonObject>()) {
+        detail = "this is not a JSON document";
+        return BackupResult::NotJson;
+    }
+    if (!doc["format"].is<const char*>() ||
+        std::strcmp(doc["format"].as<const char*>(), kBackupFormat) != 0) {
+        detail = "this is a JSON file, but not a Heliograph configuration backup";
+        return BackupResult::NotABackup;
+    }
+    out.formatVersion = doc["format_version"].is<uint16_t>()
+                            ? doc["format_version"].as<uint16_t>()
+                            : 0;
+    if (out.formatVersion == 0) {
+        detail = "the backup does not say which format version it is";
+        return BackupResult::NotABackup;
+    }
+    if (out.formatVersion > kBackupFormatVersion) {
+        detail = "the backup was written by a newer firmware (format version " +
+                 std::to_string(out.formatVersion) + "; this firmware understands " +
+                 std::to_string(kBackupFormatVersion) + ")";
+        return BackupResult::FutureFormat;
+    }
+    JsonObjectConst inner = doc["config"];
+    if (inner.isNull()) {
+        detail = "the backup carries no configuration";
+        return BackupResult::NotABackup;
+    }
+
+    if (doc["firmware_version"].is<const char*>())
+        out.firmwareVersion = doc["firmware_version"].as<const char*>();
+    if (doc["exported_at"].is<const char*>())
+        out.exportedAt = doc["exported_at"].as<const char*>();
+    out.includesSecrets = doc["includes_secrets"].as<bool>();
+
+    // Which credentials the document ACTUALLY carries, read before the configuration is parsed:
+    // once parsed, an omitted password and a stored empty one are the same empty string, and
+    // the merge has to tell them apart. A present-but-empty password counts as carried -- that
+    // is a deliberately empty credential, and refusing to apply it would silently ignore it.
+    out.hasWifiPassword  = inner["wifi"]["password"].is<const char*>();
+    out.hasMqttPassword  = inner["mqtt"]["password"].is<const char*>();
+    out.hasAdminPassword = inner["security"]["admin_password"].is<const char*>();
+
+    // Back through the store's own reader: it owns the version check, the migration chain and
+    // the validation, and a second implementation of any of those is a second place to be
+    // wrong about someone's configuration.
+    std::string blob;
+    serializeJson(inner, blob);
+    Configuration parsed;
+    switch (deserializeConfigFromStorage(blob, parsed)) {
+        case LoadResult::Ok:
+        case LoadResult::Migrated:
+            out.config = parsed;
+            return BackupResult::Ok;
+        case LoadResult::FutureVersion:
+            detail = "the configuration inside was written by a newer firmware than this one";
+            return BackupResult::FutureConfig;
+        case LoadResult::NotFound:
+        case LoadResult::Corrupt:
+            detail = "the configuration inside could not be read, or is not one this firmware "
+                     "would accept";
+            return BackupResult::Corrupt;
+    }
+    detail = "the configuration inside could not be read";
+    return BackupResult::Corrupt;
+}
+
+void applyBackup(const BackupContents& backup, Configuration& target) {
+    // Snapshot the credentials first: `target` is about to be overwritten wholesale, and the
+    // redacted case needs the values that are on the bridge right now.
+    const std::string wifiPassword  = target.wifi.password;
+    const std::string mqttPassword  = target.mqtt.password;
+    const std::string adminPassword = target.security.adminPassword;
+
+    target = backup.config;
+
+    if (!backup.hasWifiPassword) target.wifi.password = wifiPassword;
+    if (!backup.hasMqttPassword) target.mqtt.password = mqttPassword;
+    if (!backup.hasAdminPassword) target.security.adminPassword = adminPassword;
+}
+
+bool diffConfigurations(const Configuration& before, const Configuration& after,
+                        std::vector<ConfigDiffEntry>& out) {
+    out.clear();
+    JsonDocument a;
+    JsonDocument b;
+    if (!storageDocument(before, a) || !storageDocument(after, b)) {
+        return false;
+    }
+    walkDiff(a.as<JsonObjectConst>(), b.as<JsonObjectConst>(), "", out);
+    return true;
+}
+
+}  // namespace heliograph

--- a/src/config/config_backup.h
+++ b/src/config/config_backup.h
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+//
+// Configuration backup and restore: one downloadable file, and the rules for reading it back.
+//
+// The file is deliberately NOT a new serialisation of the configuration. It is a thin envelope
+// around the document ConfigurationStore already writes to NVS, which means the field list has
+// exactly one point of truth (buildStorageDocument, via serializeConfigForStorage) and a
+// setting added tomorrow lands in the backup without anyone remembering to add it here. The
+// alternative -- a second hand-maintained field list -- fails silently and is discovered by
+// someone whose restore quietly dropped a setting.
+//
+// Reading it back reuses deserializeConfigFromStorage for the same reason, and inherits its
+// migration chain for free: a backup taken on an older firmware is upgraded on the way in,
+// exactly as a stored config would be at boot.
+//
+// SECRETS. A backup omits every password unless the operator explicitly asks for them. That is
+// not squeamishness: this file lands in a downloads folder, syncs to a cloud drive, and gets
+// attached to issues. What makes the redacted form usable rather than merely safe is the merge
+// rule below -- an absent password means "keep what the bridge already has", so a redacted
+// backup restored onto a running bridge is complete. Only on a factory-fresh board does it
+// leave the credentials unset, and that board comes up in the setup portal, which is the
+// recovery path anyway.
+
+#pragma once
+
+#include <cstdint>
+#include <ctime>
+#include <string>
+#include <vector>
+
+#include "configuration.h"
+
+namespace heliograph {
+
+/// Identifies the file. Checked on restore, so a JSON document that is not one of ours is
+/// refused with an explanation rather than half-applied.
+inline constexpr const char* kBackupFormat        = "heliograph-config-backup";
+/// The ENVELOPE version, independent of kConfigVersion inside it. Bumped only when the
+/// envelope's own shape changes; the configuration within it versions itself.
+inline constexpr uint16_t    kBackupFormatVersion = 1;
+
+/// Upper bound on a backup we will accept. The configuration itself cannot exceed 3900 bytes
+/// (NVS refuses to store more), and the envelope adds a couple of hundred; the rest is slack
+/// for pretty-printing by whoever edited the file in between.
+inline constexpr size_t kMaxBackupBytes = 8192;
+
+struct BackupOptions {
+    /// Off by default, and the UI has to ask. See the note at the top of this file.
+    bool        includeSecrets = false;
+    /// Informational only -- recorded so a restore that goes wrong can be traced to the image
+    /// that produced the file. Never used to accept or refuse anything: firmware version and
+    /// config compatibility are different questions, and conflating them would refuse a
+    /// perfectly restorable file because the patch number moved.
+    std::string firmwareVersion;
+    /// ISO-8601 UTC. Empty when the bridge has no synced clock -- an absent timestamp is
+    /// honest, a 1970 one is a lie that later reads as a real date.
+    std::string exportedAt;
+};
+
+/// Renders `epoch` as "YYYY-MM-DDTHH:MM:SSZ". Returns empty when the epoch is implausible as a
+/// wall clock (before 2020), which is what an unsynced bridge has.
+std::string isoUtcTimestamp(time_t epoch);
+
+/// Builds the backup document. False only when the underlying configuration cannot be
+/// serialised at all -- in practice, one too large for NVS, which cannot have been stored.
+bool buildConfigBackup(const Configuration& config, const BackupOptions& options,
+                       std::string& out);
+
+enum class BackupResult : uint8_t {
+    Ok,
+    /// Not JSON, or not a JSON object.
+    NotJson,
+    /// Valid JSON, but missing or wrong `format`. The likeliest cause by far is the wrong
+    /// file, which is why it is told apart from the versions below.
+    NotABackup,
+    /// Envelope written by a newer firmware than this one understands.
+    FutureFormat,
+    /// The configuration inside was written by a newer firmware. Refused rather than
+    /// reinterpreted -- same rule, and the same reason, as loading from NVS.
+    FutureConfig,
+    /// The configuration inside is unreadable, or does not pass validate().
+    Corrupt,
+};
+const char* backupResultName(BackupResult result);
+
+/// A parsed backup, before anything has been applied.
+///
+/// The three `has*Password` flags are the whole reason this is a struct and not just a
+/// Configuration: `config` carries an EMPTY password both when the file redacted it and when
+/// the file recorded an empty one, and those two mean opposite things at merge time.
+struct BackupContents {
+    Configuration config;
+    bool          hasWifiPassword  = false;
+    bool          hasMqttPassword  = false;
+    bool          hasAdminPassword = false;
+    /// What the file says about itself. Only ever used to explain the file to the operator;
+    /// the flags above are what the merge acts on, because they describe what is actually
+    /// in the document rather than what its header claims.
+    bool          includesSecrets = false;
+    uint16_t      formatVersion   = 0;
+    std::string   firmwareVersion;
+    std::string   exportedAt;
+};
+
+/// Parses and validates. `detail` receives a sentence naming what was wrong, for the API to
+/// hand back verbatim -- "rejected" with no reason is the failure mode this exists to avoid.
+BackupResult parseConfigBackup(const std::string& json, BackupContents& out, std::string& detail);
+
+/// Merges a parsed backup onto `target`.
+///
+/// Everything that is not a credential is replaced outright. Each credential is replaced ONLY
+/// when the file actually carried it, so a redacted backup keeps the bridge's own passwords
+/// and cannot lock anyone out of the device they just restored.
+void applyBackup(const BackupContents& backup, Configuration& target);
+
+/// One changed setting, ready to render. Values are already strings: the preview is for a
+/// human deciding whether to press the button, not for a machine.
+struct ConfigDiffEntry {
+    std::string field;   ///< dotted path, e.g. "mqtt.host"
+    std::string before;
+    std::string after;
+};
+
+/// Every setting that differs between the two configurations, in stored-document order.
+///
+/// Computed by walking the two storage documents rather than the two structs: the walk covers
+/// a field added later without being told about it, which a hand-written comparison does not.
+///
+/// Passwords are never rendered as values. Any key named `password` or ending in `_password`
+/// comes out as "(set)" or "(not set)" -- a rule rather than a list of three, so a credential
+/// added in future is redacted before anyone has to remember that it should be.
+///
+/// False only if either configuration fails to serialise.
+bool diffConfigurations(const Configuration& before, const Configuration& after,
+                        std::vector<ConfigDiffEntry>& out);
+
+}  // namespace heliograph

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -421,6 +421,54 @@ bool ConfigurationStore::setAnnouncedDevices(const std::vector<mqtt::AnnouncedDe
     return backend_.write(kStorageKeyAnnounced, raw);
 }
 
+bool ConfigurationStore::stashRollback() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::string                 blob;
+    if (!backend_.read(kStorageKeyConfig, blob) || blob.empty()) {
+        return false;  // nothing stored yet: a factory-fresh board has nothing to undo to
+    }
+    return backend_.write(kStorageKeyRollback, blob);
+}
+
+bool ConfigurationStore::hasRollback() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::string                 blob;
+    return backend_.read(kStorageKeyRollback, blob) && !blob.empty();
+}
+
+LoadResult ConfigurationStore::rollback(Configuration& out) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::string                 previous;
+    if (!backend_.read(kStorageKeyRollback, previous) || previous.empty()) {
+        return LoadResult::NotFound;
+    }
+    // Parsed BEFORE anything is written. The blob has been through validate() once already --
+    // save() refuses to persist a configuration it would not load -- but a firmware update
+    // between the stash and the rollback can tighten a range, and swapping first and
+    // discovering that second would leave the bridge running the very configuration this call
+    // exists to escape.
+    Configuration parsed;
+    const auto    result = deserializeConfigFromStorage(previous, parsed);
+    if (result != LoadResult::Ok && result != LoadResult::Migrated) {
+        return result;
+    }
+    // The swap. The current blob is read rather than re-serialised from `out`: it is the exact
+    // bytes that are live, which is what a redo has to put back.
+    std::string current;
+    backend_.read(kStorageKeyConfig, current);
+    if (!backend_.write(kStorageKeyConfig, previous)) {
+        return LoadResult::Corrupt;  // nothing has moved; the live config is untouched
+    }
+    // A failed second half leaves the rollback slot holding what is now ALSO live. Harmless:
+    // the next rollback is then a no-op rather than a surprise, which beats leaving the slot
+    // pointing at a configuration nobody is running.
+    if (!current.empty()) {
+        backend_.write(kStorageKeyRollback, current);
+    }
+    out = parsed;
+    return result;
+}
+
 bool ConfigurationStore::factoryReset() {
     std::lock_guard<std::mutex> lock(mutex_);
     return backend_.erase();

--- a/src/config/configuration_store.h
+++ b/src/config/configuration_store.h
@@ -95,6 +95,33 @@ public:
     std::vector<mqtt::AnnouncedDevice> announcedDevices();
     bool setAnnouncedDevices(const std::vector<mqtt::AnnouncedDevice>& devices);
 
+    /// Copies the stored configuration into the rollback slot, so the restore about to
+    /// overwrite it can be undone. Call immediately before a restore, and nowhere else: doing
+    /// it on every save would double the write wear and, worse, make "the configuration from
+    /// before the restore" mean nothing in particular.
+    ///
+    /// False when nothing is stored yet (a factory-fresh board has nothing to roll back to)
+    /// or when the write was refused. A refusal is not a reason to abandon the restore -- NVS
+    /// here is 20 KB shared with the WiFi stack's own calibration data, so a second copy of
+    /// the configuration is the first thing that will not fit, and losing the safety net is
+    /// a smaller harm than refusing the operation the safety net was for. The caller reports
+    /// it instead.
+    bool stashRollback();
+
+    /// True when a rollback copy is available.
+    bool hasRollback();
+
+    /// SWAPS the rollback copy with the live configuration, and returns the now-live one.
+    ///
+    /// A swap rather than a one-shot restore, because the two writes cost the same and the
+    /// swap is what makes the button honest when pressed twice: undo, look, undo again. A
+    /// one-shot would leave the second press doing nothing with no way to say why.
+    ///
+    /// NotFound when there is no rollback copy. On any parse failure the live configuration
+    /// is left exactly as it was -- a rollback that half-applies is worse than one that
+    /// refuses, because the operator reaching for it is already recovering from something.
+    LoadResult rollback(Configuration& out);
+
 private:
     KeyValueBackend&   backend_;
     KeyValueBackend*   legacy_;
@@ -119,5 +146,11 @@ inline constexpr const char* kStorageKeyConfig = "config";
 /// Separate key, not a field in the config blob: bookkeeping must not be able to make a user's
 /// configuration unloadable, and a factory reset should take it with everything else.
 inline constexpr const char* kStorageKeyAnnounced = "announced";
+/// The configuration as it was before the last restore. Its own key rather than a second blob
+/// inside the config document: it must never be able to make the LIVE configuration
+/// unloadable, and a factory reset (which clears the whole namespace) must take it along.
+///
+/// NVS keys are capped at 15 characters, so this cannot be spelled "config.previous".
+inline constexpr const char* kStorageKeyRollback = "config.prev";
 
 }  // namespace heliograph

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -692,6 +692,14 @@ void startRestApi() {
     ctx.requestDiscovery    = [](bool extended) { return g_discovery.request(extended); };
     ctx.discoveryReport     = [] { return g_discovery.report(); };
     ctx.requestFactoryReset = [] { return g_store.factoryReset(); };
+    // The undo behind a configuration restore. Straight through to the store, which owns both
+    // the stash and the swap; the REST layer only decides when.
+    ctx.stashRollback  = [] { return g_store.stashRollback(); };
+    ctx.hasRollback    = [] { return g_store.hasRollback(); };
+    ctx.rollbackConfig = [](Configuration& out) {
+        const auto result = g_store.rollback(out);
+        return result == LoadResult::Ok || result == LoadResult::Migrated;
+    };
     // Clears a dump the operator has dealt with. Without it every later diagnostics read keeps
     // reporting the same old crash, and "is this new?" becomes unanswerable. The cached copy is
     // updated in the same breath so the next payload agrees with the flash.

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -60,16 +60,22 @@ bool RestApi::collectBody(AsyncWebServerRequest* request, const uint8_t* data, s
         // would have kept saying 4096 after the constant moved.
         sendError(request, {413, "body_too_large",
                             "request body exceeds " + std::to_string(maxBytes) + " bytes"});
+        bodyRejected_ = request;  // or the request handler replaces this with "empty body"
         return false;
     }
     if (index == 0) {
         if (bodyOwner_ != nullptr && bodyOwner_ != request) {
             sendError(request, {409, "busy", "another request is already being processed"});
+            bodyRejected_ = request;
             return false;
         }
-        bodyOwner_ = request;
+        // A fresh body from a different request: whatever the previous rejection referred to
+        // is over, and keeping a stale pointer risks a recycled address matching it.
+        bodyRejected_ = nullptr;
+        bodyOwner_    = request;
         bodyBuffer_.clear();
         bodyBuffer_.reserve(total);
+
         // A client that vanishes mid-body (WiFi drop on the setup AP is the realistic case)
         // never reaches the request handler, so nothing would release the buffer: every later
         // body-carrying request then answered 409 "busy" until a reboot. Same lesson the OTA
@@ -92,8 +98,17 @@ bool RestApi::collectBody(AsyncWebServerRequest* request, const uint8_t* data, s
     return true;
 }
 
+bool RestApi::bodyAlreadyAnswered(AsyncWebServerRequest* request) {
+    if (bodyRejected_ != request) {
+        return false;
+    }
+    bodyRejected_ = nullptr;  // consumed: this request has now been dealt with
+    return true;
+}
+
 void RestApi::releaseBody() {
-    bodyOwner_ = nullptr;
+    bodyOwner_    = nullptr;
+    bodyRejected_ = nullptr;
     bodyBuffer_.clear();
     bodyBuffer_.shrink_to_fit();
 }
@@ -214,6 +229,12 @@ bool RestApi::begin() {
         [this, authorised](AsyncWebServerRequest* request) {
             // The request handler forms the response; the body handler only collects. If the
             // body never completed, nothing was queued and this is a genuinely empty POST.
+            // collectBody may already have answered (413 too large, 409 busy). send()
+            // replaces the stored response, so falling through to the generic error below
+            // would overwrite the real reason with "a JSON body is required".
+            if (bodyAlreadyAnswered(request)) {
+                return;
+            }
             if (bodyOwner_ != request) {
                 sendError(request, {400, "empty_body", "a JSON body is required"});
                 return;
@@ -494,6 +515,12 @@ bool RestApi::begin() {
                 releaseBody();
                 return;
             }
+            // collectBody may already have answered (413 too large, 409 busy). send()
+            // replaces the stored response, so falling through to the generic error below
+            // would overwrite the real reason with "a JSON body is required".
+            if (bodyAlreadyAnswered(request)) {
+                return;
+            }
             if (bodyOwner_ != request) {
                 sendError(request, {400, "empty_body", "a JSON body is required"});
                 return;
@@ -665,6 +692,12 @@ bool RestApi::begin() {
                 releaseBody();
                 return;  // authorised() stored the 401
             }
+            // collectBody may already have answered (413 too large, 409 busy). send()
+            // replaces the stored response, so falling through to the generic error below
+            // would overwrite the real reason with "a backup file is required".
+            if (bodyAlreadyAnswered(request)) {
+                return;
+            }
             if (bodyOwner_ != request) {
                 sendError(request, {400, "empty_body", "a backup file is required"});
                 return;
@@ -720,10 +753,12 @@ bool RestApi::begin() {
                                 request->getParam("dry_run")->value() == "true";
             if (dryRun) {
                 std::string body;
-                if (!buildRestorePreviewPayload(
-                        contents, diff, rebootRequired,
-                        context_.stashRollback != nullptr && context_.hasRollback != nullptr,
-                        body)) {
+                // Actually asked, not inferred from the callbacks being wired -- which is what
+                // this argument used to be, making the field a report on our own plumbing.
+                const bool rollbackExists =
+                    context_.hasRollback != nullptr && context_.hasRollback();
+                if (!buildRestorePreviewPayload(contents, diff, rebootRequired, rollbackExists,
+                                                body)) {
                     sendError(request, {500, "payload_too_large",
                                         "the restore preview exceeded its bound"});
                     return;
@@ -1127,8 +1162,11 @@ bool RestApi::collectBody(AsyncWebServerRequest*, const uint8_t*, size_t, size_t
     out = nullptr;
     return false;
 }
+bool RestApi::bodyAlreadyAnswered(AsyncWebServerRequest*) { return false; }
+
 void RestApi::releaseBody() {
-    bodyOwner_ = nullptr;
+    bodyOwner_    = nullptr;
+    bodyRejected_ = nullptr;
     bodyBuffer_.clear();
 }
 

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -53,10 +53,13 @@ RestApi::RestApi(RestContext context, uint16_t port) : context_(std::move(contex
 /// error -- which is exactly how "a JSON body is required" ended up masking an auth failure.
 /// Authorisation belongs in the request handler, where the response is actually formed.
 bool RestApi::collectBody(AsyncWebServerRequest* request, const uint8_t* data, size_t len,
-                          size_t index, size_t total, std::string*& out) {
+                          size_t index, size_t total, std::string*& out, size_t maxBytes) {
     out = nullptr;
-    if (total > kMaxRequestBytes) {
-        sendError(request, {413, "body_too_large", "request body exceeds 4096 bytes"});
+    if (total > maxBytes) {
+        // The limit is interpolated, not spelled out. It used to say "4096" in a message that
+        // would have kept saying 4096 after the constant moved.
+        sendError(request, {413, "body_too_large",
+                            "request body exceeds " + std::to_string(maxBytes) + " bytes"});
         return false;
     }
     if (index == 0) {
@@ -464,7 +467,13 @@ bool RestApi::begin() {
 
     // Unauthenticated on purpose: it contains no secrets by construction (serializeConfig
     // omits every password), and the UI needs it to render the settings form.
-    g_server->on("/api/v1/config", HTTP_GET, [this](AsyncWebServerRequest* request) {
+    //
+    // AsyncURIMatcher::exact for the same reason /api/v1/devices needs it: a bare string URI
+    // matches "^uri(/.*)?$", so this route would otherwise swallow /api/v1/config/backup and
+    // answer a download request with the redacted settings document. The devices route learned
+    // this the hard way; the sub-routes below are why it matters here now.
+    g_server->on(AsyncURIMatcher::exact("/api/v1/config"), HTTP_GET,
+                 [this](AsyncWebServerRequest* request) {
         context_.diagnostics->recordRestRequest();
         std::string body;
         if (!serializeConfig(*context_.config, body)) {
@@ -474,8 +483,10 @@ bool RestApi::begin() {
         request->send(200, kJson, body.c_str());
     });
 
+    // Exact, like the GET above: a PATCH aimed at /api/v1/config/restore must reach a 404
+    // rather than being read as a settings patch against a body that is a backup file.
     g_server->on(
-        "/api/v1/config", HTTP_PATCH,
+        AsyncURIMatcher::exact("/api/v1/config"), HTTP_PATCH,
         [this, authorised](AsyncWebServerRequest* request) {
             // Auth here, not in the body handler. The body handler runs first; refusing there
             // left this handler to fire afterwards and replace the 401 with its own error.
@@ -592,6 +603,196 @@ bool RestApi::begin() {
             std::string* body = nullptr;
             collectBody(request, data, len, index, total, body);
         });
+
+    // Download the whole configuration as one file.
+    //
+    // Admin-gated even in its redacted form, unlike GET /config. The redacted backup carries no
+    // password, but it does carry everything else in one convenient document -- and unlike the
+    // settings endpoint, which the UI must reach to render a form, nothing needs this except a
+    // human who is already signed in.
+    g_server->on(AsyncURIMatcher::exact("/api/v1/config/backup"), HTTP_GET,
+                 [this, authorised](AsyncWebServerRequest* request) {
+        if (!authorised(request)) {
+            return;
+        }
+        context_.diagnostics->recordRestRequest();
+        const BridgeInfo info = context_.bridgeInfo();
+        BackupOptions    options;
+        // Opt-in, one query parameter, and the UI makes the operator tick a box with the
+        // consequence spelled out next to it. See the note at the top of config_backup.h.
+        options.includeSecrets =
+            request->hasParam("secrets") && request->getParam("secrets")->value() == "true";
+        options.firmwareVersion = info.firmwareVersion;
+        // Only from a synced clock. isoUtcTimestamp refuses an implausible epoch anyway; this
+        // makes the intent visible at the call site rather than relying on that.
+        options.exportedAt =
+            info.timeSynced ? isoUtcTimestamp(static_cast<time_t>(info.currentEpoch))
+                            : std::string{};
+
+        std::string body;
+        if (!buildConfigBackup(*context_.config, options, body)) {
+            sendError(request, {500, "backup_failed", "the configuration could not be exported"});
+            return;
+        }
+        auto* response = request->beginResponse(200, kJson, body.c_str());
+        // The hostname, not the display name: it is already constrained to [A-Za-z0-9-] by
+        // validate(), so it cannot break out of the quoted filename, and a display name can
+        // contain anything including a quote.
+        std::string filename = "heliograph-" + context_.config->wifi.hostname;
+        if (!options.exportedAt.empty()) {
+            filename += "-" + options.exportedAt.substr(0, 10);  // date only
+        }
+        response->addHeader("Content-Disposition",
+                            ("attachment; filename=\"" + filename + ".json\"").c_str());
+        request->send(response);
+    });
+
+    // Restore, in two steps that share one implementation: ?dry_run=true previews, without it
+    // applies. Deliberately not a stored preview the confirm step then commits -- the file is
+    // parsed afresh both times, so there is no server-side session to expire, to be raced by a
+    // second browser tab, or to apply something other than what was shown.
+    g_server->on(
+        AsyncURIMatcher::exact("/api/v1/config/restore"), HTTP_POST,
+        [this, authorised](AsyncWebServerRequest* request) {
+            // The same gate as /provision, for the same reason: the setup portal also returns
+            // on an ALREADY-CONFIGURED bridge after repeated WiFi failures, and its AP is open.
+            // Gated on whether a credential exists yet, not on whether the portal happens to be
+            // up -- otherwise anyone in radio range of a bridge whose WiFi had dropped could
+            // overwrite its entire configuration with a file.
+            const bool portal   = context_.portalActive && context_.portalActive();
+            const bool unsealed = context_.config->security.adminPassword.empty();
+            if (!(portal && unsealed) && !authorised(request)) {
+                releaseBody();
+                return;  // authorised() stored the 401
+            }
+            if (bodyOwner_ != request) {
+                sendError(request, {400, "empty_body", "a backup file is required"});
+                return;
+            }
+            BackupContents contents;
+            std::string    detail;
+            const BackupResult parsed = parseConfigBackup(bodyBuffer_, contents, detail);
+            releaseBody();
+            if (parsed != BackupResult::Ok) {
+                // The parser's own sentence, verbatim. "Rejected" with no reason is exactly the
+                // failure this endpoint must not have: the operator is holding a file and needs
+                // to know whether it is the wrong file, a newer one, or a damaged one.
+                sendError(request, {400, backupResultName(parsed), detail});
+                return;
+            }
+
+            const Configuration before = *context_.config;
+            Configuration       merged = before;
+            applyBackup(contents, merged);
+
+            // The file's configuration passed validate() on the way in, and the credentials
+            // merged over it came from a configuration that also passed. Checked anyway: this
+            // is the one place two validated halves are combined, and a bound that involves
+            // both would be invisible to either check on its own.
+            ConfigError error;
+            if (!validate(merged, error)) {
+                sendError(request, {400, "invalid_config",
+                                    error.field.empty() ? error.message
+                                                        : error.field + ": " + error.message});
+                return;
+            }
+            // Never leave the bridge without an admin password. A redacted backup restored onto
+            // a factory-fresh board would do exactly that: it would come up on the WiFi from the
+            // file, with every mutation refused for want of a credential, and the only way back
+            // in a five-second BOOT hold. Same rule /provision enforces, and the message names
+            // the way out.
+            if (merged.security.adminPassword.empty()) {
+                sendError(request, {400, "password_required",
+                                    "this backup carries no admin password and this bridge has "
+                                    "none yet; export again with secrets included, or complete "
+                                    "setup first and restore afterwards"});
+                return;
+            }
+
+            std::vector<ConfigDiffEntry> diff;
+            if (!diffConfigurations(before, merged, diff)) {
+                sendError(request, {500, "diff_failed", "could not compare the two configurations"});
+                return;
+            }
+            const bool rebootRequired = configChangeRequiresReboot(before, merged);
+
+            const bool dryRun = request->hasParam("dry_run") &&
+                                request->getParam("dry_run")->value() == "true";
+            if (dryRun) {
+                std::string body;
+                if (!buildRestorePreviewPayload(
+                        contents, diff, rebootRequired,
+                        context_.stashRollback != nullptr && context_.hasRollback != nullptr,
+                        body)) {
+                    sendError(request, {500, "payload_too_large",
+                                        "the restore preview exceeded its bound"});
+                    return;
+                }
+                request->send(200, kJson, body.c_str());
+                return;
+            }
+
+            // The undo copy goes in BEFORE the new configuration overwrites the old one --
+            // afterwards there is nothing left to copy. A refusal here (a full NVS) is reported,
+            // not fatal: losing the safety net is a smaller harm than refusing the operation it
+            // was for.
+            const bool rollbackStored =
+                context_.stashRollback != nullptr && context_.stashRollback();
+
+            if (!context_.saveConfig(merged)) {
+                sendError(request, {500, "save_failed", "could not persist the configuration"});
+                return;
+            }
+            context_.applyConfig(merged);  // lock-guarded publish; see RestContext
+
+            std::string body;
+            if (!buildRestoreResultPayload(diff.size(), rebootRequired, rollbackStored, body)) {
+                request->send(200, kJson, "{\"status\":\"restored\"}");
+            } else {
+                request->send(200, kJson, body.c_str());
+            }
+            // Deferred, like every other reboot here: the send is queued, not flushed, and
+            // restarting now would drop the response that says what happened.
+            if (rebootRequired) {
+                context_.requestReboot();
+            }
+        },
+        nullptr,
+        [this](AsyncWebServerRequest* request, uint8_t* data, size_t len, size_t index,
+               size_t total) {
+            std::string* body = nullptr;
+            // The one route with a larger bound: a backup is the whole configuration plus an
+            // envelope, which does not fit the 4096 every other body is held to.
+            collectBody(request, data, len, index, total, body, kMaxBackupBytes);
+        });
+
+    g_server->on("/api/v1/actions/undo-restore", HTTP_POST,
+                 [this, authorised, rateLimited](AsyncWebServerRequest* request) {
+        if (!authorised(request) || rateLimited(request)) {
+            return;
+        }
+        context_.diagnostics->recordRestRequest();
+        Configuration restored;
+        if (context_.rollbackConfig == nullptr || !context_.rollbackConfig(restored)) {
+            // 404 rather than 500: by far the likeliest reason is that no restore has been done
+            // on this bridge, which is the normal state and not something to retry.
+            sendError(request, {404, "no_rollback",
+                                "there is no earlier configuration to go back to"});
+            return;
+        }
+        // rollbackConfig has already written to NVS -- it swaps the two stored blobs -- so
+        // there is deliberately no saveConfig() here. Calling one would re-serialise the same
+        // configuration over the copy that was just put in place.
+        const Configuration before = *context_.config;
+        context_.applyConfig(restored);
+        const bool rebootRequired = configChangeRequiresReboot(before, restored);
+        request->send(200, kJson,
+                      rebootRequired ? "{\"status\":\"rolled_back\",\"rebooting\":true}"
+                                     : "{\"status\":\"rolled_back\",\"rebooting\":false}");
+        if (rebootRequired) {
+            context_.requestReboot();
+        }
+    });
 
     g_server->on("/api/v1/actions/poll", HTTP_POST,
                  [this, authorised, rateLimited](AsyncWebServerRequest* request) {
@@ -922,7 +1123,7 @@ void RestApi::stop() { started_ = false; }
 void RestApi::notifyState(const DeviceState&, uint64_t) {}
 
 bool RestApi::collectBody(AsyncWebServerRequest*, const uint8_t*, size_t, size_t, size_t,
-                          std::string*& out) {
+                          std::string*& out, size_t) {
     out = nullptr;
     return false;
 }

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -121,6 +121,18 @@ private:
     /// suit the one that needs it would loosen the heap guarantee everywhere else.
     bool collectBody(AsyncWebServerRequest* request, const uint8_t* data, size_t len, size_t index,
                      size_t total, std::string*& out, size_t maxBytes = kMaxRequestBytes);
+
+    /// True when collectBody already answered this request (413 too large, 409 busy).
+    ///
+    /// The request handler MUST return without sending when this is true. The body handler runs
+    /// first but the request handler runs anyway, and send() replaces any previously stored
+    /// response -- so the unconditional "a JSON body is required" that every one of these
+    /// handlers falls through to was overwriting the real reason. Upload a file one byte over
+    /// the limit and the API said the body was missing.
+    ///
+    /// Same lesson the OTA route learned with its _tempObject marker, arrived at from the
+    /// other direction: there it was the specific error being replaced by a generic one.
+    bool bodyAlreadyAnswered(AsyncWebServerRequest* request);
     void releaseBody();
 
     RestContext context_;
@@ -138,6 +150,10 @@ private:
     // corrupting this one.
     std::string                  bodyBuffer_;
     const void*                  bodyOwner_ = nullptr;
+    /// The request collectBody has already answered with an error. Compared by pointer and
+    /// never dereferenced; cleared as soon as it is read, and whenever a new body starts, so a
+    /// recycled request address cannot inherit it.
+    const void*                  bodyRejected_ = nullptr;
 };
 
 /// Minimum spacing between /actions/* calls, per the security model.

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -34,6 +34,7 @@ class AsyncWebServerRequest;
 #include "diagnostics/diagnostics.h"
 #include "app/discovery_runner.h"
 #include "drivers/driver_registry.h"
+#include "rest_payloads.h"
 #include "state/state_store.h"
 
 namespace heliograph::rest {
@@ -70,6 +71,15 @@ struct RestContext {
     /// The same wipe the BOOT-hold performs, reached over the network instead of the button --
     /// which is what a user without physical access has when a config locks them out.
     std::function<bool()> requestFactoryReset;
+    /// Copies the stored configuration into the rollback slot, so the restore about to run can
+    /// be undone. False when there was nothing stored yet, or the write was refused -- both
+    /// are reported to the caller rather than aborting the restore over them.
+    std::function<bool()> stashRollback;
+    /// Swaps the rollback copy back in and hands over the configuration that is now live.
+    /// False when there is no rollback copy, or it could not be read.
+    std::function<bool(Configuration&)> rollbackConfig;
+    /// Whether an undo is currently available, for the preview to say so up front.
+    std::function<bool()> hasRollback;
     /// Erases a stored crash dump. Returns false when there was none, or the flash refused.
     /// Admin-gated and rate-limited like every other action -- it destroys diagnostic evidence,
     /// which is exactly the sort of thing an unauthenticated caller must not be able to do.
@@ -105,8 +115,12 @@ public:
 
 private:
     /// Accumulates a chunked body into bodyBuffer_. See the note on bodyBuffer_.
+    ///
+    /// `maxBytes` is per route rather than global: a configuration restore is legitimately
+    /// larger than any other body this API takes, and raising the bound for every endpoint to
+    /// suit the one that needs it would loosen the heap guarantee everywhere else.
     bool collectBody(AsyncWebServerRequest* request, const uint8_t* data, size_t len, size_t index,
-                     size_t total, std::string*& out);
+                     size_t total, std::string*& out, size_t maxBytes = kMaxRequestBytes);
     void releaseBody();
 
     RestContext context_;

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -550,7 +550,7 @@ bool buildLogsPayload(const std::vector<std::string>& lines, uint32_t totalLines
 
 bool buildRestorePreviewPayload(const BackupContents& backup,
                                 const std::vector<ConfigDiffEntry>& diff, bool rebootRequired,
-                                bool rollbackAvailable, std::string& out, size_t maxBytes) {
+                                bool rollbackExists, std::string& out, size_t maxBytes) {
     JsonDocument doc;
     // Describe the FILE first: which bridge and which firmware wrote it is half of deciding
     // whether to apply it, and it is the half a diff of field values cannot show.
@@ -564,7 +564,7 @@ bool buildRestorePreviewPayload(const BackupContents& backup,
 
     doc["change_count"]       = diff.size();
     doc["reboot_required"]    = rebootRequired;
-    doc["rollback_available"] = rollbackAvailable;
+    doc["rollback_exists"] = rollbackExists;
     JsonArray changes         = doc["changes"].to<JsonArray>();
     for (const auto& entry : diff) {
         JsonObject e = changes.add<JsonObject>();

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -548,4 +548,41 @@ bool buildLogsPayload(const std::vector<std::string>& lines, uint32_t totalLines
     return finish(doc, out, maxBytes);
 }
 
+bool buildRestorePreviewPayload(const BackupContents& backup,
+                                const std::vector<ConfigDiffEntry>& diff, bool rebootRequired,
+                                bool rollbackAvailable, std::string& out, size_t maxBytes) {
+    JsonDocument doc;
+    // Describe the FILE first: which bridge and which firmware wrote it is half of deciding
+    // whether to apply it, and it is the half a diff of field values cannot show.
+    JsonObject source          = doc["backup"].to<JsonObject>();
+    source["format_version"]   = backup.formatVersion;
+    source["includes_secrets"] = backup.includesSecrets;
+    // Absent, not empty string: an unsynced bridge writes no timestamp, and "" rendered in a
+    // date column reads as a bug rather than as "this file is undated".
+    if (!backup.firmwareVersion.empty()) source["firmware_version"] = backup.firmwareVersion;
+    if (!backup.exportedAt.empty()) source["exported_at"] = backup.exportedAt;
+
+    doc["change_count"]       = diff.size();
+    doc["reboot_required"]    = rebootRequired;
+    doc["rollback_available"] = rollbackAvailable;
+    JsonArray changes         = doc["changes"].to<JsonArray>();
+    for (const auto& entry : diff) {
+        JsonObject e = changes.add<JsonObject>();
+        e["field"]   = entry.field;
+        e["before"]  = entry.before;
+        e["after"]   = entry.after;
+    }
+    return finish(doc, out, maxBytes);
+}
+
+bool buildRestoreResultPayload(size_t changedFields, bool rebootRequired, bool rollbackStored,
+                               std::string& out, size_t maxBytes) {
+    JsonDocument doc;
+    doc["status"]          = "restored";
+    doc["changed_fields"]  = changedFields;
+    doc["reboot_required"] = rebootRequired;
+    doc["rollback_stored"] = rollbackStored;
+    return finish(doc, out, maxBytes);
+}
+
 }  // namespace heliograph::rest

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -141,16 +141,23 @@ bool buildLogsPayload(const std::vector<std::string>& lines, uint32_t totalLines
 /// truth about a redacted backup: those credentials show as unchanged because leaving them
 /// alone is what applying it will actually do.
 ///
-/// `rollbackAvailable` is whether an undo will exist afterwards. Shown up front rather than
-/// discovered later, because on a nearly-full NVS the answer is no and that changes whether
-/// someone wants to press the button at all.
+/// `rollbackExists` is whether an undo point is stored RIGHT NOW, from an earlier restore.
+///
+/// Not "will an undo exist afterwards", which is what this field claimed until a review caught
+/// it: that cannot be known before the copy is attempted, because the attempt is the only thing
+/// that discovers whether it fits. The result payload's `rollback_stored` answers that, after
+/// the fact, truthfully.
+///
+/// What this one is for is the case where an undo point already exists: applying is about to
+/// REPLACE it, so the way back becomes this configuration rather than the older one. That is a
+/// thing someone can get wrong, and nothing else says it.
 ///
 /// A separate response bound: a restore that touches every setting produces a long table, and
 /// truncating the one screen the operator is using to decide would defeat it.
 inline constexpr size_t kMaxRestorePreviewBytes = 16384;
 bool buildRestorePreviewPayload(const BackupContents& backup,
                                 const std::vector<ConfigDiffEntry>& diff, bool rebootRequired,
-                                bool rollbackAvailable, std::string& out,
+                                bool rollbackExists, std::string& out,
                                 size_t maxBytes = kMaxRestorePreviewBytes);
 
 /// The outcome of an applied restore. `rollbackStored` false means the undo copy did not fit;

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "config/config_backup.h"
 #include "device/bridge_info.h"
 #include "device/device_state.h"
 #include "diagnostics/diagnostics.h"
@@ -17,7 +18,8 @@ namespace heliograph::rest {
 
 inline constexpr size_t kMaxResponseBytes = 8192;
 /// Bodies above this are refused with 413 before parsing, so a large POST cannot exhaust the
-/// heap just by arriving.
+/// heap just by arriving. Routes that legitimately need more say so per route -- see
+/// kMaxBackupBytes, which a configuration restore passes to collectBody.
 inline constexpr size_t kMaxRequestBytes = 4096;
 
 struct ApiError {
@@ -132,5 +134,28 @@ inline constexpr size_t kMaxLogResponseBytes = 24576;
 bool buildLogsPayload(const std::vector<std::string>& lines, uint32_t totalLines,
                       const std::string& level, std::string& out,
                       size_t maxBytes = kMaxLogResponseBytes);
+
+/// What a restore would do, before it does it.
+///
+/// The preview is computed against the MERGED result, not against the file, so it tells the
+/// truth about a redacted backup: those credentials show as unchanged because leaving them
+/// alone is what applying it will actually do.
+///
+/// `rollbackAvailable` is whether an undo will exist afterwards. Shown up front rather than
+/// discovered later, because on a nearly-full NVS the answer is no and that changes whether
+/// someone wants to press the button at all.
+///
+/// A separate response bound: a restore that touches every setting produces a long table, and
+/// truncating the one screen the operator is using to decide would defeat it.
+inline constexpr size_t kMaxRestorePreviewBytes = 16384;
+bool buildRestorePreviewPayload(const BackupContents& backup,
+                                const std::vector<ConfigDiffEntry>& diff, bool rebootRequired,
+                                bool rollbackAvailable, std::string& out,
+                                size_t maxBytes = kMaxRestorePreviewBytes);
+
+/// The outcome of an applied restore. `rollbackStored` false means the undo copy did not fit;
+/// the restore still happened, and saying so is the whole point of reporting it separately.
+bool buildRestoreResultPayload(size_t changedFields, bool rebootRequired, bool rollbackStored,
+                               std::string& out, size_t maxBytes = kMaxResponseBytes);
 
 }  // namespace heliograph::rest

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1360,9 +1360,13 @@ async function renderConfig(){
     <div class="dim" style="font-size:12px;margin-top:4px"><b>Off by default, and think before
     turning it on.</b> With it on the file holds those passwords <b>in plain text</b>, and it
     will sit in your downloads folder, sync to whatever cloud drive is watching it, and be the
-    obvious thing to attach to a bug report. With it off the file is safe to keep anywhere, and
+    obvious thing to attach to a bug report. With it off there is no password in the file, and
     restoring it onto <i>this</i> bridge still works — an absent password means “keep the one
     the bridge already has”. Only a factory-reset board needs them typed again.</div>
+    <div class="dim" style="font-size:12px;margin-top:4px">Even without passwords the file is
+    not nothing: it holds your WiFi network name, the broker address and both usernames —
+    including the admin one, which this bridge deliberately never serves over the API. Treat it
+    as private either way.</div>
     <button type="button" onclick="downloadBackup()">Download backup</button>
     <div id="bkm" class="msg" style="display:none"></div></div>
   <div class="card"><b>Restore from a backup</b>
@@ -1681,8 +1685,7 @@ async function previewRestore(){
       <td class="dim">${esc(c.before)}</td><td><b>${esc(c.after)}</b></td></tr>`).join('')}</tbody></table>
     <div class="dim" style="font-size:12px;margin-top:10px">${d.change_count} setting(s) would
     change.${d.reboot_required?' The bridge <b>restarts</b> afterwards — some of these only take effect at boot.':''}
-    ${d.rollback_available?' The configuration it has now is kept, so this can be undone.'
-      :' <b>No undo will be stored</b> — the flash had no room for a second copy.'}</div>
+    ${d.rollback_exists?' You already have an undo point from an earlier restore; this <b>replaces</b> it, so undoing afterwards comes back to the configuration the bridge has right now.':''}</div>
     <button type="button" onclick="applyRestore()">Apply these ${d.change_count} change(s)</button>`;
 }
 

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1352,6 +1352,36 @@ async function renderConfig(){
     <button onclick="saveConfig()">Save settings</button>
     <div id="cm" class="msg" style="display:none"></div>
   </div>
+  <section class="cfgsec"><h3>Backup &amp; restore</h3>
+  <div class="card"><b>Download a backup</b>
+    <div class="dim" style="font-size:12px;margin-top:10px">One file with every setting on this
+    page. Keep it somewhere other than this bridge — it is what turns a dead board into a
+    twenty-minute job instead of an evening of remembering what you configured.</div>
+    ${chk('bk_sec','Include passwords (WiFi, MQTT, admin)',false)}
+    <div class="dim" style="font-size:12px;margin-top:4px"><b>Off by default, and think before
+    turning it on.</b> With it on the file holds those passwords <b>in plain text</b>, and it
+    will sit in your downloads folder, sync to whatever cloud drive is watching it, and be the
+    obvious thing to attach to a bug report. With it off the file is safe to keep anywhere, and
+    restoring it onto <i>this</i> bridge still works — an absent password means “keep the one
+    the bridge already has”. Only a factory-reset board needs them typed again.</div>
+    <button type="button" onclick="downloadBackup()">Download backup</button>
+    <div id="bkm" class="msg" style="display:none"></div></div>
+  <div class="card"><b>Restore from a backup</b>
+    <div class="dim" style="font-size:12px;margin-top:10px">Nothing is applied until you have
+    seen exactly what would change and pressed the second button.</div>
+    <label for="rs_file">Backup file (.json)</label>
+    <input id="rs_file" type="file" accept=".json,application/json">
+    <button type="button" onclick="previewRestore()">Show what would change</button>
+    <div id="rsm" class="msg" style="display:none"></div>
+    <div id="rspv"></div></div>
+  <div class="card"><b>Undo the last restore</b>
+    <div class="dim" style="font-size:12px;margin-top:10px">The bridge keeps the configuration
+    it had immediately before the most recent restore, so a wrong file does not cost you a
+    factory reset. Only that one: an ordinary Save does not create a restore point.</div>
+    <button type="button" style="background:none;border:1px solid var(--line);color:var(--fg)"
+      onclick="undoRestore()">Go back to the previous configuration</button>
+    <div id="rbm" class="msg" style="display:none"></div></div>
+  </section>
   <section class="cfgsec"><h3>Firmware &amp; recovery</h3>
   <div class="card"><b>Firmware update (OTA)</b>
     <label for="c_fw">Firmware image (.bin)</label>
@@ -1572,6 +1602,116 @@ async function saveConfig(){
 
 // XMLHttpRequest, not fetch: fetch cannot report UPLOAD progress, and a minute of silent
 // "uploading…" reads as a hang. Auth mirrors authFetch (prompt once, retry once on 401).
+// ---------------- Backup and restore ----------------
+// The file never touches the server on the download path and never persists on the upload
+// path: a Blob built in the page, and a body posted straight from a FileReader. Nothing is
+// staged on the bridge between preview and apply, which is why the apply re-sends the file
+// rather than confirming a token -- there is no server-side session to expire, to be raced by
+// a second tab, or to apply something other than what was on screen.
+
+function backupNote(el,cls,text){const m=$(el);m.style.display='block';m.className='msg '+cls;m.textContent=text}
+
+async function downloadBackup(){
+  const withSecrets=$('#bk_sec').checked;
+  backupNote('#bkm','','Preparing…');
+  const r=await authFetch('/api/v1/config/backup'+(withSecrets?'?secrets=true':''));
+  // No null check: authFetch always answers with a response-shaped object, and the cancellation
+  // one is ok:false with cancelled:true, which httpWhy phrases properly. A `!r` guard here
+  // would silently return with nothing on screen -- the exact failure authCancelled exists to
+  // prevent.
+  if(!r.ok){backupNote('#bkm','err','Could not export: '+httpWhy(r));return}
+  const text=await r.text();
+  // Filename from the server's Content-Disposition when it survives the fetch, so the file is
+  // named after the bridge that wrote it rather than after the page that asked.
+  let name='heliograph-backup.json';
+  const cd=r.headers.get('Content-Disposition')||'';
+  const m=cd.match(/filename="([^"]+)"/);
+  if(m)name=m[1];
+  const url=URL.createObjectURL(new Blob([text],{type:'application/json'}));
+  const a=document.createElement('a');a.href=url;a.download=name;
+  // In the DOM before the click: Firefox ignores a synthetic click on a detached anchor, so a
+  // download that works in Chrome does nothing at all there, silently.
+  document.body.appendChild(a);a.click();a.remove();
+  // Revoked on the next tick, not immediately: Safari has not started the download yet when
+  // click() returns, and freeing the object URL here cancels it.
+  setTimeout(()=>URL.revokeObjectURL(url),1000);
+  backupNote('#bkm','ok','Downloaded '+name+(withSecrets?' — it contains passwords in plain text.'
+    :' — no passwords in it.'));
+}
+
+// Held between preview and apply so the confirm sends the bytes that were previewed, not a
+// re-read of a file input the user may have changed in between.
+let rsPending=null;
+
+async function readChosenBackup(){
+  const f=$('#rs_file').files[0];
+  if(!f){backupNote('#rsm','err','Choose a backup file first.');return null}
+  try{return await f.text()}
+  catch(e){backupNote('#rsm','err','Could not read that file: '+e.message);return null}
+}
+
+async function previewRestore(){
+  $('#rspv').innerHTML='';
+  const text=await readChosenBackup();
+  if(text===null)return;
+  backupNote('#rsm','','Checking the file…');
+  const r=await authFetch('/api/v1/config/restore?dry_run=true',
+    {method:'POST',headers:{'Content-Type':'application/json'},body:text});
+  const d=await r.json().catch(()=>({}));
+  if(!r.ok){
+    backupNote('#rsm','err',(d.error&&d.error.message)||httpWhy(r));
+    return;
+  }
+  rsPending=text;
+  $('#rsm').style.display='none';
+  const b=d.backup||{};
+  const src=[b.firmware_version?'written by firmware '+esc(b.firmware_version):'',
+             b.exported_at?'on '+esc(b.exported_at.replace('T',' ').replace('Z',' UTC')):'',
+             b.includes_secrets?'<b>contains passwords</b>':'contains no passwords']
+            .filter(Boolean).join(' · ');
+  if(!d.change_count){
+    $('#rspv').innerHTML=`<div class="msg ok" style="display:block">This backup matches the
+      bridge's current configuration exactly — nothing would change.<div class="dim"
+      style="font-size:12px;margin-top:6px">${src}</div></div>`;
+    return;
+  }
+  $('#rspv').innerHTML=`
+    <div class="dim" style="font-size:12px;margin-top:12px">${src}</div>
+    <table style="margin-top:10px"><thead><tr><th>Setting</th><th>Now</th><th>After restore</th></tr></thead>
+    <tbody>${(d.changes||[]).map(c=>`<tr><td>${esc(c.field)}</td>
+      <td class="dim">${esc(c.before)}</td><td><b>${esc(c.after)}</b></td></tr>`).join('')}</tbody></table>
+    <div class="dim" style="font-size:12px;margin-top:10px">${d.change_count} setting(s) would
+    change.${d.reboot_required?' The bridge <b>restarts</b> afterwards — some of these only take effect at boot.':''}
+    ${d.rollback_available?' The configuration it has now is kept, so this can be undone.'
+      :' <b>No undo will be stored</b> — the flash had no room for a second copy.'}</div>
+    <button type="button" onclick="applyRestore()">Apply these ${d.change_count} change(s)</button>`;
+}
+
+async function applyRestore(){
+  if(rsPending===null){backupNote('#rsm','err','Preview the file again before applying.');return}
+  $('#rspv').innerHTML='';
+  backupNote('#rsm','','Applying…');
+  const r=await authFetch('/api/v1/config/restore',
+    {method:'POST',headers:{'Content-Type':'application/json'},body:rsPending});
+  const d=await r.json().catch(()=>({}));
+  if(!r.ok){backupNote('#rsm','err',(d.error&&d.error.message)||httpWhy(r));return}
+  rsPending=null;
+  backupNote('#rsm','ok','Restored '+(d.changed_fields||0)+' setting(s).'+
+    (d.reboot_required?' The bridge is restarting — reload this page in ~30 seconds.'
+                      :' No restart needed.')+
+    (d.rollback_stored?' You can undo this below.':' No undo was stored — the flash was full.'));
+}
+
+async function undoRestore(){
+  if(!confirm('Go back to the configuration this bridge had before the last restore?'))return;
+  backupNote('#rbm','','Rolling back…');
+  const r=await authFetch('/api/v1/actions/undo-restore',{method:'POST'});
+  const d=await r.json().catch(()=>({}));
+  if(!r.ok){backupNote('#rbm','err',(d.error&&d.error.message)||httpWhy(r));return}
+  backupNote('#rbm','ok','Rolled back.'+(d.rebooting?' The bridge is restarting — reload in ~30 seconds.'
+    :' No restart needed.')+' Pressing this again returns to the restored configuration.');
+}
+
 async function otaUpload(){
   const f=$('#c_fw').files[0], m=$('#om'), pb=$('#opb'), pf=$('#opf'), btn=$('#ob');
   m.style.display='block';

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -322,9 +322,14 @@ async function applyRestore(){
   if(!out)return;
   rsPending=null;
   $('rm').className='msg ok';
-  $('rm').innerHTML='Restored '+(out.data.changed_fields||0)+' setting(s). The bridge is '+
-    'restarting and joining the network from the backup — this setup network disappears. '+
-    'Give it ~30 seconds.';
+  // Whether it restarts is the firmware's call, not an assumption: a restore that touched only
+  // live-applied settings does not reboot, and promising a restart that never comes leaves
+  // someone waiting for a bridge that is already back.
+  $('rm').innerHTML='Restored '+(out.data.changed_fields||0)+' setting(s). '+
+    (out.data.reboot_required
+      ? 'The bridge is restarting and joining the network from the backup — this setup network '+
+        'disappears. Give it ~30 seconds.'
+      : 'No restart was needed, so this setup network is still up.');
 }
 </script></body></html>)HTML";
 

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -34,6 +34,14 @@ button:disabled{opacity:.5;cursor:default}
 .msg.err{background:#f8514922;border:1px solid var(--bad);display:block}
 .msg.ok{background:#3fb95022;border:1px solid var(--ok);display:block}
 .hint{font-size:12px;color:var(--dim);margin-top:6px}
+/* Only the restore preview uses a table here. Same rules as the dashboard's, so the two pages
+   still read as one product. */
+table{width:100%;border-collapse:collapse;font-size:13px;margin-top:10px}
+td,th{text-align:left;padding:6px 6px;border-bottom:1px solid var(--line);vertical-align:top;
+  word-break:break-word}
+th{color:var(--dim);font-weight:500;font-size:11px;text-transform:uppercase}
+tr:last-child td{border-bottom:0}
+button.alt{background:none;border:1px solid var(--line);color:var(--fg)}
 </style></head><body><div class="w">
 <h1>Heliograph setup</h1>
 <p class="sub">Connect this bridge to your network.</p>
@@ -81,6 +89,22 @@ button:disabled{opacity:.5;cursor:default}
   <div id="m" class="msg"></div>
 </form>
 
+<!-- The other way in. A board that has just been factory-reset, or a replacement board for one
+     that died, does not need its WiFi typed and then twenty settings re-entered by hand: the
+     backup carries all of them. This is the context that makes the feature worth having, which
+     is why it is on the setup page and not only in Settings. -->
+<div class="card">
+  <b>Restore from a backup</b>
+  <p class="hint" style="margin-top:8px">Have a configuration backup from this or another
+  Heliograph? Apply it here instead of filling in the form. You will see exactly what it
+  changes before anything happens.</p>
+  <label for="rsf">Backup file (.json)</label>
+  <input id="rsf" type="file" accept=".json,application/json">
+  <button id="rsb" type="button" onclick="previewRestore()">Show what it would change</button>
+  <div id="rm" class="msg"></div>
+  <div id="rp"></div>
+</div>
+
 <div class="card">
   <p class="sub" style="margin:0">After saving, the bridge restarts and joins your network.
   This setup network disappears. Find it again by its hostname, or via your router.</p>
@@ -89,6 +113,22 @@ button:disabled{opacity:.5;cursor:default}
 <script>
 const $=s=>document.getElementById(s);
 const msg=(t,ok)=>{const m=$('m');m.textContent=t;m.className='msg '+(ok?'ok':'err')};
+const esc=s=>String(s??'').replace(/[<>&"']/g,c=>({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c]));
+
+// Basic auth by hand: fetch() will not surface the browser's credential dialog reliably, least
+// of all in the captive-portal mini-browser this page is usually opened in.
+//
+// Always UTF-8. btoa() takes a string of code units and only throws above U+00FF, so a plain
+// btoa() silently emits LATIN-1 for exactly the range that matters here -- é, ë, ü, ö, ç. The
+// firmware compares against the bytes it stored from the setup POST, which are UTF-8, so those
+// passwords would never match and the owner would be locked out of their own recovery with
+// "password not accepted" (review, 2026-07-25).
+// Trimmed: Basic auth compares bytes, and this page is most often opened in a phone's
+// captive-portal browser, where a stray autocorrect space is easy and invisible.
+function basicAuthHeader(){
+  const raw=($('curuser').value.trim()||'admin')+':'+$('cur').value;
+  return 'Basic '+btoa(String.fromCharCode(...new TextEncoder().encode(raw)));
+}
 
 // Two modes. First boot: no admin password exists, provisioning is open, and the form sets one.
 // Reconfigure: this setup network came back because the bridge lost WiFi (a router reboot is
@@ -179,18 +219,7 @@ $('f').onsubmit=async e=>{
     // boot there is nothing to preserve, so an open network still sends the empty value.
     if(!reauth||$('pw').value!=='')body.wifi.password=$('pw').value;
     if(reauth){
-      // Basic auth by hand: fetch() will not surface the browser's credential dialog reliably,
-      // least of all in the captive-portal mini-browser this page is usually opened in.
-      //
-      // Always UTF-8. btoa() takes a string of code units and only throws above U+00FF, so a
-      // plain btoa() silently emits LATIN-1 for exactly the range that matters here -- é, ë, ü,
-      // ö, ç. The firmware compares against the bytes it stored from the setup POST, which are
-      // UTF-8, so those passwords would never match and the owner would be locked out of their
-      // own recovery with "password not accepted" (review, 2026-07-25).
-      // Trimmed: Basic auth compares bytes, and this page is most often opened in a phone's
-      // captive-portal browser, where a stray autocorrect space is easy and invisible.
-      const raw=($('curuser').value.trim()||'admin')+':'+$('cur').value;
-      headers['Authorization']='Basic '+btoa(String.fromCharCode(...new TextEncoder().encode(raw)));
+      headers['Authorization']=basicAuthHeader();
     }else{
       body.security={admin_password:$('admin').value};
     }
@@ -215,6 +244,88 @@ $('f').onsubmit=async e=>{
       '<b>http://'+host+'</b> (give it ~30 seconds).';
   }catch(err){msg(err.message);$('b').disabled=false}
 };
+
+// ---------------- Restore ----------------
+// Same two-step flow as the settings page, and the same firmware endpoint. The file is posted
+// straight from a FileReader and nothing is staged on the bridge between the two steps, so
+// what gets applied is exactly what was previewed.
+
+const rmsg=(t,cls)=>{const m=$('rm');m.textContent=t;m.className='msg '+cls;m.style.display='block'};
+let rsPending=null;
+
+// Authenticated exactly like provisioning, and for the same reason: the setup network also
+// comes back on an ALREADY-CONFIGURED bridge after a WiFi outage, and its AP is open. Without
+// this, anyone in radio range of a bridge whose router had rebooted could overwrite its whole
+// configuration -- admin password, broker, relay gates -- from a file.
+function restoreHeaders(){
+  const h={'Content-Type':'application/json'};
+  if(reauth)h['Authorization']=basicAuthHeader();
+  return h;
+}
+
+async function restorePost(query){
+  const f=$('rsf').files[0];
+  if(!f){rmsg('Choose a backup file first.','err');return null}
+  if(reauth&&!$('cur').value){
+    rmsg('This bridge is already set up, so restoring needs its admin password — fill it in above.','err');
+    return null;
+  }
+  const text=rsPending!==null&&query===''?rsPending:await f.text();
+  const r=await fetch('/api/v1/config/restore'+query,
+    {method:'POST',headers:restoreHeaders(),body:text});
+  if(r.status===401){
+    rmsg('Those admin credentials were not accepted — check the username too if you ever changed it.','err');
+    return null;
+  }
+  const d=await r.json().catch(()=>({}));
+  if(!r.ok){rmsg((d.error&&d.error.message)||('HTTP '+r.status),'err');return null}
+  return {text,data:d};
+}
+
+async function previewRestore(){
+  $('rp').innerHTML='';rsPending=null;
+  rmsg('Checking the file…','');
+  const out=await restorePost('?dry_run=true');
+  if(!out)return;
+  rsPending=out.text;
+  $('rm').style.display='none';
+  const d=out.data, b=d.backup||{};
+  const src=[b.firmware_version?'written by firmware '+esc(b.firmware_version):'',
+             b.exported_at?'on '+esc(b.exported_at.replace('T',' ').replace('Z',' UTC')):'',
+             b.includes_secrets?'<b>contains passwords</b>':'contains no passwords']
+            .filter(Boolean).join(' · ');
+  if(!d.change_count){
+    $('rp').innerHTML=`<div class="msg ok">This backup matches what the bridge already has —
+      nothing would change.<div class="hint">${src}</div></div>`;
+    return;
+  }
+  // Named where it bites. A redacted backup on a fresh board leaves no WiFi password and no
+  // admin password, and the firmware refuses the second of those outright -- but the WiFi one
+  // it will happily accept, leaving a bridge that cannot join anything.
+  const noWifiPw=!b.includes_secrets;
+  $('rp').innerHTML=`<div class="hint">${src}</div>
+    <table><thead><tr><th>Setting</th><th>Now</th><th>After</th></tr></thead><tbody>
+    ${(d.changes||[]).map(c=>`<tr><td>${esc(c.field)}</td><td>${esc(c.before)}</td>
+      <td><b>${esc(c.after)}</b></td></tr>`).join('')}</tbody></table>
+    <div class="hint">${d.change_count} setting(s) would change.${
+      d.reboot_required?' The bridge restarts afterwards.':''}</div>
+    ${noWifiPw?`<div class="msg err">This backup carries no passwords, so it cannot supply the
+      WiFi password either. Fill the form in above instead, or export a new backup with
+      passwords included.</div>`:''}
+    <button type="button" onclick="applyRestore()">Apply and restart</button>`;
+}
+
+async function applyRestore(){
+  $('rp').innerHTML='';
+  rmsg('Applying…','');
+  const out=await restorePost('');
+  if(!out)return;
+  rsPending=null;
+  $('rm').className='msg ok';
+  $('rm').innerHTML='Restored '+(out.data.changed_fields||0)+' setting(s). The bridge is '+
+    'restarting and joining the network from the backup — this setup network disappears. '+
+    'Give it ~30 seconds.';
+}
 </script></body></html>)HTML";
 
 }  // namespace heliograph::web

--- a/test/test_config_backup/test_main.cpp
+++ b/test/test_config_backup/test_main.cpp
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: MIT
+// Configuration backup: round-trip, redaction, the merge rule for absent credentials, the
+// refusal of files this firmware must not apply, and the restore preview.
+
+#include <unity.h>
+
+#include <ArduinoJson.h>
+
+#include <string>
+#include <vector>
+
+#include "config/config_backup.h"
+#include "config/configuration_store.h"
+
+using namespace heliograph;
+
+void setUp() {}
+void tearDown() {}
+
+/// A configuration with every section moved off its defaults, so a field that fails to survive
+/// the round trip shows up as a difference rather than coincidentally matching the default.
+static Configuration populated() {
+    Configuration c;
+    c.bridgeName             = "Shed bridge";
+    c.wifi.ssid              = "HomeNet";
+    c.wifi.password          = "wifi-secret";
+    c.wifi.hostname          = "shed";
+    c.mqtt.enabled           = true;
+    c.mqtt.host              = "192.168.20.10";
+    c.mqtt.port              = 8883;
+    c.mqtt.username          = "bridge";
+    c.mqtt.password          = "mqtt-secret";
+    c.mqtt.baseTopic         = "solar";
+    c.mqtt.discoveryPrefix   = "ha";
+    c.mqtt.discoveryEnabled  = false;
+    c.mqtt.qos               = 1;
+    c.modbus.enabled         = false;
+    c.modbus.port            = 1502;
+    c.modbus.unitId          = 7;
+    c.modbus.diagnosticsUnitId = 240;
+    c.polling.intervalSeconds = 30;
+    c.driver.id              = "mock";
+    c.driver.autoDetect      = true;
+    c.driver.options["unit_id"] = "3";
+    c.additionalDevices.push_back({"mock", false, {{"unit_id", "4"}}});
+    c.relays.enabled         = true;
+    c.relays.roles           = {"drm0", "none"};
+    c.ntp.enabled            = false;
+    c.ntp.useDhcp            = false;
+    c.ntp.server             = "192.168.20.1";
+    c.ntp.timezone           = "UTC0";
+    c.ntp.timezoneName       = "UTC";
+    c.serial.enabled         = true;
+    c.serial.profile.baudRate = 19200;
+    c.serial.profile.parity   = SerialParity::Even;
+    c.security.adminUsername = "operator";
+    c.security.adminPassword = "admin-secret";
+    c.security.readOnlyMode  = false;
+    c.logLevel               = LogLevel::Debug;
+    return c;
+}
+
+static BackupContents parseOrFail(const std::string& json) {
+    BackupContents contents;
+    std::string    detail;
+    const auto     result = parseConfigBackup(json, contents, detail);
+    TEST_ASSERT_EQUAL_STRING("ok", backupResultName(result));
+    return contents;
+}
+
+// --------------------------------------------------------------------------------------
+// Round trip
+// --------------------------------------------------------------------------------------
+
+static void test_round_trip_with_secrets_is_lossless() {
+    const Configuration original = populated();
+    std::string         file;
+    TEST_ASSERT_TRUE(buildConfigBackup(original, {true, "0.14.0", "2026-07-26T12:00:00Z"}, file));
+
+    Configuration restored;  // defaults: nothing to inherit, so every field must come from the file
+    applyBackup(parseOrFail(file), restored);
+
+    TEST_ASSERT_EQUAL_STRING(original.bridgeName.c_str(), restored.bridgeName.c_str());
+    TEST_ASSERT_EQUAL_STRING(original.wifi.ssid.c_str(), restored.wifi.ssid.c_str());
+    TEST_ASSERT_EQUAL_STRING(original.wifi.password.c_str(), restored.wifi.password.c_str());
+    TEST_ASSERT_EQUAL_STRING(original.wifi.hostname.c_str(), restored.wifi.hostname.c_str());
+    TEST_ASSERT_EQUAL_STRING(original.mqtt.host.c_str(), restored.mqtt.host.c_str());
+    TEST_ASSERT_EQUAL_UINT16(original.mqtt.port, restored.mqtt.port);
+    TEST_ASSERT_EQUAL_STRING(original.mqtt.username.c_str(), restored.mqtt.username.c_str());
+    TEST_ASSERT_EQUAL_STRING(original.mqtt.password.c_str(), restored.mqtt.password.c_str());
+    TEST_ASSERT_EQUAL_STRING(original.mqtt.baseTopic.c_str(), restored.mqtt.baseTopic.c_str());
+    TEST_ASSERT_FALSE(restored.mqtt.discoveryEnabled);
+    TEST_ASSERT_EQUAL_UINT8(1, restored.mqtt.qos);
+    TEST_ASSERT_FALSE(restored.modbus.enabled);
+    TEST_ASSERT_EQUAL_UINT16(1502, restored.modbus.port);
+    TEST_ASSERT_EQUAL_UINT8(7, restored.modbus.unitId);
+    TEST_ASSERT_EQUAL_UINT8(240, restored.modbus.diagnosticsUnitId);
+    TEST_ASSERT_EQUAL_UINT32(30, restored.polling.intervalSeconds);
+    TEST_ASSERT_TRUE(original.driver == restored.driver);
+    TEST_ASSERT_EQUAL_size_t(1, restored.additionalDevices.size());
+    TEST_ASSERT_EQUAL_STRING("4", restored.additionalDevices[0].options.at("unit_id").c_str());
+    TEST_ASSERT_TRUE(restored.relays.enabled);
+    TEST_ASSERT_EQUAL_size_t(2, restored.relays.roles.size());
+    TEST_ASSERT_EQUAL_STRING("drm0", restored.relays.roles[0].c_str());
+    TEST_ASSERT_FALSE(restored.ntp.enabled);
+    TEST_ASSERT_EQUAL_STRING("192.168.20.1", restored.ntp.server.c_str());
+    TEST_ASSERT_EQUAL_STRING("UTC0", restored.ntp.timezone.c_str());
+    TEST_ASSERT_TRUE(restored.serial.enabled);
+    TEST_ASSERT_EQUAL_UINT32(19200, restored.serial.profile.baudRate);
+    TEST_ASSERT_EQUAL(SerialParity::Even, restored.serial.profile.parity);
+    TEST_ASSERT_EQUAL_STRING("operator", restored.security.adminUsername.c_str());
+    TEST_ASSERT_EQUAL_STRING("admin-secret", restored.security.adminPassword.c_str());
+    TEST_ASSERT_FALSE(restored.security.readOnlyMode);
+    TEST_ASSERT_EQUAL(LogLevel::Debug, restored.logLevel);
+}
+
+/// The envelope's own metadata survives, because the restore preview shows it to the operator
+/// before they commit -- "which bridge and which firmware wrote this" is half of deciding
+/// whether to apply a file at all.
+static void test_envelope_metadata_is_reported_back() {
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {false, "0.14.0", "2026-07-26T12:00:00Z"},
+                                       file));
+    const BackupContents contents = parseOrFail(file);
+    TEST_ASSERT_EQUAL_UINT16(kBackupFormatVersion, contents.formatVersion);
+    TEST_ASSERT_EQUAL_STRING("0.14.0", contents.firmwareVersion.c_str());
+    TEST_ASSERT_EQUAL_STRING("2026-07-26T12:00:00Z", contents.exportedAt.c_str());
+    TEST_ASSERT_FALSE(contents.includesSecrets);
+}
+
+/// A field added to Configuration must reach the backup without anyone editing config_backup.
+/// Asserting on the shared builder is how that stays true: both documents come from
+/// serializeConfigForStorage, so the only way to add a field to one is to add it to both.
+static void test_backup_carries_every_stored_key() {
+    std::string stored;
+    TEST_ASSERT_TRUE(serializeConfigForStorage(populated(), stored));
+    JsonDocument storedDoc;
+    TEST_ASSERT_TRUE(deserializeJson(storedDoc, stored) == DeserializationError::Ok);
+
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {true, "", ""}, file));
+    JsonDocument backupDoc;
+    TEST_ASSERT_TRUE(deserializeJson(backupDoc, file) == DeserializationError::Ok);
+
+    for (JsonPairConst kv : storedDoc.as<JsonObjectConst>()) {
+        TEST_ASSERT_FALSE_MESSAGE(backupDoc["config"][kv.key()].isNull(), kv.key().c_str());
+    }
+}
+
+// --------------------------------------------------------------------------------------
+// Secrets
+// --------------------------------------------------------------------------------------
+
+static void test_redacted_backup_contains_no_password_anywhere() {
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {false, "", ""}, file));
+    TEST_ASSERT_NULL(std::strstr(file.c_str(), "wifi-secret"));
+    TEST_ASSERT_NULL(std::strstr(file.c_str(), "mqtt-secret"));
+    TEST_ASSERT_NULL(std::strstr(file.c_str(), "admin-secret"));
+    // Not merely absent as a value: the keys are gone, so nothing round-trips an empty string
+    // back in as a deliberate "clear this password".
+    TEST_ASSERT_NULL(std::strstr(file.c_str(), "\"password\""));
+    TEST_ASSERT_NULL(std::strstr(file.c_str(), "admin_password"));
+    // The non-secret half of each credential pair is NOT a password and stays: a restore that
+    // silently dropped the MQTT username would fail to connect for a reason nothing explains.
+    TEST_ASSERT_NOT_NULL(std::strstr(file.c_str(), "bridge"));
+    TEST_ASSERT_NOT_NULL(std::strstr(file.c_str(), "operator"));
+}
+
+/// The rule that makes a redacted backup usable rather than merely safe.
+static void test_absent_password_keeps_the_one_the_bridge_already_has() {
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {false, "", ""}, file));
+
+    Configuration target;
+    target.wifi.password          = "existing-wifi";
+    target.mqtt.password          = "existing-mqtt";
+    target.security.adminPassword = "existing-admin";
+    applyBackup(parseOrFail(file), target);
+
+    TEST_ASSERT_EQUAL_STRING("existing-wifi", target.wifi.password.c_str());
+    TEST_ASSERT_EQUAL_STRING("existing-mqtt", target.mqtt.password.c_str());
+    TEST_ASSERT_EQUAL_STRING("existing-admin", target.security.adminPassword.c_str());
+    // ...while everything that is not a credential really was replaced.
+    TEST_ASSERT_EQUAL_STRING("Shed bridge", target.bridgeName.c_str());
+    TEST_ASSERT_EQUAL_STRING("HomeNet", target.wifi.ssid.c_str());
+}
+
+/// A backup WITH secrets overwrites, including onto a bridge that already has different ones.
+/// This is the "clone a bridge" path and it has to be complete.
+static void test_carried_password_replaces_the_existing_one() {
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {true, "", ""}, file));
+
+    Configuration target;
+    target.wifi.password          = "existing-wifi";
+    target.security.adminPassword = "existing-admin";
+    applyBackup(parseOrFail(file), target);
+
+    TEST_ASSERT_EQUAL_STRING("wifi-secret", target.wifi.password.c_str());
+    TEST_ASSERT_EQUAL_STRING("admin-secret", target.security.adminPassword.c_str());
+}
+
+/// Present-but-empty is a deliberate empty credential (an open WiFi network), not a redaction.
+/// Treating it as "keep" would silently ignore the operator's edit.
+static void test_an_explicitly_empty_password_is_applied() {
+    Configuration open  = populated();
+    open.wifi.password  = "";
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(open, {true, "", ""}, file));
+
+    const BackupContents contents = parseOrFail(file);
+    TEST_ASSERT_TRUE(contents.hasWifiPassword);
+
+    Configuration target;
+    target.wifi.password = "existing-wifi";
+    applyBackup(contents, target);
+    TEST_ASSERT_EQUAL_STRING("", target.wifi.password.c_str());
+}
+
+// --------------------------------------------------------------------------------------
+// Refusals
+// --------------------------------------------------------------------------------------
+
+static void test_garbage_is_not_json() {
+    BackupContents contents;
+    std::string    detail;
+    TEST_ASSERT_EQUAL(BackupResult::NotJson,
+                      parseConfigBackup("this is not json at all", contents, detail));
+    TEST_ASSERT_FALSE(detail.empty());
+}
+
+/// Valid JSON that is simply the wrong file -- by far the likeliest mistake, so it is told
+/// apart from a version problem and says so.
+static void test_a_foreign_json_file_is_refused_as_not_a_backup() {
+    BackupContents contents;
+    std::string    detail;
+    TEST_ASSERT_EQUAL(BackupResult::NotABackup,
+                      parseConfigBackup(R"({"name":"something else","value":3})", contents,
+                                        detail));
+    TEST_ASSERT_NOT_NULL(std::strstr(detail.c_str(), "not a Heliograph"));
+}
+
+static void test_a_newer_envelope_is_refused_not_guessed_at() {
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {true, "", ""}, file));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, file) == DeserializationError::Ok);
+    doc["format_version"] = kBackupFormatVersion + 1;
+    std::string tampered;
+    serializeJson(doc, tampered);
+
+    BackupContents contents;
+    std::string    detail;
+    TEST_ASSERT_EQUAL(BackupResult::FutureFormat,
+                      parseConfigBackup(tampered, contents, detail));
+    TEST_ASSERT_NOT_NULL(std::strstr(detail.c_str(), "newer firmware"));
+}
+
+/// The envelope is one version, the configuration inside is another. A file this firmware
+/// understands the shape of can still hold a configuration it must not reinterpret.
+static void test_a_newer_inner_config_is_refused_separately() {
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {true, "", ""}, file));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, file) == DeserializationError::Ok);
+    doc["config"]["version"] = kConfigVersion + 1;
+    std::string tampered;
+    serializeJson(doc, tampered);
+
+    BackupContents contents;
+    std::string    detail;
+    TEST_ASSERT_EQUAL(BackupResult::FutureConfig,
+                      parseConfigBackup(tampered, contents, detail));
+}
+
+static void test_an_envelope_with_no_configuration_is_refused() {
+    BackupContents contents;
+    std::string    detail;
+    const std::string file =
+        std::string(R"({"format":")") + kBackupFormat + R"(","format_version":1})";
+    TEST_ASSERT_EQUAL(BackupResult::NotABackup, parseConfigBackup(file, contents, detail));
+}
+
+/// A configuration this firmware would refuse to LOAD must not arrive through the restore
+/// door either -- otherwise the backup path is a way around validate().
+static void test_a_configuration_that_fails_validation_is_refused() {
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {true, "", ""}, file));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, file) == DeserializationError::Ok);
+    doc["config"]["polling"]["interval_seconds"] = 0;  // below the validated minimum
+    std::string tampered;
+    serializeJson(doc, tampered);
+
+    BackupContents contents;
+    std::string    detail;
+    TEST_ASSERT_EQUAL(BackupResult::Corrupt, parseConfigBackup(tampered, contents, detail));
+}
+
+static void test_an_oversized_file_is_refused_before_parsing() {
+    BackupContents contents;
+    std::string    detail;
+    TEST_ASSERT_EQUAL(BackupResult::NotJson,
+                      parseConfigBackup(std::string(kMaxBackupBytes + 1, 'x'), contents, detail));
+}
+
+// --------------------------------------------------------------------------------------
+// Preview
+// --------------------------------------------------------------------------------------
+
+static const ConfigDiffEntry* find(const std::vector<ConfigDiffEntry>& diff,
+                                   const std::string& field) {
+    for (const auto& e : diff) {
+        if (e.field == field) return &e;
+    }
+    return nullptr;
+}
+
+static void test_identical_configurations_have_an_empty_diff() {
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(populated(), populated(), diff));
+    TEST_ASSERT_EQUAL_size_t(0, diff.size());
+}
+
+static void test_diff_names_the_field_and_both_values() {
+    Configuration after = populated();
+    after.mqtt.host     = "broker.local";
+    after.polling.intervalSeconds = 60;
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(populated(), after, diff));
+
+    const ConfigDiffEntry* host = find(diff, "mqtt.host");
+    TEST_ASSERT_NOT_NULL(host);
+    TEST_ASSERT_EQUAL_STRING("192.168.20.10", host->before.c_str());
+    TEST_ASSERT_EQUAL_STRING("broker.local", host->after.c_str());
+
+    const ConfigDiffEntry* interval = find(diff, "polling.interval_seconds");
+    TEST_ASSERT_NOT_NULL(interval);
+    TEST_ASSERT_EQUAL_STRING("30", interval->before.c_str());
+    TEST_ASSERT_EQUAL_STRING("60", interval->after.c_str());
+}
+
+/// The preview is rendered in a browser. A password value reaching it would put the credential
+/// on a page that is one screenshot away from a support thread.
+static void test_diff_never_renders_a_password_value() {
+    Configuration after           = populated();
+    after.wifi.password           = "a-different-secret";
+    after.security.adminPassword  = "";
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(populated(), after, diff));
+    for (const auto& e : diff) {
+        TEST_ASSERT_NULL(std::strstr(e.before.c_str(), "secret"));
+        TEST_ASSERT_NULL(std::strstr(e.after.c_str(), "secret"));
+    }
+    // Changing one secret for another is not a reportable change -- both sides are "(set)" and
+    // there is nothing truthful to show. Clearing one is.
+    TEST_ASSERT_NULL(find(diff, "wifi.password"));
+    const ConfigDiffEntry* admin = find(diff, "security.admin_password");
+    TEST_ASSERT_NOT_NULL(admin);
+    TEST_ASSERT_EQUAL_STRING("(set)", admin->before.c_str());
+    TEST_ASSERT_EQUAL_STRING("(not set)", admin->after.c_str());
+}
+
+static void test_diff_reports_a_changed_list_as_one_entry() {
+    Configuration after  = populated();
+    after.relays.roles   = {"drm1", "drm2"};
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(populated(), after, diff));
+    const ConfigDiffEntry* roles = find(diff, "relays.roles");
+    TEST_ASSERT_NOT_NULL(roles);
+    TEST_ASSERT_EQUAL_STRING("[\"drm0\",\"none\"]", roles->before.c_str());
+    TEST_ASSERT_EQUAL_STRING("[\"drm1\",\"drm2\"]", roles->after.c_str());
+}
+
+/// A restore that REMOVES a device is a change the operator needs to see. Walking only the
+/// incoming side would miss it entirely.
+static void test_diff_reports_a_removed_extra_device() {
+    Configuration after = populated();
+    after.additionalDevices.clear();
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(populated(), after, diff));
+    TEST_ASSERT_NOT_NULL(find(diff, "additional_devices"));
+}
+
+/// What the preview actually previews: the merged result, not the file. With a redacted backup
+/// the credentials must show as unchanged, because that is what applying it will do.
+static void test_preview_of_a_redacted_restore_shows_no_credential_change() {
+    Configuration current          = populated();
+    current.mqtt.host              = "old.broker";
+    std::string file;
+    TEST_ASSERT_TRUE(buildConfigBackup(populated(), {false, "", ""}, file));
+
+    Configuration merged = current;
+    applyBackup(parseOrFail(file), merged);
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(current, merged, diff));
+    TEST_ASSERT_NULL(find(diff, "wifi.password"));
+    TEST_ASSERT_NULL(find(diff, "security.admin_password"));
+    TEST_ASSERT_NOT_NULL(find(diff, "mqtt.host"));
+}
+
+// --------------------------------------------------------------------------------------
+// Timestamp
+// --------------------------------------------------------------------------------------
+
+static void test_timestamp_is_iso_utc() {
+    TEST_ASSERT_EQUAL_STRING("2026-07-26T12:00:00Z", isoUtcTimestamp(1785067200).c_str());
+}
+
+/// An unsynced bridge has an epoch near zero. Stamping the file "1970-01-01" would put a date
+/// on it that reads as real; absent is the honest answer.
+static void test_an_unsynced_clock_produces_no_timestamp() {
+    TEST_ASSERT_TRUE(isoUtcTimestamp(0).empty());
+    TEST_ASSERT_TRUE(isoUtcTimestamp(1000).empty());
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_round_trip_with_secrets_is_lossless);
+    RUN_TEST(test_envelope_metadata_is_reported_back);
+    RUN_TEST(test_backup_carries_every_stored_key);
+    RUN_TEST(test_redacted_backup_contains_no_password_anywhere);
+    RUN_TEST(test_absent_password_keeps_the_one_the_bridge_already_has);
+    RUN_TEST(test_carried_password_replaces_the_existing_one);
+    RUN_TEST(test_an_explicitly_empty_password_is_applied);
+    RUN_TEST(test_garbage_is_not_json);
+    RUN_TEST(test_a_foreign_json_file_is_refused_as_not_a_backup);
+    RUN_TEST(test_a_newer_envelope_is_refused_not_guessed_at);
+    RUN_TEST(test_a_newer_inner_config_is_refused_separately);
+    RUN_TEST(test_an_envelope_with_no_configuration_is_refused);
+    RUN_TEST(test_a_configuration_that_fails_validation_is_refused);
+    RUN_TEST(test_an_oversized_file_is_refused_before_parsing);
+    RUN_TEST(test_identical_configurations_have_an_empty_diff);
+    RUN_TEST(test_diff_names_the_field_and_both_values);
+    RUN_TEST(test_diff_never_renders_a_password_value);
+    RUN_TEST(test_diff_reports_a_changed_list_as_one_entry);
+    RUN_TEST(test_diff_reports_a_removed_extra_device);
+    RUN_TEST(test_preview_of_a_redacted_restore_shows_no_credential_change);
+    RUN_TEST(test_timestamp_is_iso_utc);
+    RUN_TEST(test_an_unsynced_clock_produces_no_timestamp);
+    return UNITY_END();
+}

--- a/test/test_config_backup/test_main.cpp
+++ b/test/test_config_backup/test_main.cpp
@@ -6,6 +6,7 @@
 
 #include <ArduinoJson.h>
 
+#include <cstring>
 #include <string>
 #include <vector>
 

--- a/test/test_config_backup/test_main.cpp
+++ b/test/test_config_backup/test_main.cpp
@@ -379,6 +379,22 @@ static void test_diff_reports_a_changed_list_as_one_entry() {
 
 /// A restore that REMOVES a device is a change the operator needs to see. Walking only the
 /// incoming side would miss it entirely.
+/// The removal sweep, exercised for real. Every other field exists on both sides -- both
+/// documents come from the same serialiser -- so driver options are the ONLY place a key can
+/// genuinely disappear, which happens whenever the driver changes. Walking the incoming side
+/// alone would show nothing at all here.
+static void test_diff_reports_a_driver_option_the_restore_drops() {
+    Configuration after = populated();
+    after.driver.options.erase("unit_id");
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(populated(), after, diff));
+    const ConfigDiffEntry* dropped = find(diff, "driver.options.unit_id");
+    TEST_ASSERT_NOT_NULL(dropped);
+    TEST_ASSERT_EQUAL_STRING("3", dropped->before.c_str());
+    TEST_ASSERT_EQUAL_STRING("(absent)", dropped->after.c_str());
+}
+
 static void test_diff_reports_a_removed_extra_device() {
     Configuration after = populated();
     after.additionalDevices.clear();
@@ -441,6 +457,7 @@ int main() {
     RUN_TEST(test_diff_names_the_field_and_both_values);
     RUN_TEST(test_diff_never_renders_a_password_value);
     RUN_TEST(test_diff_reports_a_changed_list_as_one_entry);
+    RUN_TEST(test_diff_reports_a_driver_option_the_restore_drops);
     RUN_TEST(test_diff_reports_a_removed_extra_device);
     RUN_TEST(test_preview_of_a_redacted_restore_shows_no_credential_change);
     RUN_TEST(test_timestamp_is_iso_utc);

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -318,6 +318,108 @@ static void test_an_invalid_config_is_never_persisted() {
     TEST_ASSERT_FALSE(backend.contains(kStorageKeyConfig));
 }
 
+// --- the rollback slot ------------------------------------------------------------------------
+
+static void test_nothing_to_roll_back_to_on_a_fresh_board() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    TEST_ASSERT_FALSE(store.hasRollback());
+    TEST_ASSERT_FALSE(store.stashRollback());
+    Configuration out;
+    TEST_ASSERT_EQUAL(LoadResult::NotFound, store.rollback(out));
+}
+
+static void test_stash_then_rollback_returns_the_earlier_configuration() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    auto               before = provisionedConfig();
+    before.bridgeName         = "before restore";
+    TEST_ASSERT_TRUE(store.save(before));
+
+    TEST_ASSERT_TRUE(store.stashRollback());
+    TEST_ASSERT_TRUE(store.hasRollback());
+
+    auto after       = provisionedConfig();
+    after.bridgeName = "after restore";
+    TEST_ASSERT_TRUE(store.save(after));
+
+    Configuration recovered;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.rollback(recovered));
+    TEST_ASSERT_EQUAL_STRING("before restore", recovered.bridgeName.c_str());
+
+    // ...and it is live, not merely returned: the next boot must find it too.
+    Configuration reloaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(reloaded));
+    TEST_ASSERT_EQUAL_STRING("before restore", reloaded.bridgeName.c_str());
+}
+
+/// The swap. Pressing undo twice returns to where you were, rather than doing nothing the
+/// second time with no way to explain why.
+static void test_rolling_back_twice_returns_to_the_restored_configuration() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    auto               before = provisionedConfig();
+    before.bridgeName         = "before restore";
+    store.save(before);
+    store.stashRollback();
+    auto after       = provisionedConfig();
+    after.bridgeName = "after restore";
+    store.save(after);
+
+    Configuration first;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.rollback(first));
+    TEST_ASSERT_EQUAL_STRING("before restore", first.bridgeName.c_str());
+
+    Configuration second;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.rollback(second));
+    TEST_ASSERT_EQUAL_STRING("after restore", second.bridgeName.c_str());
+}
+
+/// The safety net is allowed to fail. NVS here is 20 KB shared with the WiFi stack, so a
+/// second copy of the configuration is the first thing that will not fit -- and the restore
+/// must still be possible, with the caller told there is no undo.
+static void test_a_rollback_slot_that_does_not_fit_is_reported_not_fatal() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    store.save(provisionedConfig());
+    backend.writeFails = true;
+    TEST_ASSERT_FALSE(store.stashRollback());
+    backend.writeFails = false;
+    TEST_ASSERT_FALSE(store.hasRollback());
+}
+
+/// A rollback copy this firmware can no longer read must leave the live configuration alone.
+/// Whoever reaches for undo is already recovering from something; half-applying is worse than
+/// refusing.
+static void test_an_unreadable_rollback_leaves_the_live_config_untouched() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    auto               live = provisionedConfig();
+    live.bridgeName         = "still running";
+    store.save(live);
+    backend.write(kStorageKeyRollback, "{not json");
+
+    Configuration out;
+    TEST_ASSERT_EQUAL(LoadResult::Corrupt, store.rollback(out));
+
+    Configuration reloaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(reloaded));
+    TEST_ASSERT_EQUAL_STRING("still running", reloaded.bridgeName.c_str());
+}
+
+static void test_factory_reset_takes_the_rollback_slot_with_it() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    store.save(provisionedConfig());
+    TEST_ASSERT_TRUE(store.stashRollback());
+
+    TEST_ASSERT_TRUE(store.factoryReset());
+    TEST_ASSERT_FALSE(store.hasRollback());
+    // Explicitly: the stashed copy holds the WiFi and admin passwords too, so leaving it
+    // behind would make "erases everything, including passwords" untrue.
+    TEST_ASSERT_TRUE(backend.raw(kStorageKeyRollback).empty());
+}
+
 // --- corruption and versions ----------------------------------------------------------------
 
 static void test_corrupt_blob_falls_back_to_defaults() {
@@ -835,5 +937,11 @@ int main(int, char**) {
     RUN_TEST(test_ota_refuses_more_data_than_announced);
     RUN_TEST(test_ota_write_without_begin_is_refused);
     RUN_TEST(test_ota_end_without_any_data_is_refused);
+    RUN_TEST(test_nothing_to_roll_back_to_on_a_fresh_board);
+    RUN_TEST(test_stash_then_rollback_returns_the_earlier_configuration);
+    RUN_TEST(test_rolling_back_twice_returns_to_the_restored_configuration);
+    RUN_TEST(test_a_rollback_slot_that_does_not_fit_is_reported_not_fatal);
+    RUN_TEST(test_an_unreadable_rollback_leaves_the_live_config_untouched);
+    RUN_TEST(test_factory_reset_takes_the_rollback_slot_with_it);
     return UNITY_END();
 }

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1204,6 +1204,90 @@ static void test_modbus_write_stays_off_whatever_the_config_says() {
 
 // NTP feedback: before sync the API must say so honestly (null, never a 1970 date dressed
 // up as real); after sync it carries the local wall-clock and the last sync moment.
+// --- restore preview ----------------------------------------------------------------------
+
+/// The preview is the last thing between a wrong file and an applied configuration, so it has
+/// to carry the three facts the decision rests on: what the file is, what changes, and whether
+/// there is a way back.
+static void test_restore_preview_carries_the_file_and_the_changes() {
+    BackupContents backup;
+    backup.formatVersion   = kBackupFormatVersion;
+    backup.firmwareVersion = "0.13.2";
+    backup.exportedAt      = "2026-07-26T12:00:00Z";
+    backup.includesSecrets = false;
+    const std::vector<ConfigDiffEntry> diff{{"mqtt.host", "old.broker", "new.broker"},
+                                            {"polling.interval_seconds", "10", "30"}};
+
+    std::string body;
+    TEST_ASSERT_TRUE(rest::buildRestorePreviewPayload(backup, diff, true, true, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_EQUAL_STRING("0.13.2", doc["backup"]["firmware_version"]);
+    TEST_ASSERT_EQUAL_STRING("2026-07-26T12:00:00Z", doc["backup"]["exported_at"]);
+    TEST_ASSERT_FALSE(doc["backup"]["includes_secrets"].as<bool>());
+    TEST_ASSERT_EQUAL_INT(2, doc["change_count"].as<int>());
+    TEST_ASSERT_TRUE(doc["reboot_required"].as<bool>());
+    TEST_ASSERT_TRUE(doc["rollback_available"].as<bool>());
+    TEST_ASSERT_EQUAL_STRING("mqtt.host", doc["changes"][0]["field"]);
+    TEST_ASSERT_EQUAL_STRING("old.broker", doc["changes"][0]["before"]);
+    TEST_ASSERT_EQUAL_STRING("new.broker", doc["changes"][0]["after"]);
+}
+
+/// An undated backup renders as undated. Emitting "" would put an empty cell in a date column,
+/// which reads as a bug rather than as "the bridge that wrote this had no clock".
+static void test_restore_preview_omits_an_absent_export_date() {
+    BackupContents backup;
+    backup.formatVersion = kBackupFormatVersion;
+    std::string body;
+    TEST_ASSERT_TRUE(rest::buildRestorePreviewPayload(backup, {}, false, false, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_TRUE(doc["backup"]["exported_at"].isNull());
+    TEST_ASSERT_TRUE(doc["backup"]["firmware_version"].isNull());
+    TEST_ASSERT_EQUAL_INT(0, doc["change_count"].as<int>());
+    TEST_ASSERT_FALSE(doc["rollback_available"].as<bool>());
+}
+
+/// The preview is rendered in a browser and is exactly the sort of screen that ends up in a
+/// support thread. diffConfigurations already redacts; this asserts the payload does not
+/// reintroduce a value on its way out.
+static void test_restore_preview_of_a_real_backup_leaks_no_password() {
+    Configuration before;
+    before.wifi.ssid              = "HomeNet";
+    before.wifi.password          = "before-secret";
+    before.security.adminPassword = "before-admin";
+
+    Configuration after           = before;
+    after.wifi.password           = "after-secret";
+    after.security.adminPassword  = "";
+    after.mqtt.host               = "broker.local";
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(before, after, diff));
+
+    BackupContents backup;
+    backup.formatVersion = kBackupFormatVersion;
+    std::string body;
+    TEST_ASSERT_TRUE(rest::buildRestorePreviewPayload(backup, diff, false, true, body));
+    TEST_ASSERT_NULL(std::strstr(body.c_str(), "before-secret"));
+    TEST_ASSERT_NULL(std::strstr(body.c_str(), "after-secret"));
+    TEST_ASSERT_NULL(std::strstr(body.c_str(), "before-admin"));
+    TEST_ASSERT_NOT_NULL(std::strstr(body.c_str(), "(not set)"));
+}
+
+/// rollback_stored is reported separately from status on purpose: the restore succeeded AND
+/// there is no undo is a real combination on a full flash, and one field cannot say both.
+static void test_restore_result_reports_a_missing_undo_separately() {
+    std::string body;
+    TEST_ASSERT_TRUE(rest::buildRestoreResultPayload(7, true, false, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_EQUAL_STRING("restored", doc["status"]);
+    TEST_ASSERT_EQUAL_INT(7, doc["changed_fields"].as<int>());
+    TEST_ASSERT_TRUE(doc["reboot_required"].as<bool>());
+    TEST_ASSERT_FALSE(doc["rollback_stored"].as<bool>());
+}
+
 static void test_status_payload_reports_clock_sync_state() {
     Rig        r;
     const auto state = r.poll();
@@ -2083,5 +2167,9 @@ int main(int, char**) {
     RUN_TEST(test_prometheus_build_info_carries_the_version);
     RUN_TEST(test_the_mock_hybrid_also_exports);
     RUN_TEST(test_status_payload_reports_clock_sync_state);
+    RUN_TEST(test_restore_preview_carries_the_file_and_the_changes);
+    RUN_TEST(test_restore_preview_omits_an_absent_export_date);
+    RUN_TEST(test_restore_preview_of_a_real_backup_leaks_no_password);
+    RUN_TEST(test_restore_result_reports_a_missing_undo_separately);
     return UNITY_END();
 }

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1227,7 +1227,7 @@ static void test_restore_preview_carries_the_file_and_the_changes() {
     TEST_ASSERT_FALSE(doc["backup"]["includes_secrets"].as<bool>());
     TEST_ASSERT_EQUAL_INT(2, doc["change_count"].as<int>());
     TEST_ASSERT_TRUE(doc["reboot_required"].as<bool>());
-    TEST_ASSERT_TRUE(doc["rollback_available"].as<bool>());
+    TEST_ASSERT_TRUE(doc["rollback_exists"].as<bool>());
     TEST_ASSERT_EQUAL_STRING("mqtt.host", doc["changes"][0]["field"]);
     TEST_ASSERT_EQUAL_STRING("old.broker", doc["changes"][0]["before"]);
     TEST_ASSERT_EQUAL_STRING("new.broker", doc["changes"][0]["after"]);
@@ -1245,7 +1245,7 @@ static void test_restore_preview_omits_an_absent_export_date() {
     TEST_ASSERT_TRUE(doc["backup"]["exported_at"].isNull());
     TEST_ASSERT_TRUE(doc["backup"]["firmware_version"].isNull());
     TEST_ASSERT_EQUAL_INT(0, doc["change_count"].as<int>());
-    TEST_ASSERT_FALSE(doc["rollback_available"].as<bool>());
+    TEST_ASSERT_FALSE(doc["rollback_exists"].as<bool>());
 }
 
 /// The preview is rendered in a browser and is exactly the sort of screen that ends up in a


### PR DESCRIPTION
> **Stacked on #51** (`feat/settings-page-sections`) — the Backup & Restore card lands in the section structure that PR adds. Merge #51 first and the base retargets to `main` on its own.

A bridge accumulates twenty settings you chose once and forgot: broker address, base topic, bus addresses, timezone, relay roles. Until now the only copy lived in one 20 KB NVS partition on one board.

## The file is the stored document, wrapped

Deliberately **not** a new serialisation. It is a thin envelope around what `ConfigurationStore` already writes to NVS, which buys two things a second hand-maintained field list cannot:

- **One point of truth.** A setting added next month lands in the backup without anyone remembering to add it. There is a test asserting both documents carry the same keys, so drift is caught here rather than discovered by someone whose restore silently dropped a field.
- **The migration chain, free.** Reading back goes through `deserializeConfigFromStorage`, so a backup from an older firmware is upgraded on the way in exactly as a stored config is at boot.

The envelope versions itself separately from the configuration inside it, and both are checked. A file from newer firmware is refused, not reinterpreted.

## Secrets off by default — and that is what makes it *usable*

Not squeamishness. This file lands in a downloads folder, syncs to a cloud drive, and is the obvious thing to attach to a bug report.

What makes the redacted form complete rather than merely safe is the merge rule: **an absent password means "keep the one the bridge already has"**. A redacted backup restored onto a running bridge changes nothing about its credentials. Only a factory-fresh board has nothing to inherit — and a restore that would leave *that* board with no admin password is refused outright, because the alternative is a bridge on your WiFi nobody can reconfigure, recoverable only by a five-second BOOT hold.

Keys are removed rather than emptied, so nothing round-trips an empty string back as a deliberate "clear this password". A password that *is* present and empty **is** applied — an open WiFi network is not a redaction, and the two are told apart by whether the key exists.

## Preview, then apply

The diff runs against the **merged result**, not the file, so it tells the truth about a redacted backup: credentials show as unchanged, because that is what applying it will do.

It walks the two storage documents rather than comparing field by field — same anti-drift reason. Passwords are redacted by a **rule** (any key named `password` or ending `_password`), not a list of three, so a credential added later is covered before anyone remembers it should be.

Nothing is staged between the two calls. The apply re-sends the file rather than confirming a token: no server-side session to expire, to be raced by a second tab, or to apply something other than what was on screen.

## The undo

The configuration is copied to a second NVS key immediately before a restore overwrites it, and undo **swaps** the two — press it twice and you are back at the restored config, which beats a button that silently does nothing the second time.

Only a restore creates a restore point. Doing it on every Save would double the flash wear and make "the configuration from before the restore" mean nothing in particular.

**The copy is allowed to fail.** NVS here is 20 KB shared with the WiFi stack's own PHY calibration data, so a second copy of the configuration is the first thing that will not fit. The restore still goes ahead, with `rollback_stored: false` saying so — losing the safety net is a smaller harm than refusing the operation it was for.

## Restoring during setup

The captive portal offers the same restore. This is the context that makes the feature worth having: a replacement board takes a file instead of twenty fields typed by hand.

Same gate as `/api/v1/provision`, for the same reason — that portal is **not** exclusive to first boot. It returns on an already-configured bridge after repeated WiFi failures and its AP is open, so the gate is "does an admin password exist yet", not "is the portal up".

## Two incidental fixes this needed

- **`GET`/`PATCH /api/v1/config` now use `AsyncURIMatcher::exact`.** A bare-string URI matches `^uri(/.*)?$`, so the GET would have swallowed `/api/v1/config/backup` and answered a download request with the redacted settings document — the same trap `/api/v1/devices` already carries a comment about.
- **`collectBody` takes a per-route byte cap.** A backup is legitimately larger than any other body here; raising the global 4096 to suit it would loosen the heap bound everywhere else. Its 413 message interpolates the limit now instead of hardcoding `4096` next to a constant that can move.

## Verification

**675 native tests** (up from 643) — round-trip with and without secrets, key parity against the storage document, the merge rule both ways, an explicitly-empty password, six refusal paths, the diff including redaction and a removed device, and the rollback slot including a failed stash and an unreadable copy.

All four boards build with **zero warnings from `src/`** · cppcheck high clean · ruff clean · `check_layering.sh` 6/6 · `check_web_js.py` OK.

The restore preview was driven **end to end in a browser** against a stubbed API — real file input, real fetch, real diff table, password rendered as `(set)` → `(not set)`.

## Not verified on hardware

The NVS headroom question is real and I could not settle it off-device: whether a second ~3.9 KB blob actually fits alongside the WiFi stack's calibration data in the 20 KB partition. The code handles both answers, and `rollback_stored` reports which one you got — worth a look at the first restore on the real bridge.

---

## Self-review found two real defects

**A 413 was being replaced by "a backup file is required".** `collectBody` answers 413 for an oversized body and returns false *without claiming ownership*, so the request handler fires anyway, sees no body and sends its own 400 — and `send()` replaces the stored response. Upload a file one byte over the limit and the API told you the body was missing: the one message guaranteed to send someone looking in the wrong place. Pre-existing on `/provision` and `PATCH /config`; the restore route inherited it, and on a route whose entire input is a file it is far easier to hit. Fixed centrally with `bodyAlreadyAnswered()`, so all three routes stop overwriting the real reason.

**`rollback_available` was reporting on its own plumbing.** It was passed `stashRollback != nullptr && hasRollback != nullptr` — whether the *callbacks were wired* — while being documented as "whether an undo will exist afterwards" and rendered in the UI as "no undo will be stored, the flash had no room". None of that was measured; it would have said the same on a device with 20 KB free and on one with none.

And `hasRollback()` was therefore **never actually called** — a wired callback whose only use was a null check, plus a store method reachable only from tests. Dead, and I fed it a null check while it was dead. Same class as the `Diagnostics::reset()` finding in #50.

Whether an undo will exist cannot be known before the copy is attempted — attempting it *is* what discovers whether it fits, and `rollback_stored` in the result already answers that truthfully. So the field now asks `hasRollback()` and means what it can mean: an undo point exists **right now**, and applying replaces it, so the way back becomes this configuration rather than the older one. Renamed `rollback_exists`.

### Two overstatements, also fixed

The download card called a redacted backup "safe to keep anywhere". It carries no password, but it does carry the WiFi network name, the broker address and **both usernames — including the admin one**, which `security.md` goes out of its way never to serve over the API.

The setup page announced a restart unconditionally; the firmware only reboots when `configChangeRequiresReboot` says so.

### A coverage gap

The diff walker's removal sweep had no test reaching it. Both documents come from the same serialiser, so every top-level field exists on both sides — driver options are the only place a key can genuinely disappear. The test I thought covered it goes through the array path instead. Added the real one.

**676 native tests**, four boards clean, layering 6/6.
