### PR TITLE
Let the bridge record a bus it cannot understand

### DIFF
--- a/docs/adding-a-device.md
+++ b/docs/adding-a-device.md
@@ -160,12 +160,85 @@ worked for the EverSolar driver:
    software/dongle talks to the device, or replaying a community implementation's
    sequence. Decode frame by frame before writing any code
    (`tools/decode_eversolar.py` is the working example of such a decoder).
+
+   **The bridge can do the tap itself** — see [§6](#6-capturing-an-unknown-device) below.
+   It is already wired to the bus, so you need no USB-RS485 adapter and no laptop within
+   cable reach of the inverter.
 2. Read `docs/eversolar-protocol.md` and `src/drivers/eversolar_legacy/` as the
    reference structure: framing/checksum in a parser (host-tested), sequencing in the
    driver, brand knowledge nowhere else.
 3. Open an issue early with your captures. Protocol sequencing has failure modes that
    only show on real hardware over days (our sunrise-recovery saga is the cautionary
    tale), so plan for a soak-test phase.
+
+## 6. Capturing an unknown device
+
+When the discovery wizard finishes and names nothing, it offers **"Record the raw bus"**.
+That is this feature, and it needs no working driver — which is the point, because the
+devices worth capturing are exactly the ones nothing here can talk to yet.
+
+It listens. The bridge transmits nothing for the whole window; on a protocol you do not
+understand, a stray write is the one thing that could actually disturb the device.
+
+**Make the other end talk while it runs.** A passive tap records nothing on a quiet bus.
+Start the vendor app, plug in the monitoring dongle, press whatever makes it poll — or
+just wait, if something already polls on a cycle.
+
+### Read the checksum count first
+
+The report leads with how many records carried a valid checksum, and that number answers
+the question that actually blocks you:
+
+| What you see | What it means |
+|---|---|
+| Bytes, and valid checksums | Right line speed. Go decode. |
+| Bytes, **no** valid checksums | Almost always the **wrong baud rate** — try the next one. Failing that, a protocol that is neither Modbus RTU nor AA55, in which case the hex is still exactly what you want. |
+| No bytes at all | Either nothing spoke while it ran, or the wiring is wrong. A/B swapped is the usual one, then termination. |
+
+The device's baud rate is part of what you do not know yet, so guess and iterate. 9600 is
+by far the most common; then 19200, then 115200.
+
+### What comes out
+
+A text file you can attach to an issue directly:
+
+```
+# Heliograph raw RS485 capture
+# line: 9600 baud, none parity, 8 data bits, 1 stop bits
+# frame boundaries cut on 4 ms of silence
+# 12 frames, 143 bytes, 12 valid Modbus CRC, 0 valid AA55
+#
+# time_ms  gap_ms  len  checksum  bytes
+       0       0    8  modbus    01 03 00 00 00 0A C5 CD
+      41      33   25  modbus    01 03 14 00 00 09 C4 ... 
+```
+
+**Write down what the device is and what was talking to it while this ran.** That context
+is the one part nobody can recover from the bytes, and it is the difference between a
+useful capture and a wall of hex.
+
+### One honest limit: framing above 19200
+
+There is no request/response structure to lean on the way a driver has, so records are cut
+on an idle gap — the Modbus t3.5 rule, 3.5 character times of silence. At 9600 and 19200
+that gap is 4 ms and 2 ms, comfortably wider than the read loop's resolution.
+
+**At 38400 and above the real gap is under a millisecond**, finer than anything polling a
+UART can observe, so adjacent frames may land in one record. The byte stream is still
+complete and in order; only the cut points are approximate. A merged record shows up as a
+failed checksum rather than as silence — so on a fast line, judge the capture by the hex,
+not by the checksum count.
+
+### Bounds worth knowing
+
+- Polling stops for the whole window, and the bus is held exclusively.
+- Maximum 300 seconds per run, 256 records, 256 bytes per record — and **12 KB of captured
+  bytes in total**, which is the bound that actually bites first. The other two are a product,
+  and a product of two independently chosen limits bounds nothing: 256 × 256 would render to
+  about 220 KB of hex, which no board here can hold.
+- **Full means stopped, not "oldest dropped".** For a handshake the interesting part is the
+  registration dance at the beginning, and a ring buffer would reliably discard exactly
+  that. A truncated capture says so.
 
 ## Why writes are dormant
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -21,6 +21,8 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 | GET | `/api/v1/config` | — | Config **without secrets** |
 | PATCH | `/api/v1/config` | **✔** | Change config |
 | POST | `/api/v1/actions/discover` | **✔** | Start discovery |
+| POST | `/api/v1/actions/capture` | **✔** | Record raw RS485 traffic (`?seconds=&baud=&parity=&frames=`) |
+| GET | `/api/v1/capture` | — | The last capture, with per-frame hex and checksum verdicts |
 | POST | `/api/v1/actions/poll` | **✔** | Force an immediate poll |
 | POST | `/api/v1/actions/reboot` | **✔** | Reboot |
 | POST | `/api/v1/actions/clear-coredump` | **✔** | Discard a stored crash dump (404 when there is none) |
@@ -333,6 +335,63 @@ There is no `response_timeout_ms` here. Read deadlines are per-driver compile-ti
 a field on this object would have been a knob that changed nothing.
 
 While the override is off these fields are stored but not validated — they configure nothing.
+
+## Capturing an unknown device
+
+`POST /api/v1/actions/capture` records raw RS485 traffic without needing a driver that
+understands it. Contributor-facing; [docs/adding-a-device.md](adding-a-device.md#6-capturing-an-unknown-device)
+is the guide, this is the wire contract.
+
+| Parameter | Default | Range |
+|---|---|---|
+| `seconds` | 30 | 1–300 |
+| `frames` | 64 | 1–256 |
+| `baud` | 9600 | 300–921600 |
+| `parity` | `none` | `none`, `even`, `odd` |
+| `data_bits` | 8 | 5–8 |
+| `stop_bits` | 1 | 1–2 |
+
+202 on acceptance; **409** when a capture or a discovery run is already using the bus. Both
+take it exclusively, and rs485Task runs discovery first, so a capture accepted alongside one
+would record the tail of the probe run.
+
+The capture runs on the task that owns the bus, **instead of** that cycle's poll — the same
+handover discovery uses. That is the concurrency answer: there is no iteration in which the bus
+is being listened to and polled, so the two cannot interleave. The bridge transmits nothing for
+the whole window.
+
+`GET /api/v1/capture` returns the report, poll it for progress:
+
+```json
+{
+  "status": "done",
+  "line": { "baud_rate": 9600, "parity": "none", "data_bits": 8, "stop_bits": 1,
+            "idle_gap_ms": 4 },
+  "requested_seconds": 30, "max_frames": 64, "elapsed_ms": 30012,
+  "summary": { "frames": 12, "bytes": 143, "modbus_crc_ok": 12, "aa55_frames_ok": 0,
+               "truncated": false },
+  "frames": [
+    { "offset_ms": 0, "gap_before_ms": 0, "length": 8, "modbus_crc_ok": true,
+      "aa55_ok": false, "hex": "01 03 00 00 00 0A C5 CD" }
+  ]
+}
+```
+
+**`summary.modbus_crc_ok` is the number to read first.** A capture at the wrong baud rate
+produces plenty of bytes and zero valid checksums, and without that count the operator
+concludes the device is mute when it is merely being listened to at the wrong speed.
+
+The line settings are echoed in full because on an unidentified device they are a *guess*, and
+every number in the report is only meaningful against the guess that produced it.
+
+Frames are cut on `idle_gap_ms` of silence, derived from the baud rate (Modbus t3.5) and
+floored at 2 ms. Above 19200 the true gap is finer than the read loop can resolve, so adjacent
+frames may merge into one record — the byte stream stays complete and ordered, only the cut
+points are approximate. Stated here rather than left to be discovered from confusing output.
+
+The report is bounded at 64 KB and the capture stops when full rather than dropping the oldest:
+for a handshake the interesting part is at the beginning, and a ring buffer would reliably
+discard exactly that. `summary.truncated` says which happened.
 
 ## Applying changes: `reboot_required`
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -351,9 +351,10 @@ is the guide, this is the wire contract.
 | `data_bits` | 8 | 5–8 |
 | `stop_bits` | 1 | 1–2 |
 
-202 on acceptance; **409** when a capture or a discovery run is already using the bus. Both
-take it exclusively, and rs485Task runs discovery first, so a capture accepted alongside one
-would record the tail of the probe run.
+202 on acceptance; **409** when a capture or a discovery run is already using the bus. The guard
+is symmetric — `/actions/discover` refuses while a capture is pending or running too. It has to
+be: rs485Task checks discovery first, so a discovery accepted alongside a pending capture would
+jump the queue and the capture would then record the tail of the probe run.
 
 The capture runs on the task that owns the bus, **instead of** that cycle's poll — the same
 handover discovery uses. That is the concurrency answer: there is no iteration in which the bus

--- a/platformio.ini
+++ b/platformio.ini
@@ -77,6 +77,7 @@ build_src_filter =
     +<drivers/driver_registry.cpp>
     +<drivers/discovery_engine.cpp>
     +<app/discovery_runner.cpp>
+    +<app/capture_runner.cpp>
     +<drivers/eversolar_legacy/>
     +<drivers/growatt_modbus/>
     +<drivers/solax_x1/>

--- a/src/app/capture_runner.cpp
+++ b/src/app/capture_runner.cpp
@@ -76,8 +76,16 @@ bool CaptureRunner::runIfRequested(Transport& transport, const std::function<voi
             std::lock_guard<std::mutex> guard(mutex_);
             report_.status     = CaptureStatus::Failed;
             report_.error      = "those line settings could not be applied";
-            report_.finishedMs = clock_ ? clock_() : 0;
+            // A failed configure may still have half-applied something to the UART, so the
+            // driver's settings do have to go back on. The lock-failure path above is the one
+            // case where nothing was touched.
+            report_.lineReconfigured = true;
+            report_.finishedMs       = clock_ ? clock_() : 0;
             return true;
+        }
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            report_.lineReconfigured = true;
         }
         // Anything already buffered predates the capture and belongs to whatever the driver was
         // doing; timestamping it as the first frame would put a lie at offset 0.
@@ -109,6 +117,7 @@ bool CaptureRunner::runIfRequested(Transport& transport, const std::function<voi
         report_.pmuFrames    = capture.pmuFrames();
         report_.truncated    = capture.truncated();
         report_.idleGapMs    = capture.idleGapMs();
+        report_.lineReconfigured = true;
         report_.status       = CaptureStatus::Done;
         report_.finishedMs   = clock_ ? clock_() : 0;
     }

--- a/src/app/capture_runner.cpp
+++ b/src/app/capture_runner.cpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+
+#include "capture_runner.h"
+
+#include <array>
+#include <utility>
+
+namespace heliograph {
+
+const char* captureStatusName(CaptureStatus status) {
+    switch (status) {
+        case CaptureStatus::Idle:      return "idle";
+        case CaptureStatus::Requested: return "requested";
+        case CaptureStatus::Running:   return "running";
+        case CaptureStatus::Done:      return "done";
+        case CaptureStatus::Failed:    return "failed";
+    }
+    return "unknown";
+}
+
+CaptureRunner::CaptureRunner(ClockFn clock) : clock_(std::move(clock)) {}
+
+bool CaptureRunner::busy() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return report_.status == CaptureStatus::Requested || report_.status == CaptureStatus::Running;
+}
+
+bool CaptureRunner::request(const diag::CaptureConfig& config, const SerialProfile& profile) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (report_.status == CaptureStatus::Requested || report_.status == CaptureStatus::Running) {
+        return false;
+    }
+    // The previous capture is discarded rather than appended to. Two runs at different line
+    // settings in one report would be actively misleading -- the whole value of the checksum
+    // counts is that they describe ONE guess at the line.
+    report_             = CaptureReport{};
+    report_.status      = CaptureStatus::Requested;
+    report_.config      = config;
+    report_.profile     = profile;
+    report_.requestedMs = clock_ ? clock_() : 0;
+    return true;
+}
+
+bool CaptureRunner::runIfRequested(Transport& transport, const std::function<void()>& onTick) {
+    diag::CaptureConfig config;
+    SerialProfile       profile;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (report_.status != CaptureStatus::Requested) {
+            return false;
+        }
+        report_.status    = CaptureStatus::Running;
+        report_.startedMs = clock_ ? clock_() : 0;
+        config            = report_.config;
+        profile           = report_.profile;
+    }
+
+    diag::FrameCapture capture(config, profile);
+
+    // Everything below runs OUTSIDE the lock: it takes as long as the capture window, and
+    // report() has to stay answerable the whole time for the page polling for progress.
+    {
+        // The bus lock, held for the whole window. A capture that shared the line with a poll
+        // would record the bridge's own traffic interleaved with the device's and present it as
+        // one stream. The timeout is generous but finite: a bus held by a wedged transaction
+        // should report "busy", not hang the task.
+        TransportLock lock(transport, 2000);
+        if (!lock.held()) {
+            std::lock_guard<std::mutex> guard(mutex_);
+            report_.status     = CaptureStatus::Failed;
+            report_.error      = "the RS485 bus was busy";
+            report_.finishedMs = clock_ ? clock_() : 0;
+            return true;
+        }
+        if (!transport.configure(profile)) {
+            std::lock_guard<std::mutex> guard(mutex_);
+            report_.status     = CaptureStatus::Failed;
+            report_.error      = "those line settings could not be applied";
+            report_.finishedMs = clock_ ? clock_() : 0;
+            return true;
+        }
+        // Anything already buffered predates the capture and belongs to whatever the driver was
+        // doing; timestamping it as the first frame would put a lie at offset 0.
+        transport.flushInput();
+
+        const uint64_t start = transport.nowMs();
+        capture.begin(start);
+        std::array<uint8_t, 128> buffer{};
+        while (!capture.done(transport.nowMs())) {
+            if (onTick) {
+                onTick();
+            }
+            const size_t got =
+                transport.read(buffer.data(), buffer.size(), kCaptureReadTimeoutMs);
+            // Fed even when nothing arrived: a zero-length feed is what advances time, and
+            // without it the silence that ends a record would never be observed. A reader that
+            // only fed real bytes would emit one record per burst of traffic and never close
+            // the last one.
+            capture.feed(buffer.data(), got, transport.nowMs());
+        }
+        capture.finish(transport.nowMs());
+    }
+
+    {
+        std::lock_guard<std::mutex> guard(mutex_);
+        report_.frames       = capture.frames();
+        report_.totalBytes   = capture.totalBytes();
+        report_.modbusFrames = capture.modbusFrames();
+        report_.pmuFrames    = capture.pmuFrames();
+        report_.truncated    = capture.truncated();
+        report_.idleGapMs    = capture.idleGapMs();
+        report_.status       = CaptureStatus::Done;
+        report_.finishedMs   = clock_ ? clock_() : 0;
+    }
+    return true;
+}
+
+CaptureReport CaptureRunner::report() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return report_;
+}
+
+}  // namespace heliograph

--- a/src/app/capture_runner.h
+++ b/src/app/capture_runner.h
@@ -49,6 +49,15 @@ struct CaptureReport {
     uint32_t modbusFrames  = 0;
     uint32_t pmuFrames     = 0;
     bool     truncated     = false;
+    /// True once the line has been reconfigured to `profile`, so the caller knows it has to put
+    /// the driver's own settings back.
+    ///
+    /// Not the same as "the capture ran". A run that could not take the bus never touched the
+    /// line, and restoring it anyway means calling begin() on every driver -- which for the
+    /// AA55 family is a registration handshake, i.e. real traffic on a bus that just reported
+    /// itself busy. Doing that as a reflex after a failure is how a capture that recorded
+    /// nothing still disturbs a working install.
+    bool     lineReconfigured = false;
     /// The idle gap actually used, in ms. Reported because it is derived from the baud rate and
     /// floored, so it is not something the operator can work out from what they asked for.
     uint32_t idleGapMs     = 0;

--- a/src/app/capture_runner.h
+++ b/src/app/capture_runner.h
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+//
+// Runs a passive bus capture on the task that owns the RS485 bus.
+//
+// Exactly the DiscoveryRunner pattern, and for exactly the same reason: the web handler cannot
+// listen to the bus itself. It would block an AsyncTCP callback for the whole capture window,
+// and two components on the bus at once is what the bus lock exists to prevent. So the handler
+// *requests*, and rs485Task picks it up.
+//
+// That handover is also the answer to "does this interfere with the driver's polling?" -- not a
+// flag someone has to remember to check, but structure: rs485Task runs the capture INSTEAD of
+// its poll cycle, one or the other per iteration, the same way discovery already works. Polling
+// cannot overlap a capture because there is no iteration in which both happen.
+//
+// The one thing this does that discovery does not: it reconfigures the line to settings the
+// operator chose, which for an unidentified device is usually not the driver's. The caller must
+// put the line back afterwards -- see the restoreDriverLine() call in main.
+
+#pragma once
+
+#include <functional>
+#include <mutex>
+#include <string>
+
+#include "device/clock.h"
+#include "diagnostics/frame_capture.h"
+#include "transport/transport.h"
+
+namespace heliograph {
+
+enum class CaptureStatus : uint8_t {
+    Idle,
+    /// Requested, not yet picked up by rs485Task.
+    Requested,
+    Running,
+    Done,
+    /// Could not run at all (the bus lock was not free).
+    Failed,
+};
+
+const char* captureStatusName(CaptureStatus status);
+
+struct CaptureReport {
+    CaptureStatus status = CaptureStatus::Idle;
+    diag::CaptureConfig        config;
+    SerialProfile              profile;
+    std::vector<diag::CapturedFrame> frames;
+    uint32_t totalBytes    = 0;
+    uint32_t modbusFrames  = 0;
+    uint32_t pmuFrames     = 0;
+    bool     truncated     = false;
+    /// The idle gap actually used, in ms. Reported because it is derived from the baud rate and
+    /// floored, so it is not something the operator can work out from what they asked for.
+    uint32_t idleGapMs     = 0;
+    uint64_t requestedMs   = 0;
+    uint64_t startedMs     = 0;
+    uint64_t finishedMs    = 0;
+    std::string error;  ///< only set when status == Failed
+};
+
+class CaptureRunner {
+public:
+    explicit CaptureRunner(ClockFn clock);
+
+    /// Called from the web task. False when a capture is already pending or running -- the REST
+    /// layer turns that into 409. A second capture of the same bus while the first is listening
+    /// would have to share the line settings anyway.
+    bool request(const diag::CaptureConfig& config, const SerialProfile& profile);
+
+    /// Called from rs485Task. Runs a pending request and returns true if it ran.
+    ///
+    /// `onTick` is called on every read iteration, on the caller's task. A capture window is
+    /// tens of seconds inside a single rs485Task iteration, so the task watchdog has to be fed
+    /// from in here -- the same arrangement discovery needs for its probe loop, and for the
+    /// same reason.
+    bool runIfRequested(Transport& transport, const std::function<void()>& onTick = {});
+
+    CaptureReport report() const;
+    bool          busy() const;
+
+private:
+    ClockFn            clock_;
+    mutable std::mutex mutex_;
+    CaptureReport      report_;
+};
+
+/// How long a single read may block inside the capture loop.
+///
+/// Short on purpose. It bounds how precisely a gap can be seen, it bounds how often the
+/// watchdog is fed, and it bounds how long a stop takes to notice. 5 ms is well inside the
+/// t3.5 gap at 9600 and 19200 -- the rates at which framing is honest at all -- and gives the
+/// watchdog two hundred feeds a second.
+inline constexpr uint32_t kCaptureReadTimeoutMs = 5;
+
+/// Ceiling on a requested window. A capture holds the bus lock for its whole duration, so this
+/// is also the longest anyone can stop the inverter being polled with one authenticated
+/// request.
+inline constexpr uint32_t kMaxCaptureSeconds = 300;
+
+}  // namespace heliograph

--- a/src/diagnostics/frame_capture.cpp
+++ b/src/diagnostics/frame_capture.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+
+#include "frame_capture.h"
+
+#include <algorithm>
+
+#include "protocols/modbus/modbus_rtu.h"
+#include "protocols/pmu/pmu_protocol.h"
+
+namespace heliograph::diag {
+namespace {
+
+/// Bits on the wire per character: start + data + optional parity + stop.
+uint32_t bitsPerCharacter(const SerialProfile& profile) {
+    return 1u + profile.dataBits + (profile.parity == SerialParity::None ? 0u : 1u) +
+           profile.stopBits;
+}
+
+bool modbusCrcHolds(const std::vector<uint8_t>& bytes) {
+    // Four is the shortest thing that can carry one: unit, function and two CRC bytes. Below
+    // that there is nothing to check rather than a check that fails.
+    if (bytes.size() < 4) {
+        return false;
+    }
+    const uint16_t expected = modbus::crc16(bytes.data(), bytes.size() - 2);
+    // Transmitted low byte first.
+    const uint16_t actual =
+        static_cast<uint16_t>(bytes[bytes.size() - 2]) |
+        static_cast<uint16_t>(static_cast<uint16_t>(bytes[bytes.size() - 1]) << 8);
+    return expected == actual;
+}
+
+bool pmuFrameHolds(const std::vector<uint8_t>& bytes) {
+    pmu::Frame frame;
+    return pmu::parseFrame(bytes.data(), bytes.size(), frame) == pmu::ParseResult::Ok;
+}
+
+}  // namespace
+
+uint32_t idleGapMsFor(const SerialProfile& profile) {
+    if (profile.baudRate == 0) {
+        return 2;
+    }
+    // 3.5 characters, in milliseconds, rounded up so the gap is never shorter than the rule.
+    const uint64_t bits   = static_cast<uint64_t>(bitsPerCharacter(profile)) * 7u;  // 3.5 * 2
+    const uint64_t micros = (bits * 1000000u) / (2u * profile.baudRate);
+    const uint32_t ms     = static_cast<uint32_t>((micros + 999u) / 1000u);
+    // See the header: below this the reader cannot tell one gap from another, and claiming
+    // otherwise would be a resolution we do not have.
+    return std::max<uint32_t>(ms, 2);
+}
+
+FrameCapture::FrameCapture(const CaptureConfig& config, const SerialProfile& profile)
+    : config_(config),
+      gapMs_(config.idleGapMs != 0 ? config.idleGapMs : idleGapMsFor(profile)) {
+    frames_.reserve(config_.maxFrames);
+}
+
+void FrameCapture::begin(uint64_t nowMs) {
+    startMs_    = nowMs;
+    lastByteMs_ = nowMs;
+}
+
+void FrameCapture::feed(const uint8_t* data, size_t len, uint64_t nowMs) {
+    // Silence long enough to be a frame boundary closes whatever is open -- checked before the
+    // new bytes are appended, so the gap is measured against the previous record and not
+    // swallowed into it.
+    if (openHasBytes_ && nowMs - lastByteMs_ >= gapMs_) {
+        closeFrame();
+    }
+    if (len == 0 || data == nullptr) {
+        return;
+    }
+    if (frames_.size() >= config_.maxFrames || totalBytes_ >= config_.maxTotalBytes) {
+        truncated_ = true;
+        return;
+    }
+    if (!openHasBytes_) {
+        open_             = CapturedFrame{};
+        open_.offsetMs    = static_cast<uint32_t>(nowMs - startMs_);
+        open_.gapBeforeMs = static_cast<uint32_t>(nowMs - lastByteMs_);
+        openHasBytes_     = true;
+    }
+    for (size_t i = 0; i < len; ++i) {
+        if (totalBytes_ >= config_.maxTotalBytes) {
+            truncated_ = true;
+            break;
+        }
+        if (open_.bytes.size() >= config_.maxFrameBytes) {
+            // A record at its byte bound is closed and a new one started rather than dropping
+            // the overflow: on a fast line where the gap is unresolvable this is the only thing
+            // keeping one giant record from being the whole capture. It is a cut the protocol
+            // did not make, which is why gapBeforeMs on the next record will read 0.
+            closeFrame();
+            if (frames_.size() >= config_.maxFrames) {
+                truncated_ = true;
+                return;
+            }
+            open_             = CapturedFrame{};
+            open_.offsetMs    = static_cast<uint32_t>(nowMs - startMs_);
+            open_.gapBeforeMs = 0;
+            openHasBytes_     = true;
+        }
+        open_.bytes.push_back(data[i]);
+        ++totalBytes_;
+    }
+    lastByteMs_ = nowMs;
+}
+
+void FrameCapture::finish(uint64_t nowMs) {
+    (void)nowMs;
+    if (openHasBytes_) {
+        closeFrame();
+    }
+}
+
+void FrameCapture::closeFrame() {
+    if (!openHasBytes_) {
+        return;
+    }
+    // The verdicts are computed once, here, rather than on every read of the report: a report
+    // may be fetched repeatedly by a page that is polling, and a CRC over every record each
+    // time is work with a fixed answer.
+    open_.modbusCrcValid = modbusCrcHolds(open_.bytes);
+    open_.pmuFrameValid  = pmuFrameHolds(open_.bytes);
+    frames_.push_back(std::move(open_));
+    open_         = CapturedFrame{};
+    openHasBytes_ = false;
+}
+
+bool FrameCapture::done(uint64_t nowMs) const {
+    return truncated_ || frames_.size() >= config_.maxFrames ||
+           totalBytes_ >= config_.maxTotalBytes || (nowMs - startMs_) >= config_.durationMs;
+}
+
+uint32_t FrameCapture::modbusFrames() const {
+    uint32_t n = 0;
+    for (const auto& f : frames_) {
+        if (f.modbusCrcValid) ++n;
+    }
+    return n;
+}
+
+uint32_t FrameCapture::pmuFrames() const {
+    uint32_t n = 0;
+    for (const auto& f : frames_) {
+        if (f.pmuFrameValid) ++n;
+    }
+    return n;
+}
+
+}  // namespace heliograph::diag

--- a/src/diagnostics/frame_capture.h
+++ b/src/diagnostics/frame_capture.h
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+//
+// Passive recording of raw RS485 traffic, for a device no driver in this build can identify.
+//
+// This is the tool the "adding a device" guide asks a contributor to reach for first: watch the
+// official dongle or monitoring software talk to the inverter, decode the frames, and only then
+// write code. Until now that meant owning a USB-RS485 adapter and a laptop within cable reach
+// of the inverter. The bridge is already wired to that bus.
+//
+// Deliberately protocol-blind. It knows nothing about what the bytes mean and needs no working
+// driver -- that is the entire point, because the devices worth capturing are exactly the ones
+// nothing here can talk to yet. What it does add is two checksum verdicts per record, which is
+// not decoding: it is how you find out whether the line settings you guessed are right.
+//
+// FRAMING, AND ITS ONE HONEST LIMIT. There is no request/response structure to lean on the way
+// a driver has, so records are cut on an idle gap -- the Modbus t3.5 rule, 3.5 character times
+// of silence. That works cleanly at 9600 and 19200. At 38400 and above the real gap is under a
+// millisecond, which is finer than the read loop can resolve, so adjacent frames may land in
+// one record. The byte stream is still complete and in order; only the cut points are
+// approximate, and a merged record shows up as a failed checksum rather than as silence. Said
+// here, and in the UI, rather than left for a contributor to discover from confusing output.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "transport/serial_profile.h"
+
+namespace heliograph::diag {
+
+/// One run of bytes, bounded by silence on both sides (see the framing note above).
+struct CapturedFrame {
+    /// Milliseconds since the capture started, at the FIRST byte of this record. Relative
+    /// rather than wall-clock: a capture is read as a sequence, and the bridge may well have no
+    /// synced clock when someone is standing at it with the cover off.
+    uint32_t             offsetMs = 0;
+    /// Silence before this record, in milliseconds. Part of the protocol evidence: a device
+    /// that answers 20 ms after a request behaves differently from one that takes 200.
+    uint32_t             gapBeforeMs = 0;
+    std::vector<uint8_t> bytes;
+    /// Modbus RTU: the trailing two bytes are a correct CRC-16 over the rest.
+    bool                 modbusCrcValid = false;
+    /// The AA55 framing family: header, structure and 16-bit sum checksum all hold.
+    bool                 pmuFrameValid = false;
+};
+
+struct CaptureConfig {
+    /// How long to listen. The operator picks this: it has to cover whatever makes the other
+    /// device talk, which might be a poll cycle or a button press on a dongle.
+    uint32_t durationMs = 30000;
+    size_t   maxFrames     = 64;
+    size_t   maxFrameBytes = 256;
+    /// The bound that actually matters, and the reason it is stated separately from the two
+    /// above: those are a PRODUCT, and a product of two independently chosen limits is not a
+    /// bound on anything. 256 records of 256 bytes each renders to roughly 220 KB of JSON hex,
+    /// which no board here can hold, let alone copy into a response.
+    ///
+    /// This caps the payload directly, whatever shape the traffic turns out to have. 12 KB of
+    /// captured bytes is ~36 KB of hex and a ~40 KB response -- which the Relay-6CH, the one
+    /// board with no PSRAM to fall back on, can hold alongside a copy of it.
+    ///
+    /// Generous for the job: a registration handshake is a handful of frames of tens of bytes,
+    /// and a full Modbus response is 255. This is not a logging facility.
+    size_t   maxTotalBytes = 12288;
+    /// Silence that ends a record. Zero means "derive it from the line", which is what the
+    /// REST layer passes; an explicit value exists for tests and for a protocol whose inter-
+    /// frame gap is known to differ.
+    uint32_t idleGapMs = 0;
+};
+
+/// The 3.5-character silence Modbus RTU uses as a frame boundary, in whole milliseconds.
+///
+/// Floored at 2 ms, and that floor is doing real work: above 19200 baud the true gap is a
+/// fraction of a millisecond, finer than anything that polls a UART can observe. Returning the
+/// arithmetic answer would claim a resolution the reader does not have; the floor states the
+/// resolution it actually has, and the framing note above says what that costs.
+uint32_t idleGapMsFor(const SerialProfile& profile);
+
+/// Accumulates bytes into records. Pure: no UART, no clock of its own, every time value passed
+/// in. The reading loop lives in CaptureRunner, on the task that owns the bus.
+class FrameCapture {
+public:
+    FrameCapture(const CaptureConfig& config, const SerialProfile& profile);
+
+    /// Marks the start of the capture window. Every offsetMs is measured from here.
+    void begin(uint64_t nowMs);
+
+    /// Hands over bytes just read. `len == 0` is a normal and necessary call: it advances time
+    /// so that silence can close the open record. A reader that only called this when it had
+    /// bytes would never cut the last frame before a long quiet stretch.
+    void feed(const uint8_t* data, size_t len, uint64_t nowMs);
+
+    /// Closes the open record, if any. Call once when the window ends.
+    void finish(uint64_t nowMs);
+
+    /// True when the window has elapsed or the record bound is reached.
+    bool done(uint64_t nowMs) const;
+
+    /// True when the capture stopped because it filled up rather than because time ran out.
+    ///
+    /// Full means STOPPED, not "oldest dropped". For a handshake -- the case this exists for --
+    /// the interesting part is the registration dance at the beginning, and a ring buffer would
+    /// reliably throw away exactly that.
+    bool truncated() const { return truncated_; }
+
+    const std::vector<CapturedFrame>& frames() const { return frames_; }
+    uint32_t totalBytes() const { return totalBytes_; }
+    /// The gap actually in force, derived or explicit. Reported rather than recomputed by the
+    /// caller: an explicit config value overrides the derivation, and a report that recomputed
+    /// it would describe a rule the capture did not follow.
+    uint32_t idleGapMs() const { return gapMs_; }
+    /// Records whose Modbus CRC held. The single most useful number in the report: a capture at
+    /// the wrong baud rate produces plenty of bytes and zero valid checksums.
+    uint32_t modbusFrames() const;
+    uint32_t pmuFrames() const;
+
+private:
+    void closeFrame();
+
+    CaptureConfig        config_;
+    uint32_t             gapMs_ = 0;
+    uint64_t             startMs_ = 0;
+    uint64_t             lastByteMs_ = 0;
+    uint32_t             totalBytes_ = 0;
+    bool                 truncated_ = false;
+    CapturedFrame        open_;
+    bool                 openHasBytes_ = false;
+    std::vector<CapturedFrame> frames_;
+};
+
+}  // namespace heliograph::diag

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <vector>
 
+#include "app/capture_runner.h"
 #include "app/discovery_runner.h"
 #include "boards/board.h"
 #include "config/configuration.h"
@@ -199,6 +200,9 @@ std::atomic<status::LedColor> g_statusLedColor{status::LedColor::Off};
 
 /// Owns discovery runs. The web handler requests; rs485Task runs, because it owns the bus.
 DiscoveryRunner g_discovery{g_registry, nowMs};
+
+/// Owns passive bus captures, on the same terms and for the same reason.
+CaptureRunner g_capture{nowMs};
 
 /// The configured driver, or the highest-priority one compiled in. No manufacturer name here.
 std::string selectedDriverId() {
@@ -691,6 +695,16 @@ void startRestApi() {
     };
     ctx.requestDiscovery    = [](bool extended) { return g_discovery.request(extended); };
     ctx.discoveryReport     = [] { return g_discovery.report(); };
+    // Refused while discovery is pending or running as well as while another capture is: both
+    // want exclusive use of the same bus, and rs485Task runs discovery first, so a capture
+    // accepted alongside one would sit queued and then record the tail of the probe run.
+    ctx.requestCapture = [](const diag::CaptureConfig& config, const SerialProfile& profile) {
+        if (g_discovery.busy()) {
+            return false;
+        }
+        return g_capture.request(config, profile);
+    };
+    ctx.captureReport = [] { return g_capture.report(); };
     ctx.requestFactoryReset = [] { return g_store.factoryReset(); };
     // Clears a dump the operator has dealt with. Without it every later diagnostics read keeps
     // reporting the same old crash, and "is this new?" becomes unanswerable. The cached copy is
@@ -772,6 +786,26 @@ void reconcileAnnouncedDevices(const BridgeInfo& bridge) {
     g_announcedReconciled = true;
 }
 
+/// Puts every driver back on the bus and the line back where it belongs.
+///
+/// Needed after anything that took the bus away from the poll loop and left it changed.
+/// Discovery re-registers every inverter and resets the line to the driver's own first
+/// profile; a capture leaves the line on whatever the operator asked to listen at. Both end
+/// with a bus the driver no longer agrees with, so both end here.
+void restoreDriverLine() {
+    for (auto& d : g_drivers) {
+        d->begin(g_transport);
+    }
+    if (!g_drivers.empty()) {
+        // begin() has just put the line back on the driver's own first profile, exactly as it
+        // does at boot. Without this, running discovery from the web UI on a healthy bridge
+        // silently undid the stored override and the inverter went quiet until the next power
+        // cycle -- the same failure that override exists to prevent, on the one path that
+        // reconfigures the line at runtime.
+        applySerialOverride();
+    }
+}
+
 void rs485Task(void* /*arg*/) {
     for (;;) {
         // One feed per iteration. The 120 s budget covers a normal iteration; an extended
@@ -792,20 +826,29 @@ void rs485Task(void* /*arg*/) {
         // response timeout. The one feed above covered a run that was a handful of probes long.
         if (g_discovery.runIfRequested(g_transport, [] { esp_task_wdt_reset(); })) {
             Serial.printf("[discovery] %s\n", g_discovery.report().outcome.reason.c_str());
-            // The probe left the bus re-registered; make the driver pick that up rather than
-            // poll a stale address.
-            // Every device, not just the first: the probe re-registered the whole bus.
-            for (auto& d : g_drivers) {
-                d->begin(g_transport);
-            }
-            if (!g_drivers.empty()) {
-                // ...and begin() has just put the line back on the driver's own first profile,
-                // exactly as it does at boot. Without this, running discovery from the web UI
-                // on a healthy bridge silently undid the override and the inverter went quiet
-                // until the next power cycle -- the same failure this override exists to
-                // prevent, on the one path that reconfigures the line at runtime.
-                applySerialOverride();
-            }
+            // The probe left the bus re-registered and the line on the driver's default; make
+            // every device pick that up rather than poll a stale address.
+            restoreDriverLine();
+            vTaskDelay(pdMS_TO_TICKS(250));
+            continue;
+        }
+        // A capture, on exactly the same terms: instead of this cycle's poll, not alongside it.
+        // That is the whole concurrency answer -- there is no iteration in which the bus is
+        // being listened to AND polled, so the two cannot interleave by construction.
+        //
+        // The watchdog is fed per read iteration, not once here: a window is tens of seconds
+        // inside this single iteration, which the 120 s budget above would not survive on its
+        // own at the maximum window length.
+        if (g_capture.runIfRequested(g_transport, [] { esp_task_wdt_reset(); })) {
+            const auto report = g_capture.report();
+            log::info("capture: %u frames, %u bytes, %u with a valid Modbus CRC",
+                      static_cast<unsigned>(report.frames.size()),
+                      static_cast<unsigned>(report.totalBytes),
+                      static_cast<unsigned>(report.modbusFrames));
+            // The capture listened at line settings the operator chose, which for an
+            // unidentified device is precisely NOT the driver's. Leaving them in place would
+            // silence a working inverter until the next reboot.
+            restoreDriverLine();
             vTaskDelay(pdMS_TO_TICKS(250));
             continue;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -693,11 +693,19 @@ void startRestApi() {
         // Hand it to loop() instead, with enough time for the socket to flush.
         g_rebootAtMs = nowMs() + 1500;
     };
-    ctx.requestDiscovery    = [](bool extended) { return g_discovery.request(extended); };
+    // Symmetric with requestCapture below, and it has to be: rs485Task checks discovery FIRST,
+    // so a discovery accepted while a capture was merely pending would jump the queue and the
+    // capture would then record the tail of the probe run -- exactly what the guard on the
+    // other side exists to prevent. Guarding one direction only left that hole open.
+    ctx.requestDiscovery = [](bool extended) {
+        if (g_capture.busy()) {
+            return false;
+        }
+        return g_discovery.request(extended);
+    };
     ctx.discoveryReport     = [] { return g_discovery.report(); };
     // Refused while discovery is pending or running as well as while another capture is: both
-    // want exclusive use of the same bus, and rs485Task runs discovery first, so a capture
-    // accepted alongside one would sit queued and then record the tail of the probe run.
+    // want exclusive use of the same bus.
     ctx.requestCapture = [](const diag::CaptureConfig& config, const SerialProfile& profile) {
         if (g_discovery.busy()) {
             return false;
@@ -845,10 +853,15 @@ void rs485Task(void* /*arg*/) {
                       static_cast<unsigned>(report.frames.size()),
                       static_cast<unsigned>(report.totalBytes),
                       static_cast<unsigned>(report.modbusFrames));
-            // The capture listened at line settings the operator chose, which for an
-            // unidentified device is precisely NOT the driver's. Leaving them in place would
-            // silence a working inverter until the next reboot.
-            restoreDriverLine();
+            // Only when the line was actually changed. The capture listens at settings the
+            // operator chose, which for an unidentified device is precisely NOT the driver's,
+            // so leaving them in place would silence a working inverter until the next reboot.
+            // But a run that could not take the bus never got that far, and re-running begin()
+            // on every driver is a registration handshake on the AA55 family -- real traffic,
+            // on a bus that just said it was busy.
+            if (report.lineReconfigured) {
+                restoreDriverLine();
+            }
             vTaskDelay(pdMS_TO_TICKS(250));
             continue;
         }

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -714,7 +714,11 @@ bool RestApi::begin() {
         const bool extended = request->hasParam("extended") &&
                               request->getParam("extended")->value() == "true";
         if (!context_.requestDiscovery(extended)) {
-            sendError(request, {409, "already_running", "discovery is already in progress"});
+            // Not only discovery: a capture holds the same bus, and main refuses this while one
+            // is pending or running. Saying "discovery is already in progress" while the real
+            // reason was a capture sent the operator looking at the wrong tab.
+            sendError(request, {409, "bus_busy",
+                                "a discovery run or a capture is already using the bus"});
             return;
         }
         request->send(202, kJson, "{\"status\":\"accepted\"}");

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -720,6 +720,91 @@ bool RestApi::begin() {
         request->send(202, kJson, "{\"status\":\"accepted\"}");
     });
 
+    // Raw bus capture, for a device discovery could not name. Every parameter travels in the
+    // query: they are four numbers and an enum, and a JSON body would need the whole
+    // collectBody dance for that.
+    g_server->on("/api/v1/actions/capture", HTTP_POST,
+                 [this, authorised, rateLimited](AsyncWebServerRequest* request) {
+        if (!authorised(request) || rateLimited(request)) {
+            return;
+        }
+        if (context_.requestCapture == nullptr) {
+            sendError(request, {404, "no_capture", "this build cannot capture"});
+            return;
+        }
+        const auto number = [request](const char* name, long fallback) -> long {
+            if (!request->hasParam(name)) return fallback;
+            return std::strtol(request->getParam(name)->value().c_str(), nullptr, 10);
+        };
+
+        diag::CaptureConfig config;
+        const long seconds = number("seconds", 30);
+        if (seconds < 1 || seconds > static_cast<long>(kMaxCaptureSeconds)) {
+            // Bounded because a capture holds the bus for its whole window: this is also the
+            // longest one authenticated request can stop the inverter being polled.
+            sendError(request, {400, "invalid_parameter",
+                                "seconds must be between 1 and " +
+                                    std::to_string(kMaxCaptureSeconds)});
+            return;
+        }
+        config.durationMs = static_cast<uint32_t>(seconds) * 1000u;
+        const long frames = number("frames", 64);
+        if (frames < 1 || frames > 256) {
+            sendError(request, {400, "invalid_parameter", "frames must be between 1 and 256"});
+            return;
+        }
+        config.maxFrames = static_cast<size_t>(frames);
+
+        // The line to listen at. There is no driver to ask -- that is the whole situation this
+        // endpoint exists for -- so the operator supplies it, and a wrong guess shows up in the
+        // report as bytes with no valid checksums rather than as silence.
+        SerialProfile profile;
+        const long    baud = number("baud", 9600);
+        if (baud < 300 || baud > 921600) {
+            sendError(request, {400, "invalid_parameter", "baud must be between 300 and 921600"});
+            return;
+        }
+        profile.baudRate = static_cast<uint32_t>(baud);
+        if (request->hasParam("parity")) {
+            SerialParity parity{};
+            if (!parseParity(request->getParam("parity")->value().c_str(), parity)) {
+                sendError(request, {400, "invalid_parameter", "parity must be none, even or odd"});
+                return;
+            }
+            profile.parity = parity;
+        }
+        const long dataBits = number("data_bits", 8);
+        const long stopBits = number("stop_bits", 1);
+        if (dataBits < 5 || dataBits > 8 || stopBits < 1 || stopBits > 2) {
+            sendError(request, {400, "invalid_parameter",
+                                "data_bits must be 5-8 and stop_bits 1 or 2"});
+            return;
+        }
+        profile.dataBits = static_cast<uint8_t>(dataBits);
+        profile.stopBits = static_cast<uint8_t>(stopBits);
+
+        if (!context_.requestCapture(config, profile)) {
+            sendError(request, {409, "bus_busy",
+                                "a capture or discovery run is already using the bus"});
+            return;
+        }
+        request->send(202, kJson, "{\"status\":\"accepted\"}");
+    });
+
+    g_server->on("/api/v1/capture", HTTP_GET, [this](AsyncWebServerRequest* request) {
+        context_.diagnostics->recordRestRequest();
+        if (context_.captureReport == nullptr) {
+            sendError(request, {404, "no_capture", "this build cannot capture"});
+            return;
+        }
+        std::string body;
+        if (!buildCapturePayload(context_.captureReport(), context_.clock(), body)) {
+            sendError(request, {500, "payload_too_large", "the capture exceeded its bound"});
+            return;
+        }
+        request->send(200, kJson, body.c_str());
+    });
+
     g_server->on("/api/v1/actions/factory-reset", HTTP_POST,
                  [this, authorised, rateLimited](AsyncWebServerRequest* request) {
         if (!authorised(request) || rateLimited(request)) {

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -32,6 +32,7 @@ class AsyncWebServerRequest;
 #include "device/command.h"
 #include "device/device_state.h"
 #include "diagnostics/diagnostics.h"
+#include "app/capture_runner.h"
 #include "app/discovery_runner.h"
 #include "drivers/driver_registry.h"
 #include "state/state_store.h"
@@ -66,6 +67,11 @@ struct RestContext {
     std::function<bool(bool extended)> requestDiscovery;
     /// Current discovery report, for the wizard to poll.
     std::function<DiscoveryReport()> discoveryReport;
+    /// Start a passive bus capture. Returns false when one is already running -- or when
+    /// discovery is, since both take exclusive use of the same bus.
+    std::function<bool(const diag::CaptureConfig&, const SerialProfile&)> requestCapture;
+    /// The current capture report, for the wizard to poll and then download.
+    std::function<CaptureReport()> captureReport;
     /// Wipes stored configuration including credentials, then reboots into the setup portal.
     /// The same wipe the BOOT-hold performs, reached over the network instead of the button --
     /// which is what a user without physical access has when a config locks them out.

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -548,4 +548,60 @@ bool buildLogsPayload(const std::vector<std::string>& lines, uint32_t totalLines
     return finish(doc, out, maxBytes);
 }
 
+bool buildCapturePayload(const CaptureReport& report, uint64_t nowMs, std::string& out,
+                         size_t maxBytes) {
+    JsonDocument doc;
+    doc["status"] = captureStatusName(report.status);
+    if (!report.error.empty()) {
+        doc["error"] = report.error;
+    }
+    // The line it actually listened at, echoed in full. On an unidentified device this is a
+    // guess, and every number below is only meaningful against the guess that produced it --
+    // a report that omitted it would be uninterpretable a day later.
+    JsonObject line   = doc["line"].to<JsonObject>();
+    line["baud_rate"] = report.profile.baudRate;
+    line["parity"]    = parityName(report.profile.parity);
+    line["data_bits"] = report.profile.dataBits;
+    line["stop_bits"] = report.profile.stopBits;
+    line["idle_gap_ms"] = report.idleGapMs;
+
+    doc["requested_seconds"] = report.config.durationMs / 1000;
+    doc["max_frames"]        = report.config.maxFrames;
+    if (report.startedMs != 0) {
+        const uint64_t end = report.finishedMs != 0 ? report.finishedMs : nowMs;
+        doc["elapsed_ms"]  = end - report.startedMs;
+    }
+
+    JsonObject summary       = doc["summary"].to<JsonObject>();
+    summary["frames"]        = report.frames.size();
+    summary["bytes"]         = report.totalBytes;
+    // THE number to read first. A capture at the wrong baud rate produces plenty of bytes and
+    // zero valid checksums, and without this the operator concludes the device is mute.
+    summary["modbus_crc_ok"] = report.modbusFrames;
+    summary["aa55_frames_ok"] = report.pmuFrames;
+    summary["truncated"]     = report.truncated;
+
+    JsonArray frames = doc["frames"].to<JsonArray>();
+    for (const auto& f : report.frames) {
+        JsonObject e        = frames.add<JsonObject>();
+        e["offset_ms"]      = f.offsetMs;
+        e["gap_before_ms"]  = f.gapBeforeMs;
+        e["length"]         = f.bytes.size();
+        e["modbus_crc_ok"]  = f.modbusCrcValid;
+        e["aa55_ok"]        = f.pmuFrameValid;
+        // Uppercase, space-separated: the form every protocol document and every decoder
+        // example in docs/ uses, so a captured frame can be compared against one by eye.
+        std::string hex;
+        hex.reserve(f.bytes.size() * 3);
+        for (size_t i = 0; i < f.bytes.size(); ++i) {
+            static const char kDigits[] = "0123456789ABCDEF";
+            if (i != 0) hex.push_back(' ');
+            hex.push_back(kDigits[f.bytes[i] >> 4]);
+            hex.push_back(kDigits[f.bytes[i] & 0x0F]);
+        }
+        e["hex"] = hex;
+    }
+    return finish(doc, out, maxBytes);
+}
+
 }  // namespace heliograph::rest

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "app/capture_runner.h"
 #include "device/bridge_info.h"
 #include "device/device_state.h"
 #include "diagnostics/diagnostics.h"
@@ -132,5 +133,15 @@ inline constexpr size_t kMaxLogResponseBytes = 24576;
 bool buildLogsPayload(const std::vector<std::string>& lines, uint32_t totalLines,
                       const std::string& level, std::string& out,
                       size_t maxBytes = kMaxLogResponseBytes);
+
+/// A raw bus capture, for a device nothing in this build can identify.
+///
+/// Bounded separately and generously: this is hex, which is two characters per byte before JSON
+/// quoting, and the default 64x256 window can produce well over the 8 KB a normal response is
+/// held to. Truncating the one artefact a contributor is going to paste into an issue would
+/// defeat the feature.
+inline constexpr size_t kMaxCaptureResponseBytes = 65536;
+bool buildCapturePayload(const CaptureReport& report, uint64_t nowMs, std::string& out,
+                         size_t maxBytes = kMaxCaptureResponseBytes);
 
 }  // namespace heliograph::rest

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -550,6 +550,143 @@ let wizStoredDriverId=null, wizStoredOptions={};
 let wizFound={};
 const STEPS=['Interface','Mode','Probing','Candidates','Confirm','Test poll','Save'];
 
+// ---------------- Raw bus capture ----------------
+// Offered when discovery names nothing. Records what is actually on the wire without needing a
+// driver that understands it -- which is the point, because the devices worth capturing are
+// exactly the ones nothing here can talk to.
+
+let capTimer=null;
+
+function captureCard(){
+  return `<div class="card" style="margin-top:14px"><b>Still nothing? Record the raw bus</b>
+    <p class="dim">This listens to the RS485 line and writes down every byte, without needing a
+    driver that understands them. It is the first thing
+    <b>docs/adding-a-device.md</b> asks for when adding support for a new device — and if you
+    send the result with an issue, someone can work out the protocol from it.</p>
+    <p class="dim"><b>Polling stops for the whole recording</b>, and the bridge stays silent
+    throughout: it only listens. Make the other end talk while it runs — start the vendor app,
+    plug in the monitoring dongle, or just wait for its own poll cycle.</p>
+    <label for="cap_baud">Listen at</label>
+    <select id="cap_baud">${[9600,19200,38400,57600,115200].map(b=>
+      `<option ${b===9600?'selected':''}>${b}</option>`).join('')}</select>
+    <div class="dim" style="font-size:12px">The device's baud rate is part of what you do not
+    know yet. Guess, look at the result, and try another: a <b>wrong</b> rate gives plenty of
+    bytes and <b>no valid checksums</b>, which is exactly how you tell. 9600 first — it is by
+    far the most common.</div>
+    <label for="cap_par">Parity</label>
+    <select id="cap_par">${['none','even','odd'].map(p=>`<option>${p}</option>`).join('')}</select>
+    <label for="cap_secs">Record for (seconds)</label>
+    <input id="cap_secs" type="number" value="30" min="1" max="300">
+    <button onclick="startCapture()">Start recording</button>
+    <div id="capm" class="msg" style="display:none"></div>
+    <div id="capout"></div></div>`;
+}
+
+async function startCapture(){
+  const secs=Number($('#cap_secs').value)||30;
+  const q='?seconds='+secs+'&baud='+$('#cap_baud').value+'&parity='+$('#cap_par').value;
+  const m=$('#capm');m.style.display='block';m.className='msg';m.textContent='Starting…';
+  $('#capout').innerHTML='';
+  const r=await authFetch('/api/v1/actions/capture'+q,{method:'POST'});
+  if(!r.ok&&r.status!==202){
+    const d=await r.json().catch(()=>({}));
+    m.className='msg err';m.textContent=(d.error&&d.error.message)||httpWhy(r);
+    return;
+  }
+  m.textContent='Recording… make the other device talk now.';
+  // Polled rather than pushed: the capture runs on the bus task, and the only thing that
+  // knows it has finished is the report itself.
+  if(capTimer)clearInterval(capTimer);
+  capTimer=setInterval(pollCapture,1000);
+}
+
+async function pollCapture(){
+  // renderWizard() rebuilds #wiz wholesale, so a step change while a capture is running takes
+  // these elements with it. Stop rather than throw on a null every second for the rest of the
+  // session -- the report is still there to fetch when the card comes back.
+  if(!$('#capm')){clearInterval(capTimer);capTimer=null;return}
+  const r=await fetch('/api/v1/capture');
+  if(!r.ok)return;
+  const d=await r.json();
+  const m=$('#capm');
+  if(d.status==='requested'||d.status==='running'){
+    m.textContent='Recording… '+Math.round((d.elapsed_ms||0)/1000)+' of '+
+      (d.requested_seconds||0)+' s — '+(d.summary?d.summary.bytes:0)+' bytes so far.';
+    return;
+  }
+  clearInterval(capTimer);capTimer=null;
+  if(d.status==='failed'){m.className='msg err';m.textContent='Could not record: '+esc(d.error||'unknown');return}
+  if(d.status==='idle')return;
+  renderCapture(d);
+}
+
+function renderCapture(d){
+  const s=d.summary||{}, m=$('#capm');
+  const ok=(s.modbus_crc_ok||0)+(s.aa55_frames_ok||0);
+  // The verdict, stated rather than left to be inferred from a table of hex. Bytes with no
+  // valid checksum is the signature of a wrong baud rate, and that is a different problem
+  // from a silent bus -- telling them apart is most of the value of doing this at all.
+  if(!s.bytes){
+    m.className='msg err';
+    m.textContent='Nothing at all on the line at '+d.line.baud_rate+' baud. Either the device '+
+      'said nothing while this ran, or the wiring is wrong (A/B swapped is the usual one).';
+  }else if(!ok){
+    m.className='msg err';
+    m.textContent=s.bytes+' bytes, but not one valid checksum. That is what a wrong baud rate '+
+      'looks like — try another from the list. It can also mean a protocol neither Modbus RTU '+
+      'nor AA55, which the hex below is still worth keeping.';
+  }else{
+    m.className='msg ok';
+    m.textContent=s.frames+' frames, '+s.bytes+' bytes, '+ok+' with a valid checksum at '+
+      d.line.baud_rate+' baud. That is the right line speed.';
+  }
+  $('#capout').innerHTML=`
+    ${s.truncated?`<div class="msg err" style="display:block">Stopped early — the frame limit
+      was reached. The beginning is kept, which is the part a handshake needs.</div>`:''}
+    <table style="margin-top:10px"><thead><tr><th>Time</th><th>Gap</th><th>Len</th>
+      <th>Checksum</th><th>Bytes</th></tr></thead><tbody>
+      ${(d.frames||[]).map(f=>`<tr><td class="n">${f.offset_ms} ms</td>
+        <td class="n dim">${f.gap_before_ms} ms</td><td class="n">${f.length}</td>
+        <td>${f.modbus_crc_ok?'<span style="color:var(--ok)">Modbus</span>':
+             f.aa55_ok?'<span style="color:var(--ok)">AA55</span>':
+             '<span class="dim">—</span>'}</td>
+        <td style="font:12px/1.5 ui-monospace,Menlo,monospace;word-break:break-all">${esc(f.hex)}</td></tr>`).join('')}
+    </tbody></table>
+    <button onclick="downloadCapture()">Download as a text file</button>
+    <div class="dim" style="font-size:12px">Attach it to an issue. Note down what the device is
+    and what was talking to it while this ran — that context is the part nobody can recover
+    from the bytes.</div>`;
+  window.g_capture=d;
+}
+
+// Built here rather than served as a second format by the firmware: it is presentation, the
+// page already has the data, and a text renderer on the device would be flash spent on
+// something the browser does for nothing.
+function downloadCapture(){
+  const d=window.g_capture; if(!d)return;
+  const s=d.summary||{};
+  const lines=[
+    '# Heliograph raw RS485 capture',
+    '# line: '+d.line.baud_rate+' baud, '+d.line.parity+' parity, '+d.line.data_bits+
+      ' data bits, '+d.line.stop_bits+' stop bits',
+    '# frame boundaries cut on '+d.line.idle_gap_ms+' ms of silence',
+    '# '+s.frames+' frames, '+s.bytes+' bytes, '+(s.modbus_crc_ok||0)+' valid Modbus CRC, '+
+      (s.aa55_frames_ok||0)+' valid AA55'+(s.truncated?' (stopped at the frame limit)':''),
+    '#',
+    '# time_ms  gap_ms  len  checksum  bytes',
+    ...(d.frames||[]).map(f=>
+      String(f.offset_ms).padStart(8)+'  '+String(f.gap_before_ms).padStart(6)+'  '+
+      String(f.length).padStart(3)+'  '+
+      (f.modbus_crc_ok?'modbus  ':f.aa55_ok?'aa55    ':'-       ')+'  '+f.hex)];
+  const url=URL.createObjectURL(new Blob([lines.join('\n')+'\n'],{type:'text/plain'}));
+  const a=document.createElement('a');a.href=url;
+  a.download='heliograph-capture-'+d.line.baud_rate+'.txt';
+  // In the DOM before the click: Firefox ignores a synthetic click on a detached anchor, so a
+  // download that works in Chrome does nothing at all there, silently.
+  document.body.appendChild(a);a.click();a.remove();
+  setTimeout(()=>URL.revokeObjectURL(url),1000);
+}
+
 function stepBar(){
   return '<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:14px">'+
     STEPS.map((n,i)=>`<span class="tag" style="${i+1===wizStep?'border-color:#2f81f7;color:var(--fg)':''}">${i+1}. ${n}</span>`).join('')+
@@ -636,6 +773,11 @@ function renderWizard(){
       </div>`;
     });
     h+=`<button onclick="wizStep=2;renderWizard()" style="background:none;border:1px solid var(--line);color:var(--fg)">Back</button></div>`;
+    // The dead end this exists for. Discovery has finished and named nothing, and up to now
+    // the wizard's only remaining advice was "check your wiring". A raw capture is the next
+    // real step -- and it is the first step docs/adding-a-device.md asks a contributor for, so
+    // offering it here turns a failed scan into the start of a driver instead of a shrug.
+    if(!c.length)h+=captureCard();
   } else if(wizStep===5){
     h+=`<div class="card"><b>Step 5 — Confirm</b>
     <p class="dim">Nothing is saved until step 7. An uncertain match is never selected for you

--- a/test/test_capture/test_main.cpp
+++ b/test/test_capture/test_main.cpp
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: MIT
+// Passive bus capture: idle-gap framing, the checksum verdicts that tell an operator whether
+// their baud guess was right, the memory bounds, and the runner's handover to the bus task.
+
+#include <unity.h>
+
+#include <cstring>
+#include <vector>
+
+#include "app/capture_runner.h"
+#include "diagnostics/frame_capture.h"
+#include "protocols/modbus/modbus_rtu.h"
+#include "protocols/pmu/pmu_protocol.h"
+#include "support/mock_transport.h"
+
+using namespace heliograph;
+using heliograph::diag::CaptureConfig;
+using heliograph::diag::FrameCapture;
+using heliograph::test::MockTransport;
+
+void setUp() {}
+void tearDown() {}
+
+static SerialProfile profileAt(uint32_t baud) {
+    SerialProfile p;
+    p.baudRate = baud;
+    return p;
+}
+
+/// A well-formed Modbus RTU read request, CRC and all.
+static std::vector<uint8_t> modbusFrame(uint8_t unit) {
+    std::vector<uint8_t> f{unit, 0x03, 0x00, 0x00, 0x00, 0x02};
+    const uint16_t       crc = modbus::crc16(f.data(), f.size());
+    f.push_back(static_cast<uint8_t>(crc & 0xFF));
+    f.push_back(static_cast<uint8_t>(crc >> 8));
+    return f;
+}
+
+static void feed(FrameCapture& c, const std::vector<uint8_t>& bytes, uint64_t at) {
+    c.feed(bytes.data(), bytes.size(), at);
+}
+
+// --------------------------------------------------------------------------------------
+// The idle gap
+// --------------------------------------------------------------------------------------
+
+/// 3.5 characters at 9600 8N1 is 10 bits x 3.5 / 9600 = 3.65 ms, rounded up.
+static void test_idle_gap_follows_the_baud_rate() {
+    TEST_ASSERT_EQUAL_UINT32(4, diag::idleGapMsFor(profileAt(9600)));
+    TEST_ASSERT_EQUAL_UINT32(2, diag::idleGapMsFor(profileAt(19200)));
+}
+
+/// Above 19200 the true gap is a fraction of a millisecond -- finer than anything polling a
+/// UART can see. The floor states the resolution the reader actually has instead of claiming
+/// one it does not; the header and the UI both say what that costs.
+static void test_the_gap_is_floored_at_the_readers_resolution() {
+    TEST_ASSERT_EQUAL_UINT32(2, diag::idleGapMsFor(profileAt(38400)));
+    TEST_ASSERT_EQUAL_UINT32(2, diag::idleGapMsFor(profileAt(115200)));
+}
+
+/// Parity adds a bit to every character, so it lengthens the gap. Small, but it is the
+/// difference between cutting frames correctly and merging them on a marginal line.
+static void test_parity_lengthens_the_gap() {
+    SerialProfile even = profileAt(9600);
+    even.parity        = SerialParity::Even;
+    TEST_ASSERT_TRUE(diag::idleGapMsFor(even) >= diag::idleGapMsFor(profileAt(9600)));
+}
+
+/// A zero baud rate cannot happen through the API, which bounds it -- but dividing by it
+/// would be a crash rather than a bad number, so it is handled rather than assumed away.
+static void test_a_zero_baud_rate_does_not_divide_by_zero() {
+    TEST_ASSERT_EQUAL_UINT32(2, diag::idleGapMsFor(profileAt(0)));
+}
+
+// --------------------------------------------------------------------------------------
+// Framing
+// --------------------------------------------------------------------------------------
+
+static void test_silence_between_bursts_cuts_them_into_frames() {
+    CaptureConfig config;
+    config.idleGapMs = 4;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(1000);
+
+    feed(capture, {0x01, 0x03, 0x04}, 1000);
+    feed(capture, {0x05, 0x06}, 1001);       // 1 ms later: same frame
+    capture.feed(nullptr, 0, 1010);          // 9 ms of silence: cuts it
+    feed(capture, {0x02, 0x03}, 1010);
+    capture.finish(1020);
+
+    TEST_ASSERT_EQUAL_size_t(2, capture.frames().size());
+    TEST_ASSERT_EQUAL_size_t(5, capture.frames()[0].bytes.size());
+    TEST_ASSERT_EQUAL_size_t(2, capture.frames()[1].bytes.size());
+    TEST_ASSERT_EQUAL_UINT32(0, capture.frames()[0].offsetMs);
+    TEST_ASSERT_EQUAL_UINT32(10, capture.frames()[1].offsetMs);
+    TEST_ASSERT_EQUAL_UINT32(9, capture.frames()[1].gapBeforeMs);
+    TEST_ASSERT_EQUAL_UINT32(7, capture.totalBytes());
+}
+
+/// The zero-length feed is not a nicety: it is the only thing that advances time while the
+/// line is quiet. Without it the last burst before a silence would never be closed, and a
+/// reader that only fed real bytes would emit one record per traffic burst.
+static void test_a_trailing_frame_is_closed_by_finish() {
+    CaptureConfig config;
+    config.idleGapMs = 4;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(0);
+    feed(capture, {0xAA, 0x55}, 1);
+    TEST_ASSERT_EQUAL_size_t(0, capture.frames().size());  // still open
+    capture.finish(2);
+    TEST_ASSERT_EQUAL_size_t(1, capture.frames().size());
+}
+
+/// A record at its byte bound is cut and a new one started rather than dropping the overflow.
+/// On a fast line, where the gap is unresolvable, this is the only thing keeping the entire
+/// capture from becoming one enormous record.
+static void test_an_overlong_burst_is_split_rather_than_truncated() {
+    CaptureConfig config;
+    config.idleGapMs     = 4;
+    config.maxFrameBytes = 8;
+    FrameCapture capture(config, profileAt(115200));
+    capture.begin(0);
+    feed(capture, std::vector<uint8_t>(20, 0x5A), 0);
+    capture.finish(1);
+
+    TEST_ASSERT_EQUAL_size_t(3, capture.frames().size());
+    TEST_ASSERT_EQUAL_size_t(8, capture.frames()[0].bytes.size());
+    TEST_ASSERT_EQUAL_size_t(8, capture.frames()[1].bytes.size());
+    TEST_ASSERT_EQUAL_size_t(4, capture.frames()[2].bytes.size());
+    TEST_ASSERT_EQUAL_UINT32(20, capture.totalBytes());
+    // A cut the protocol did not make says so: no silence preceded it.
+    TEST_ASSERT_EQUAL_UINT32(0, capture.frames()[1].gapBeforeMs);
+}
+
+// --------------------------------------------------------------------------------------
+// Checksum verdicts -- the "is my baud rate right" signal
+// --------------------------------------------------------------------------------------
+
+static void test_a_real_modbus_frame_is_recognised() {
+    CaptureConfig config;
+    config.idleGapMs = 4;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(0);
+    feed(capture, modbusFrame(1), 0);
+    capture.finish(1);
+
+    TEST_ASSERT_EQUAL_size_t(1, capture.frames().size());
+    TEST_ASSERT_TRUE(capture.frames()[0].modbusCrcValid);
+    TEST_ASSERT_EQUAL_UINT32(1, capture.modbusFrames());
+}
+
+/// The whole point of the verdict. A capture at the wrong baud produces plenty of bytes and no
+/// valid checksums, and that count is what tells the operator to try another rate rather than
+/// concluding the device is mute.
+static void test_a_corrupted_frame_reports_a_failed_crc() {
+    CaptureConfig config;
+    config.idleGapMs = 4;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(0);
+    auto bad = modbusFrame(1);
+    bad[3] ^= 0xFF;  // one flipped bit in the payload, CRC now wrong
+    feed(capture, bad, 0);
+    capture.finish(1);
+
+    TEST_ASSERT_FALSE(capture.frames()[0].modbusCrcValid);
+    TEST_ASSERT_EQUAL_UINT32(0, capture.modbusFrames());
+}
+
+static void test_an_aa55_frame_is_recognised_as_its_own_family() {
+    CaptureConfig config;
+    config.idleGapMs = 4;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(0);
+
+    uint8_t buf[64];
+    size_t  n = 0;
+    TEST_ASSERT_EQUAL(pmu::BuildResult::Ok,
+                      pmu::buildRequest(pmu::cmd::kOfflineQuery, pmu::kBroadcastAddress, nullptr,
+                                        0, buf, sizeof(buf), n));
+    TEST_ASSERT_TRUE(n > 0);
+    feed(capture, std::vector<uint8_t>(buf, buf + n), 0);
+    capture.finish(1);
+
+    TEST_ASSERT_TRUE(capture.frames()[0].pmuFrameValid);
+    TEST_ASSERT_EQUAL_UINT32(1, capture.pmuFrames());
+}
+
+/// Too short to carry a CRC at all. "No checksum to check" must not read as "checksum failed",
+/// and must certainly not read past the front of the buffer looking for one.
+static void test_a_two_byte_record_is_not_claimed_either_way() {
+    CaptureConfig config;
+    config.idleGapMs = 4;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(0);
+    feed(capture, {0x01, 0x02}, 0);
+    capture.finish(1);
+
+    TEST_ASSERT_FALSE(capture.frames()[0].modbusCrcValid);
+    TEST_ASSERT_FALSE(capture.frames()[0].pmuFrameValid);
+}
+
+// --------------------------------------------------------------------------------------
+// Bounds
+// --------------------------------------------------------------------------------------
+
+/// Full means STOPPED, not "oldest dropped". For a handshake -- the case this feature exists
+/// for -- the interesting part is the registration dance at the beginning, and a ring buffer
+/// would reliably discard exactly that.
+static void test_filling_up_keeps_the_first_frames_and_says_so() {
+    CaptureConfig config;
+    config.idleGapMs = 4;
+    config.maxFrames = 2;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(0);
+    feed(capture, {0x01}, 0);
+    feed(capture, {0x02}, 100);
+    feed(capture, {0x03}, 200);
+    feed(capture, {0x04}, 300);
+    capture.finish(400);
+
+    TEST_ASSERT_EQUAL_size_t(2, capture.frames().size());
+    TEST_ASSERT_EQUAL_UINT8(0x01, capture.frames()[0].bytes[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x02, capture.frames()[1].bytes[0]);
+    TEST_ASSERT_TRUE(capture.truncated());
+    TEST_ASSERT_TRUE(capture.done(1));
+}
+
+/// The bound that actually holds. maxFrames and maxFrameBytes are a product, and a product of
+/// two independently chosen limits bounds nothing -- 256 records of 256 bytes renders to about
+/// 220 KB of JSON hex, which no board here can hold. This caps the payload directly.
+static void test_the_byte_ceiling_stops_the_capture() {
+    CaptureConfig config;
+    config.idleGapMs     = 4;
+    config.maxTotalBytes = 10;
+    config.maxFrames     = 100;
+    config.maxFrameBytes = 100;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(0);
+    feed(capture, std::vector<uint8_t>(50, 0x11), 0);
+    capture.finish(1);
+
+    TEST_ASSERT_EQUAL_UINT32(10, capture.totalBytes());
+    TEST_ASSERT_TRUE(capture.truncated());
+    TEST_ASSERT_TRUE(capture.done(1));
+}
+
+static void test_the_window_ends_the_capture() {
+    CaptureConfig config;
+    config.durationMs = 50;
+    FrameCapture capture(config, profileAt(9600));
+    capture.begin(1000);
+    TEST_ASSERT_FALSE(capture.done(1049));
+    TEST_ASSERT_TRUE(capture.done(1050));
+    TEST_ASSERT_FALSE(capture.truncated());  // time ran out, it did not fill up
+}
+
+// --------------------------------------------------------------------------------------
+// The runner: handover, bus ownership, failure paths
+// --------------------------------------------------------------------------------------
+
+static uint64_t g_clock = 0;
+
+static CaptureConfig shortWindow() {
+    CaptureConfig config;
+    config.durationMs = 20;
+    config.idleGapMs  = 4;
+    return config;
+}
+
+static void test_nothing_runs_until_something_is_requested() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    TEST_ASSERT_FALSE(runner.busy());
+    TEST_ASSERT_FALSE(runner.runIfRequested(transport));
+    TEST_ASSERT_EQUAL(CaptureStatus::Idle, runner.report().status);
+}
+
+/// Bytes have to arrive DURING the window, not before it: runIfRequested flushes the input
+/// first, precisely so traffic that predates the capture cannot be timestamped as its first
+/// frame. injectNoise() lands in the buffer that flush clears, so this drives the line through
+/// the noise pattern instead -- one byte per read, which is what a live bus looks like to this
+/// loop.
+static void test_a_requested_capture_reads_the_line_and_reports() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.msPerRead    = 1;  // the simulated clock only moves when the loop reads
+    transport.infiniteNoise = true;
+    transport.noisePattern  = modbusFrame(3);
+
+    TEST_ASSERT_TRUE(runner.request(shortWindow(), profileAt(9600)));
+    TEST_ASSERT_TRUE(runner.busy());
+    TEST_ASSERT_EQUAL(CaptureStatus::Requested, runner.report().status);
+
+    TEST_ASSERT_TRUE(runner.runIfRequested(transport));
+    const auto report = runner.report();
+    TEST_ASSERT_EQUAL(CaptureStatus::Done, report.status);
+    // A byte every millisecond never reaches the 4 ms gap, so it is one continuous record --
+    // which is exactly what a fast line looks like, and what the framing note warns about.
+    TEST_ASSERT_EQUAL_size_t(1, report.frames.size());
+    TEST_ASSERT_TRUE(report.totalBytes >= 15);
+    TEST_ASSERT_EQUAL_UINT32(report.totalBytes, report.frames[0].bytes.size());
+    TEST_ASSERT_EQUAL_UINT32(4, report.idleGapMs);
+    TEST_ASSERT_FALSE(runner.busy());
+}
+
+/// Traffic already buffered when the capture starts belongs to whatever the driver was doing.
+/// Recording it would put a frame at offset 0 that the capture never witnessed.
+static void test_traffic_from_before_the_window_is_not_recorded() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.msPerRead = 1;
+    transport.injectNoise(modbusFrame(3));  // arrived before the capture was asked for
+
+    runner.request(shortWindow(), profileAt(9600));
+    runner.runIfRequested(transport);
+    TEST_ASSERT_EQUAL_UINT32(0, runner.report().totalBytes);
+}
+
+/// The bus is taken for the whole window and the line is put on the requested settings --
+/// which for an unidentified device is exactly the point, since the driver's guess is what
+/// failed. The buffer is flushed first so traffic that predates the capture cannot be
+/// timestamped as its first frame.
+static void test_the_capture_owns_the_bus_and_sets_the_line() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.msPerRead = 1;
+
+    runner.request(shortWindow(), profileAt(19200));
+    runner.runIfRequested(transport);
+
+    TEST_ASSERT_EQUAL_INT(1, transport.lockCalls);
+    TEST_ASSERT_EQUAL_INT(1, transport.unlockCalls);
+    TEST_ASSERT_FALSE(transport.locked);
+    TEST_ASSERT_EQUAL_INT(1, transport.configureCalls);
+    TEST_ASSERT_EQUAL_INT(1, transport.flushCalls);
+    // Passive throughout: a capture that transmitted would be recording its own voice, and on
+    // an unknown protocol a stray write is the one thing that could actually disturb a device.
+    TEST_ASSERT_EQUAL_size_t(0, transport.writes.size());
+}
+
+static void test_a_second_request_is_refused_while_one_is_pending() {
+    CaptureRunner runner([] { return g_clock; });
+    TEST_ASSERT_TRUE(runner.request(shortWindow(), profileAt(9600)));
+    TEST_ASSERT_FALSE(runner.request(shortWindow(), profileAt(19200)));
+}
+
+/// A capture cannot wait for the bus: it would hold the task while the window ran down and
+/// then report an empty result as though the line were silent.
+static void test_a_busy_bus_fails_the_capture_with_a_reason() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.lockFails = true;
+
+    runner.request(shortWindow(), profileAt(9600));
+    TEST_ASSERT_TRUE(runner.runIfRequested(transport));
+    const auto report = runner.report();
+    TEST_ASSERT_EQUAL(CaptureStatus::Failed, report.status);
+    TEST_ASSERT_FALSE(report.error.empty());
+    TEST_ASSERT_FALSE(runner.busy());  // and a retry is possible
+}
+
+static void test_line_settings_that_will_not_apply_fail_rather_than_record_nothing() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.configureSucceeds = false;
+
+    runner.request(shortWindow(), profileAt(9600));
+    TEST_ASSERT_TRUE(runner.runIfRequested(transport));
+    TEST_ASSERT_EQUAL(CaptureStatus::Failed, runner.report().status);
+    // The bus is handed back even on the failure path.
+    TEST_ASSERT_FALSE(transport.locked);
+}
+
+/// The watchdog feed. A window is tens of seconds inside ONE rs485Task iteration, so without a
+/// per-iteration callback the task watchdog resets the board mid-capture.
+static void test_the_tick_callback_fires_throughout_the_window() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.msPerRead = 1;
+
+    int ticks = 0;
+    runner.request(shortWindow(), profileAt(9600));
+    runner.runIfRequested(transport, [&ticks] { ++ticks; });
+    // 20 ms of window at 1 ms per read: many feeds, not one.
+    TEST_ASSERT_TRUE(ticks >= 10);
+}
+
+/// A new run replaces the old report rather than appending. Two runs at different line
+/// settings in one report would make the checksum counts meaningless -- their whole value is
+/// that they describe a single guess at the line.
+static void test_a_new_capture_discards_the_previous_result() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.msPerRead     = 1;
+    transport.infiniteNoise = true;
+    transport.noisePattern  = modbusFrame(3);
+    runner.request(shortWindow(), profileAt(9600));
+    runner.runIfRequested(transport);
+    TEST_ASSERT_EQUAL_size_t(1, runner.report().frames.size());
+
+    runner.request(shortWindow(), profileAt(19200));
+    TEST_ASSERT_EQUAL_size_t(0, runner.report().frames.size());
+    TEST_ASSERT_EQUAL_UINT32(0, runner.report().totalBytes);
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_idle_gap_follows_the_baud_rate);
+    RUN_TEST(test_the_gap_is_floored_at_the_readers_resolution);
+    RUN_TEST(test_parity_lengthens_the_gap);
+    RUN_TEST(test_a_zero_baud_rate_does_not_divide_by_zero);
+    RUN_TEST(test_silence_between_bursts_cuts_them_into_frames);
+    RUN_TEST(test_a_trailing_frame_is_closed_by_finish);
+    RUN_TEST(test_an_overlong_burst_is_split_rather_than_truncated);
+    RUN_TEST(test_a_real_modbus_frame_is_recognised);
+    RUN_TEST(test_a_corrupted_frame_reports_a_failed_crc);
+    RUN_TEST(test_an_aa55_frame_is_recognised_as_its_own_family);
+    RUN_TEST(test_a_two_byte_record_is_not_claimed_either_way);
+    RUN_TEST(test_filling_up_keeps_the_first_frames_and_says_so);
+    RUN_TEST(test_the_byte_ceiling_stops_the_capture);
+    RUN_TEST(test_the_window_ends_the_capture);
+    RUN_TEST(test_nothing_runs_until_something_is_requested);
+    RUN_TEST(test_a_requested_capture_reads_the_line_and_reports);
+    RUN_TEST(test_traffic_from_before_the_window_is_not_recorded);
+    RUN_TEST(test_the_capture_owns_the_bus_and_sets_the_line);
+    RUN_TEST(test_a_second_request_is_refused_while_one_is_pending);
+    RUN_TEST(test_a_busy_bus_fails_the_capture_with_a_reason);
+    RUN_TEST(test_line_settings_that_will_not_apply_fail_rather_than_record_nothing);
+    RUN_TEST(test_the_tick_callback_fires_throughout_the_window);
+    RUN_TEST(test_a_new_capture_discards_the_previous_result);
+    return UNITY_END();
+}

--- a/test/test_capture/test_main.cpp
+++ b/test/test_capture/test_main.cpp
@@ -357,6 +357,36 @@ static void test_a_busy_bus_fails_the_capture_with_a_reason() {
     TEST_ASSERT_EQUAL(CaptureStatus::Failed, report.status);
     TEST_ASSERT_FALSE(report.error.empty());
     TEST_ASSERT_FALSE(runner.busy());  // and a retry is possible
+    TEST_ASSERT_EQUAL_INT(0, transport.configureCalls);
+    // The caller keys its recovery off this. Restoring a line that was never touched means
+    // calling begin() on every driver, which on the AA55 family is a registration handshake --
+    // real traffic, on a bus that has just reported itself busy.
+    TEST_ASSERT_FALSE(report.lineReconfigured);
+}
+
+/// The other failure. Here the UART may well have been half-reconfigured before it refused, so
+/// the driver's settings DO have to go back on -- the opposite answer to the case above, which
+/// is why one boolean carries it rather than the status.
+static void test_failing_line_settings_still_ask_for_the_line_back() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.configureSucceeds = false;
+
+    runner.request(shortWindow(), profileAt(9600));
+    runner.runIfRequested(transport);
+    TEST_ASSERT_EQUAL(CaptureStatus::Failed, runner.report().status);
+    TEST_ASSERT_TRUE(runner.report().lineReconfigured);
+}
+
+static void test_a_completed_capture_asks_for_the_line_back() {
+    CaptureRunner runner([] { return g_clock; });
+    MockTransport transport;
+    transport.msPerRead = 1;
+
+    runner.request(shortWindow(), profileAt(19200));
+    runner.runIfRequested(transport);
+    TEST_ASSERT_EQUAL(CaptureStatus::Done, runner.report().status);
+    TEST_ASSERT_TRUE(runner.report().lineReconfigured);
 }
 
 static void test_line_settings_that_will_not_apply_fail_rather_than_record_nothing() {
@@ -425,6 +455,8 @@ int main() {
     RUN_TEST(test_the_capture_owns_the_bus_and_sets_the_line);
     RUN_TEST(test_a_second_request_is_refused_while_one_is_pending);
     RUN_TEST(test_a_busy_bus_fails_the_capture_with_a_reason);
+    RUN_TEST(test_failing_line_settings_still_ask_for_the_line_back);
+    RUN_TEST(test_a_completed_capture_asks_for_the_line_back);
     RUN_TEST(test_line_settings_that_will_not_apply_fail_rather_than_record_nothing);
     RUN_TEST(test_the_tick_callback_fires_throughout_the_window);
     RUN_TEST(test_a_new_capture_discards_the_previous_result);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1204,6 +1204,103 @@ static void test_modbus_write_stays_off_whatever_the_config_says() {
 
 // NTP feedback: before sync the API must say so honestly (null, never a 1970 date dressed
 // up as real); after sync it carries the local wall-clock and the last sync moment.
+// --- capture payload ------------------------------------------------------------------------
+
+static CaptureReport captureWithOneFrame() {
+    CaptureReport report;
+    report.status            = CaptureStatus::Done;
+    report.profile.baudRate  = 19200;
+    report.config.durationMs = 30000;
+    report.config.maxFrames  = 64;
+    report.idleGapMs         = 2;
+    report.startedMs         = 1000;
+    report.finishedMs        = 31000;
+    report.totalBytes        = 4;
+    report.modbusFrames      = 1;
+    diag::CapturedFrame frame;
+    frame.offsetMs       = 120;
+    frame.gapBeforeMs    = 33;
+    frame.bytes          = {0x01, 0x03, 0xC0, 0x0B};
+    frame.modbusCrcValid = true;
+    report.frames.push_back(frame);
+    return report;
+}
+
+/// Hex uppercase and space-separated, matching every protocol document and decoder example in
+/// docs/ -- so a captured frame can be held up against one by eye.
+static void test_capture_payload_renders_hex_the_way_the_docs_do() {
+    std::string body;
+    TEST_ASSERT_TRUE(rest::buildCapturePayload(captureWithOneFrame(), 31000, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_EQUAL_STRING("01 03 C0 0B", doc["frames"][0]["hex"]);
+    TEST_ASSERT_EQUAL_INT(4, doc["frames"][0]["length"].as<int>());
+    TEST_ASSERT_EQUAL_INT(120, doc["frames"][0]["offset_ms"].as<int>());
+    TEST_ASSERT_EQUAL_INT(33, doc["frames"][0]["gap_before_ms"].as<int>());
+    TEST_ASSERT_TRUE(doc["frames"][0]["modbus_crc_ok"].as<bool>());
+}
+
+/// The line is echoed in full because on an unidentified device it is a guess, and every
+/// number in the report is only meaningful against the guess that produced it.
+static void test_capture_payload_echoes_the_line_it_listened_at() {
+    std::string body;
+    TEST_ASSERT_TRUE(rest::buildCapturePayload(captureWithOneFrame(), 31000, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_EQUAL_STRING("done", doc["status"]);
+    TEST_ASSERT_EQUAL_INT(19200, doc["line"]["baud_rate"].as<int>());
+    TEST_ASSERT_EQUAL_STRING("none", doc["line"]["parity"]);
+    TEST_ASSERT_EQUAL_INT(2, doc["line"]["idle_gap_ms"].as<int>());
+    TEST_ASSERT_EQUAL_INT(30, doc["requested_seconds"].as<int>());
+    TEST_ASSERT_EQUAL_INT(30000, doc["elapsed_ms"].as<int>());
+    TEST_ASSERT_EQUAL_INT(1, doc["summary"]["modbus_crc_ok"].as<int>());
+    TEST_ASSERT_EQUAL_INT(4, doc["summary"]["bytes"].as<int>());
+    TEST_ASSERT_FALSE(doc["summary"]["truncated"].as<bool>());
+}
+
+/// A failure has to carry its reason. "failed" alone leaves the operator unable to tell a busy
+/// bus from line settings the UART refused.
+static void test_a_failed_capture_carries_its_reason() {
+    CaptureReport report;
+    report.status = CaptureStatus::Failed;
+    report.error  = "the RS485 bus was busy";
+    std::string body;
+    TEST_ASSERT_TRUE(rest::buildCapturePayload(report, 0, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_EQUAL_STRING("failed", doc["status"]);
+    TEST_ASSERT_EQUAL_STRING("the RS485 bus was busy", doc["error"]);
+}
+
+/// A capture filled to its byte ceiling must still serialise, because that is the case a
+/// contributor reaches on a busy bus -- and a 500 at the moment the artefact matters is exactly
+/// the failure this bound exists to prevent.
+///
+/// The ceiling is maxTotalBytes, deliberately, and not maxFrames x maxFrameBytes: the product
+/// of two independently chosen limits is not a bound on anything. 256 x 256 renders to about
+/// 220 KB of hex, which no board here can hold. Asserting on the reachable worst case rather
+/// than an unreachable one is the whole point.
+static void test_a_capture_filled_to_its_byte_ceiling_fits_in_the_response() {
+    const diag::CaptureConfig limits;  // the defaults the REST layer cannot exceed
+    CaptureReport             report;
+    report.status = CaptureStatus::Done;
+    size_t written = 0;
+    while (written < limits.maxTotalBytes) {
+        const size_t n = std::min(limits.maxFrameBytes, limits.maxTotalBytes - written);
+        diag::CapturedFrame frame;
+        frame.offsetMs    = 4294967295u;  // widest rendering of every numeric field
+        frame.gapBeforeMs = 4294967295u;
+        frame.bytes.assign(n, 0xA5);
+        report.frames.push_back(frame);
+        written += n;
+    }
+    report.totalBytes = static_cast<uint32_t>(written);
+
+    std::string body;
+    TEST_ASSERT_TRUE(rest::buildCapturePayload(report, 0, body));
+    TEST_ASSERT_TRUE(body.size() <= rest::kMaxCaptureResponseBytes);
+}
+
 static void test_status_payload_reports_clock_sync_state() {
     Rig        r;
     const auto state = r.poll();
@@ -2083,5 +2180,9 @@ int main(int, char**) {
     RUN_TEST(test_prometheus_build_info_carries_the_version);
     RUN_TEST(test_the_mock_hybrid_also_exports);
     RUN_TEST(test_status_payload_reports_clock_sync_state);
+    RUN_TEST(test_capture_payload_renders_hex_the_way_the_docs_do);
+    RUN_TEST(test_capture_payload_echoes_the_line_it_listened_at);
+    RUN_TEST(test_a_failed_capture_carries_its_reason);
+    RUN_TEST(test_a_capture_filled_to_its_byte_ceiling_fits_in_the_response);
     return UNITY_END();
 }

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -26,6 +26,8 @@ echo "==> 2. The host-testable core must not depend on Arduino or ESP-IDF"
 core_paths=(
     src/device
     src/protocols/byte_order.h
+    src/diagnostics/frame_capture.h
+    src/diagnostics/frame_capture.cpp
     src/protocols/modbus/modbus_rtu.h
     src/protocols/modbus/modbus_rtu.cpp
     src/protocols/pmu/pmu_protocol.h


### PR DESCRIPTION
> Branched off `main`, independent of #51 and #52. Touches the Discovery wizard rather than the settings form, so it should merge cleanly in any order.

When discovery finishes and names nothing, the wizard's only remaining advice was *"check your wiring"*. That is a dead end for the case that matters most — a device nobody has written a driver for yet. This turns it into the first step of writing one.

`docs/adding-a-device.md` already asks contributors to capture real traffic before writing code. Until now that meant owning a USB-RS485 adapter and getting a laptop within cable reach of the inverter. The bridge is already wired to that bus.

## Protocol-blind on purpose

It knows nothing about what the bytes mean and needs **no working driver** — which is the point, because the devices worth capturing are exactly the ones nothing here can talk to. It only listens; the bridge transmits nothing for the whole window, because on a protocol you do not understand a stray write is the one thing that could actually disturb the device.

What it adds is a Modbus CRC and an AA55 checksum verdict per record. That is not decoding — it is how you learn whether the line settings you guessed are right. **The summary leads with the count**, because a capture at the wrong baud rate produces plenty of bytes and zero valid checksums, and without that number the operator concludes the device is mute when it is merely being listened to at the wrong speed.

## Interference is answered by structure, not a flag

`CaptureRunner` is the `DiscoveryRunner` pattern: the web handler *requests*, and `rs485Task` runs the capture **instead of** that cycle's poll. There is no iteration in which the bus is both listened to and polled, so the two cannot interleave by construction rather than by remembering to check something.

It is also refused while discovery is pending — `rs485Task` runs discovery first, so a capture accepted alongside one would record the tail of the probe run.

The one thing a capture does that discovery does not is leave the line on settings the operator chose, which for an unidentified device is precisely *not* the driver's. Both paths now end in `restoreDriverLine()`, which also removes duplication the discovery path had grown.

## Two bounds worth explaining

**Framing.** No request/response structure to lean on, so records are cut on an idle gap (Modbus t3.5). Honest at 9600 and 19200. **At 38400 and above the real gap is under a millisecond** — finer than anything polling a UART can resolve — so adjacent frames may merge. The byte stream stays complete and ordered; only the cut points are approximate. Said in the header, the docs *and* the UI rather than left to be discovered from confusing output. `idleGapMsFor()` floors at 2 ms for the same reason: the arithmetic answer would claim a resolution the reader does not have.

**Memory.** `maxFrames` and `maxFrameBytes` are a **product**, and a product of two independently chosen limits bounds nothing — 256 × 256 renders to ~220 KB of JSON hex, which no board here can hold. I found this by writing the worst-case test and watching it fail. The payload is now capped directly at 12 KB of captured bytes → ~36 KB of hex → a ~40 KB response, which the Relay-6CH (the one board with no PSRAM to fall back on) can hold alongside a copy of it.

**Full means stopped, not "oldest dropped".** For a handshake the interesting part is the registration dance at the beginning, and a ring buffer would reliably discard exactly that.

## Output

```
# Heliograph raw RS485 capture
# line: 9600 baud, none parity, 8 data bits, 1 stop bits
# frame boundaries cut on 4 ms of silence
# 12 frames, 143 bytes, 12 valid Modbus CRC, 0 valid AA55
#
# time_ms  gap_ms  len  checksum  bytes
       0       0    8  modbus    01 03 00 00 00 0A C5 CD
```

Built in the page, not served as a second format by the firmware: it is presentation, the browser already has the data, and a text renderer on the device would be flash spent on something the browser does for free. The format matches what `docs/` already uses for protocol notes, so a captured frame can be held against a protocol document by eye.

## Verification

**670 native tests** (up from 643) — framing rules, checksum verdicts including a deliberately corrupted frame, both memory ceilings, and the runner's handover: bus taken and released, line configured, input flushed so traffic from *before* the window is not recorded, nothing ever written, watchdog callback firing throughout, and the failure paths for a busy bus and unusable line settings.

All four boards build with **zero warnings from `src/`** · cppcheck high clean · `check_layering.sh` 6/6 (`frame_capture` added to the host-testable core paths) · `check_web_js.py` OK.

## Not verified on hardware

I have no unidentified device to point this at. Framing and verdicts are exercised against constructed byte streams and a mock transport, but **the gap-resolution claim rests on the read loop behaving on a real UART the way it does in the mock**. The first real capture is worth doing at 9600 against a device whose protocol is already known — the EverSolar, say — so the output can be checked against `docs/eversolar-protocol.md`.

---

## Self-review found two real defects

**`restoreDriverLine()` ran even when the capture never touched the line.** `rs485Task` called it unconditionally whenever `runIfRequested` returned true — including the path where the bus lock could not be taken and nothing had been reconfigured. That path calls `begin()` on every driver, and `begin()` on the AA55 family is a *registration handshake*: real traffic, put onto a bus that had just reported itself busy, in response to a capture that recorded nothing.

Status alone cannot answer it, because the two failures want opposite treatment — a lock failure touched nothing, while a configure failure may have half-applied something to the UART and *does* need the line put back. So the report now carries `lineReconfigured`, set the moment the line changes.

**The bus guard only faced one way.** `requestCapture` refused while discovery was busy; `requestDiscovery` did **not** refuse while a capture was busy — and `rs485Task` checks discovery *first*. So a discovery requested while a capture was merely pending would jump the queue, and the capture would then record the tail of the probe run. Which is verbatim what my own comment said the guard existed to prevent: I wrote the reasoning and implemented half of it. Symmetric now, and the discovery route's 409 no longer claims "discovery is already in progress" when the real reason was a capture.

Three tests pin the distinction: lock failure asserts `configure` was never called *and* that the line must not be restored; configure failure asserts the opposite; a completed run asserts it too.

**672 native tests**, four boards clean, cppcheck high clean, layering 6/6.
