### PR TITLE
docs(readme): fix the '2009' inverter year + sharpen the pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,24 @@
 > A heliograph signalled messages with sunlight. This one translates what your solar
 > inverter is saying into languages the rest of your network speaks.
 
-Heliograph is open-source firmware for a small, cheap box that sits next to your solar
-inverter and talks to it over its own communication port. It **reads** the inverter and hands
-the data to whatever you already use — **Home Assistant, MQTT, Modbus TCP, a REST/JSON API, or
+<p align="center">
+  <a href="https://github.com/Timdebruijn/heliograph/releases/latest"><img src="https://img.shields.io/github/v/release/Timdebruijn/heliograph?sort=semver&color=brightgreen" alt="Latest release"></a>
+  <a href="https://github.com/Timdebruijn/heliograph/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Timdebruijn/heliograph/ci.yml?branch=main&label=CI" alt="CI status"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license"></a>
+  <img src="https://img.shields.io/badge/runs%20on-ESP32--S3-informational" alt="Runs on ESP32-S3">
+</p>
+
+**Your solar inverter, finally yours.** Whether it is fifteen years old and abandoned by its
+manufacturer or fresh out of the box, Heliograph is open-source firmware for a small, cheap box
+that sits next to it and speaks its native protocol. It **reads** the inverter and hands the
+data to whatever you already use — **Home Assistant, MQTT, Modbus TCP, a REST/JSON API, or
 Prometheus** — and on the relay boards it can also **turn the inverter down** when you want it
-to produce less. New Modbus inverters can be added as a **TOML data file** — no C++, no
-firmware fork. It runs entirely on your own network. No account, no cloud, no subscription.
+to produce less. New Modbus inverters go in as a **TOML data file** — no C++, no firmware fork.
+It runs entirely on your own network. No account, no cloud, no subscription.
+
+<p align="center">
+  <a href="https://timdebruijn.github.io/heliograph/"><strong>⚡ Flash it from your browser — nothing to install →</strong></a>
+</p>
 
 <p align="center">
   <img src="docs/images/dashboard.png" width="480" alt="Heliograph's built-in web dashboard showing live production from a long-unsupported EverSolar inverter">
@@ -85,10 +97,14 @@ Full walkthrough: [docs/adding-a-device.md](docs/adding-a-device.md).
 
 ---
 
-## Will this work for my inverter?
+## Which inverters work today?
 
-**Start here.** This is the question that decides whether the rest is worth your time, and
-the honest answer today is: only if your inverter is in this table.
+**Start here** — this is the question that decides whether the rest is worth your time. One
+inverter family is in daily production use; several more are implemented and waiting for their
+first real-world confirmation. And if yours is not on the list yet, you are not stuck: adding a
+Modbus inverter is a data file, not a code change (see
+[Help support your own inverter](#help-support-your-own-inverter)). The honest, per-family
+picture:
 
 | Inverter family | Connection | Status |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ to produce less. New Modbus inverters can be added as a **TOML data file** — n
 firmware fork. It runs entirely on your own network. No account, no cloud, no subscription.
 
 <p align="center">
-  <img src="docs/images/dashboard.png" width="480" alt="Heliograph's built-in web dashboard showing live production from a 2009 EverSolar inverter">
+  <img src="docs/images/dashboard.png" width="480" alt="Heliograph's built-in web dashboard showing live production from a long-unsupported EverSolar inverter">
   <br>
-  <em>The built-in dashboard — a 2009 EverSolar read live over RS485, with no cloud and no app in between.</em>
+  <em>The built-in dashboard — a long-unsupported EverSolar read live over RS485, with no cloud and no app in between.</em>
 </p>
 
 ---
@@ -24,7 +24,7 @@ Solar inverters are built to last twenty years. The software around them is not.
 
 - **The manufacturer's monitoring died.** The portal was shut down, the app stopped working,
   or the monitoring dongle is no longer supported. The inverter still produces perfectly —
-  you just cannot see it any more. Heliograph exists because of a 2009 EverSolar that
+  you just cannot see it any more. Heliograph exists because of an EverSolar that
   outlived its own monitoring portal.
 - **Your data goes to their cloud first.** Production figures from equipment in your own
   home travel to a manufacturer's server, come back minutes later, and vanish when your


### PR DESCRIPTION
Follow-up to #56 (already merged). Two README-only fixes that landed on the branch *after* #56 was merged, so they never reached `main`:

## 1. Correctness — drop the unverified "2009"
The merged README describes the reference inverter as a "2009 EverSolar" in two image captions and the *problem* section. **That year is wrong** — the owner's unit is mid-2010s (model TL3000-20), and the "2009" was an unverified carry-over. In a README that trades on being honest, an invented date is exactly the wrong thing to ship. Removed; the hook ("an inverter that outlived its own monitoring") needs no year.

## 2. Pitch — masthead, badges, browser-flash CTA
- Lead with the value in one line: *"Your solar inverter, finally yours"* — explicitly **old or new** (fifteen years old and abandoned, or fresh out of the box).
- Release / CI / license / ESP32-S3 badges under the title.
- Prominent **⚡ Flash it from your browser** call to action (the web installer was buried at step 2).
- Reframe *"Will this work for my inverter?"* → *"Which inverters work today?"*: one family in production, several implemented-and-waiting, and "add your own as a data file" if not listed — **without** touching the honest per-family support table. Confident, not overclaiming: no "works with every inverter", because it doesn't (1 Beta, 4 Experimental).

Docs-only; no firmware build triggered. Draft for your review — I did not merge #56 and will not merge this either.
