### PR TITLE
test: merge driver-family suites into one binary each (faster native run)

### DIFF
--- a/test/test_eversolar/checksum.cpp
+++ b/test/test_eversolar/checksum.cpp
@@ -11,8 +11,6 @@
 using namespace heliograph::pmu;
 namespace fx = heliograph::fixtures;
 
-void setUp() {}
-void tearDown() {}
 
 // --- checksum ---------------------------------------------------------------------------
 
@@ -182,8 +180,7 @@ static void test_valid_response_passes_checksum() {
                       parseFrame(fx::kRespNormalInfoSingle, fx::kRespNormalInfoSingleLen, f));
 }
 
-int main(int, char**) {
-    UNITY_BEGIN();
+void run_eversolar_checksum() {
     RUN_TEST(test_checksum_is_plain_byte_sum);
     RUN_TEST(test_checksum_includes_the_header);
     RUN_TEST(test_checksum_wraps_at_16_bits);
@@ -200,5 +197,4 @@ int main(int, char**) {
     RUN_TEST(test_all_zero_frame_is_rejected);
     RUN_TEST(test_checksum_of_zero_is_valid_when_the_sum_wraps);
     RUN_TEST(test_valid_response_passes_checksum);
-    return UNITY_END();
 }

--- a/test/test_eversolar/driver.cpp
+++ b/test/test_eversolar/driver.cpp
@@ -23,8 +23,6 @@ using Payload = FakeEversolarDevice::Payload;
 static uint64_t g_now = 0;
 static uint64_t clockFn() { return g_now; }
 
-void setUp() { g_now = 1000; }
-void tearDown() {}
 
 /// A driver wired to a simulated inverter. Tests describe the device, not the byte script.
 struct Rig {
@@ -695,8 +693,7 @@ static void test_snapshots_are_immutable_and_independent() {
                               store.snapshot()->measurements.find(measurement_id::kAcPowerTotal)->value);
 }
 
-int main(int, char**) {
-    UNITY_BEGIN();
+void run_eversolar_driver() {
     RUN_TEST(test_begin_configures_the_only_known_profile);
     RUN_TEST(test_begin_broadcasts_re_register);
     RUN_TEST(test_begin_fails_when_the_line_cannot_be_configured);
@@ -738,5 +735,7 @@ int main(int, char**) {
     RUN_TEST(test_backoff_is_bounded);
     RUN_TEST(test_diagnostics_track_the_cycle_without_leaking_payload);
     RUN_TEST(test_snapshots_are_immutable_and_independent);
-    return UNITY_END();
 }
+
+// Reset the fake clock before each test, as the original per-suite setUp did.
+void eversolar_driver_reset() { g_now = 1000; }

--- a/test/test_eversolar/parser.cpp
+++ b/test/test_eversolar/parser.cpp
@@ -12,8 +12,6 @@
 using namespace heliograph::eversolar;
 namespace fx = heliograph::fixtures;
 
-void setUp() {}
-void tearDown() {}
 
 static constexpr double kEps = 1e-9;
 static const Address    kInverter = inverterAddress(0x10);
@@ -433,8 +431,7 @@ static void test_model_is_anchored_on_the_manufacturer_field() {
     TEST_ASSERT_EQUAL_STRING("", modelFromIdString("", "Ever-Solar").c_str());
 }
 
-int main(int, char**) {
-    UNITY_BEGIN();
+void run_eversolar_parser() {
     RUN_TEST(test_expected_frame_length_needs_the_length_byte);
     RUN_TEST(test_expected_frame_length_is_overhead_plus_payload);
     RUN_TEST(test_partial_frame_is_incomplete_not_invalid);
@@ -478,5 +475,4 @@ int main(int, char**) {
     RUN_TEST(test_registration_ack_is_recognised);
     RUN_TEST(test_registration_nak_is_not_an_ack);
     RUN_TEST(test_inverter_id_is_extracted_verbatim);
-    return UNITY_END();
 }

--- a/test/test_eversolar/test_main.cpp
+++ b/test/test_eversolar/test_main.cpp
@@ -1,0 +1,26 @@
+// One binary for the whole Eversolar family — checksum, parser and driver — so the shared
+// src/ is linked once here instead of three times, one per former suite. Each sub-suite keeps
+// its own translation unit (checksum.cpp / parser.cpp / driver.cpp) and its file-local statics;
+// this file owns the single Unity setUp/tearDown/main that the framework allows per binary.
+#include <unity.h>
+
+// Sub-suites, defined in the sibling translation units.
+void run_eversolar_checksum();
+void run_eversolar_parser();
+void run_eversolar_driver();
+
+// The driver suite runs against a fake clock; its original setUp reset that clock before every
+// test. Only the driver tests use it, so calling this before the checksum/parser tests too is
+// harmless — it just writes a value they never read.
+void eversolar_driver_reset();
+
+void setUp() { eversolar_driver_reset(); }
+void tearDown() {}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    run_eversolar_checksum();
+    run_eversolar_parser();
+    run_eversolar_driver();
+    return UNITY_END();
+}

--- a/test/test_modbus/client.cpp
+++ b/test/test_modbus/client.cpp
@@ -17,8 +17,6 @@ using namespace heliograph;
 using namespace heliograph::modbus;
 using heliograph::test::MockTransport;
 
-void setUp() {}
-void tearDown() {}
 
 namespace {
 
@@ -194,8 +192,7 @@ static void test_a_zero_length_read_is_refused() {
     TEST_ASSERT_TRUE(t.writes.empty());
 }
 
-int main(int, char**) {
-    UNITY_BEGIN();
+void run_modbus_client() {
     RUN_TEST(test_a_good_reply_decodes);
     RUN_TEST(test_an_exception_reports_its_code);
     RUN_TEST(test_silence_is_a_timeout);
@@ -206,5 +203,4 @@ int main(int, char**) {
     RUN_TEST(test_a_reply_with_too_few_registers_is_refused);
     RUN_TEST(test_a_reply_with_exactly_the_requested_count_is_ok);
     RUN_TEST(test_a_zero_length_read_is_refused);
-    return UNITY_END();
 }

--- a/test/test_modbus/rtu.cpp
+++ b/test/test_modbus/rtu.cpp
@@ -12,8 +12,6 @@
 
 using namespace heliograph::modbus;
 
-void setUp() {}
-void tearDown() {}
 
 // --- CRC ----------------------------------------------------------------------------------
 
@@ -242,8 +240,7 @@ static void test_write_exception_is_reported() {
     TEST_ASSERT_EQUAL_HEX8(0x04, resp.exceptionCode);
 }
 
-int main(int, char**) {
-    UNITY_BEGIN();
+void run_modbus_rtu() {
     RUN_TEST(test_crc_matches_the_canonical_vector);
     RUN_TEST(test_crc_second_vector);
     RUN_TEST(test_read_request_is_framed_low_crc_byte_first);
@@ -262,5 +259,4 @@ int main(int, char**) {
     RUN_TEST(test_registers_overflowing_the_caller_buffer_are_refused);
     RUN_TEST(test_write_single_echo_is_validated);
     RUN_TEST(test_write_exception_is_reported);
-    return UNITY_END();
 }

--- a/test/test_modbus/test_main.cpp
+++ b/test/test_modbus/test_main.cpp
@@ -1,0 +1,17 @@
+// One binary for the Modbus family — the RTU framing codec and the client — so the shared src/
+// is linked once here instead of once per former suite. Each sub-suite keeps its own translation
+// unit and its file-local statics; this file owns the single Unity setUp/tearDown/main.
+#include <unity.h>
+
+void run_modbus_rtu();
+void run_modbus_client();
+
+void setUp() {}
+void tearDown() {}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    run_modbus_rtu();
+    run_modbus_client();
+    return UNITY_END();
+}

--- a/test/test_sunspec/driver.cpp
+++ b/test/test_sunspec/driver.cpp
@@ -16,8 +16,6 @@ using namespace heliograph;
 using heliograph::test::FakeSunspecDevice;
 using heliograph::test::MockTransport;
 
-void setUp() {}
-void tearDown() {}
 
 namespace {
 
@@ -390,8 +388,7 @@ static void test_the_driver_is_read_only() {
     TEST_ASSERT_EQUAL(CommandResult::Unsupported, d.execute(cmd));
 }
 
-int main(int, char**) {
-    UNITY_BEGIN();
+void run_sunspec_driver() {
     RUN_TEST(test_probe_identifies_the_device_from_the_common_model);
     RUN_TEST(test_the_whole_chain_is_mapped_not_just_the_usable_model);
     RUN_TEST(test_poll_publishes_scaled_readings);
@@ -411,5 +408,4 @@ int main(int, char**) {
     RUN_TEST(test_an_undecodable_model_counts_an_invalid_frame);
     RUN_TEST(test_a_silent_device_does_not_poll);
     RUN_TEST(test_the_driver_is_read_only);
-    return UNITY_END();
 }

--- a/test/test_sunspec/parser.cpp
+++ b/test/test_sunspec/parser.cpp
@@ -13,8 +13,6 @@
 
 using namespace heliograph::sunspec;
 
-void setUp() {}
-void tearDown() {}
 
 namespace {
 
@@ -170,8 +168,7 @@ static void test_common_model_too_short_is_refused() {
     TEST_ASSERT_FALSE(decodeCommon(b.data(), b.size(), id));
 }
 
-int main(int, char**) {
-    UNITY_BEGIN();
+void run_sunspec_parser() {
     RUN_TEST(test_model_ids);
     RUN_TEST(test_scale_factor_is_applied_with_its_sign);
     RUN_TEST(test_signed_points_decode_negative);
@@ -183,5 +180,4 @@ int main(int, char**) {
     RUN_TEST(test_a_truncated_block_is_refused);
     RUN_TEST(test_common_model_strings);
     RUN_TEST(test_common_model_too_short_is_refused);
-    return UNITY_END();
 }

--- a/test/test_sunspec/test_main.cpp
+++ b/test/test_sunspec/test_main.cpp
@@ -1,0 +1,17 @@
+// One binary for the SunSpec family — parser and driver — so the shared src/ is linked once
+// here instead of once per former suite. Each sub-suite keeps its own translation unit and its
+// file-local statics; this file owns the single Unity setUp/tearDown/main.
+#include <unity.h>
+
+void run_sunspec_parser();
+void run_sunspec_driver();
+
+void setUp() {}
+void tearDown() {}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    run_sunspec_parser();
+    run_sunspec_driver();
+    return UNITY_END();
+}


### PR DESCRIPTION
## Why
The native test run is slow because of **how many binaries** it builds, not how many assertions it runs. Each `test/` folder links its own executable against the same ~57 shared `src/` objects, so every suite costs ~0.8–2.0s **regardless of test count** — a 5-case suite (`test_boot_button`, 0.87s) costs about the same as a 121-case one (`test_rest`, 1.85s). The assertions themselves run in milliseconds.

Measured baseline: **730 cases across 27 binaries ≈ 36s**. Pruning test *cases* would barely move that — the lever is the binary count.

## What
Merge the three same-subsystem families that were split across seven binaries:

| Family | Was | Now | Cases |
|---|---|---|---|
| eversolar | `checksum` + `parser` + `driver` | `test_eversolar` | 100 |
| sunspec | `parser` + `driver` | `test_sunspec` | 30 |
| modbus | `rtu` + `client` | `test_modbus` | 28 |

Each sub-suite keeps its **own translation unit** (file-local statics and helpers untouched). The new `test_main.cpp` owns the single Unity `setUp`/`tearDown`/`main` allowed per binary and calls each sub-runner between one `UNITY_BEGIN`/`END`. The eversolar driver's fake-clock reset moved into `eversolar_driver_reset()`, called from the shared `setUp`.

## Result
- **7 binaries → 3**, **~5s off** the native suite, **zero coverage loss** — all 158 cases in these families still pass (full suite: 740/740, the extra 10 are `test_rate_limiter` from `main`).
- No test case removed or changed.
- This is the pattern for consolidating the rest (27 → ~6–8) if we want the bigger ~15–20s win — a separate decision (speed vs. per-suite isolation).

## Minor
Unity labels output lines with `test_main.cpp` (where `UNITY_BEGIN` runs) rather than the sub-file; the line number and the unique test name are still correct, so failures remain locatable.

Draft for review — I will not merge it.
