### PR TITLE
fix(web): the password dialog wiped what was being typed into it

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -250,11 +250,21 @@ const authCancelled=()=>({ok:false,status:0,cancelled:true,
 const httpWhy=r=>r.cancelled?'cancelled (admin password required)':'HTTP '+r.status;
 async function authFetch(url,opts={}){
   if(!sessionStorage.getItem('sb_auth')&&!await askAuth(false))return authCancelled();
+  // Which credentials THIS request is about to use, remembered for the 401 branch below.
+  const used=sessionStorage.getItem('sb_auth');
   let r=await fetch(url,{...opts,headers:{...(opts.headers||{}),...authHeader()}});
   if(r.status===401){
-    clearAuth();
-    // retry=true: the dialog explains that the username is a candidate too.
-    if(!await askAuth(true))return authCancelled();
+    // Only discard what this request actually used. Several tabs call authFetch from the same
+    // 5 s refresh, so two can be in flight with the same bad credentials at once: the first
+    // 401 prompts, the password is accepted and stored -- and then the second 401 arrives and
+    // used to clear those working credentials and ask for them all over again. Reads to the
+    // user as "I just signed in and it forgot". If they have already been replaced, retry with
+    // the new ones instead of prompting.
+    if(sessionStorage.getItem('sb_auth')===used){
+      clearAuth();
+      // retry=true: the dialog explains that the username is a candidate too.
+      if(!await askAuth(true))return authCancelled();
+    }
     r=await fetch(url,{...opts,headers:{...(opts.headers||{}),...authHeader()}});
   }
   if(r.status!==401)rememberUser();

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -174,9 +174,29 @@ function authHeader(){
 // `retry` is true when this prompt follows a 401. That case has to say so: a wrong USERNAME and
 // a wrong PASSWORD are now both possible and they fail identically, so an unexplained second
 // dialog reads as "bad password" and the user retypes the password forever.
+// Only ONE prompt may be in flight, and every later caller shares it.
+//
+// Without this the password box could not be filled in at all. refresh() runs on a 5 s timer and
+// calls loadLogs(), which calls authFetch, which calls this -- and the timer does not wait for
+// the dialog to be answered. So every five seconds a SECOND askAuth ran while the first was
+// still open, and its first act was to overwrite un.value and blank p.value: the user's typing
+// was wiped mid-word, forever. Two more consequences hid behind it -- d.onclose was reassigned,
+// orphaning the first promise so it never resolved, and showModal() on an already-open dialog
+// throws InvalidStateError.
+//
+// It bit the Logs tab specifically because Settings fetches its config once
+// (`!$('#cfgform').innerHTML`) while Logs re-fetches on every refresh. Reported from hardware
+// 2026-07-26: signing in on Settings first was the only way through.
+let authPrompt=null;
 async function askAuth(retry){
+  if(authPrompt){
+    // A later caller may know something the open prompt does not -- that the credentials were
+    // just refused. Surface that without touching the fields being typed into.
+    if(retry){const e=$('#autherr');if(e)e.style.display='block'}
+    return authPrompt;
+  }
   const remembered=sessionStorage.getItem('sb_user');
-  return new Promise(resolve=>{
+  authPrompt=new Promise(resolve=>{
     const d=$('#authdlg'),p=$('#authpw'),un=$('#authu'),err=$('#autherr');
     un.value=remembered||'admin';
     err.style.display=retry?'block':'none';
@@ -204,6 +224,10 @@ async function askAuth(retry){
     };
     d.showModal();
   });
+  // Cleared before the value is handed back, so the next 401 opens a fresh prompt rather than
+  // handing every future caller this one's answer. finally, not a plain assignment: a throw in
+  // showModal() must not leave the guard latched with no dialog on screen.
+  try{return await authPrompt}finally{authPrompt=null}
 }
 // Promotes the username that was just proven to work. Anything else stays pending, so the next
 // prompt offers the last name the device actually accepted rather than the last one typed.

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -57,6 +57,7 @@ def main() -> int:
                 script = path.read_text()
                 status |= check_version_compare(script, scratch)
                 status |= check_auth_prompt_reentrancy(script, scratch)
+                status |= check_auth_fetch_race(script, scratch)
     return status
 
 
@@ -103,8 +104,25 @@ def extract_function(source, name):
         start = source.find(f"function {name}(")
     if start < 0:
         return None
+    # Walk the PARAMETER LIST to its closing paren first, then take the brace after it.
+    # Starting the brace match at the first `{` after the name is wrong for a default argument
+    # that is an object: `authFetch(url,opts={})` closed depth on the `}` of `{}` and returned
+    # a function cut off at its own signature, which node then reported as a syntax error two
+    # lines further down -- reading as "the page is broken" rather than "the extractor is".
     depth = 0
-    for i in range(source.index("{", start), len(source)):
+    body_start = None
+    for i in range(source.index("(", start), len(source)):
+        if source[i] == "(":
+            depth += 1
+        elif source[i] == ")":
+            depth -= 1
+            if depth == 0:
+                body_start = source.index("{", i)
+                break
+    if body_start is None:
+        return None
+    depth = 0
+    for i in range(body_start, len(source)):
         if source[i] == "{":
             depth += 1
         elif source[i] == "}":
@@ -220,6 +238,75 @@ const fail = m => {{ console.error(m); bad++; }};
     path.write_text(harness)
     result = subprocess.run(["node", str(path)], capture_output=True, text=True)
     print(f"auth prompt re-entrancy: {'OK' if result.returncode == 0 else 'FAIL'}")
+    if result.returncode != 0:
+        print(result.stdout + result.stderr)
+        return 1
+    return 0
+
+
+def check_auth_fetch_race(script, scratch):
+    """A late 401 must not throw away credentials another caller just got accepted.
+
+    Same root cause as the prompt bug: several tabs call authFetch from one 5 s refresh, so two
+    requests can be in flight carrying the same stale credentials. The first 401 prompts, the
+    password is accepted and stored -- and the second 401, arriving after, used to clear it and
+    prompt again. To the user that is "I just signed in and it forgot".
+    """
+    parts = []
+    for fn in ("authFetch", "askAuth"):
+        body = extract_function(script, fn)
+        if body is None:
+            print(f"FAIL: {fn}() not found in index_html.h; this check needs updating")
+            return 1
+        parts.append(body)
+    harness = (
+        """
+const store = {};
+const sessionStorage = {getItem:k=>k in store?store[k]:null, setItem:(k,v)=>{store[k]=v},
+                        removeItem:k=>{delete store[k]}};
+const authHeader = () => store['sb_auth'] ? {'Authorization':'Basic '+store['sb_auth']} : {};
+const clearAuth = () => { delete store['sb_auth'] };
+const rememberUser = () => {};
+const authCancelled = () => ({ok:false,status:0,cancelled:true});
+const btoa = s => Buffer.from(s, 'binary').toString('base64');
+let authPrompt = null;
+let prompts = 0;
+
+// The dialog is not exercised here; askAuth is replaced so the race is the only variable.
+const realAskAuth = null;
+"""
+        + parts[0]
+        + """
+async function askAuth(retry){ prompts++; store['sb_auth'] = 'GOOD'; return true; }
+
+// 401 for anything that is not the good token; 200 once it is.
+let served = [];
+const fetch = async (url, opts) => {
+  const auth = (opts.headers||{})['Authorization'] || '';
+  served.push(auth);
+  return {status: auth === 'Basic GOOD' ? 200 : 401, ok: auth === 'Basic GOOD'};
+};
+
+let bad = 0;
+const fail = m => { console.error(m); bad++; };
+
+(async () => {
+  // Both callers start with the same stale credentials, exactly as two tabs on one refresh do.
+  store['sb_auth'] = 'STALE';
+  const [a, b] = await Promise.all([authFetch('/api/v1/logs'), authFetch('/api/v1/diagnostics')]);
+
+  if (!a.ok || !b.ok) fail(`both callers should end up authorised, got ${a.status} and ${b.status}`);
+  if (store['sb_auth'] !== 'GOOD') fail('the accepted credentials were cleared again: ' + store['sb_auth']);
+  if (prompts !== 1) fail(`the user was asked ${prompts} times; once is enough`);
+
+  process.exit(bad === 0 ? 0 : 1);
+})();
+"""
+    )
+    path = pathlib.Path(scratch) / "auth_fetch_race.js"
+    path.write_text(harness)
+    result = subprocess.run(["node", str(path)], capture_output=True, text=True)
+    print(f"auth fetch race: {'OK' if result.returncode == 0 else 'FAIL'}")
     if result.returncode != 0:
         print(result.stdout + result.stderr)
         return 1

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -54,7 +54,9 @@ def main() -> int:
                 status = 1
                 continue
             if name.endswith("index_html.h"):
-                status |= check_version_compare(path.read_text(), scratch)
+                script = path.read_text()
+                status |= check_version_compare(script, scratch)
+                status |= check_auth_prompt_reentrancy(script, scratch)
     return status
 
 
@@ -90,8 +92,15 @@ VERSION_CASES = [
 
 
 def extract_function(source, name):
-    """Pulls one top-level `function name(...){...}` out by brace matching."""
-    start = source.find(f"function {name}(")
+    """Pulls one top-level `function name(...){...}` out by brace matching.
+
+    Keeps an `async` prefix when there is one -- without it the extracted body still contains
+    `await` and node refuses to parse it, which would read as "the check is broken" rather than
+    "the function is async".
+    """
+    start = source.find(f"async function {name}(")
+    if start < 0:
+        start = source.find(f"function {name}(")
     if start < 0:
         return None
     depth = 0
@@ -132,6 +141,85 @@ process.exit(bad === 0 ? 0 : 1);
     path.write_text(harness)
     result = subprocess.run(["node", str(path)], capture_output=True, text=True)
     print(f"version comparison: {'OK' if result.returncode == 0 else 'FAIL'}")
+    if result.returncode != 0:
+        print(result.stdout + result.stderr)
+        return 1
+    return 0
+
+
+def check_auth_prompt_reentrancy(script, scratch):
+    """A second askAuth() while one is open must not disturb what is being typed.
+
+    refresh() runs on a 5 s timer and several tabs call authFetch from it, so a second prompt
+    IS requested while the first is still open -- that is normal operation, not an edge case.
+    Until 0.15.2 the second call reset the username field and blanked the password field, so
+    on the Logs tab the box emptied itself every five seconds and could not be filled in at
+    all (reported from hardware 2026-07-26). Asserted here rather than left to review because
+    the failure needs a stopwatch and an unauthenticated session to see by hand.
+    """
+    body = extract_function(script, "askAuth")
+    if body is None:
+        print("FAIL: askAuth() not found in index_html.h; this check needs updating")
+        return 1
+    harness = f"""
+// Minimal DOM: only what askAuth touches.
+const els = {{
+  '#authdlg': {{returnValue:'', onclose:null, open:false,
+                showModal(){{ if(this.open) throw new Error('InvalidStateError'); this.open=true }},
+                close(v){{ this.open=false; this.returnValue=v; this.onclose && this.onclose() }}}},
+  '#authpw': {{value:''}}, '#authu': {{value:''}}, '#autherr': {{style:{{display:'none'}}}},
+}};
+const $ = s => els[s];
+const store = {{}};
+const sessionStorage = {{getItem:k=>k in store?store[k]:null, setItem:(k,v)=>{{store[k]=v}},
+                         removeItem:k=>{{delete store[k]}}}};
+const btoa = s => Buffer.from(s, 'binary').toString('base64');
+let authPrompt = null;
+{body}
+
+let bad = 0;
+const fail = m => {{ console.error(m); bad++; }};
+
+(async () => {{
+  const first = askAuth(false);
+  await null;                       // let the prompt open
+  // The user starts typing.
+  $('#authu').value = 'beheerder';
+  $('#authpw').value = 'halfway-typed';
+
+  // The 5 s refresh fires while they are mid-word.
+  const second = askAuth(false);
+  await null;
+
+  if ($('#authpw').value !== 'halfway-typed') fail('password field was wiped by a second askAuth');
+  if ($('#authu').value !== 'beheerder') fail('username field was reset by a second askAuth');
+  if (!$('#authdlg').open) fail('dialog was closed by a second askAuth');
+
+  // A third, this time signalling a refusal: allowed to show the error, not to touch the fields.
+  askAuth(true);
+  await null;
+  if ($('#authpw').value !== 'halfway-typed') fail('retry=true wiped the password field');
+
+  // Finishing the dialog must resolve EVERY waiter, not only the last one.
+  $('#authdlg').close('ok');
+  const results = await Promise.all([first, second]);
+  if (!results.every(r => r === true)) fail('not every caller received the answer: ' + JSON.stringify(results));
+  if (store['sb_auth'] !== btoa('beheerder:halfway-typed')) fail('wrong credentials stored: ' + store['sb_auth']);
+
+  // And the guard must release, so a later 401 can prompt again.
+  const later = askAuth(false);
+  await null;
+  if (!$('#authdlg').open) fail('a later askAuth did not reopen the dialog');
+  $('#authdlg').close('');
+  await later;
+
+  process.exit(bad === 0 ? 0 : 1);
+}})();
+"""
+    path = pathlib.Path(scratch) / "auth_prompt.js"
+    path.write_text(harness)
+    result = subprocess.run(["node", str(path)], capture_output=True, text=True)
+    print(f"auth prompt re-entrancy: {'OK' if result.returncode == 0 else 'FAIL'}")
     if result.returncode != 0:
         print(result.stdout + result.stderr)
         return 1


### PR DESCRIPTION
Found on hardware while testing 0.15.1: **the Logs tab's password box could not be filled in at all.** Typing a password takes longer than five seconds, and every five seconds the field emptied itself.

## Cause

`refresh()` runs on a 5 s timer and calls `loadLogs()` → `authFetch` → `askAuth`. The timer does not wait for the dialog to be answered, so a second `askAuth` runs while the first is still open — and its first three statements are:

```js
un.value=remembered||'admin';
err.style.display=retry?'block':'none';
p.value='';
```

Two further failures hid behind that one:

- `d.onclose` was reassigned each time, orphaning the first promise so it never resolved
- `showModal()` on an already-open dialog throws `InvalidStateError` — *after* the fields were cleared

The existing `logsAuthStop` latch does not help: it only engages once a 401 has come back, and this happens while the very first prompt is still open.

## Why the Logs tab specifically

Settings fetches its config once (`!$('#cfgform').innerHTML`), so its prompt is never re-requested and survives. Logs re-fetches on every refresh. Signing in on Settings first and letting `sessionStorage` carry the credentials to Logs was the only way through — which is exactly how it was found.

## Fix

`askAuth` serves one prompt at a time and hands every later caller the same pending promise. A `retry=true` arriving while a prompt is open still surfaces the "not accepted" line — that is information the open dialog does not have — but touches nothing being typed. The guard clears in a `finally`, so a throw cannot latch it with no dialog on screen.

## Test

`check_web_js.py` grows an eighth check that drives the real `askAuth` against a stub DOM: type into the fields, fire a second and a third prompt, assert nothing was disturbed, then assert every waiter resolves and the guard releases so a later 401 can prompt again.

Confirmed it fails on the pre-fix code — all three field assertions plus the `InvalidStateError`:

```
auth prompt re-entrancy: FAIL
password field was wiped by a second askAuth
username field was reset by a second askAuth
retry=true wiped the password field
Error: InvalidStateError
```

`extract_function()` now keeps an `async` prefix; without it the extracted body still contains `await` and node refuses to parse it.

## Verification

Firmware builds; ruff, layering 8/8, and all four web-JS checks pass. No firmware-side change — this is entirely in the embedded page.
