### PR TITLE
Let the mock driver be more than one inverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,21 @@ pio run -e waveshare-rs485-can   # or -relay-1ch / -relay-6ch
 ```
 
 The `mock` environment runs the full output stack against a simulated inverter — useful for
-UI and integration work without an RS485 bus.
+UI and integration work without an RS485 bus. It adds two virtual relays and compiles the real
+drivers out; the **driver itself is in every shipped image**, so on real hardware you can just
+pick *Mock Inverter* under Settings → Driver.
+
+It models a three-phase hybrid with two MPPTs and a battery — deliberately unlike any single
+real device, so an output adapter that quietly assumed one phase or no battery has something to
+fail against. Give each one a `unit_id` under **Extra devices** and you can run a whole
+simulated fleet: separate device ids, separate MQTT subtrees and Home Assistant devices,
+consecutive Modbus unit ids, and one `device` label per instance in Prometheus. Their solar
+curves are staggered, so they report different values at the same moment rather than one number
+multiplied by N — which is what makes a shared store or an off-by-one unit id visible instead of
+plausible.
+
+What it cannot do is anything at the byte level: it ignores the transport entirely, so protocol
+framing, checksums and timing still need real hardware.
 
 All inverter drivers are **read-only**, and that is not in tension with the curtailment above:
 no driver ever writes to your inverter over its protocol. Sending a setpoint would need a

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -230,6 +230,16 @@ single-inverter install.
 { "additional_devices": [ { "driver_id": "growatt_modbus", "options": { "unit_id": "2" } } ] }
 ```
 
+The mock driver takes the same `unit_id`, so a fleet can be simulated without hardware — each
+instance gets its own device id, topic subtree and Modbus unit, and its solar curve is staggered
+so the instances do not all report the same value at once:
+
+```json
+{ "driver": { "id": "mock_inverter", "options": { "unit_id": "1" } },
+  "additional_devices": [ { "driver_id": "mock_inverter", "options": { "unit_id": "2" } },
+                          { "driver_id": "mock_inverter", "options": { "unit_id": "3" } } ] }
+```
+
 Sending the array **replaces** it; omitting it leaves it alone. There is no per-element patch:
 the list has no stable key to merge on, and an index the caller believes is element 2 may not be
 after someone else's edit. `driver_id` may not be empty — for `driver` an empty id means "pick

--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <cstdio>
 #include <string>
 
 #include "diagnostics/logger.h"
@@ -34,10 +35,25 @@ constexpr double kPeakDcWatts = 6000.0;
 /// quarter of the day has passed -- which looks broken and is the opposite of what a
 /// demonstration driver is for. Booting into peak output shows the stack working immediately,
 /// and the night still arrives a few minutes later.
-double solarFraction(uint64_t nowMs, uint64_t dayLengthMs) {
+///
+/// `instance` staggers the curve so that several simulated inverters do not move in lockstep.
+/// What needs testing is several devices reporting DIFFERENT non-zero values at once: a fleet
+/// reporting one identical number makes a shared store, a mislabelled Prometheus series or a
+/// Modbus unit off by one look exactly like correct output.
+///
+/// A THIRTY-SECOND of a day apart, not a sixteenth. The cycle starts at midday and daylight
+/// runs a quarter-day either side, so at a sixteenth the eighth instance would be 7/16 behind
+/// and sit in the dark at boot -- a fleet where the last members report nothing is not the
+/// demonstration this is for. At 1/32 the whole run of kMaxDevices spans 7/32 of a day and
+/// every one of them is producing.
+///
+/// Instance 1 gets no offset, so the single-mock case is bit-for-bit what it always was.
+double solarFraction(uint64_t nowMs, uint64_t dayLengthMs, uint8_t instance) {
     if (dayLengthMs == 0) {
         return 0.0;
     }
+    const uint64_t offset = (instance > 0 ? instance - 1u : 0u) * (dayLengthMs / 32ULL);
+    nowMs += offset;
     const double raw = static_cast<double>(nowMs % dayLengthMs) / static_cast<double>(dayLengthMs);
     const double phase = raw < 0.5 ? raw + 0.5 : raw - 0.5;  // shift midnight -> midday
     if (phase < 0.25 || phase > 0.75) {
@@ -75,11 +91,35 @@ DriverDescriptor makeDescriptor(bool writable) {
                               // leaving the one driver everybody has compiled in unbounded
                               // would make "the numeric driver options" a claim about most of
                               // them (review, 2026-07-25).
-                              1, 1440}};
+                              1, 1440},
+                 DriverOption{"unit_id", "Simulated unit",
+                              "Which simulated inverter this is. Give each mock under Extra "
+                              "devices its own number: it is what keeps them apart, and it "
+                              "staggers their solar curves so they do not all report the same "
+                              "value at the same moment.",
+                              "1", {}, 1, static_cast<long>(kMaxDevices)}};
+    // Named like the real drivers' address option, which buys two things: the settings page
+    // already warns when two devices share a `unit_id`, and DiscoveryCandidate::address() has
+    // something to report.
+    //
+    // Safe despite the note in discovery_engine.h about a sweep turning one address assignment
+    // into nine: the engine skips every driver with supportsAutoDetection false, and this is
+    // the driver that comment names. The sweep can never reach it.
+    x.addressOptionKey = "unit_id";
     return x;
 }
 
 }  // namespace
+
+std::string mockSerialNumber(uint8_t instance) {
+    // Ten digits, zero-padded: instance 1 comes out as "MOCK-0000000001", exactly the constant
+    // every mock reported before it could be told apart. An existing single-mock install
+    // therefore keeps its device id -- and with it its REST path, its MQTT topic subtree and
+    // its Home Assistant entities -- across this change, with no retained topics orphaned.
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "MOCK-%010u", static_cast<unsigned>(instance));
+    return buf;
+}
 
 const DriverDescriptor& readOnlyDescriptor() {
     static const DriverDescriptor d = makeDescriptor(false);
@@ -106,6 +146,17 @@ MockOptions optionsFrom(const heliograph::DriverOptions& values, bool writable) 
                   d.optionOr(values, "day_length_minutes").c_str(),
                   static_cast<unsigned long long>(out.dayLengthMs / 60000ULL));
     }
+    long unit = 0;
+    if (d.numericOption(values, "unit_id", unit)) {
+        out.instance = static_cast<uint8_t>(unit);
+    } else {
+        // Warned about rather than silently defaulted: this option decides the device's
+        // IDENTITY, so falling back to 1 on a typo hands the second mock the first one's id
+        // and it disappears at boot as a duplicate -- which is the exact failure this option
+        // was added to remove.
+        log::warn("MOCK unit_id '%s' invalid, using %u",
+                  d.optionOr(values, "unit_id").c_str(), static_cast<unsigned>(out.instance));
+    }
     return out;
 }
 
@@ -113,10 +164,15 @@ MockDriver::MockDriver(ClockFn clock, MockOptions options)
     : clock_(std::move(clock)), options_(options) {
     identity_.manufacturer    = "Heliograph open-source project";
     identity_.model           = "Mock Hybrid 6000";
-    identity_.serialNumber    = "MOCK-0000000001";
+    identity_.serialNumber    = mockSerialNumber(options.instance);
     identity_.firmwareVersion = "1.0.0";
     identity_.protocolName    = "none (simulated)";
     identity_.driverId        = options.writable ? "mock_inverter_writable" : "mock_inverter";
+    // Set as well as the serial, not instead of it. deviceId() prefers the serial, so this
+    // changes nothing today -- but instanceKey is what identifies a device before its first
+    // poll, and leaving it empty here would make the mock the one driver that behaves
+    // differently at exactly the moment the store keys are minted.
+    identity_.instanceKey     = std::to_string(static_cast<unsigned>(options.instance));
 
     capabilities_.addRead(InverterCapability::ReadAcPower);
     capabilities_.addRead(InverterCapability::ReadAcVoltage);
@@ -184,7 +240,7 @@ PollResult MockDriver::poll(DeviceState& state) {
     }
 
     const uint64_t now      = clock_ ? clock_() : 0;
-    const double   fraction = solarFraction(now, options_.dayLengthMs);
+    const double   fraction = solarFraction(now, options_.dayLengthMs, options_.instance);
     const double   dcPower  = kPeakDcWatts * fraction;
     const double   acPower  = dcPower * 0.97;
 

--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <string>
 
+#include "device/device_state.h"  // kMaxDevices, the bound on the instance option
 #include "diagnostics/logger.h"
 
 namespace heliograph::mock {
@@ -42,10 +43,16 @@ constexpr double kPeakDcWatts = 6000.0;
 /// Modbus unit off by one look exactly like correct output.
 ///
 /// A THIRTY-SECOND of a day apart, not a sixteenth. The cycle starts at midday and daylight
-/// runs a quarter-day either side, so at a sixteenth the eighth instance would be 7/16 behind
-/// and sit in the dark at boot -- a fleet where the last members report nothing is not the
-/// demonstration this is for. At 1/32 the whole run of kMaxDevices spans 7/32 of a day and
-/// every one of them is producing.
+/// runs a quarter-day either side, so at a sixteenth the eighth instance would already be dark
+/// the moment the bridge boots -- and a fleet whose last members report nothing from the outset
+/// is not the demonstration this is for. At 1/32 the whole run of kMaxDevices spans 7/32 of a
+/// day, which puts every one of them in daylight AT BOOT (1.0 down to 0.195 of peak).
+///
+/// They do NOT all stay there, and that is the second thing this buys. As the day advances they
+/// set one by one, last instance first, so a running fleet is a mix of producing and dark
+/// devices -- which is what exercises the rule that a total is null when no device reported the
+/// channel rather than 0, and the per-device online/stale handling underneath it. A fleet that
+/// rose and set in unison would never reach that state at all.
 ///
 /// Instance 1 gets no offset, so the single-mock case is bit-for-bit what it always was.
 double solarFraction(uint64_t nowMs, uint64_t dayLengthMs, uint8_t instance) {

--- a/src/drivers/mock/mock_driver.h
+++ b/src/drivers/mock/mock_driver.h
@@ -12,6 +12,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 
 #include "device/clock.h"
 #include "drivers/inverter_driver.h"
@@ -35,7 +36,25 @@ struct MockOptions {
     /// useless for the demonstrating and testing it exists to do. Configurable via the
     /// "day_length_minutes" driver option.
     uint64_t dayLengthMs = 10ULL * 60 * 1000;
+    /// Which simulated inverter this is, 1..kMaxDevices.
+    ///
+    /// The whole reason this exists: identity. Every mock used to report the same hardcoded
+    /// serial, so deviceId() -- which prefers the serial -- was identical for every instance,
+    /// and a second one configured under `additional_devices` was dropped at boot as a
+    /// duplicate. The descriptor claimed supportsMultipleDevices and no two instances could
+    /// actually differ in anything, which made that claim empty.
+    ///
+    /// It also staggers the simulated day, so several instances produce DIFFERENT non-zero
+    /// values at the same moment. Without that a fleet of mocks is one curve multiplied by N,
+    /// and a per-device bug -- a shared store, a mislabelled Prometheus series, a Modbus unit
+    /// off by one -- looks exactly like correct output.
+    uint8_t instance = 1;
 };
+
+/// Serial number a given instance reports. Instance 1 yields "MOCK-0000000001", byte-identical
+/// to the constant every mock used to report -- so an existing single-mock install keeps its
+/// device id, its MQTT topics and its Home Assistant entities across this change.
+std::string mockSerialNumber(uint8_t instance);
 
 /// Maps generic string options onto this driver's settings, like every driver does.
 MockOptions optionsFrom(const heliograph::DriverOptions& values, bool writable);

--- a/test/test_driver_registry/test_main.cpp
+++ b/test/test_driver_registry/test_main.cpp
@@ -507,6 +507,40 @@ static void test_instances_are_staggered_so_they_do_not_report_in_lockstep() {
     }
 }
 
+/// The second thing the stagger buys, and the reason it is not a nicety. Later in the day the
+/// fleet is a MIX of producing and dark devices, which is the only way to reach the rule that a
+/// total is null when no device reported the channel rather than 0. A fleet rising and setting
+/// in unison never produces that state.
+///
+/// Pinned because it is now a documented property. It also guards the geometry from the other
+/// side: a stagger wide enough to be interesting must not be so wide that instances are dark at
+/// boot, which the test above asserts.
+static void test_a_running_fleet_ends_up_part_producing_and_part_dark() {
+    const auto powerAt = [](uint64_t nowMs, uint8_t unit) {
+        mock::MockOptions options;
+        options.instance = unit;
+        mock::MockDriver driver([nowMs] { return nowMs; }, options);
+        test::MockTransport t;
+        driver.begin(t);
+        DeviceState state;
+        state.lastPollAttemptMs = 1;
+        TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
+        const auto* p = state.measurements.find(measurement_id::kAcPowerTotal);
+        TEST_ASSERT_NOT_NULL(p);
+        return p->value;
+    };
+
+    // A twentieth into the default ten-minute day: the run has begun to set from the far end.
+    const uint64_t later = (10ULL * 60 * 1000) / 20;
+    int producing = 0;
+    int dark      = 0;
+    for (uint8_t unit = 1; unit <= static_cast<uint8_t>(kMaxDevices); ++unit) {
+        (powerAt(later, unit) > 0.0 ? producing : dark)++;
+    }
+    TEST_ASSERT_TRUE(producing > 0);
+    TEST_ASSERT_TRUE(dark > 0);
+}
+
 /// The bound is the device table's, so a config that would not fit is refused at the option
 /// rather than discovered at boot.
 static void test_an_instance_beyond_the_device_table_is_refused() {
@@ -551,6 +585,7 @@ int main(int, char**) {
     RUN_TEST(test_a_mock_instance_carries_its_key_as_well_as_its_serial);
     RUN_TEST(test_instance_one_keeps_the_id_it_always_had);
     RUN_TEST(test_instances_are_staggered_so_they_do_not_report_in_lockstep);
+    RUN_TEST(test_a_running_fleet_ends_up_part_producing_and_part_dark);
     RUN_TEST(test_an_instance_beyond_the_device_table_is_refused);
     return UNITY_END();
 }

--- a/test/test_driver_registry/test_main.cpp
+++ b/test/test_driver_registry/test_main.cpp
@@ -423,6 +423,101 @@ static void test_an_unbounded_option_stays_free_form() {
     TEST_ASSERT_TRUE(validateDriverOptions(d, {{"note", "999999"}}, e));
 }
 
+// --- the mock as a fleet --------------------------------------------------------------------
+
+/// The defect this option exists to remove. Every mock reported one hardcoded serial, and
+/// deviceId() prefers the serial -- so a second mock under `additional_devices` resolved to the
+/// same id and was dropped at boot as a duplicate. The descriptor claimed
+/// supportsMultipleDevices while no two instances could differ in anything.
+static void test_two_mock_instances_get_different_device_ids() {
+    test::MockTransport transport;
+    DriverRegistry      registry;
+    registerBuiltinDrivers(registry);
+
+    auto a = registry.create("mock_inverter", transport, DriverOptions{{"unit_id", "1"}});
+    auto b = registry.create("mock_inverter", transport, DriverOptions{{"unit_id", "2"}});
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+
+    TEST_ASSERT_EQUAL_STRING("mock_inverter-MOCK-0000000001", a->identity().deviceId().c_str());
+    TEST_ASSERT_EQUAL_STRING("mock_inverter-MOCK-0000000002", b->identity().deviceId().c_str());
+}
+
+/// Set as well as the serial. instanceKey is what identifies a device BEFORE its first poll,
+/// when the state-store keys are minted, and leaving it empty would make the mock the one
+/// driver that behaves differently at exactly that moment.
+static void test_a_mock_instance_carries_its_key_as_well_as_its_serial() {
+    test::MockTransport transport;
+    DriverRegistry      registry;
+    registerBuiltinDrivers(registry);
+    auto d = registry.create("mock_inverter", transport, DriverOptions{{"unit_id", "5"}});
+    TEST_ASSERT_EQUAL_STRING("5", d->identity().instanceKey.c_str());
+    TEST_ASSERT_EQUAL_STRING("MOCK-0000000005", d->identity().serialNumber.c_str());
+}
+
+/// The compatibility promise. Instance 1 must produce byte-for-byte the id every existing
+/// single-mock install already has, or upgrading orphans its retained MQTT topics and its Home
+/// Assistant entities.
+static void test_instance_one_keeps_the_id_it_always_had() {
+    TEST_ASSERT_EQUAL_STRING("MOCK-0000000001", mock::mockSerialNumber(1).c_str());
+    test::MockTransport transport;
+    DriverRegistry      registry;
+    registerBuiltinDrivers(registry);
+    // No unit_id at all: exactly what a config stored before this option existed looks like.
+    auto d = registry.create("mock_inverter", transport, DriverOptions{});
+    TEST_ASSERT_EQUAL_STRING("mock_inverter-MOCK-0000000001", d->identity().deviceId().c_str());
+}
+
+/// Different values at the same instant, which is the whole point. A fleet all reporting one
+/// identical number makes a shared store, a mislabelled Prometheus series or a Modbus unit off
+/// by one look exactly like correct output.
+static void test_instances_are_staggered_so_they_do_not_report_in_lockstep() {
+    test::MockTransport transport;
+    DriverRegistry      registry;
+    registerBuiltinDrivers(registry);
+
+    // Built directly with a FROZEN clock rather than through the factory, which uses
+    // steady_clock: the simulated day is only ten minutes long, so a real clock puts these
+    // three at an arbitrary point on the curve and the assertions below would pass or fail
+    // depending on when the suite happened to run.
+    const auto powerOf = [](uint8_t unit) {
+        mock::MockOptions options;
+        options.instance = unit;
+        mock::MockDriver driver([] { return uint64_t{0}; }, options);
+        test::MockTransport t;
+        driver.begin(t);
+        DeviceState state;
+        state.lastPollAttemptMs = 1;
+        TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
+        const auto* p = state.measurements.find(measurement_id::kAcPowerTotal);
+        TEST_ASSERT_NOT_NULL(p);
+        return p->value;
+    };
+
+    // The whole run the device table allows, not just a couple: the point of 1/32 is that even
+    // the last one is still in daylight.
+    double previous = 0.0;
+    for (uint8_t unit = 1; unit <= static_cast<uint8_t>(kMaxDevices); ++unit) {
+        const double power = powerOf(unit);
+        TEST_ASSERT_TRUE(power > 0.0);
+        if (unit > 1) {
+            TEST_ASSERT_TRUE(std::fabs(power - previous) > 1.0);
+        }
+        previous = power;
+    }
+}
+
+/// The bound is the device table's, so a config that would not fit is refused at the option
+/// rather than discovered at boot.
+static void test_an_instance_beyond_the_device_table_is_refused() {
+    DriverOptionError error;
+    TEST_ASSERT_FALSE(validateDriverOptions(mock::readOnlyDescriptor(),
+                                            DriverOptions{{"unit_id", "99"}}, error));
+    TEST_ASSERT_EQUAL_STRING("unit_id", error.key.c_str());
+    TEST_ASSERT_TRUE(validateDriverOptions(mock::readOnlyDescriptor(),
+                                           DriverOptions{{"unit_id", "8"}}, error));
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_a_numeric_option_out_of_range_is_refused);
@@ -452,5 +547,10 @@ int main(int, char**) {
     RUN_TEST(test_numeric_option_falls_back_to_the_declared_default);
     RUN_TEST(test_numeric_option_refuses_unknown_and_non_numeric_keys);
     RUN_TEST(test_numeric_option_handles_a_range_starting_at_zero);
+    RUN_TEST(test_two_mock_instances_get_different_device_ids);
+    RUN_TEST(test_a_mock_instance_carries_its_key_as_well_as_its_serial);
+    RUN_TEST(test_instance_one_keeps_the_id_it_always_had);
+    RUN_TEST(test_instances_are_staggered_so_they_do_not_report_in_lockstep);
+    RUN_TEST(test_an_instance_beyond_the_device_table_is_refused);
     return UNITY_END();
 }


### PR DESCRIPTION
Found while answering a question from Tim: *"maar dingen zoals meerdere inverters kan ik niet simuleren"*. He was right and my first answer was wrong — I'd read `supportsMultipleDevices = true` in the descriptor and stopped there.

## The descriptor was claiming something it could not do

Every mock set the same hardcoded serial:

```cpp
identity_.serialNumber = "MOCK-0000000001";
```

`deviceId()` prefers the serial, so a second mock under `additional_devices` resolved to the **same id** and the boot loop dropped it as a duplicate. `supportsMultipleDevices = true` was an empty claim — and multi-device, the one feature that otherwise needs several real inverters on a bus to exercise, was exactly what you could not simulate.

The escape real drivers have is `instanceKey`, set from their address option. The mock had no such option: its only setting was `day_length_minutes`, so there was no field two instances could disagree on.

## What changed

A `unit_id` option, named like the real drivers' so the settings page's existing duplicate-address warning applies to it and `DiscoveryCandidate::address()` has something to report. Bounded at `kMaxDevices`, so a config that could not fit the device table is refused at the option rather than discovered at boot.

Setting `addressOptionKey` is safe despite the warning in `discovery_engine.h` about a sweep turning one address assignment into nine: the engine skips every driver with `supportsAutoDetection false`, and the mock is the driver that comment names.

**The curves are staggered**, a thirty-second of a day apart. That is the point, not a nicety: a fleet all reporting one identical number makes a shared store, a mislabelled Prometheus series or a Modbus unit off by one look exactly like correct output.

A thirty-second and not a sixteenth, because the cycle starts at midday with a quarter-day of light either side — at 1/16 the eighth instance would be 7/16 behind and sit in the dark at boot.

## Nothing changes for an existing install

Instance 1 yields `MOCK-0000000001`, byte-for-byte the old constant, and a stored config with no `unit_id` falls back to the declared default of 1 — which parses cleanly and warns about nothing. A bridge already running a single mock keeps its device id, REST path, MQTT subtree and Home Assistant entities, with no retained topics orphaned. Instance 1 also takes no phase offset, so its curve is unchanged.

## What this now makes testable without hardware

Separate device ids and state stores · separate MQTT subtrees and HA devices · consecutive Modbus unit ids · one `device` label per instance in Prometheus · the dashboard's fleet totals and per-device counts, with values that actually differ.

## Verification

**710 native tests** (five new): two instances get different ids; the instance key is set alongside the serial; instance 1 is unchanged both with and without the option; the whole run of eight is simultaneously producing and pairwise different; an instance past the device table is refused.

The stagger test builds the drivers directly with a **frozen clock** rather than through the factory, which uses `steady_clock` — the simulated day is ten minutes long, so a real clock would put the instances at an arbitrary point on the curve and the assertions would pass or fail depending on when the suite ran.

All four boards build with zero warnings from `src/` · cppcheck high clean · layering 6/6.

---

## Self-review found two things

**A comment that was true for exactly one instant.** It claimed 1/32 puts "every one of them in daylight" — full stop. Against the arithmetic that holds at *boot* (1.0 down to 0.195 of peak) and not after: a twentieth into the day the eighth instance has already set, and at a fifth, six of the eight are dark.

That mattered more than the wording, because the behaviour the sentence glossed over is the **second reason to stagger at all**: a running fleet becomes a mix of producing and dark devices, and that mix is the only way to reach the rule that a total is `null` when no device reported the channel rather than `0`, plus the per-device online/stale handling under it. A fleet rising and setting in unison never produces that state. Now stated, and pinned by a test that asserts the mix — a documented property with no test is a property that drifts.

**`kMaxDevices` was arriving by accident.** Used directly for the option's upper bound but only reachable through `inverter_driver.h` → `device/device_state.h`. Compiles today; stops compiling the day someone tidies those headers, for a reason with nothing to do with this file. Included explicitly.

**711 native tests**, four boards clean, cppcheck high clean, layering 6/6.
