### PR TITLE
chore: cleanup — deduplicate, name magic values, retire drifted references

### DIFF
--- a/src/commands/command_dispatcher.cpp
+++ b/src/commands/command_dispatcher.cpp
@@ -18,31 +18,7 @@ bool onStep(double value, double minimum, double step) {
 }  // namespace
 
 CommandDispatcher::CommandDispatcher(ClockFn clock, RateLimitPolicy rateLimit)
-    : clock_(std::move(clock)), rateLimit_(rateLimit) {}
-
-bool CommandDispatcher::allowedByRateLimit(uint64_t nowMs) {
-    // Clamped rather than wrapped. On unsigned types a clock that goes backwards turns the
-    // subtraction into a huge number, which reads as "ages ago" and refills the whole allowance
-    // -- the throttle fails OPEN. Not reachable with the esp_timer-backed monotonic clock this
-    // ships with, but the clock is injectable and the failure direction is the permissive one,
-    // so it is clamped here the way DeviceContext::due() and updateStaleness() already do.
-    const uint64_t since = nowMs > lastAcceptedMs_ ? nowMs - lastAcceptedMs_ : 0;
-    if (everAccepted_ && since >= rateLimit_.minIntervalMs) {
-        burstUsed_ = 0;  // quiet long enough, the allowance refills
-    }
-    if (burstUsed_ < rateLimit_.burst) {
-        ++burstUsed_;
-        everAccepted_   = true;
-        lastAcceptedMs_ = nowMs;
-        return true;
-    }
-    if (!everAccepted_ || since >= rateLimit_.minIntervalMs) {
-        everAccepted_   = true;
-        lastAcceptedMs_ = nowMs;
-        return true;
-    }
-    return false;
-}
+    : clock_(std::move(clock)), rateLimit_(rateLimit), limiter_(rateLimit) {}
 
 namespace {
 
@@ -152,7 +128,7 @@ DispatchOutcome CommandDispatcher::dispatch(const InverterCommand& command,
     {
         std::lock_guard<std::mutex> lock(m_);
         const bool allowed = changesRunState(command) ? allowedAsRelease(now)
-                                                      : allowedByRateLimit(now);
+                                                      : limiter_.allow(now);
         if (!allowed) {
             return {CommandResult::RateLimited, "too many commands; try again shortly"};
         }

--- a/src/commands/command_dispatcher.h
+++ b/src/commands/command_dispatcher.h
@@ -58,8 +58,9 @@ public:
     /// The lock covers ONLY the rate-limiter bookkeeping and is released before the driver runs.
     /// execute() on a real driver is an RS485 transaction that waits up to 2 s for the bus lock
     /// and then up to 3 s for the reply, and holding a mutex across that would stall every other
-    /// caller for seconds -- the same mistake main.cpp:492 documents finding live in Phase 3,
-    /// where a seconds-long bus transaction ran inside an AsyncTCP callback. Bus exclusivity is
+    /// caller for seconds -- the same mistake the deferred-poll comment in main.cpp's REST
+    /// action handler documents finding live in Phase 3, where a seconds-long bus transaction
+    /// ran inside an AsyncTCP callback. Bus exclusivity is
     /// already the transport's job (Transport::lock), so this mutex does not need to provide it.
     ///
     /// Consequence worth knowing: the kill switch is re-read immediately before execute() to
@@ -87,7 +88,7 @@ private:
 
     // Releases run on their own track: they are never blocked by restricting traffic, but they
     // still keep a minimum spacing so a loop cannot saturate the bus with them. See
-    // releasesRestriction() for why they are treated apart at all.
+    // changesRunState() for why they are treated apart at all.
     bool     everReleased_  = false;
     uint64_t lastReleaseMs_ = 0;
 };

--- a/src/commands/command_dispatcher.h
+++ b/src/commands/command_dispatcher.h
@@ -55,8 +55,8 @@ public:
     /// and then up to 3 s for the reply, and holding a mutex across that would stall every other
     /// caller for seconds -- the same mistake the deferred-poll comment in main.cpp's REST
     /// action handler documents finding live in Phase 3, where a seconds-long bus transaction
-    /// ran inside an AsyncTCP callback. Bus exclusivity is
-    /// already the transport's job (Transport::lock), so this mutex does not need to provide it.
+    /// ran inside an AsyncTCP callback. Bus exclusivity is already the transport's job
+    /// (Transport::lock), so this mutex does not need to provide it.
     ///
     /// Consequence worth knowing: the kill switch is re-read immediately before execute() to
     /// narrow the window, but a command already on the bus cannot be recalled by switching to
@@ -66,7 +66,9 @@ public:
 private:
     bool allowedAsRelease(uint64_t nowMs);
 
-    ClockFn           clock_;
+    ClockFn clock_;
+    /// Backs the RELEASE track only. The ordinary track's copy lives inside limiter_; this one
+    /// stays because allowedAsRelease() needs the interval and is not a RateLimiter.
     RateLimitPolicy   rateLimit_;
     std::atomic<bool> readOnly_{true};
 

--- a/src/commands/command_dispatcher.h
+++ b/src/commands/command_dispatcher.h
@@ -15,19 +15,14 @@
 #include <mutex>
 #include <string>
 
+#include "rate_limiter.h"
+
 #include "device/capability.h"
 #include "device/clock.h"
 #include "device/command.h"
 #include "drivers/inverter_driver.h"
 
 namespace heliograph {
-
-struct RateLimitPolicy {
-    /// Minimum spacing between accepted commands.
-    uint32_t minIntervalMs = 1000;
-    /// How many may be issued back to back before the spacing applies.
-    uint32_t burst = 3;
-};
 
 struct DispatchOutcome {
     CommandResult result = CommandResult::Rejected;
@@ -69,7 +64,6 @@ public:
     DispatchOutcome dispatch(const InverterCommand& command, InverterDriver& driver);
 
 private:
-    bool allowedByRateLimit(uint64_t nowMs);
     bool allowedAsRelease(uint64_t nowMs);
 
     ClockFn           clock_;
@@ -79,16 +73,14 @@ private:
     /// Guards the rate-limiter fields below, and nothing else.
     std::mutex m_;
 
-    // Explicit flag, not a "0 means never" sentinel: millis() at boot IS near zero, and
-    // the sentinel collision let the first post-boot window bypass the throttle (found by
-    // the RelayController's twin of this logic, 2026-07-22).
-    bool     everAccepted_   = false;
-    uint64_t lastAcceptedMs_ = 0;
-    uint32_t burstUsed_      = 0;
+    /// The ordinary track. See rate_limiter.h for the two traps its arithmetic avoids.
+    RateLimiter limiter_;
 
     // Releases run on their own track: they are never blocked by restricting traffic, but they
     // still keep a minimum spacing so a loop cannot saturate the bus with them. See
-    // changesRunState() for why they are treated apart at all.
+    // changesRunState() for why they are treated apart at all. Kept as its own two fields
+    // rather than a second RateLimiter: a burst of 0 happens to reproduce this exactly, but
+    // relying on that equivalence would hide the intent behind an accident of the arithmetic.
     bool     everReleased_  = false;
     uint64_t lastReleaseMs_ = 0;
 };

--- a/src/config/config_backup.cpp
+++ b/src/config/config_backup.cpp
@@ -10,6 +10,14 @@
 #include "configuration_store.h"
 
 namespace heliograph {
+
+// The relationship between the two bounds, pinned here rather than in config_backup.h so that
+// header keeps its light include set -- rest_payloads.h pulls it in, and reaching for
+// kMaxStoredConfigBytes there would drag configuration_store.h's <map>, <mutex> and the MQTT
+// announced-devices header along behind it.
+static_assert(kMaxBackupBytes > kMaxStoredConfigBytes,
+              "a backup must have room for the largest configuration plus its envelope");
+
 namespace {
 
 /// Keys whose value must never be rendered or exported. A rule, not a list: a credential

--- a/src/config/config_backup.h
+++ b/src/config/config_backup.h
@@ -4,7 +4,7 @@
 //
 // The file is deliberately NOT a new serialisation of the configuration. It is a thin envelope
 // around the document ConfigurationStore already writes to NVS, which means the field list has
-// exactly one point of truth (buildStorageDocument, via serializeConfigForStorage) and a
+// exactly one point of truth (serializeConfigForStorage) and a
 // setting added tomorrow lands in the backup without anyone remembering to add it here. The
 // alternative -- a second hand-maintained field list -- fails silently and is discovered by
 // someone whose restore quietly dropped a setting.
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "configuration.h"
+#include "configuration_store.h"  // kMaxStoredConfigBytes
 
 namespace heliograph {
 
@@ -39,10 +40,12 @@ inline constexpr const char* kBackupFormat        = "heliograph-config-backup";
 /// envelope's own shape changes; the configuration within it versions itself.
 inline constexpr uint16_t    kBackupFormatVersion = 1;
 
-/// Upper bound on a backup we will accept. The configuration itself cannot exceed 3900 bytes
-/// (NVS refuses to store more), and the envelope adds a couple of hundred; the rest is slack
-/// for pretty-printing by whoever edited the file in between.
+/// Upper bound on a backup we will accept. The configuration itself cannot exceed
+/// kMaxStoredConfigBytes (NVS refuses to store more), and the envelope adds a couple of
+/// hundred; the rest is slack for pretty-printing by whoever edited the file in between.
 inline constexpr size_t kMaxBackupBytes = 8192;
+static_assert(kMaxBackupBytes > kMaxStoredConfigBytes,
+              "a backup must have room for the largest configuration plus its envelope");
 
 struct BackupOptions {
     /// Off by default, and the UI has to ask. See the note at the top of this file.

--- a/src/config/config_backup.h
+++ b/src/config/config_backup.h
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include "configuration.h"
-#include "configuration_store.h"  // kMaxStoredConfigBytes
 
 namespace heliograph {
 
@@ -44,8 +43,6 @@ inline constexpr uint16_t    kBackupFormatVersion = 1;
 /// kMaxStoredConfigBytes (NVS refuses to store more), and the envelope adds a couple of
 /// hundred; the rest is slack for pretty-printing by whoever edited the file in between.
 inline constexpr size_t kMaxBackupBytes = 8192;
-static_assert(kMaxBackupBytes > kMaxStoredConfigBytes,
-              "a backup must have room for the largest configuration plus its envelope");
 
 struct BackupOptions {
     /// Off by default, and the UI has to ask. See the note at the top of this file.

--- a/src/config/config_sections.h
+++ b/src/config/config_sections.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+//
+// The part of the configuration document that both writers agree on.
+//
+// A Configuration is serialised twice, for two audiences: serializeConfigForStorage writes the
+// blob that goes into NVS, serializeConfig writes the body of GET /api/v1/config. They differ
+// in exactly one respect -- what they do with credentials. The store keeps them, because the
+// bridge has to reconnect after a reboot; the API replaces each with a `*_set` flag, because
+// that endpoint is unauthenticated and a mask is not a redaction.
+//
+// Everything else -- what the bridge is called, which driver, which broker, the poll interval,
+// the line settings -- is the same field written the same way, and until now it was written
+// twice in two files. The failure mode of that is specific and quiet: add a setting, remember
+// the API writer, forget the storage writer, and the UI shows the field, accepts a change,
+// reports success, and loses it on the next reboot. Nothing throws, nothing logs.
+//
+// An internal header rather than part of configuration.h: the two callers live in different
+// translation units, but nobody else has any business calling this, and configuration.h is
+// included widely enough that dragging ArduinoJson into it would be a real cost.
+
+#pragma once
+
+#include <ArduinoJson.h>
+
+#include "configuration.h"
+
+namespace heliograph::config_sections {
+
+/// Writes every section that is identical in both documents. Callers add `version` and their
+/// own credential handling on top; the objects this creates (`wifi`, `mqtt`) are left open for
+/// exactly that.
+void writeCommon(JsonDocument& doc, const Configuration& config);
+
+}  // namespace heliograph::config_sections

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -2,6 +2,7 @@
 
 #include "configuration.h"
 
+#include "config_sections.h"
 #include "json_limits.h"
 #include "relays/drm.h"
 
@@ -305,38 +306,31 @@ bool validate(const Configuration& config, ConfigError& error) {
     return true;
 }
 
-bool serializeConfig(const Configuration& config, std::string& out, size_t maxBytes,
-                     const bool* rebootRequired) {
-    JsonDocument doc;
-    doc["version"]     = config.version;
+namespace config_sections {
+
+void writeCommon(JsonDocument& doc, const Configuration& config) {
     doc["bridge_name"] = config.bridgeName;
 
-    JsonObject wifi   = doc["wifi"].to<JsonObject>();
-    wifi["ssid"]      = config.wifi.ssid;
-    wifi["hostname"]  = config.wifi.hostname;
-    // Not the password, not a mask of it. Only whether one is stored.
-    wifi["password_set"] = !config.wifi.password.empty();
+    // Left open: each caller adds its own credential handling to these two objects.
+    JsonObject wifi  = doc["wifi"].to<JsonObject>();
+    wifi["ssid"]     = config.wifi.ssid;
+    wifi["hostname"] = config.wifi.hostname;
 
-    JsonObject mqtt        = doc["mqtt"].to<JsonObject>();
-    mqtt["enabled"]        = config.mqtt.enabled;
-    mqtt["host"]           = config.mqtt.host;
-    mqtt["port"]           = config.mqtt.port;
-    // The username is half of a credential pair -- omitted like the password, with only a
-    // *_set flag. It is not needed to identify the broker (host/topic do that) and handing
-    // an unauthenticated LAN reader half the login is a leak worth closing.
-    mqtt["username_set"]   = !config.mqtt.username.empty();
-    mqtt["password_set"]   = !config.mqtt.password.empty();
-    mqtt["base_topic"]     = config.mqtt.baseTopic;
+    JsonObject mqtt           = doc["mqtt"].to<JsonObject>();
+    mqtt["enabled"]           = config.mqtt.enabled;
+    mqtt["host"]              = config.mqtt.host;
+    mqtt["port"]              = config.mqtt.port;
+    mqtt["base_topic"]        = config.mqtt.baseTopic;
     mqtt["discovery_prefix"]  = config.mqtt.discoveryPrefix;
     mqtt["discovery_enabled"] = config.mqtt.discoveryEnabled;
     mqtt["qos"]               = config.mqtt.qos;
 
-    JsonObject modbus              = doc["modbus"].to<JsonObject>();
-    modbus["enabled"]              = config.modbus.enabled;
-    modbus["port"]                 = config.modbus.port;
-    modbus["unit_id"]              = config.modbus.unitId;
-    modbus["diagnostics_unit_id"]  = config.modbus.diagnosticsUnitId;
-    modbus["write_enabled"]        = config.modbus.writeEnabled;
+    JsonObject modbus             = doc["modbus"].to<JsonObject>();
+    modbus["enabled"]             = config.modbus.enabled;
+    modbus["port"]                = config.modbus.port;
+    modbus["unit_id"]             = config.modbus.unitId;
+    modbus["diagnostics_unit_id"] = config.modbus.diagnosticsUnitId;
+    modbus["write_enabled"]       = config.modbus.writeEnabled;
 
     doc["polling"]["interval_seconds"] = config.polling.intervalSeconds;
 
@@ -346,14 +340,13 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
         relayRoles.add(role);
     }
 
-    JsonObject driver           = doc["driver"].to<JsonObject>();
-    driver["id"]                = config.driver.id;
-    driver["auto_detect"]       = config.driver.autoDetect;
-    JsonObject options = driver["options"].to<JsonObject>();
+    JsonObject driver     = doc["driver"].to<JsonObject>();
+    driver["id"]          = config.driver.id;
+    driver["auto_detect"] = config.driver.autoDetect;
+    JsonObject options    = driver["options"].to<JsonObject>();
     for (const auto& [key, value] : config.driver.options) {
         options[key] = value;
     }
-
 
     // Always emitted, empty or not, so a client can tell "this firmware has no idea about
     // extra devices" from "this bridge has none configured".
@@ -383,17 +376,38 @@ bool serializeConfig(const Configuration& config, std::string& out, size_t maxBy
     serial["data_bits"] = config.serial.profile.dataBits;
     serial["stop_bits"] = config.serial.profile.stopBits;
 
-    JsonObject security = doc["security"].to<JsonObject>();
-    // The admin username is omitted for the same reason mqtt.username is, in the mqtt block
-    // above: it is half of a credential pair, this endpoint is unauthenticated, and Basic has no
-    // brute-force protection. Serving it turned guessing the login into guessing only the
-    // password. Unlike the MQTT one it needs no *_set flag -- validate() requires it to be
-    // non-empty, so "is one set" is always yes and would say nothing.
-    security["password_set"]   = !config.security.adminPassword.empty();
-    security["read_only_mode"] = config.security.readOnlyMode;
-
     doc["updates"]["check_enabled"] = config.updates.checkEnabled;
     doc["logging"]["level"]         = logLevelName(config.logLevel);
+}
+
+}  // namespace config_sections
+
+bool serializeConfig(const Configuration& config, std::string& out, size_t maxBytes,
+                     const bool* rebootRequired) {
+    JsonDocument doc;
+    // The API reports the version the configuration WAS LOADED AS, where the store writes the
+    // version it is being written in. The only field where the two documents disagree on the
+    // value rather than on the redaction, which is why it is not in writeCommon().
+    doc["version"] = config.version;
+    config_sections::writeCommon(doc, config);
+
+    // Not the password, not a mask of it. Only whether one is stored.
+    doc["wifi"]["password_set"] = !config.wifi.password.empty();
+
+    // The username is half of a credential pair -- omitted like the password, with only a
+    // *_set flag. It is not needed to identify the broker (host/topic do that) and handing
+    // an unauthenticated LAN reader half the login is a leak worth closing.
+    doc["mqtt"]["username_set"] = !config.mqtt.username.empty();
+    doc["mqtt"]["password_set"] = !config.mqtt.password.empty();
+
+    JsonObject security = doc["security"].to<JsonObject>();
+    // The admin username is omitted for the same reason mqtt.username is, above: it is half of
+    // a credential pair, this endpoint is unauthenticated, and Basic has no brute-force
+    // protection. Serving it turned guessing the login into guessing only the password. Unlike
+    // the MQTT one it needs no *_set flag -- validate() requires it to be non-empty, so "is one
+    // set" is always yes and would say nothing.
+    security["password_set"]   = !config.security.adminPassword.empty();
+    security["read_only_mode"] = config.security.readOnlyMode;
 
     // PATCH response only: tells a non-UI client whether the change it just made is waiting
     // on a restart. Absent from GET (nothing was changed there).

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -385,9 +385,12 @@ void writeCommon(JsonDocument& doc, const Configuration& config) {
 bool serializeConfig(const Configuration& config, std::string& out, size_t maxBytes,
                      const bool* rebootRequired) {
     JsonDocument doc;
-    // The API reports the version the configuration WAS LOADED AS, where the store writes the
-    // version it is being written in. The only field where the two documents disagree on the
-    // value rather than on the redaction, which is why it is not in writeCommon().
+    // Reads from the struct where serializeConfigForStorage writes kConfigVersion directly.
+    // In practice these are the same number -- Configuration::version defaults to
+    // kConfigVersion and deserializeConfigFromStorage stamps it back to kConfigVersion after a
+    // migration, so nothing can currently make them differ -- but the store must write the
+    // version it is WRITING regardless of what the struct happens to hold, so the two stay
+    // apart rather than being folded into writeCommon().
     doc["version"] = config.version;
     config_sections::writeCommon(doc, config);
 

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -2,6 +2,7 @@
 
 #include "configuration.h"
 
+#include "json_limits.h"
 #include "relays/drm.h"
 
 #include <ArduinoJson.h>
@@ -15,20 +16,7 @@
 namespace heliograph {
 namespace {
 
-bool finish(const JsonDocument& doc, std::string& out, size_t maxBytes) {
-    if (doc.overflowed()) {
-        return false;
-    }
-    const size_t needed = measureJson(doc);
-    if (needed > maxBytes) {
-        return false;
-    }
-    std::string buffer;
-    buffer.resize(needed + 1);
-    buffer.resize(serializeJson(doc, buffer.data(), buffer.size()));
-    out = std::move(buffer);
-    return true;
-}
+using json_limits::finish;
 
 /// Applies a string field if present. Returns false only on a type error.
 bool patchString(JsonVariantConst v, std::string& target, const char* field, ConfigError& error) {

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -2,6 +2,8 @@
 
 #include "configuration_store.h"
 
+#include "json_limits.h"
+
 #include <ArduinoJson.h>
 
 #include <cstring>
@@ -146,17 +148,8 @@ bool serializeConfigForStorage(const Configuration& config, std::string& out) {
     doc["updates"]["check_enabled"] = config.updates.checkEnabled;
     doc["logging"]["level"]         = logLevelName(config.logLevel);
 
-    if (doc.overflowed()) {
-        return false;
-    }
     // Refuse rather than write a truncated blob -- see kMaxStoredConfigBytes.
-    const size_t needed = measureJson(doc);
-    if (needed > kMaxStoredConfigBytes) {
-        return false;
-    }
-    out.resize(needed + 1);
-    out.resize(serializeJson(doc, out.data(), out.size()));
-    return true;
+    return json_limits::finish(doc, out, kMaxStoredConfigBytes);
 }
 
 namespace {

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -75,8 +75,9 @@ std::string MemoryBackend::raw(const std::string& key) const {
 
 bool serializeConfigForStorage(const Configuration& config, std::string& out) {
     JsonDocument doc;
-    // The version this blob is being WRITTEN in, which is what the migration chain reads back.
-    // Not config.version, which records what it was last loaded as.
+    // kConfigVersion directly, not config.version: this records the version the blob is being
+    // WRITTEN in, which is what the migration chain reads back on the next boot. Reading it
+    // from the struct would make a corrupted or hand-set field able to mislabel the format.
     doc["version"] = kConfigVersion;
     config_sections::writeCommon(doc, config);
 

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -149,10 +149,9 @@ bool serializeConfigForStorage(const Configuration& config, std::string& out) {
     if (doc.overflowed()) {
         return false;
     }
-    // NVS caps a string entry at 4000 bytes. Refuse rather than write a truncated blob that
-    // would fail to parse on the next boot and look like corruption.
+    // Refuse rather than write a truncated blob -- see kMaxStoredConfigBytes.
     const size_t needed = measureJson(doc);
-    if (needed > 3900) {
+    if (needed > kMaxStoredConfigBytes) {
         return false;
     }
     out.resize(needed + 1);

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -2,6 +2,7 @@
 
 #include "configuration_store.h"
 
+#include "config_sections.h"
 #include "json_limits.h"
 
 #include <ArduinoJson.h>
@@ -74,79 +75,21 @@ std::string MemoryBackend::raw(const std::string& key) const {
 
 bool serializeConfigForStorage(const Configuration& config, std::string& out) {
     JsonDocument doc;
-    doc["version"]     = kConfigVersion;
-    doc["bridge_name"] = config.bridgeName;
+    // The version this blob is being WRITTEN in, which is what the migration chain reads back.
+    // Not config.version, which records what it was last loaded as.
+    doc["version"] = kConfigVersion;
+    config_sections::writeCommon(doc, config);
 
-    JsonObject wifi = doc["wifi"].to<JsonObject>();
-    wifi["ssid"]     = config.wifi.ssid;
-    wifi["password"] = config.wifi.password;  // storage only, never a response body
-    wifi["hostname"] = config.wifi.hostname;
-
-    JsonObject mqtt = doc["mqtt"].to<JsonObject>();
-    mqtt["enabled"]           = config.mqtt.enabled;
-    mqtt["host"]              = config.mqtt.host;
-    mqtt["port"]              = config.mqtt.port;
-    mqtt["username"]          = config.mqtt.username;
-    mqtt["password"]          = config.mqtt.password;
-    mqtt["base_topic"]        = config.mqtt.baseTopic;
-    mqtt["discovery_prefix"]  = config.mqtt.discoveryPrefix;
-    mqtt["discovery_enabled"] = config.mqtt.discoveryEnabled;
-    mqtt["qos"]               = config.mqtt.qos;
-
-    JsonObject modbus = doc["modbus"].to<JsonObject>();
-    modbus["enabled"]             = config.modbus.enabled;
-    modbus["port"]                = config.modbus.port;
-    modbus["unit_id"]             = config.modbus.unitId;
-    modbus["diagnostics_unit_id"] = config.modbus.diagnosticsUnitId;
-    modbus["write_enabled"]       = config.modbus.writeEnabled;
-
-    doc["polling"]["interval_seconds"] = config.polling.intervalSeconds;
-    doc["relays"]["enabled"]           = config.relays.enabled;
-    JsonArray storedRoles              = doc["relays"]["roles"].to<JsonArray>();
-    for (const auto& role : config.relays.roles) {
-        storedRoles.add(role);
-    }
-
-    JsonObject driver     = doc["driver"].to<JsonObject>();
-    driver["id"]          = config.driver.id;
-    driver["auto_detect"] = config.driver.autoDetect;
-    JsonObject options    = driver["options"].to<JsonObject>();
-    for (const auto& [key, value] : config.driver.options) {
-        options[key] = value;
-    }
-
-
-    JsonObject ntp       = doc["ntp"].to<JsonObject>();
-    ntp["enabled"]       = config.ntp.enabled;
-    ntp["use_dhcp"]      = config.ntp.useDhcp;
-    ntp["server"]        = config.ntp.server;
-    ntp["timezone"]      = config.ntp.timezone;
-    ntp["timezone_name"] = config.ntp.timezoneName;
-
-    JsonArray extra = doc["additional_devices"].to<JsonArray>();
-    for (const auto& d : config.additionalDevices) {
-        JsonObject e   = extra.add<JsonObject>();
-        e["driver_id"] = d.id;
-        JsonObject o   = e["options"].to<JsonObject>();
-        for (const auto& [key, value] : d.options) {
-            o[key] = value;
-        }
-    }
-
-    JsonObject serial   = doc["serial"].to<JsonObject>();
-    serial["override"]  = config.serial.enabled;
-    serial["baud_rate"] = config.serial.profile.baudRate;
-    serial["parity"]    = parityName(config.serial.profile.parity);
-    serial["data_bits"] = config.serial.profile.dataBits;
-    serial["stop_bits"] = config.serial.profile.stopBits;
+    // The credentials, which is the whole of what this document has that the API view does not.
+    // Storage only, never a response body.
+    doc["wifi"]["password"] = config.wifi.password;
+    doc["mqtt"]["username"] = config.mqtt.username;
+    doc["mqtt"]["password"] = config.mqtt.password;
 
     JsonObject security        = doc["security"].to<JsonObject>();
     security["admin_username"] = config.security.adminUsername;
     security["admin_password"] = config.security.adminPassword;
     security["read_only_mode"] = config.security.readOnlyMode;
-
-    doc["updates"]["check_enabled"] = config.updates.checkEnabled;
-    doc["logging"]["level"]         = logLevelName(config.logLevel);
 
     // Refuse rather than write a truncated blob -- see kMaxStoredConfigBytes.
     return json_limits::finish(doc, out, kMaxStoredConfigBytes);

--- a/src/config/configuration_store.h
+++ b/src/config/configuration_store.h
@@ -18,6 +18,16 @@
 
 namespace heliograph {
 
+/// Ceiling on the serialised configuration blob.
+///
+/// NVS caps a single string entry at 4000 bytes. This sits just under it so a config that has
+/// outgrown the store is REFUSED at serialise time rather than written truncated -- a truncated
+/// blob fails to parse on the next boot and presents as corruption, which is a much worse
+/// symptom than a save that says no. Named here because config_backup.h needs the same number
+/// to size its own envelope bound, and a value restated in prose in a second file is a value
+/// that will eventually be wrong in one of them.
+inline constexpr size_t kMaxStoredConfigBytes = 3900;
+
 /// Minimal key/value persistence. The whole configuration is stored as one JSON blob plus a
 /// version key -- simpler than a key per field, and migration becomes ordinary JSON work.
 class KeyValueBackend {

--- a/src/json_limits.h
+++ b/src/json_limits.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+//
+// One rule for turning a JsonDocument into bytes: measure first, refuse if it does not fit.
+//
+// Lives at the root rather than under outputs/ or config/ because both need it and neither
+// owns it. It was duplicated byte-for-byte between outputs/json_util.h and
+// config/configuration.cpp precisely because there was no such place -- config/ writing the
+// NVS blob and outputs/ writing REST and MQTT payloads are the same problem, and a bound that
+// drifted in one copy would have gone unnoticed in the other.
+//
+// It depends on ArduinoJson and nothing else, which is what makes it placeable here at all.
+
+#pragma once
+
+#include <ArduinoJson.h>
+
+#include <string>
+
+namespace heliograph::json_limits {
+
+/// Serialises and enforces the size ceiling. The document is built first and measured after:
+/// ArduinoJson v7 grows elastically, so the bound is applied here rather than by pre-sizing.
+/// Returns false (leaving `out` untouched) on overflow rather than truncating -- a truncated
+/// JSON document is not a smaller answer, it is an unparseable one.
+inline bool finish(const JsonDocument& doc, std::string& out, size_t maxBytes) {
+    if (doc.overflowed()) {
+        return false;  // allocation failed under memory pressure
+    }
+    const size_t needed = measureJson(doc);
+    if (needed > maxBytes) {
+        return false;
+    }
+    std::string buffer;
+    buffer.resize(needed + 1);
+    buffer.resize(serializeJson(doc, buffer.data(), buffer.size()));
+    out = std::move(buffer);
+    return true;
+}
+
+}  // namespace heliograph::json_limits

--- a/src/ota/ota_manager.cpp
+++ b/src/ota/ota_manager.cpp
@@ -26,12 +26,7 @@ const char* otaResultName(OtaResult result) {
 OtaResult OtaManager::finishHash() {
     uint8_t digest[32];
     hasher_.finish(digest);
-    writtenSha256_.assign(64, '\0');
-    static const char kHex[] = "0123456789abcdef";
-    for (size_t i = 0; i < 32; ++i) {
-        writtenSha256_[i * 2]     = kHex[digest[i] >> 4];
-        writtenSha256_[i * 2 + 1] = kHex[digest[i] & 0x0F];
-    }
+    writtenSha256_ = toHex(digest, sizeof(digest));
     if (expectedSha_.empty()) {
         return OtaResult::Ok;  // nothing was promised; a hand-picked file has nothing to check
     }

--- a/src/ota/sha256.cpp
+++ b/src/ota/sha256.cpp
@@ -149,17 +149,21 @@ void Sha256::finish(uint8_t out[32]) {
     }
 }
 
+std::string toHex(const uint8_t* data, size_t len) {
+    static const char kHex[] = "0123456789abcdef";
+    std::string       out;
+    out.reserve(len * 2);
+    for (size_t i = 0; i < len; ++i) {
+        out.push_back(kHex[data[i] >> 4]);
+        out.push_back(kHex[data[i] & 0x0F]);
+    }
+    return out;
+}
+
 std::string Sha256::finishHex() {
     uint8_t digest[32];
     finish(digest);
-    static const char kHex[] = "0123456789abcdef";
-    std::string       out;
-    out.reserve(64);
-    for (unsigned char byte : digest) {
-        out.push_back(kHex[byte >> 4]);
-        out.push_back(kHex[byte & 0x0F]);
-    }
-    return out;
+    return toHex(digest, sizeof(digest));
 }
 
 bool hexDigestEquals(const std::string& expectedHex, const uint8_t digest[32]) {

--- a/src/ota/sha256.h
+++ b/src/ota/sha256.h
@@ -49,6 +49,11 @@ private:
     size_t   buffered_ = 0;
 };
 
+/// Lowercase hex of a byte range. Separate from Sha256 because the OTA path needs both forms
+/// of the same digest -- the bytes, to compare against what was promised, and the text, to put
+/// in an error message and the status payload -- and finish() may only be called once.
+std::string toHex(const uint8_t* data, size_t len);
+
 /// Compares a user-supplied hex digest against a computed one, case-insensitively.
 ///
 /// False on any length other than 64 or any non-hex character, so a truncated or malformed

--- a/src/outputs/json_util.h
+++ b/src/outputs/json_util.h
@@ -9,6 +9,8 @@
 
 #include <string>
 
+#include "json_limits.h"
+
 #include "device/bridge_info.h"
 #include "device/capability.h"
 #include "device/command.h"
@@ -17,23 +19,9 @@
 
 namespace heliograph::json_util {
 
-/// Serialises and enforces the size ceiling. The document is built first and measured after:
-/// ArduinoJson v7 grows elastically, so the bound is applied here rather than by pre-sizing.
-/// Returns false (leaving `out` untouched) on overflow rather than truncating.
-inline bool finish(const JsonDocument& doc, std::string& out, size_t maxBytes) {
-    if (doc.overflowed()) {
-        return false;  // allocation failed under memory pressure
-    }
-    const size_t needed = measureJson(doc);
-    if (needed > maxBytes) {
-        return false;
-    }
-    std::string buffer;
-    buffer.resize(needed + 1);
-    buffer.resize(serializeJson(doc, buffer.data(), buffer.size()));
-    out = std::move(buffer);
-    return true;
-}
+/// Re-exported so the payload builders keep saying `finish(...)`. The definition lives in
+/// json_limits.h because config/ needs the same rule for the NVS blob.
+using json_limits::finish;
 
 /// Omit rather than emit "": absent means "this protocol does not report it".
 inline void addOptional(JsonObject obj, const char* key, const std::string& value) {

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+//
+// Token-bucket throttle: a burst allowance that refills after a quiet period.
+//
+// WHY THIS IS SHARED, when the two users deliberately kept their own copies until 0.16.0.
+// The comment on RelayController's copy argued that "two small, independently testable copies
+// beat a coupling between the inverter write path and the bridge actuator" -- and then, in the
+// same paragraph, recorded that the copies had drifted: the relay copy found two bugs that the
+// dispatcher only adopted afterwards. That is the argument against duplication, written out by
+// the duplication itself.
+//
+// The coupling that comment feared does not follow from sharing. This is a value type, not a
+// base class: each user owns an instance, keeps its own policy, its own locking (the dispatcher
+// holds a mutex around its call; the relay controller does not need one), and its own decision
+// about WHICH operations are throttled at all. Nothing about the inverter write path reaches
+// the relays through it. What is shared is only the arithmetic -- and the arithmetic is where
+// both bugs were.
+//
+// THE TWO TRAPS, both found on hardware and both fixed here once:
+//
+//  1. "Never accepted" is an explicit flag, not a lastAcceptedMs_ == 0 sentinel. millis() at
+//     boot IS near zero, so the sentinel collides exactly during the first seconds after a
+//     restart -- the throttle would let an unlimited burst through precisely when a bridge is
+//     coming up and something is retrying.
+//
+//  2. Elapsed time is clamped, never wrapped. On an unsigned type a clock that steps backwards
+//     turns the subtraction into an enormous number, which reads as "quiet for ages" and
+//     refills the whole allowance. The throttle would fail OPEN. Not reachable with the
+//     esp_timer-backed monotonic clock this ships with, but the clock is injectable and the
+//     failure direction is the permissive one.
+//
+// Header-only: fifteen lines of arithmetic that both callers should be able to inline, and no
+// new translation unit to register in platformio.ini's build_src_filter.
+
+#pragma once
+
+#include <cstdint>
+
+namespace heliograph {
+
+struct RateLimitPolicy {
+    /// Minimum spacing between accepted commands.
+    uint32_t minIntervalMs = 1000;
+    /// How many may be issued back to back before the spacing applies.
+    uint32_t burst = 3;
+};
+
+/// Not thread-safe by design. Callers that need it hold their own lock around allow(), because
+/// only they know how much else belongs inside the same critical section.
+class RateLimiter {
+public:
+    RateLimiter() = default;
+    explicit RateLimiter(RateLimitPolicy policy) : policy_(policy) {}
+
+    void setPolicy(RateLimitPolicy policy) { policy_ = policy; }
+
+    /// True if this call may proceed, and records it as accepted. False leaves the state
+    /// untouched, so a refused call does not consume the allowance.
+    bool allow(uint64_t nowMs) {
+        const uint64_t since = nowMs > lastAcceptedMs_ ? nowMs - lastAcceptedMs_ : 0;  // trap 2
+        if (everAccepted_ && since >= policy_.minIntervalMs) {
+            burstUsed_ = 0;  // quiet long enough, the allowance refills
+        }
+        if (burstUsed_ < policy_.burst) {
+            ++burstUsed_;
+            accept(nowMs);
+            return true;
+        }
+        if (!everAccepted_ || since >= policy_.minIntervalMs) {  // trap 1
+            accept(nowMs);
+            return true;
+        }
+        return false;
+    }
+
+private:
+    void accept(uint64_t nowMs) {
+        everAccepted_   = true;
+        lastAcceptedMs_ = nowMs;
+    }
+
+    RateLimitPolicy policy_{};
+    bool            everAccepted_   = false;
+    uint64_t        lastAcceptedMs_ = 0;
+    uint32_t        burstUsed_      = 0;
+};
+
+}  // namespace heliograph

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -2,7 +2,7 @@
 //
 // Token-bucket throttle: a burst allowance that refills after a quiet period.
 //
-// WHY THIS IS SHARED, when the two users deliberately kept their own copies until 0.16.0.
+// WHY THIS IS SHARED, when the two users deliberately kept their own copies for three releases.
 // The comment on RelayController's copy argued that "two small, independently testable copies
 // beat a coupling between the inverter write path and the bridge actuator" -- and then, in the
 // same paragraph, recorded that the copies had drifted: the relay copy found two bugs that the
@@ -51,8 +51,6 @@ class RateLimiter {
 public:
     RateLimiter() = default;
     explicit RateLimiter(RateLimitPolicy policy) : policy_(policy) {}
-
-    void setPolicy(RateLimitPolicy policy) { policy_ = policy; }
 
     /// True if this call may proceed, and records it as accepted. False leaves the state
     /// untouched, so a refused call does not consume the allowance.

--- a/src/relays/relay_controller.cpp
+++ b/src/relays/relay_controller.cpp
@@ -5,7 +5,7 @@
 namespace heliograph {
 
 RelayController::RelayController(ClockFn clock, RateLimitPolicy rateLimit)
-    : clock_(std::move(clock)), rateLimit_(rateLimit) {}
+    : clock_(std::move(clock)), limiter_(rateLimit) {}
 
 void RelayController::begin(uint8_t count, RelayApplyFn apply) {
     count_ = count > kMaxRelays ? kMaxRelays : count;
@@ -20,32 +20,6 @@ void RelayController::allOff() {
             apply_(i, false);
         }
     }
-}
-
-// Same refill logic as CommandDispatcher::allowedByRateLimit. This copy found two problems
-// first and the dispatcher has since adopted both: "has ever accepted" as an explicit flag
-// rather than a lastAcceptedMs_ == 0 sentinel (millis() at boot IS near zero, so the sentinel
-// collides exactly when the device just started), and a clamped elapsed time so a clock that
-// moves backwards cannot wrap the subtraction into "ages ago" and refill the whole allowance.
-// Duplicated rather than shared through a base class by intent: two small, independently
-// testable copies beat a coupling between the inverter write path and the bridge actuator.
-bool RelayController::allowedByRateLimit(uint64_t nowMs) {
-    const uint64_t since = nowMs > lastAcceptedMs_ ? nowMs - lastAcceptedMs_ : 0;
-    if (everAccepted_ && since >= rateLimit_.minIntervalMs) {
-        burstUsed_ = 0;
-    }
-    if (burstUsed_ < rateLimit_.burst) {
-        ++burstUsed_;
-        everAccepted_   = true;
-        lastAcceptedMs_ = nowMs;
-        return true;
-    }
-    if (!everAccepted_ || since >= rateLimit_.minIntervalMs) {
-        everAccepted_   = true;
-        lastAcceptedMs_ = nowMs;
-        return true;
-    }
-    return false;
 }
 
 CommandResult RelayController::set(uint8_t index, bool energised) {
@@ -65,7 +39,7 @@ CommandResult RelayController::set(uint8_t index, bool energised) {
     // direction and must never wait behind a throttle.
     if (energised) {
         const uint64_t now = clock_ ? clock_() : 0;
-        if (!allowedByRateLimit(now)) {
+        if (!allowedToAssert(now)) {
             return CommandResult::RateLimited;
         }
     }
@@ -97,7 +71,7 @@ CommandResult RelayController::applyPattern(const std::vector<bool>& pattern) {
     // pattern is the safe direction and passes unconditionally, like set(index, false).
     if (assertsAny) {
         const uint64_t now = clock_ ? clock_() : 0;
-        if (!allowedByRateLimit(now)) {
+        if (!allowedToAssert(now)) {
             return CommandResult::RateLimited;
         }
     }

--- a/src/relays/relay_controller.cpp
+++ b/src/relays/relay_controller.cpp
@@ -22,14 +22,29 @@ void RelayController::allOff() {
     }
 }
 
-CommandResult RelayController::set(uint8_t index, bool energised) {
-    // 1. Global kill switch, before anything else -- identical position to the dispatcher.
+// Gates 1 and 2, in the order the dispatcher uses. One definition so a gate added later cannot
+// be added to set() and forgotten in applyPattern() -- the direction in which that mistake
+// fails is a relay that moves when it should have been refused.
+//
+//   1. Global kill switch, before anything else.
+//   2. Feature flag. A relay board with default settings must be inert.
+//
+// Gates 3 (what is being addressed) and 4 (the rate limit) differ per operation and stay with
+// their callers: an index versus a pattern width, one token versus one token for the whole
+// pattern.
+CommandResult RelayController::checkGates() const {
     if (readOnly_) {
         return CommandResult::ReadOnlyMode;
     }
-    // 2. Feature flag. A relay board with default settings must be inert.
     if (!enabled_) {
         return CommandResult::Rejected;
+    }
+    return CommandResult::Ok;
+}
+
+CommandResult RelayController::set(uint8_t index, bool energised) {
+    if (const CommandResult gate = checkGates(); gate != CommandResult::Ok) {
+        return gate;
     }
     // 3. Index validity.
     if (index >= count_) {
@@ -51,11 +66,8 @@ CommandResult RelayController::set(uint8_t index, bool energised) {
 }
 
 CommandResult RelayController::applyPattern(const std::vector<bool>& pattern) {
-    if (readOnly_) {
-        return CommandResult::ReadOnlyMode;
-    }
-    if (!enabled_) {
-        return CommandResult::Rejected;
+    if (const CommandResult gate = checkGates(); gate != CommandResult::Ok) {
+        return gate;
     }
     if (pattern.size() != static_cast<size_t>(count_)) {
         return CommandResult::OutOfRange;

--- a/src/relays/relay_controller.h
+++ b/src/relays/relay_controller.h
@@ -70,6 +70,11 @@ public:
     bool    readOnlyMode() const { return readOnly_; }
 
 private:
+    /// The gates every relay operation passes, whatever it is asking for: the global kill
+    /// switch, then the feature flag. Ok means "keep going", anything else is the refusal to
+    /// return. Shared so a gate added later cannot land in one entry point and not the other.
+    CommandResult checkGates() const;
+
     /// One token per accepted assert. Its own instance, so relay traffic and inverter write
     /// traffic can never consume each other's allowance -- see rate_limiter.h for why the
     /// arithmetic is shared but the state is not.

--- a/src/relays/relay_controller.h
+++ b/src/relays/relay_controller.h
@@ -19,7 +19,8 @@
 #include <functional>
 #include <vector>
 
-#include "commands/command_dispatcher.h"  // RateLimitPolicy
+#include "rate_limiter.h"  // RateLimitPolicy, RateLimiter
+
 #include "device/clock.h"
 #include "device/command.h"  // CommandResult vocabulary
 
@@ -69,22 +70,18 @@ public:
     bool    readOnlyMode() const { return readOnly_; }
 
 private:
-    bool allowedByRateLimit(uint64_t nowMs);
+    /// One token per accepted assert. Its own instance, so relay traffic and inverter write
+    /// traffic can never consume each other's allowance -- see rate_limiter.h for why the
+    /// arithmetic is shared but the state is not.
+    bool allowedToAssert(uint64_t nowMs) { return limiter_.allow(nowMs); }
 
-    ClockFn         clock_;
-    RateLimitPolicy rateLimit_;
-    RelayApplyFn    apply_;
-    uint8_t         count_    = 0;
-    bool            readOnly_ = true;
-    bool            enabled_  = false;
-    bool            state_[kMaxRelays] = {};
-
-    // An explicit flag, not a "0 means never" sentinel: millis() at boot IS near zero, and a
-    // sentinel collision there let the first post-boot burst bypass the throttle (caught by
-    // test_rate_limit_throttles_on_but_never_off). CommandDispatcher carries the same flag.
-    bool     everAccepted_   = false;
-    uint64_t lastAcceptedMs_ = 0;
-    uint32_t burstUsed_      = 0;
+    ClockFn      clock_;
+    RelayApplyFn apply_;
+    RateLimiter  limiter_;
+    uint8_t      count_    = 0;
+    bool         readOnly_ = true;
+    bool         enabled_  = false;
+    bool         state_[kMaxRelays] = {};
 };
 
 }  // namespace heliograph

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -4,7 +4,10 @@
 #include <unity.h>
 
 #include <cstring>
+#include <set>
 #include <string>
+
+#include <ArduinoJson.h>
 
 #include "config/configuration_store.h"
 #include "network/provisioning_policy.h"
@@ -285,6 +288,78 @@ static void test_the_storage_serialiser_is_the_only_one_that_writes_secrets() {
 
     TEST_ASSERT_TRUE(forApi.find("GeheimWifiWachtwoord") == std::string::npos);
     TEST_ASSERT_TRUE(forStorage.find("GeheimWifiWachtwoord") != std::string::npos);
+}
+
+/// Collects every key PATH in a document ("mqtt.qos", "relays.roles"), so two documents can be
+/// compared on shape rather than on the order or the values they happen to carry.
+static void collectKeyPaths(JsonVariantConst v, const std::string& prefix,
+                            std::set<std::string>& out) {
+    if (!v.is<JsonObjectConst>()) {
+        return;
+    }
+    for (JsonPairConst kv : v.as<JsonObjectConst>()) {
+        const std::string path = prefix.empty() ? std::string(kv.key().c_str())
+                                                : prefix + "." + kv.key().c_str();
+        out.insert(path);
+        collectKeyPaths(kv.value(), path, out);  // arrays stop here, which is what we want
+    }
+}
+
+/// THE invariant behind config_sections::writeCommon.
+///
+/// The API document and the stored document are written by one shared function plus a short
+/// per-caller tail. This asserts that the tail is the ONLY thing that differs: every key in one
+/// must appear in the other, except the credential keys listed here by name.
+///
+/// It exists because the failure it guards is silent. Before the writers were merged, a setting
+/// added to serializeConfig and forgotten in serializeConfigForStorage produced a settings page
+/// that showed the field, accepted a change, reported success, and lost it on the next reboot --
+/// nothing threw and nothing logged. Merging the writers makes that mistake hard; this makes it
+/// impossible to land unnoticed, including if someone later adds a field to one tail instead of
+/// to writeCommon().
+static void test_the_two_config_documents_differ_only_in_their_credentials() {
+    const auto  c = provisionedConfig();
+    std::string forApi;
+    std::string forStorage;
+    TEST_ASSERT_TRUE(serializeConfig(c, forApi));
+    TEST_ASSERT_TRUE(serializeConfigForStorage(c, forStorage));
+
+    JsonDocument api;
+    JsonDocument stored;
+    TEST_ASSERT_EQUAL(DeserializationError::Ok, deserializeJson(api, forApi).code());
+    TEST_ASSERT_EQUAL(DeserializationError::Ok, deserializeJson(stored, forStorage).code());
+
+    std::set<std::string> apiKeys;
+    std::set<std::string> storedKeys;
+    collectKeyPaths(api.as<JsonVariantConst>(), "", apiKeys);
+    collectKeyPaths(stored.as<JsonVariantConst>(), "", storedKeys);
+
+    // The redaction, stated as data. Anything outside these two lists that appears in only one
+    // document is drift, not design.
+    const std::set<std::string> apiOnly{"wifi.password_set", "mqtt.username_set",
+                                        "mqtt.password_set", "security.password_set"};
+    const std::set<std::string> storedOnly{"wifi.password",          "mqtt.username",
+                                           "mqtt.password",         "security.admin_username",
+                                           "security.admin_password"};
+
+    for (const auto& key : apiKeys) {
+        if (apiOnly.count(key) != 0) continue;
+        TEST_ASSERT_TRUE_MESSAGE(storedKeys.count(key) != 0,
+                                 ("in the API document but not stored: " + key).c_str());
+    }
+    for (const auto& key : storedKeys) {
+        if (storedOnly.count(key) != 0) continue;
+        TEST_ASSERT_TRUE_MESSAGE(apiKeys.count(key) != 0,
+                                 ("stored but not in the API document: " + key).c_str());
+    }
+    // And the redactions themselves are really present, so the lists above cannot silently rot
+    // into a pair of unused constants that make the loops above vacuous.
+    for (const auto& key : apiOnly) {
+        TEST_ASSERT_TRUE_MESSAGE(apiKeys.count(key) != 0, key.c_str());
+    }
+    for (const auto& key : storedOnly) {
+        TEST_ASSERT_TRUE_MESSAGE(storedKeys.count(key) != 0, key.c_str());
+    }
 }
 
 static void test_factory_reset_wipes_credentials() {
@@ -1034,6 +1109,7 @@ int main(int, char**) {
     RUN_TEST(test_ntp_without_dhcp_needs_a_server);
     RUN_TEST(test_ntp_timezone_must_not_be_empty);
     RUN_TEST(test_secrets_survive_the_round_trip);
+    RUN_TEST(test_the_two_config_documents_differ_only_in_their_credentials);
     RUN_TEST(test_the_storage_serialiser_is_the_only_one_that_writes_secrets);
     RUN_TEST(test_factory_reset_wipes_credentials);
     RUN_TEST(test_a_failed_write_is_reported_not_swallowed);

--- a/test/test_rate_limiter/test_main.cpp
+++ b/test/test_rate_limiter/test_main.cpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+// The shared throttle, and the two traps its arithmetic exists to avoid.
+//
+// Both users -- CommandDispatcher for inverter writes, RelayController for DRM contacts --
+// already cover it through their own gate tests. This suite exists because those two prove it
+// twice from the outside while neither states the invariants directly, and because both traps
+// below were found on hardware in one copy and only later fixed in the other. Now there is one
+// copy, and this is where it says what it guarantees.
+
+#include <unity.h>
+
+#include "rate_limiter.h"
+
+using heliograph::RateLimiter;
+using heliograph::RateLimitPolicy;
+
+void setUp() {}
+void tearDown() {}
+
+// --- the ordinary contract ------------------------------------------------------------------
+
+static void test_the_burst_is_spent_then_the_spacing_applies() {
+    RateLimiter limiter{RateLimitPolicy{1000, 3}};
+    TEST_ASSERT_TRUE(limiter.allow(10000));
+    TEST_ASSERT_TRUE(limiter.allow(10001));
+    TEST_ASSERT_TRUE(limiter.allow(10002));
+    TEST_ASSERT_FALSE(limiter.allow(10003));  // burst gone, spacing not yet met
+}
+
+static void test_a_quiet_period_refills_the_whole_allowance() {
+    RateLimiter limiter{RateLimitPolicy{1000, 2}};
+    TEST_ASSERT_TRUE(limiter.allow(5000));
+    TEST_ASSERT_TRUE(limiter.allow(5001));
+    TEST_ASSERT_FALSE(limiter.allow(5002));
+    TEST_ASSERT_TRUE(limiter.allow(6002));   // exactly minIntervalMs later
+    TEST_ASSERT_TRUE(limiter.allow(6003));   // and the burst is back
+}
+
+/// A refusal must not move the clock forward, or a caller that retries in a tight loop would
+/// push its own next opportunity out indefinitely -- the throttle would become a lockout.
+static void test_a_refusal_does_not_consume_the_allowance() {
+    RateLimiter limiter{RateLimitPolicy{1000, 1}};
+    TEST_ASSERT_TRUE(limiter.allow(1000));
+    for (uint64_t t = 1001; t < 1999; ++t) {
+        TEST_ASSERT_FALSE(limiter.allow(t));
+    }
+    TEST_ASSERT_TRUE(limiter.allow(2000));  // still exactly one interval after the ACCEPTED one
+}
+
+// --- trap 1: the boot-time sentinel -----------------------------------------------------------
+
+/// millis() at boot IS near zero. A limiter that used lastAcceptedMs_ == 0 to mean "never
+/// accepted" would read t=0 as "accepted at time 0, ages ago" and let an unbounded burst
+/// through in the first seconds after a restart -- exactly when something is retrying.
+static void test_time_zero_is_not_mistaken_for_never_accepted() {
+    RateLimiter limiter{RateLimitPolicy{1000, 1}};
+    TEST_ASSERT_TRUE(limiter.allow(0));
+    TEST_ASSERT_FALSE(limiter.allow(0));
+    TEST_ASSERT_FALSE(limiter.allow(1));
+    TEST_ASSERT_FALSE(limiter.allow(999));
+    TEST_ASSERT_TRUE(limiter.allow(1000));
+}
+
+// --- trap 2: the clock that steps backwards ---------------------------------------------------
+
+/// Elapsed time is clamped, not wrapped. On an unsigned type a backwards clock turns the
+/// subtraction into an enormous number, which reads as "quiet for ages" and refills everything:
+/// the throttle fails OPEN, the permissive direction. The shipping clock is monotonic, but it
+/// is injectable, so this is the behaviour under an injected one.
+static void test_a_backwards_clock_does_not_refill_the_allowance() {
+    RateLimiter limiter{RateLimitPolicy{1000, 1}};
+    TEST_ASSERT_TRUE(limiter.allow(100000));
+    TEST_ASSERT_FALSE(limiter.allow(100001));
+    TEST_ASSERT_FALSE(limiter.allow(50000));  // clock jumped back; must NOT be treated as ages
+    TEST_ASSERT_FALSE(limiter.allow(1));
+}
+
+// --- the degenerate policies ------------------------------------------------------------------
+
+/// burst 0 means "spacing only, no allowance". The dispatcher's release track has exactly this
+/// shape and deliberately keeps its own fields rather than relying on this equivalence -- but
+/// the equivalence had better be real, or a future caller that does use it gets a surprise.
+static void test_a_zero_burst_leaves_only_the_spacing() {
+    RateLimiter limiter{RateLimitPolicy{1000, 0}};
+    TEST_ASSERT_TRUE(limiter.allow(500));   // first call: never accepted before
+    TEST_ASSERT_FALSE(limiter.allow(501));
+    TEST_ASSERT_TRUE(limiter.allow(1500));
+}
+
+/// A zero interval is "burst only, refilled every call", not a division by anything.
+static void test_a_zero_interval_never_refuses() {
+    RateLimiter limiter{RateLimitPolicy{0, 1}};
+    for (uint64_t t = 0; t < 100; ++t) {
+        TEST_ASSERT_TRUE(limiter.allow(t));
+    }
+}
+
+/// Default-constructed and policy-constructed must agree, since RelayController default-
+/// constructs its member and assigns the policy through the constructor initialiser list.
+static void test_the_default_policy_is_one_second_and_three() {
+    RateLimiter limiter;
+    TEST_ASSERT_TRUE(limiter.allow(10000));
+    TEST_ASSERT_TRUE(limiter.allow(10000));
+    TEST_ASSERT_TRUE(limiter.allow(10000));
+    TEST_ASSERT_FALSE(limiter.allow(10000));
+    TEST_ASSERT_TRUE(limiter.allow(11000));
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_the_burst_is_spent_then_the_spacing_applies);
+    RUN_TEST(test_a_quiet_period_refills_the_whole_allowance);
+    RUN_TEST(test_a_refusal_does_not_consume_the_allowance);
+    RUN_TEST(test_time_zero_is_not_mistaken_for_never_accepted);
+    RUN_TEST(test_a_backwards_clock_does_not_refill_the_allowance);
+    RUN_TEST(test_a_zero_burst_leaves_only_the_spacing);
+    RUN_TEST(test_a_zero_interval_never_refuses);
+    RUN_TEST(test_the_default_policy_is_one_second_and_three);
+    return UNITY_END();
+}

--- a/test/test_sha256/test_main.cpp
+++ b/test/test_sha256/test_main.cpp
@@ -121,6 +121,20 @@ static void test_a_null_chunk_is_ignored_not_hashed() {
                              h.finishHex().c_str());
 }
 
+// --- hex rendering ------------------------------------------------------------------------
+
+/// Lowercase, two characters per byte, leading zeroes kept. A renderer that dropped the high
+/// nibble of 0x0f would produce a 63-character string that no comparison could ever match, and
+/// the OTA error message would show a digest that is not the one that was computed.
+static void test_hex_renders_every_byte_as_two_lowercase_characters() {
+    const uint8_t bytes[] = {0x00, 0x0f, 0xa5, 0xff};
+    TEST_ASSERT_EQUAL_STRING("000fa5ff", heliograph::ota::toHex(bytes, sizeof(bytes)).c_str());
+    TEST_ASSERT_EQUAL_STRING("", heliograph::ota::toHex(bytes, 0).c_str());
+    // The length is honoured, not the array: OtaManager renders a 32-byte digest out of a
+    // buffer it sizes itself, and a renderer that ignored len would read past it.
+    TEST_ASSERT_EQUAL_STRING("000f", heliograph::ota::toHex(bytes, 2).c_str());
+}
+
 // --- the comparison ---------------------------------------------------------------------------
 
 static void test_a_matching_hex_digest_compares_equal() {
@@ -177,6 +191,7 @@ int main() {
     RUN_TEST(test_every_length_across_two_blocks_is_self_consistent);
     RUN_TEST(test_reset_makes_the_object_reusable);
     RUN_TEST(test_a_null_chunk_is_ignored_not_hashed);
+    RUN_TEST(test_hex_renders_every_byte_as_two_lowercase_characters);
     RUN_TEST(test_a_matching_hex_digest_compares_equal);
     RUN_TEST(test_a_malformed_expectation_is_refused);
     RUN_TEST(test_one_wrong_bit_is_refused);

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -158,6 +158,39 @@ else
     echo "OK"
 fi
 
+echo "==> 8. No comment cites a line number in our own source"
+# A "see main.cpp:492" is correct on the day it is written and wrong on the next edit to that
+# file -- the reader then follows it to an unrelated line and either trusts the wrong code or
+# stops trusting the comments. Two had already rotted by 0.15.0: main.cpp:492 pointed at the
+# boot-button handler and not at the deferred-poll seam it meant. Name the function or the
+# concept instead; those move with the code.
+#
+# Only OUR files. A pointer into a pinned library (WebRequest.cpp:114 in rest_api.h) is
+# verifiable against a fixed version and does not drift under us, so it is allowed.
+#
+# Portability note: this deliberately avoids `find -printf` (GNU only -- it silently yields
+# nothing on the macOS BSD find every local run uses, which turned the filename alternation
+# into an empty group and matched every `{width:02X}` format spec in tools/).
+lineref=""
+for f in $(git ls-files 'src/*.cpp' 'src/*.h' 'test/*.cpp' 'test/*.h' 'tools/*.py' \
+           ':!:src/web/assets/*'); do
+    for cited in $(grep -oE '[A-Za-z_][A-Za-z0-9_]*\.(cpp|h|py|sh):[0-9]+' "$f" | sort -u); do
+        base=${cited%%:*}
+        # Ours only: a pointer into a pinned library is verifiable against a fixed version.
+        if git ls-files --error-unmatch "*/$base" >/dev/null 2>&1; then
+            lineref="$lineref
+      $f cites $cited"
+        fi
+    done
+done
+if [ -n "$lineref" ]; then
+    echo "FAIL: comment points at a line number in our own source, which will drift:"
+    printf '%s\n' "$lineref" | sed '/^[[:space:]]*$/d'
+    status=1
+else
+    echo "OK"
+fi
+
 echo
 if [ $status -eq 0 ]; then
     echo "RESULT: PASS"


### PR DESCRIPTION
Audit-driven cleanup. No external behaviour changes; the one thing that does change on the wire is JSON **key order**, called out below.

## What the audit found

The codebase was already in good shape, so this is smaller than the brief anticipated. Reporting that honestly matters as much as the diff:

- **Warnings:** zero from `src/` on a clean build of all four envs, and zero from cppcheck across 229 files. Every warning in a firmware build comes from pinned third-party code — eModbus's deprecated `AsyncClient::close(bool)` and its own `%u`/`uint32_t` format mismatch, plus `-Wmissing-field-initializers` out of Espressif's `spi_dev_s`/`cdc_line_control_state_t` headers. Not fixable without patching dependencies, and suppressing them would be the hack the brief rules out. **Left alone.**
- **Deprecations:** none in our own code. The single `containsKey` mention is a comment explaining why it is avoided.
- **Dead code:** none. 369 declared functions scanned, all 12 candidates turned out to be reachable; 91 JS functions across both web assets, none dead; no TODO/FIXME/HACK, no commented-out blocks.
- **Duplication:** five real cases, all addressed here.

## The commits

Each is independently revertable.

| Commit | What |
|---|---|
| `chore: name the NVS size cap…` | `kMaxStoredConfigBytes` replaces a bare `3900` that `config_backup.h` restated in prose; three comment references that had rotted; **new layering rule 8** |
| `refactor: one definition of "serialise, or refuse…"` | the measure-then-bound helper existed three times → `src/json_limits.h` |
| `refactor: one digest-to-hex renderer…` | two nibble loops in the OTA path → `toHex()` |
| `refactor: one writer for the config fields both documents share` | ~40 lines written twice → `config_sections::writeCommon` |
| `refactor: one rate limiter, two independent instances` | reverses a documented decision — see below |
| `refactor: one definition of the relay safety gates` | `set()`/`applyPattern()` shared two safety checks |

## Two things worth a reviewer's attention

### 1. The rate limiter reverses an earlier decision

`relay_controller.cpp` argued the two copies were deliberate: *"two small, independently testable copies beat a coupling between the inverter write path and the bridge actuator."* The same paragraph then recorded that the copies **had drifted** — the relay copy found two bugs the dispatcher only adopted afterwards.

`RateLimiter` is a value type, not a base class. Each user keeps its own instance, policy, locking and decision about what is throttled; relay traffic and inverter writes still cannot consume each other's allowance. Only the arithmetic is shared — which is where both bugs were.

Both traps are now asserted directly, and **each mutation was reintroduced and confirmed to fail the test** before being reverted.

### 2. JSON key order changes

Config content is byte-for-byte equivalent — verified by dumping both documents from a fully populated `Configuration` before and after: 43 fields each, none added, none removed, no value changed. But key **order** moves:

- `security` moves after `updates`/`logging` (both documents)
- `mqtt` username/password move to the end of the mqtt object (both)
- `wifi.password` moves after `hostname` (storage only)
- `additional_devices` and `ntp` swap (storage only, now matching the API view)

Nothing consumes order — both documents are read back by key, the settings page parses JSON, and no test compares a serialised document as a string. Flagged because it does change the bytes in NVS and on the wire.

## New guard

`check_layering.sh` rule 8: a comment may not cite a line number in a file we own. Two such pointers had already rotted by 0.15.0. Library references stay allowed — they are pinned to a fixed version and do not drift under us. Verified the rule fails on the exact reference it was written for.

## Dependencies — reported, not touched

ArduinoJson 7.4.3, eModbus 1.7.4 and espMqttClient 1.7.3 are current. **AsyncTCP is pinned at 3.4.10 (latest 3.5.0)** and **ESPAsyncWebServer at v3.11.2 (latest 3.12.0, released 2026-07-26)**. Not bumped: `docs/decisions.md` makes toolchain and library bumps hardware-tested changes, and `dependency-check.yml` already opens a monthly tracking issue. eModbus's last release is 2025-06-17 — over a year — which is the only mild staleness signal.

## Verification

- 739 host tests (8 new), all pass
- Clean rebuild of all four firmware envs: SUCCESS, no warnings from `src/`
- cppcheck 0/0 over 229 files, ruff check + format, layering 8/8, web-JS and measurement-id checks
