### PR TITLE
feat: static IP addressing (#61)

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -180,7 +180,8 @@ authenticate must ask the user for it rather than read it back; the factory valu
 
 ```json
 {
-  "wifi":  { "ssid": "thuis", "password_set": true },
+  "wifi":  { "ssid": "thuis", "password_set": true,
+             "ip": "", "gateway": "", "subnet": "", "dns1": "", "dns2": "" },
   "mqtt":  { "host": "10.0.0.5", "port": 1883, "username_set": true, "password_set": true },
   "modbus": { "enabled": true, "port": 502, "unit_id": 1, "write_enabled": false },
   "polling": { "interval_seconds": 10 },
@@ -191,6 +192,34 @@ authenticate must ask the user for it rather than read it back; the factory valu
   "logging": { "level": "info" }
 }
 ```
+
+## Addressing
+
+`wifi.ip` empty means DHCP, and that is the whole switch — there is no separate enable flag.
+Setting it makes the other four fields meaningful; clearing it must clear them too, or the
+`PATCH` is refused rather than storing a half-configuration that reads as if it were in effect.
+
+`GET /api/v1/status` reports both `bridge.ip_mode` (`"dhcp"` or `"static"` — how the address was
+**asked for**) and `bridge.ip_address` (what the interface **ended up with**, absent while none
+has been assigned). They are separate on purpose: on a bridge whose static address the driver
+refused, they disagree, and that disagreement is the only visible sign of it.
+
+Changing any addressing field needs a restart, like the rest of the network settings.
+
+**A wrong static address does not fail loudly.** The association still succeeds — WiFi is layer 2
+and addressing is layer 3 — so the bridge joins the network and is simply unreachable. `PATCH`
+therefore refuses everything it can see from here: anything that is not four decimal octets, a
+mask with a hole in it or not starting at 255, an address naming the network or the broadcast, a
+gateway outside the subnet or equal to our own, and leftover fields after the address was
+cleared. Two more rules exist because their failure is silent rather than loud:
+
+- a static address with **no DNS server** while an NTP server or MQTT broker is configured by
+  name — the stack would resolve nothing, the clock would never sync, and nothing would say so
+- a static address with NTP enabled and **no `ntp.server`**, even with `ntp.use_dhcp` on: there
+  is no lease to provide one
+
+What no check can know is whether the address is already taken. If a bridge does go missing,
+hold BOOT for five seconds to factory-reset and start again from the setup portal.
 
 `PATCH` accepts `"password": "..."` / `"username": "..."` to set either. An omitted field stays
 unchanged. Credentials never appear in logs, in SSE, in MQTT, or in Prometheus.

--- a/platformio.ini
+++ b/platformio.ini
@@ -97,6 +97,7 @@ build_src_filter =
     +<config/configuration_store.cpp>
     +<config/config_backup.cpp>
     +<network/provisioning_policy.cpp>
+    +<network/ipv4.cpp>
     +<network/rtc_time.cpp>
     +<network/wifi_manager.cpp>
     +<config/nvs_backend.cpp>

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -4,11 +4,13 @@
 
 #include "config_sections.h"
 #include "json_limits.h"
+#include "network/ipv4.h"
 #include "relays/drm.h"
 
 #include <ArduinoJson.h>
 
 #include <algorithm>
+#include <functional>
 #include <limits>
 #include <cstdlib>
 #include <cstring>
@@ -136,6 +138,108 @@ bool checkLength(const std::string& value, size_t max, const char* field, Config
     if (value.size() > max) {
         error = {field, "must be at most " + std::to_string(max) + " characters"};
         return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+namespace {
+
+/// Every way a static address can be wrong that we can see from here.
+///
+/// This is the cheapest place in the whole system to catch these, and the most expensive place
+/// to miss them: a refusal at PATCH time costs the operator a corrected form, while a stored
+/// mistake costs a bridge that never comes back and a walk to wherever it is mounted. So the
+/// rules are deliberately strict, and each one refuses a configuration that would have been
+/// accepted, stored, and then silently unreachable.
+bool validateStaticIp(const Configuration& config, ConfigError& error) {
+    const auto& w = config.wifi;
+
+    // DHCP: the address fields must be empty too. Leaving a gateway behind after clearing the
+    // address stores a half-configuration that reads as if it were in effect.
+    if (!w.staticIp()) {
+        for (const auto& [value, field] :
+             {std::pair{std::cref(w.gateway), "wifi.gateway"},
+              std::pair{std::cref(w.subnet), "wifi.subnet"},
+              std::pair{std::cref(w.dns1), "wifi.dns1"},
+              std::pair{std::cref(w.dns2), "wifi.dns2"}}) {
+            if (!value.get().empty()) {
+                error = {field, "must be empty when wifi.ip is empty (DHCP)"};
+                return false;
+            }
+        }
+        return true;
+    }
+
+    uint32_t ip = 0, gateway = 0, subnet = 0;
+    if (!net::parseIpv4(w.ip, ip)) {
+        error = {"wifi.ip", "must be four decimal octets, for example 192.168.1.50"};
+        return false;
+    }
+    if (!net::parseIpv4(w.gateway, gateway)) {
+        error = {"wifi.gateway", "required with a static address, as four decimal octets"};
+        return false;
+    }
+    if (!net::parseIpv4(w.subnet, subnet)) {
+        error = {"wifi.subnet", "required with a static address, for example 255.255.255.0"};
+        return false;
+    }
+    // A mask with a hole in it is not something anyone means to type, and lwip's behaviour with
+    // one is not worth discovering in production. This ALSO covers a trap in the Arduino core:
+    // WiFiSTAClass::config() silently reinterprets its arguments as the ESP8266 ordering
+    // (ip, dns, gw, subnet) when the mask's first octet is not 255 -- so an unusual mask does
+    // not fail, it configures something else entirely. Every contiguous mask from /1 to /31
+    // that is worth using starts with 255; /1..7 do not, and are refused here as well.
+    if (!net::isContiguousMask(subnet) || (subnet >> 24) != 0xFFu) {
+        error = {"wifi.subnet", "must be a contiguous mask starting at 255, for example "
+                                "255.255.255.0"};
+        return false;
+    }
+    if (net::isNetworkAddress(ip, subnet)) {
+        error = {"wifi.ip", "names the network, not a host on it"};
+        return false;
+    }
+    if (net::isBroadcastAddress(ip, subnet)) {
+        error = {"wifi.ip", "is the broadcast address, not a host"};
+        return false;
+    }
+    if (!net::sameSubnet(ip, gateway, subnet)) {
+        error = {"wifi.gateway", "is not reachable from wifi.ip with this subnet mask"};
+        return false;
+    }
+    if (ip == gateway) {
+        error = {"wifi.ip", "is the same as wifi.gateway"};
+        return false;
+    }
+    uint32_t dns = 0;
+    for (const auto& [value, field] : {std::pair{std::cref(w.dns1), "wifi.dns1"},
+                                       std::pair{std::cref(w.dns2), "wifi.dns2"}}) {
+        if (!value.get().empty() && !net::parseIpv4(value.get(), dns)) {
+            error = {field, "must be four decimal octets"};
+            return false;
+        }
+    }
+
+    // The rule that keeps a static bridge from being quietly half-dead.
+    //
+    // With no DNS server the stack resolves nothing. The bridge still boots, still answers on
+    // its address, and still looks healthy -- while NTP never syncs and an MQTT broker named
+    // rather than numbered is never found. Nothing throws; the clock simply stays wrong and the
+    // logs stay stamped from uptime. Refusing here is the only point at which anyone is looking.
+    if (w.dns1.empty() && w.dns2.empty()) {
+        if (config.ntp.enabled && !config.ntp.server.empty() &&
+            !net::looksLikeIpLiteral(config.ntp.server)) {
+            error = {"wifi.dns1", "required: ntp.server is a name (" + config.ntp.server +
+                                      ") and a static address has no other resolver"};
+            return false;
+        }
+        if (config.mqtt.enabled && !config.mqtt.host.empty() &&
+            !net::looksLikeIpLiteral(config.mqtt.host)) {
+            error = {"wifi.dns1", "required: mqtt.host is a name (" + config.mqtt.host +
+                                      ") and a static address has no other resolver"};
+            return false;
+        }
     }
     return true;
 }
@@ -303,6 +407,9 @@ bool validate(const Configuration& config, ConfigError& error) {
         error = {"ntp.server", "required when ntp is enabled and dhcp is off"};
         return false;
     }
+    if (!validateStaticIp(config, error)) {
+        return false;
+    }
     return true;
 }
 
@@ -315,6 +422,14 @@ void writeCommon(JsonDocument& doc, const Configuration& config) {
     JsonObject wifi  = doc["wifi"].to<JsonObject>();
     wifi["ssid"]     = config.wifi.ssid;
     wifi["hostname"] = config.wifi.hostname;
+    // Addressing is not a credential, so it is the same in both documents. Always emitted,
+    // empty or not: a client has to be able to tell "this bridge uses DHCP" from "this firmware
+    // has no idea about static addressing", and an absent key says only the second.
+    wifi["ip"]      = config.wifi.ip;
+    wifi["gateway"] = config.wifi.gateway;
+    wifi["subnet"]  = config.wifi.subnet;
+    wifi["dns1"]    = config.wifi.dns1;
+    wifi["dns2"]    = config.wifi.dns2;
 
     JsonObject mqtt           = doc["mqtt"].to<JsonObject>();
     mqtt["enabled"]           = config.mqtt.enabled;
@@ -433,7 +548,13 @@ bool configChangeRequiresReboot(const Configuration& a, const Configuration& b) 
     // it). timezone_name and write_enabled carry no runtime effect. This set mirrors
     // RESTART_NEEDED in the web UI.
     return a.wifi.ssid != b.wifi.ssid || a.wifi.password != b.wifi.password ||
-           a.wifi.hostname != b.wifi.hostname || a.mqtt.enabled != b.mqtt.enabled ||
+           a.wifi.hostname != b.wifi.hostname ||
+           // Addressing is applied once, between WiFi.mode() and WiFi.begin(). Changing it
+           // live would mean tearing down every listening socket underneath the request that
+           // asked for the change, so it waits for a restart like the rest of this list.
+           a.wifi.ip != b.wifi.ip || a.wifi.gateway != b.wifi.gateway ||
+           a.wifi.subnet != b.wifi.subnet || a.wifi.dns1 != b.wifi.dns1 ||
+           a.wifi.dns2 != b.wifi.dns2 || a.mqtt.enabled != b.mqtt.enabled ||
            a.mqtt.host != b.mqtt.host || a.mqtt.port != b.mqtt.port ||
            a.mqtt.username != b.mqtt.username || a.mqtt.password != b.mqtt.password ||
            a.mqtt.baseTopic != b.mqtt.baseTopic ||
@@ -483,6 +604,13 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
         if (!patchString(wifi["ssid"], merged.wifi.ssid, "wifi.ssid", error)) return false;
         if (!patchString(wifi["hostname"], merged.wifi.hostname, "wifi.hostname", error)) return false;
         if (!patchSecret(wifi, "password", merged.wifi.password, "wifi.password", error)) return false;
+        // Plain strings, not secrets: an empty one means "no static address" and is a value the
+        // operator can legitimately send to go back to DHCP. validate() checks the combination.
+        if (!patchString(wifi["ip"], merged.wifi.ip, "wifi.ip", error)) return false;
+        if (!patchString(wifi["gateway"], merged.wifi.gateway, "wifi.gateway", error)) return false;
+        if (!patchString(wifi["subnet"], merged.wifi.subnet, "wifi.subnet", error)) return false;
+        if (!patchString(wifi["dns1"], merged.wifi.dns1, "wifi.dns1", error)) return false;
+        if (!patchString(wifi["dns2"], merged.wifi.dns2, "wifi.dns2", error)) return false;
     }
 
     if (JsonObjectConst mqtt = doc["mqtt"]; !mqtt.isNull()) {

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -221,6 +221,20 @@ bool validateStaticIp(const Configuration& config, ConfigError& error) {
         }
     }
 
+    // There is no DHCP on a static address, so ntp.use_dhcp cannot supply anything.
+    //
+    // esp_sntp_servermode_dhcp() puts the lease-provided server at index 0 and the configured
+    // one at index 1 as fallback. With no lease, index 0 is never filled -- and if ntp.server is
+    // empty, index 1 is never set either. The result is NTP enabled with no server at all: the
+    // clock never syncs, every log line stays stamped from uptime, and nothing reports an error.
+    // The DHCP path is allowed to leave the server empty precisely because the lease covers it;
+    // that reasoning does not survive here.
+    if (config.ntp.enabled && config.ntp.server.empty()) {
+        error = {"ntp.server", "required with a static address: there is no DHCP lease to "
+                               "provide one"};
+        return false;
+    }
+
     // The rule that keeps a static bridge from being quietly half-dead.
     //
     // With no DNS server the stack resolves nothing. The bridge still boots, still answers on

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -30,6 +30,21 @@ struct WifiConfig {
     std::string ssid;
     std::string password;  ///< never serialised, never logged
     std::string hostname = "heliograph";
+
+    /// Static addressing. An empty `ip` means DHCP, and that is the whole switch -- there is no
+    /// separate enable flag, because a flag and an address can disagree and then something has
+    /// to decide which one wins while the operator is looking at the other.
+    ///
+    /// Kept as text rather than packed integers to match the rest of the config model, to make
+    /// a backup file readable, and because "what did I type" is the question an operator asks
+    /// when a bridge does not come back. validate() refuses anything that does not parse.
+    std::string ip;
+    std::string gateway;
+    std::string subnet;
+    std::string dns1;
+    std::string dns2;
+
+    bool staticIp() const { return !ip.empty(); }
 };
 
 struct MqttSettings {

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -161,6 +161,11 @@ LoadResult deserializeConfigFromStorage(const std::string& json, Configuration& 
         if (wifi["ssid"].is<const char*>())     parsed.wifi.ssid     = wifi["ssid"].as<const char*>();
         if (wifi["password"].is<const char*>()) parsed.wifi.password = wifi["password"].as<const char*>();
         if (wifi["hostname"].is<const char*>()) parsed.wifi.hostname = wifi["hostname"].as<const char*>();
+        if (wifi["ip"].is<const char*>())       parsed.wifi.ip       = wifi["ip"].as<const char*>();
+        if (wifi["gateway"].is<const char*>())  parsed.wifi.gateway  = wifi["gateway"].as<const char*>();
+        if (wifi["subnet"].is<const char*>())   parsed.wifi.subnet   = wifi["subnet"].as<const char*>();
+        if (wifi["dns1"].is<const char*>())     parsed.wifi.dns1     = wifi["dns1"].as<const char*>();
+        if (wifi["dns2"].is<const char*>())     parsed.wifi.dns2     = wifi["dns2"].as<const char*>();
     }
     if (JsonObjectConst mqtt = doc["mqtt"]; !mqtt.isNull()) {
         if (mqtt["enabled"].is<bool>())            parsed.mqtt.enabled = mqtt["enabled"].as<bool>();

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -43,6 +43,15 @@ struct BridgeInfo {
 
     bool    wifiConnected  = false;
     int16_t wifiRssiDbm    = 0;
+    /// The address in use, and how it was obtained.
+    ///
+    /// Both, because they answer different questions. `ipAddress` is what the interface ended
+    /// up with; `staticIp` is what was asked for. On a bridge that was configured static and
+    /// fell back -- or whose static address was refused by the driver -- those disagree, and
+    /// that disagreement is the only visible sign of it. Reporting only the configuration would
+    /// state an intention as if it were a fact.
+    std::string ipAddress;
+    bool        staticIp = false;
     bool    mqttConnected  = false;
     bool    modbusListening = false;
     uint16_t modbusClients  = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,6 +286,8 @@ BridgeInfo bridgeInfo() {
     info.resetReason      = static_cast<uint16_t>(esp_reset_reason());
     info.wifiConnected    = g_wifi.connected();
     info.wifiRssiDbm      = g_wifi.rssi();
+    info.ipAddress        = g_wifi.ipAddress();
+    info.staticIp         = g_config.wifi.staticIp();
     info.mqttConnected    = g_mqtt && g_mqtt->connected();
     info.modbusListening  = g_modbus.running();
     info.modbusClients    = g_modbus.activeClients();

--- a/src/network/ipv4.cpp
+++ b/src/network/ipv4.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+
+#include "ipv4.h"
+
+namespace heliograph::net {
+
+bool parseIpv4(const std::string& text, uint32_t& out) {
+    uint32_t addr   = 0;
+    size_t   i      = 0;
+    const size_t n  = text.size();
+    for (int octet = 0; octet < 4; ++octet) {
+        if (octet > 0) {
+            if (i >= n || text[i] != '.') return false;
+            ++i;
+        }
+        if (i >= n || text[i] < '0' || text[i] > '9') return false;
+        // A leading zero is refused rather than accepted-and-decimal. "010" is octal to some
+        // tools and decimal to others; a config that means different things to different
+        // readers is exactly what this module exists to prevent.
+        const bool leadingZero = text[i] == '0';
+        uint32_t   value       = 0;
+        size_t     digits      = 0;
+        while (i < n && text[i] >= '0' && text[i] <= '9') {
+            value = value * 10 + static_cast<uint32_t>(text[i] - '0');
+            if (value > 255) return false;
+            ++i;
+            ++digits;
+        }
+        if (digits > 1 && leadingZero) return false;
+        addr = (addr << 8) | value;
+    }
+    if (i != n) return false;  // trailing text, including a trailing dot or a port
+    out = addr;
+    return true;
+}
+
+std::string formatIpv4(uint32_t addr) {
+    std::string out;
+    out.reserve(15);
+    for (int shift = 24; shift >= 0; shift -= 8) {
+        if (shift != 24) out.push_back('.');
+        out += std::to_string((addr >> shift) & 0xFFu);
+    }
+    return out;
+}
+
+bool isContiguousMask(uint32_t mask) {
+    // Ones then zeros: the complement plus one must be a power of two. 0.0.0.0 is not a usable
+    // mask here (it would put every address in one subnet and defeat every check below), and
+    // 255.255.255.255 leaves no host addresses at all.
+    if (mask == 0 || mask == 0xFFFFFFFFu) return false;
+    const uint32_t inverted = ~mask;
+    return (inverted & (inverted + 1)) == 0;
+}
+
+uint8_t maskPrefixLength(uint32_t mask) {
+    uint8_t bits = 0;
+    while (mask & 0x80000000u) {
+        ++bits;
+        mask <<= 1;
+    }
+    return bits;
+}
+
+bool sameSubnet(uint32_t a, uint32_t b, uint32_t mask) { return (a & mask) == (b & mask); }
+
+bool isNetworkAddress(uint32_t addr, uint32_t mask) { return (addr & ~mask) == 0; }
+
+bool isBroadcastAddress(uint32_t addr, uint32_t mask) { return (addr & ~mask) == (~mask); }
+
+bool looksLikeIpLiteral(const std::string& text) {
+    uint32_t ignored = 0;
+    return parseIpv4(text, ignored);
+}
+
+}  // namespace heliograph::net

--- a/src/network/ipv4.h
+++ b/src/network/ipv4.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+//
+// IPv4 text and subnet arithmetic, with no network stack behind it.
+//
+// Exists as its own module because static-IP configuration is validated in config/ (where the
+// settings are checked before they are stored) and applied in network/ (where they reach the
+// WiFi driver), and both need exactly the same notion of what a valid address is. Pure, so the
+// rules that decide whether a bridge will still be reachable after a reboot are host-tested
+// rather than discovered on a roof.
+//
+// STRICT ON PURPOSE. inet_aton() and friends accept "10.1" as 10.0.0.1, treat a leading zero as
+// octal, and shrug at trailing text. Every one of those is a way for an operator to type
+// something that reads like the address they meant and configures a different one -- and the
+// symptom is a bridge that never comes back. Only four decimal octets, nothing else.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace heliograph::net {
+
+/// Parses dotted-quad IPv4 into host byte order. False on anything that is not exactly four
+/// decimal octets in 0..255: no shorthand, no leading zeros, no whitespace, no trailing text.
+bool parseIpv4(const std::string& text, uint32_t& out);
+
+std::string formatIpv4(uint32_t addr);
+
+/// True for a contiguous netmask -- a run of ones followed by a run of zeros. 255.255.255.0 and
+/// 255.255.254.0 yes; 255.0.255.0 no. A non-contiguous mask is not a mask anyone means to type,
+/// and lwip's behaviour with one is not something to find out in production.
+bool isContiguousMask(uint32_t mask);
+
+/// Prefix length of a contiguous mask (255.255.255.0 -> 24). Undefined for a non-contiguous one,
+/// so check first.
+uint8_t maskPrefixLength(uint32_t mask);
+
+bool sameSubnet(uint32_t a, uint32_t b, uint32_t mask);
+
+/// The all-zero host part: names the network, never a host.
+bool isNetworkAddress(uint32_t addr, uint32_t mask);
+/// The all-ones host part: the directed broadcast, never a host.
+bool isBroadcastAddress(uint32_t addr, uint32_t mask);
+
+/// Whether a configured host/server string is a literal address rather than a name.
+///
+/// Used for the rule that a static configuration with no DNS server must not be accepted while
+/// something is still configured by name -- see validate(). Deliberately the same strict parse:
+/// a string this rejects is treated as a NAME, which is the conservative direction (it demands
+/// a resolver rather than assuming none is needed).
+bool looksLikeIpLiteral(const std::string& text);
+
+}  // namespace heliograph::net

--- a/src/network/wifi_manager.cpp
+++ b/src/network/wifi_manager.cpp
@@ -193,6 +193,14 @@ void WifiManager::attemptConnect() {
     ++attempt_;
     attemptInFlight_  = true;
     attemptStartedMs_ = 0;  // set by loop() on the next tick
+    // Immediately before every begin(), not once at startup. Three paths reach an association:
+    // the first attempt, a back-off retry, and the return from the setup portal -- and that last
+    // one goes through stopPortal()'s WiFi.mode(WIFI_STA), which may rebuild the STA netif and
+    // take the addressing with it. Applying it once in begin() left that to chance, and the way
+    // it fails is a static bridge quietly coming back on DHCP at a different address. Here the
+    // invariant is simply "the addressing is in place before every begin()", with no transition
+    // to reason about. config() is idempotent, and on a reconnect there is no lease to disturb.
+    applyAddressing();
     WiFi.begin(config_.wifi.ssid.c_str(), config_.wifi.password.c_str());
 }
 
@@ -232,7 +240,6 @@ void WifiManager::begin(const Configuration& config) {
     // The mode() call above initialised the network stack; DHCP has not run yet -- the
     // one safe moment for pre-lease lwip configuration (see setNetworkStackReadyHook).
     fireStackReadyHook();
-    applyAddressing();
     state_ = ProvisioningState::Connecting;
     attemptConnect();
 }

--- a/src/network/wifi_manager.cpp
+++ b/src/network/wifi_manager.cpp
@@ -134,34 +134,46 @@ void WifiManager::startMdns() {
 /// after mode() for the same reason fireStackReadyHook() does -- the netif exists, DHCP has not
 /// run yet.
 ///
-/// The all-INADDR_NONE call is not a no-op and is not skipped: NetworkInterface::config() reads
-/// an all-zero address as "clear", stops the DHCP client, wipes the IP info, and then restarts
-/// the DHCP client. Calling it explicitly on the DHCP path makes a bridge that has just been
-/// switched back from a static address behave the same as one that never had one, without a
-/// reboot-shaped difference between them.
+/// NOT INADDR_NONE, AND THIS IS A TRAP WORTH THE PARAGRAPH. Every tutorial spells "go back to
+/// DHCP" as WiFi.config(INADDR_NONE, ...), and the Arduino layer does treat INADDR_NONE as its
+/// "unset" sentinel -- but lwip defines it as 0xFFFFFFFF, while the layer that actually decides,
+/// NetworkInterface::config(), clears and restarts the DHCP client only when the address is
+/// ZERO. Handing it INADDR_NONE therefore stops the DHCP client, configures 255.255.255.255 as
+/// a static address, and never starts DHCP again -- on the default path every bridge takes.
+/// Verified against core 3.3.9's own source, not inferred. All-zeroes is the form that reaches
+/// the clearing branch.
+///
+/// The call is made explicitly rather than skipped so a bridge that has just been switched back
+/// from a static address behaves the same as one that never had one, without a reboot-shaped
+/// difference between them.
 ///
 /// Nothing is validated here. validate() already refused everything that does not parse, and
 /// repeating the rules in a second place is how two answers to the same question appear.
 void WifiManager::applyAddressing() {
-    const auto& w = config_.wifi;
+    const auto&     w    = config_.wifi;
+    const IPAddress none(0, 0, 0, 0);
     if (!w.staticIp()) {
-        WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+        WiFi.config(none, none, none);
         log::info("net: DHCP");
         return;
     }
-    const auto toAddr = [](const std::string& text) {
+    uint32_t   maskRaw = 0;
+    const auto toAddr  = [&none](const std::string& text) {
         uint32_t raw = 0;
         if (!net::parseIpv4(text, raw)) {
-            return IPAddress(INADDR_NONE);
+            return none;  // unreachable: validate() refused anything that does not parse
         }
         // parseIpv4 yields host byte order, most significant octet first.
         return IPAddress((raw >> 24) & 0xFF, (raw >> 16) & 0xFF, (raw >> 8) & 0xFF, raw & 0xFF);
     };
+    net::parseIpv4(w.subnet, maskRaw);
     const IPAddress ip   = toAddr(w.ip);
     const IPAddress gw   = toAddr(w.gateway);
     const IPAddress mask = toAddr(w.subnet);
-    const IPAddress dns1 = w.dns1.empty() ? IPAddress(INADDR_NONE) : toAddr(w.dns1);
-    const IPAddress dns2 = w.dns2.empty() ? IPAddress(INADDR_NONE) : toAddr(w.dns2);
+    // An omitted DNS server is all-zeroes, which esp_netif reads as "none set" -- the same
+    // encoding the clearing path above relies on.
+    const IPAddress dns1 = w.dns1.empty() ? none : toAddr(w.dns1);
+    const IPAddress dns2 = w.dns2.empty() ? none : toAddr(w.dns2);
 
     if (!WiFi.config(ip, gw, mask, dns1, dns2)) {
         // Reported, then carried on with. A refusal here leaves the DHCP client running, which
@@ -169,16 +181,12 @@ void WifiManager::applyAddressing() {
         // only way anyone learns the address they configured is not the one in use.
         log::error("net: static address %s was refused by the driver; falling back to DHCP",
                    w.ip.c_str());
-        WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+        WiFi.config(none, none, none);
         return;
     }
     log::info("net: static %s/%u gw %s dns %s", w.ip.c_str(),
-              static_cast<unsigned>(net::maskPrefixLength([&] {
-                  uint32_t raw = 0;
-                  net::parseIpv4(w.subnet, raw);
-                  return raw;
-              }())),
-              w.gateway.c_str(), w.dns1.empty() ? "(none)" : w.dns1.c_str());
+              static_cast<unsigned>(net::maskPrefixLength(maskRaw)), w.gateway.c_str(),
+              w.dns1.empty() ? "(none)" : w.dns1.c_str());
 }
 
 void WifiManager::attemptConnect() {

--- a/src/network/wifi_manager.cpp
+++ b/src/network/wifi_manager.cpp
@@ -10,6 +10,7 @@
 #include <esp_mac.h>
 
 #include "diagnostics/logger.h"
+#include "network/ipv4.h"
 
 namespace heliograph {
 
@@ -125,6 +126,61 @@ void WifiManager::startMdns() {
     log::info("mdns: %s.local", config_.wifi.hostname.c_str());
 }
 
+/// Hands the addressing to the driver, before any association is attempted.
+///
+/// ORDER MATTERS AND IS NOT OPTIONAL. WiFi.config() must run before WiFi.begin(): the static
+/// address has to be in place when the association completes, or the DHCP client the stack
+/// starts by default wins the race and the configured address is never used. This sits right
+/// after mode() for the same reason fireStackReadyHook() does -- the netif exists, DHCP has not
+/// run yet.
+///
+/// The all-INADDR_NONE call is not a no-op and is not skipped: NetworkInterface::config() reads
+/// an all-zero address as "clear", stops the DHCP client, wipes the IP info, and then restarts
+/// the DHCP client. Calling it explicitly on the DHCP path makes a bridge that has just been
+/// switched back from a static address behave the same as one that never had one, without a
+/// reboot-shaped difference between them.
+///
+/// Nothing is validated here. validate() already refused everything that does not parse, and
+/// repeating the rules in a second place is how two answers to the same question appear.
+void WifiManager::applyAddressing() {
+    const auto& w = config_.wifi;
+    if (!w.staticIp()) {
+        WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+        log::info("net: DHCP");
+        return;
+    }
+    const auto toAddr = [](const std::string& text) {
+        uint32_t raw = 0;
+        if (!net::parseIpv4(text, raw)) {
+            return IPAddress(INADDR_NONE);
+        }
+        // parseIpv4 yields host byte order, most significant octet first.
+        return IPAddress((raw >> 24) & 0xFF, (raw >> 16) & 0xFF, (raw >> 8) & 0xFF, raw & 0xFF);
+    };
+    const IPAddress ip   = toAddr(w.ip);
+    const IPAddress gw   = toAddr(w.gateway);
+    const IPAddress mask = toAddr(w.subnet);
+    const IPAddress dns1 = w.dns1.empty() ? IPAddress(INADDR_NONE) : toAddr(w.dns1);
+    const IPAddress dns2 = w.dns2.empty() ? IPAddress(INADDR_NONE) : toAddr(w.dns2);
+
+    if (!WiFi.config(ip, gw, mask, dns1, dns2)) {
+        // Reported, then carried on with. A refusal here leaves the DHCP client running, which
+        // is the outcome most likely to keep the bridge reachable -- and the log line is the
+        // only way anyone learns the address they configured is not the one in use.
+        log::error("net: static address %s was refused by the driver; falling back to DHCP",
+                   w.ip.c_str());
+        WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+        return;
+    }
+    log::info("net: static %s/%u gw %s dns %s", w.ip.c_str(),
+              static_cast<unsigned>(net::maskPrefixLength([&] {
+                  uint32_t raw = 0;
+                  net::parseIpv4(w.subnet, raw);
+                  return raw;
+              }())),
+              w.gateway.c_str(), w.dns1.empty() ? "(none)" : w.dns1.c_str());
+}
+
 void WifiManager::attemptConnect() {
     ++attempt_;
     attemptInFlight_  = true;
@@ -168,6 +224,7 @@ void WifiManager::begin(const Configuration& config) {
     // The mode() call above initialised the network stack; DHCP has not run yet -- the
     // one safe moment for pre-lease lwip configuration (see setNetworkStackReadyHook).
     fireStackReadyHook();
+    applyAddressing();
     state_ = ProvisioningState::Connecting;
     attemptConnect();
 }
@@ -254,6 +311,7 @@ void        WifiManager::startPortal() { portalActive_ = true; }
 void        WifiManager::stopPortal() { portalActive_ = false; }
 void        WifiManager::startMdns() {}
 void        WifiManager::attemptConnect() {}
+void        WifiManager::applyAddressing() {}
 void        WifiManager::fireStackReadyHook() {}
 
 }  // namespace heliograph

--- a/src/network/wifi_manager.h
+++ b/src/network/wifi_manager.h
@@ -60,6 +60,9 @@ private:
     void stopPortal();
     void startMdns();
     void attemptConnect();
+    /// Applies wifi.ip/gateway/subnet/dns to the driver. Must run after WiFi.mode() and
+    /// before WiFi.begin(); see the definition for why that ordering is not negotiable.
+    void applyAddressing();
     void fireStackReadyHook();
     /// Captive-portal DNS: while the setup AP is up, every name resolves to us, so the
     /// phone's connectivity probe lands on our web server and the OS pops the setup page

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -86,6 +86,13 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     // downstream could otherwise tell a Relay-6CH image from an RS485-CAN one, and the wrong
     // one runs happily on the wrong pins.
     b["board_id"]           = bridge.boardId;
+    // What the interface HAS, and how it was asked for -- see BridgeInfo. Empty while the
+    // portal is up and nothing has been assigned yet, so it is omitted rather than reported
+    // as "" (the house rule: absent means "no answer", never a blank that reads like one).
+    if (!bridge.ipAddress.empty()) {
+        b["ip_address"] = bridge.ipAddress;
+    }
+    b["ip_mode"] = bridge.staticIp ? "static" : "dhcp";
     // A firmware constant, not configuration: the settings page needs it to stop offering an
     // "Add a device" button past the point the bridge would refuse the save.
     b["max_devices"]        = static_cast<unsigned>(kMaxDevices);

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1133,6 +1133,16 @@ function tzOptions(ntp){
   return h+`<option value="__custom" ${sel===null?'selected':''}>Custom (POSIX string)…</option>`;
 }
 window.tzToggle=()=>{$('#tzcustom').classList.toggle('hide',$('#c_ntptz').value!=='__custom')};
+// Hidden rather than disabled on DHCP: an empty field that is still on screen reads as "you may
+// fill this in", and on DHCP filling it in is exactly what validate() refuses. window.-scoped
+// like tzToggle, because it is called from an inline onchange.
+window.ipModeToggle=()=>{
+  const on=$('#c_ipmode').value==='static';
+  $('#c_ipfields').classList.toggle('hide',!on);
+  // A first switch to static lands on a blank form, and the mask is the one field nobody can
+  // guess from the others -- so offer the one almost every home network uses.
+  if(on&&!$('#c_sn').value)$('#c_sn').value='255.255.255.0';
+};
 
 // ---------------- Settings ----------------
 let cfgDrivers=null, cfgBefore=null;
@@ -1146,6 +1156,8 @@ const RESTART_NEEDED={
   'wifi.ssid':'WiFi network',
   'wifi.password':'WiFi password',
   'wifi.hostname':'Hostname',
+  'wifi.ip':'IP address','wifi.gateway':'Gateway','wifi.subnet':'Subnet mask',
+  'wifi.dns1':'DNS server','wifi.dns2':'Second DNS server',
   'mqtt.enabled':'MQTT on/off','mqtt.host':'MQTT broker','mqtt.port':'MQTT port',
   'mqtt.username':'MQTT username','mqtt.password':'MQTT password',
   'mqtt.base_topic':'MQTT base topic','mqtt.discovery_enabled':'Home Assistant discovery',
@@ -1405,6 +1417,27 @@ async function renderConfig(){
     <select id="c_ssidpick" style="display:none;margin-top:6px"
       onchange="if(this.value){document.querySelector('#c_ssid').value=this.value}"></select>
     ${pw('c_wpw','Password',c.wifi.password_set)}</div>
+  <div class="card"><b>Addressing</b> <span class="tag" style="font-weight:400">needs restart</span>
+    <label for="c_ipmode">How this bridge gets its address</label>
+    <select id="c_ipmode" onchange="ipModeToggle()">
+      <option value="dhcp"${c.wifi.ip?'':' selected'}>Automatic (DHCP)</option>
+      <option value="static"${c.wifi.ip?' selected':''}>Static</option>
+    </select>
+    <div class="dim" style="font-size:12px">DHCP suits almost everyone. Choose static when the
+    network has no DHCP server, or when something else refers to this bridge by a fixed
+    address.</div>
+    <div id="c_ipfields" class="${c.wifi.ip?'':'hide'}" style="margin-top:12px">
+      ${txt('c_ip','IP address',c.wifi.ip,'This bridge, for example 192.168.1.50.')}
+      ${txt('c_gw','Gateway',c.wifi.gateway,'Usually your router, and it must sit inside the same subnet as the address above.')}
+      ${txt('c_sn','Subnet mask',c.wifi.subnet||'255.255.255.0','255.255.255.0 unless your network says otherwise.')}
+      ${txt('c_dns1','DNS server',c.wifi.dns1,'Required as soon as anything here is configured by name — an NTP server or an MQTT broker. Without it the clock never syncs and nothing says so.')}
+      ${txt('c_dns2','Second DNS server (optional)',c.wifi.dns2)}
+      <div class="dim" style="font-size:12px;margin-top:8px"><b>Get this wrong and the bridge
+      disappears.</b> A wrong address does not stop it joining the WiFi — it joins, and is then
+      simply unreachable. The settings are checked before they are stored, but the check cannot
+      know whether the address is already taken. If it does go missing: hold BOOT for five
+      seconds to factory-reset and start again from the setup portal.</div>
+    </div></div>
   <div class="card"><b>Time (NTP)</b> <span class="tag" style="font-weight:400">needs restart</span>${chk('c_ntpe','Enabled',c.ntp.enabled)}
     ${chk('c_ntpd','Use NTP server from DHCP',c.ntp.use_dhcp)}
     ${txt('c_ntps','NTP server (fallback)',c.ntp.server)}
@@ -1640,7 +1673,14 @@ async function saveConfig(){
   const body={bridge_name:v('c_name'),
     ...(window.g_relayCount>0?{relays:{enabled:b('c_rle'),
       roles:Array.from({length:window.g_relayCount},(_,i)=>v('c_rlr'+i))}}:{}),
-    wifi:{ssid:v('c_ssid'),hostname:v('c_host')},
+    // On DHCP every address field is sent EMPTY, not omitted: clearing is how a bridge goes back
+    // from static, and an omitted key means "leave alone" to the patch handler. Trimmed, because
+    // a trailing space fails the parse while the field still looks right.
+    wifi:{ssid:v('c_ssid'),hostname:v('c_host'),
+          ...(v('c_ipmode')==='static'
+              ?{ip:v('c_ip').trim(),gateway:v('c_gw').trim(),subnet:v('c_sn').trim(),
+                dns1:v('c_dns1').trim(),dns2:v('c_dns2').trim()}
+              :{ip:'',gateway:'',subnet:'',dns1:'',dns2:''})},
     mqtt:{enabled:b('c_mqe'),host:v('c_mqh'),port:n('c_mqp'),
           base_topic:v('c_mqt'),discovery_enabled:b('c_mqd')},
     modbus:{enabled:b('c_mbe'),port:n('c_mbp'),unit_id:n('c_mbu')},

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1429,7 +1429,7 @@ async function renderConfig(){
     <div id="c_ipfields" class="${c.wifi.ip?'':'hide'}" style="margin-top:12px">
       ${txt('c_ip','IP address',c.wifi.ip,'This bridge, for example 192.168.1.50.')}
       ${txt('c_gw','Gateway',c.wifi.gateway,'Usually your router, and it must sit inside the same subnet as the address above.')}
-      ${txt('c_sn','Subnet mask',c.wifi.subnet||'255.255.255.0','255.255.255.0 unless your network says otherwise.')}
+      ${txt('c_sn','Subnet mask',c.wifi.subnet,'255.255.255.0 unless your network says otherwise.')}
       ${txt('c_dns1','DNS server',c.wifi.dns1,'Required as soon as anything here is configured by name — an NTP server or an MQTT broker. Without it the clock never syncs and nothing says so.')}
       ${txt('c_dns2','Second DNS server (optional)',c.wifi.dns2)}
       <div class="dim" style="font-size:12px;margin-top:8px"><b>Get this wrong and the bridge

--- a/test/test_config_backup/test_main.cpp
+++ b/test/test_config_backup/test_main.cpp
@@ -437,8 +437,29 @@ static void test_an_unsynced_clock_produces_no_timestamp() {
     TEST_ASSERT_TRUE(isoUtcTimestamp(1000).empty());
 }
 
+/// A backup carries the addressing, so restoring one taken on another network would hand this
+/// bridge an address that cannot work here -- and the preview is what stands between the
+/// operator and that. It covers the new fields for free because they go through writeCommon,
+/// which is exactly the kind of "free" that stops being true when someone adds a field
+/// somewhere else. Pinned so it cannot quietly stop covering them.
+static void test_the_restore_preview_shows_an_address_change() {
+    Configuration before;
+    before.wifi.ssid = "thuis";
+    Configuration after = before;
+    after.wifi.ip       = "192.168.1.50";
+    after.wifi.gateway  = "192.168.1.1";
+    after.wifi.subnet   = "255.255.255.0";
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(before, after, diff));
+    TEST_ASSERT_NOT_NULL_MESSAGE(find(diff, "wifi.ip"), "an address change must be previewed");
+    TEST_ASSERT_NOT_NULL(find(diff, "wifi.gateway"));
+    TEST_ASSERT_NOT_NULL(find(diff, "wifi.subnet"));
+}
+
 int main() {
     UNITY_BEGIN();
+    RUN_TEST(test_the_restore_preview_shows_an_address_change);
     RUN_TEST(test_round_trip_with_secrets_is_lossless);
     RUN_TEST(test_envelope_metadata_is_reported_back);
     RUN_TEST(test_backup_carries_every_stored_key);

--- a/test/test_ipv4/test_main.cpp
+++ b/test/test_ipv4/test_main.cpp
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+// IPv4 parsing and subnet arithmetic.
+//
+// These rules decide whether a bridge is still reachable after a reboot, so they are checked
+// here rather than trusted. The parse is deliberately stricter than the C library's: every
+// shorthand inet_aton() accepts is a way to type something that reads like one address and
+// configures another, and the symptom of that is a device nobody can reach.
+
+#include <unity.h>
+
+#include <cstring>
+#include <string>
+
+#include "network/ipv4.h"
+
+using namespace heliograph::net;
+
+void setUp() {}
+void tearDown() {}
+
+static uint32_t ip(const char* text) {
+    uint32_t v = 0;
+    TEST_ASSERT_TRUE_MESSAGE(parseIpv4(text, v), text);
+    return v;
+}
+
+// --- parsing ----------------------------------------------------------------------------------
+
+static void test_the_ordinary_forms_parse() {
+    TEST_ASSERT_EQUAL_HEX32(0xC0A80101u, ip("192.168.1.1"));
+    TEST_ASSERT_EQUAL_HEX32(0x00000000u, ip("0.0.0.0"));
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFu, ip("255.255.255.255"));
+    TEST_ASSERT_EQUAL_HEX32(0x0A140018u, ip("10.20.0.24"));
+}
+
+/// Everything inet_aton() would have accepted, refused. Each of these reads like an address a
+/// person meant to type and resolves to a different one.
+static void test_the_shorthands_the_c_library_accepts_are_refused() {
+    uint32_t v = 0;
+    TEST_ASSERT_FALSE_MESSAGE(parseIpv4("10.1", v), "two octets");
+    TEST_ASSERT_FALSE_MESSAGE(parseIpv4("10.0.1", v), "three octets");
+    TEST_ASSERT_FALSE_MESSAGE(parseIpv4("1.2.3.4.5", v), "five octets");
+    TEST_ASSERT_FALSE_MESSAGE(parseIpv4("0x0A.1.1.1", v), "hex octet");
+    // The one that bites hardest: 010 is 8 to some tools and 10 to others.
+    TEST_ASSERT_FALSE_MESSAGE(parseIpv4("010.1.1.1", v), "leading zero");
+    TEST_ASSERT_FALSE_MESSAGE(parseIpv4("192.168.001.1", v), "leading zero mid-address");
+}
+
+static void test_malformed_input_is_refused() {
+    uint32_t v = 0;
+    for (const char* bad : {"", ".", "1.2.3.", "1.2.3.4.", ".1.2.3.4", "1.2..4", "256.1.1.1",
+                            "1.2.3.256", "-1.2.3.4", "1.2.3.4 ", " 1.2.3.4", "1.2.3.4:80",
+                            "192.168.1.1/24", "hostname", "pool.ntp.org", "::1"}) {
+        TEST_ASSERT_FALSE_MESSAGE(parseIpv4(bad, v), bad);
+    }
+}
+
+/// 255 is the boundary the octet check sits on, so both sides of it are pinned.
+static void test_the_octet_boundary() {
+    uint32_t v = 0;
+    TEST_ASSERT_TRUE(parseIpv4("255.255.255.255", v));
+    TEST_ASSERT_FALSE(parseIpv4("256.255.255.255", v));
+    TEST_ASSERT_FALSE(parseIpv4("255.255.255.256", v));
+    // A value that overflows only after several digits must not wrap into range.
+    TEST_ASSERT_FALSE(parseIpv4("99999.1.1.1", v));
+}
+
+static void test_format_round_trips_the_parse() {
+    for (const char* text : {"0.0.0.0", "192.168.1.1", "255.255.255.255", "10.20.0.24"}) {
+        TEST_ASSERT_EQUAL_STRING(text, formatIpv4(ip(text)).c_str());
+    }
+}
+
+// --- masks ------------------------------------------------------------------------------------
+
+static void test_contiguous_masks_are_accepted() {
+    for (const char* text : {"255.0.0.0", "255.255.0.0", "255.255.255.0", "255.255.255.252",
+                             "255.255.254.0", "128.0.0.0"}) {
+        TEST_ASSERT_TRUE_MESSAGE(isContiguousMask(ip(text)), text);
+    }
+}
+
+static void test_a_mask_with_a_hole_is_refused() {
+    for (const char* text : {"255.0.255.0", "255.255.0.255", "0.255.255.255", "255.255.255.253"}) {
+        TEST_ASSERT_FALSE_MESSAGE(isContiguousMask(ip(text)), text);
+    }
+}
+
+/// Both degenerate ends. 0.0.0.0 would put every address in one subnet and make every check
+/// below vacuously true; 255.255.255.255 leaves no host addresses at all.
+static void test_the_degenerate_masks_are_refused() {
+    TEST_ASSERT_FALSE(isContiguousMask(ip("0.0.0.0")));
+    TEST_ASSERT_FALSE(isContiguousMask(ip("255.255.255.255")));
+}
+
+static void test_prefix_lengths() {
+    TEST_ASSERT_EQUAL_UINT8(8, maskPrefixLength(ip("255.0.0.0")));
+    TEST_ASSERT_EQUAL_UINT8(24, maskPrefixLength(ip("255.255.255.0")));
+    TEST_ASSERT_EQUAL_UINT8(30, maskPrefixLength(ip("255.255.255.252")));
+    TEST_ASSERT_EQUAL_UINT8(23, maskPrefixLength(ip("255.255.254.0")));
+}
+
+// --- subnet arithmetic ------------------------------------------------------------------------
+
+static void test_same_subnet() {
+    const uint32_t mask = ip("255.255.255.0");
+    TEST_ASSERT_TRUE(sameSubnet(ip("192.168.1.10"), ip("192.168.1.1"), mask));
+    TEST_ASSERT_FALSE(sameSubnet(ip("192.168.1.10"), ip("192.168.2.1"), mask));
+    // A wider mask puts them together again -- the case a /23 network actually has.
+    TEST_ASSERT_TRUE(sameSubnet(ip("192.168.1.10"), ip("192.168.0.1"), ip("255.255.254.0")));
+}
+
+static void test_network_and_broadcast_are_recognised() {
+    const uint32_t mask = ip("255.255.255.0");
+    TEST_ASSERT_TRUE(isNetworkAddress(ip("192.168.1.0"), mask));
+    TEST_ASSERT_FALSE(isNetworkAddress(ip("192.168.1.1"), mask));
+    TEST_ASSERT_TRUE(isBroadcastAddress(ip("192.168.1.255"), mask));
+    TEST_ASSERT_FALSE(isBroadcastAddress(ip("192.168.1.254"), mask));
+    // On a /30 the usable range is two addresses, and both ends are unusable.
+    const uint32_t p30 = ip("255.255.255.252");
+    TEST_ASSERT_TRUE(isNetworkAddress(ip("10.0.0.4"), p30));
+    TEST_ASSERT_TRUE(isBroadcastAddress(ip("10.0.0.7"), p30));
+    TEST_ASSERT_FALSE(isNetworkAddress(ip("10.0.0.5"), p30));
+    TEST_ASSERT_FALSE(isBroadcastAddress(ip("10.0.0.6"), p30));
+}
+
+// --- the literal-vs-name distinction ----------------------------------------------------------
+
+/// Drives the rule that a static configuration with no DNS must not be accepted while something
+/// is still configured by name. Anything not a literal counts as a name, which is the
+/// conservative direction: it demands a resolver rather than assuming none is needed.
+static void test_names_are_not_mistaken_for_addresses() {
+    TEST_ASSERT_TRUE(looksLikeIpLiteral("192.168.1.10"));
+    TEST_ASSERT_FALSE(looksLikeIpLiteral("pool.ntp.org"));
+    TEST_ASSERT_FALSE(looksLikeIpLiteral("mqtt.local"));
+    TEST_ASSERT_FALSE(looksLikeIpLiteral("homeassistant"));
+    TEST_ASSERT_FALSE(looksLikeIpLiteral(""));
+    // A name that begins like an address is still a name.
+    TEST_ASSERT_FALSE(looksLikeIpLiteral("10.0.0.1.nip.io"));
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_the_ordinary_forms_parse);
+    RUN_TEST(test_the_shorthands_the_c_library_accepts_are_refused);
+    RUN_TEST(test_malformed_input_is_refused);
+    RUN_TEST(test_the_octet_boundary);
+    RUN_TEST(test_format_round_trips_the_parse);
+    RUN_TEST(test_contiguous_masks_are_accepted);
+    RUN_TEST(test_a_mask_with_a_hole_is_refused);
+    RUN_TEST(test_the_degenerate_masks_are_refused);
+    RUN_TEST(test_prefix_lengths);
+    RUN_TEST(test_same_subnet);
+    RUN_TEST(test_network_and_broadcast_are_recognised);
+    RUN_TEST(test_names_are_not_mistaken_for_addresses);
+    return UNITY_END();
+}

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -847,6 +847,32 @@ static void test_no_dns_is_fine_when_nothing_is_configured_by_name() {
     TEST_ASSERT_TRUE_MESSAGE(validate(c, e), e.field.c_str());
 }
 
+/// The other quiet one, found reviewing the first. ntp.use_dhcp means "take the server from the
+/// DHCP lease" -- and a static address has no lease. Index 0 is never filled, and with an empty
+/// ntp.server index 1 is never set either, so NTP runs with no server at all: the clock never
+/// syncs and every log line stays stamped from uptime. The DHCP path may leave the server empty
+/// because the lease covers it; that reasoning does not survive a static address.
+static void test_a_static_address_needs_an_ntp_server_even_with_use_dhcp_on() {
+    auto c        = staticConfig();
+    c.ntp.enabled = true;
+    c.ntp.useDhcp = true;
+    c.ntp.server.clear();
+    ConfigError e;
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("ntp.server", e.field.c_str());
+
+    // Naming one is enough -- use_dhcp then merely means "prefer the lease if there ever is one".
+    c.ntp.server = "192.168.1.1";
+    TEST_ASSERT_TRUE_MESSAGE(validate(c, e), e.field.c_str());
+
+    // And on DHCP the empty server stays legal, because the lease really does supply it.
+    auto d        = provisionedConfig();
+    d.ntp.enabled = true;
+    d.ntp.useDhcp = true;
+    d.ntp.server.clear();
+    TEST_ASSERT_TRUE_MESSAGE(validate(d, e), e.field.c_str());
+}
+
 static void test_static_addressing_round_trips_through_storage_and_patch() {
     MemoryBackend      backend;
     ConfigurationStore store(backend);
@@ -1363,6 +1389,7 @@ int main(int, char**) {
     RUN_TEST(test_taking_the_gateways_own_address_is_refused);
     RUN_TEST(test_a_static_address_with_no_dns_is_refused_while_a_name_is_configured);
     RUN_TEST(test_no_dns_is_fine_when_nothing_is_configured_by_name);
+    RUN_TEST(test_a_static_address_needs_an_ntp_server_even_with_use_dhcp_on);
     RUN_TEST(test_static_addressing_round_trips_through_storage_and_patch);
     RUN_TEST(test_changing_the_address_requires_a_restart);
     RUN_TEST(test_overlong_strings_are_refused_at_the_boundary);

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -642,15 +642,246 @@ static void test_the_stored_blob_fits_nvs_comfortably() {
     c.security.adminPassword = std::string(64, 'x');
     c.driver.options["layout"] = std::string(128, 'x');
 
+    c.wifi.ip      = "192.168.100.200";
+    c.wifi.gateway = "192.168.100.254";
+    c.wifi.subnet  = "255.255.255.0";
+    c.wifi.dns1    = "192.168.100.253";
+    c.wifi.dns2    = "192.168.100.252";
+
     ConfigError e;
     TEST_ASSERT_TRUE_MESSAGE(validate(c, e), "a maximal config must still be valid");
     std::string blob;
     TEST_ASSERT_TRUE(serializeConfigForStorage(c, blob));
-    TEST_ASSERT_TRUE(blob.size() < 3900);
+    TEST_ASSERT_TRUE(blob.size() < kMaxStoredConfigBytes);
+
+    // The property that actually matters: even everything-at-maximum leaves most of the entry
+    // free, so the next field to be added is not a cliff. Measured 1822 of 3900 when static
+    // addressing was added (0.16.0); the assertion is half the cap, so it has room to drift and
+    // still fails before anything is at risk.
+    TEST_ASSERT_TRUE_MESSAGE(blob.size() < kMaxStoredConfigBytes / 2,
+                             std::to_string(blob.size()).c_str());
 
     std::string typical;
     TEST_ASSERT_TRUE(serializeConfigForStorage(provisionedConfig(), typical));
-    TEST_ASSERT_TRUE(typical.size() < 1000);
+    // A canary, not a limit. Moved from 1000 to 1200 when the five addressing fields were added
+    // -- they are emitted empty on a DHCP bridge, which costs ~55 bytes and took a typical blob
+    // from 983 to 1038. Raised deliberately and with the numbers written down, because a
+    // threshold quietly nudged whenever it trips stops being evidence of anything.
+    TEST_ASSERT_TRUE_MESSAGE(typical.size() < 1200, std::to_string(typical.size()).c_str());
+}
+
+static Configuration staticConfig() {
+    auto c         = provisionedConfig();
+    c.wifi.ip      = "192.168.1.50";
+    c.wifi.gateway = "192.168.1.1";
+    c.wifi.subnet  = "255.255.255.0";
+    c.wifi.dns1    = "192.168.1.1";
+    return c;
+}
+
+/// Whatever the writer emits, the reader must take back — all of it.
+///
+/// Serialise, parse, serialise again: if the reader ignores a field the writer produced, the
+/// second blob differs and this fails, naming nothing in particular but failing reliably. That
+/// is the point — it needs no per-field maintenance, so it keeps working for fields nobody has
+/// thought of yet.
+///
+/// Written because exactly this went wrong while adding static addressing: the five new keys
+/// were added to writeCommon and forgotten in deserializeConfigFromStorage, so a bridge would
+/// have saved its static address and come back on DHCP after a reboot. The writer-vs-writer
+/// drift check could not see it — it compares the two documents to each other, and both were
+/// correct. Nothing else in the suite covered the return trip in full.
+static void test_everything_the_writer_emits_the_reader_takes_back() {
+    auto c = staticConfig();
+    c.additionalDevices.push_back([] {
+        DriverSettings d;
+        d.id                = "sunspec";
+        d.options["unit_id"] = "2";
+        return d;
+    }());
+    c.relays.roles          = {"drm0", "drm5"};
+    c.relays.enabled        = true;
+    c.serial.enabled        = true;
+    c.serial.profile.parity = SerialParity::Even;
+    c.updates.checkEnabled  = false;
+    c.logLevel              = LogLevel::Debug;
+
+    std::string first;
+    TEST_ASSERT_TRUE(serializeConfigForStorage(c, first));
+
+    Configuration back;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, deserializeConfigFromStorage(first, back));
+
+    std::string second;
+    TEST_ASSERT_TRUE(serializeConfigForStorage(back, second));
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(first.c_str(), second.c_str(),
+                                     "a field the writer emits is not read back");
+}
+
+// --- static addressing ------------------------------------------------------------------------
+//
+// Each of these refuses a configuration that would otherwise be stored, applied at the next
+// boot, and leave a bridge unreachable at whatever height it is mounted. The PATCH handler is
+// the last moment anyone is looking at it, so that is where they live.
+
+static void test_a_sound_static_configuration_is_accepted() {
+    ConfigError e;
+    TEST_ASSERT_TRUE_MESSAGE(validate(staticConfig(), e), e.field.c_str());
+}
+
+static void test_an_empty_ip_means_dhcp_and_needs_nothing_else() {
+    auto        c = provisionedConfig();
+    ConfigError e;
+    TEST_ASSERT_TRUE(validate(c, e));
+    TEST_ASSERT_FALSE(c.wifi.staticIp());
+}
+
+/// A gateway left behind after clearing the address is a half-configuration that reads as if it
+/// were in effect. Refused so the form cannot lie about what the bridge will do.
+static void test_leftover_fields_without_an_ip_are_refused() {
+    auto        c = provisionedConfig();
+    ConfigError e;
+    c.wifi.gateway = "192.168.1.1";
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("wifi.gateway", e.field.c_str());
+}
+
+static void test_the_address_fields_must_parse() {
+    ConfigError e;
+    struct { const char* value; const char* field; } cases[] = {
+        {"192.168.1", "wifi.ip"},
+        {"010.0.0.5", "wifi.ip"},
+        {"not-an-ip", "wifi.ip"},
+    };
+    for (const auto& tc : cases) {
+        auto c    = staticConfig();
+        c.wifi.ip = tc.value;
+        TEST_ASSERT_FALSE_MESSAGE(validate(c, e), tc.value);
+        TEST_ASSERT_EQUAL_STRING(tc.field, e.field.c_str());
+    }
+}
+
+/// The mask rule is not style. WiFiSTAClass::config() reinterprets its arguments as the ESP8266
+/// ordering when the mask's first octet is not 255 -- so an odd mask does not fail, it silently
+/// configures a different gateway.
+static void test_a_mask_the_arduino_core_would_reinterpret_is_refused() {
+    ConfigError e;
+    for (const char* mask : {"0.0.0.0", "255.0.255.0", "128.0.0.0", "255.255.255.255"}) {
+        auto c        = staticConfig();
+        c.wifi.subnet = mask;
+        TEST_ASSERT_FALSE_MESSAGE(validate(c, e), mask);
+        TEST_ASSERT_EQUAL_STRING("wifi.subnet", e.field.c_str());
+    }
+}
+
+static void test_an_unreachable_gateway_is_refused() {
+    auto        c  = staticConfig();
+    ConfigError e;
+    c.wifi.gateway = "10.0.0.1";  // not inside 192.168.1.0/24
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("wifi.gateway", e.field.c_str());
+}
+
+static void test_the_network_and_broadcast_addresses_are_refused() {
+    ConfigError e;
+    auto        c = staticConfig();
+    c.wifi.ip     = "192.168.1.0";
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("wifi.ip", e.field.c_str());
+
+    c         = staticConfig();
+    c.wifi.ip = "192.168.1.255";
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("wifi.ip", e.field.c_str());
+}
+
+static void test_taking_the_gateways_own_address_is_refused() {
+    auto        c = staticConfig();
+    ConfigError e;
+    c.wifi.ip     = c.wifi.gateway;
+    TEST_ASSERT_FALSE(validate(c, e));
+    TEST_ASSERT_EQUAL_STRING("wifi.ip", e.field.c_str());
+}
+
+/// THE quiet one. With no DNS the stack resolves nothing: the bridge boots, answers on its
+/// address, looks healthy -- and never syncs its clock, because pool.ntp.org is a name. Nothing
+/// throws. This is the only moment anyone is looking.
+static void test_a_static_address_with_no_dns_is_refused_while_a_name_is_configured() {
+    ConfigError e;
+
+    auto c      = staticConfig();
+    c.wifi.dns1 = "";
+    c.wifi.dns2 = "";
+    c.ntp.enabled = true;
+    c.ntp.server  = "pool.ntp.org";
+    TEST_ASSERT_FALSE_MESSAGE(validate(c, e), "a named NTP server needs a resolver");
+    TEST_ASSERT_EQUAL_STRING("wifi.dns1", e.field.c_str());
+
+    // An MQTT broker named rather than numbered is the same problem.
+    c            = staticConfig();
+    c.wifi.dns1  = "";
+    c.wifi.dns2  = "";
+    c.ntp.server = "192.168.1.1";  // numbered, so NTP is fine
+    c.mqtt.enabled = true;
+    c.mqtt.host    = "homeassistant.local";
+    TEST_ASSERT_FALSE_MESSAGE(validate(c, e), "a named broker needs a resolver");
+    TEST_ASSERT_EQUAL_STRING("wifi.dns1", e.field.c_str());
+}
+
+/// ...and the complement: everything numbered needs no resolver, so demanding one would be a
+/// rule that refuses a perfectly workable network.
+static void test_no_dns_is_fine_when_nothing_is_configured_by_name() {
+    auto c         = staticConfig();
+    c.wifi.dns1    = "";
+    c.wifi.dns2    = "";
+    c.ntp.enabled  = true;
+    c.ntp.server   = "192.168.1.1";
+    c.mqtt.enabled = true;
+    c.mqtt.host    = "192.168.1.10";
+    ConfigError e;
+    TEST_ASSERT_TRUE_MESSAGE(validate(c, e), e.field.c_str());
+
+    // A disabled output does not count either -- its host is never resolved.
+    c.mqtt.enabled = false;
+    c.mqtt.host    = "homeassistant.local";
+    TEST_ASSERT_TRUE_MESSAGE(validate(c, e), e.field.c_str());
+}
+
+static void test_static_addressing_round_trips_through_storage_and_patch() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+    TEST_ASSERT_TRUE(store.save(staticConfig()));
+
+    Configuration loaded;
+    TEST_ASSERT_EQUAL(LoadResult::Ok, store.load(loaded));
+    TEST_ASSERT_EQUAL_STRING("192.168.1.50", loaded.wifi.ip.c_str());
+    TEST_ASSERT_EQUAL_STRING("255.255.255.0", loaded.wifi.subnet.c_str());
+    TEST_ASSERT_TRUE(loaded.wifi.staticIp());
+
+    // Back to DHCP: clearing every field is a legal patch, and must leave nothing behind.
+    ConfigError e;
+    TEST_ASSERT_TRUE(applyConfigPatch(
+        R"({"wifi":{"ip":"","gateway":"","subnet":"","dns1":"","dns2":""}})", loaded, e));
+    TEST_ASSERT_FALSE(loaded.wifi.staticIp());
+    TEST_ASSERT_TRUE(validate(loaded, e));
+    TEST_ASSERT_TRUE(loaded.wifi.gateway.empty());
+}
+
+/// The network is read once, between WiFi.mode() and WiFi.begin(). Changing it live would tear
+/// down every listening socket underneath the request that asked for the change.
+static void test_changing_the_address_requires_a_restart() {
+    const auto before = staticConfig();
+    auto       after  = before;
+    after.wifi.ip     = "192.168.1.51";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(before, after));
+
+    after         = before;
+    after.wifi.dns2 = "9.9.9.9";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(before, after));
+
+    after            = before;
+    after.bridgeName = "Something else";
+    TEST_ASSERT_FALSE(configChangeRequiresReboot(before, after));
 }
 
 static void test_overlong_strings_are_refused_at_the_boundary() {
@@ -1121,6 +1352,19 @@ int main(int, char**) {
     RUN_TEST(test_a_stored_config_that_no_longer_validates_is_corrupt);
     RUN_TEST(test_missing_fields_fall_back_to_defaults);
     RUN_TEST(test_the_stored_blob_fits_nvs_comfortably);
+    RUN_TEST(test_everything_the_writer_emits_the_reader_takes_back);
+    RUN_TEST(test_a_sound_static_configuration_is_accepted);
+    RUN_TEST(test_an_empty_ip_means_dhcp_and_needs_nothing_else);
+    RUN_TEST(test_leftover_fields_without_an_ip_are_refused);
+    RUN_TEST(test_the_address_fields_must_parse);
+    RUN_TEST(test_a_mask_the_arduino_core_would_reinterpret_is_refused);
+    RUN_TEST(test_an_unreachable_gateway_is_refused);
+    RUN_TEST(test_the_network_and_broadcast_addresses_are_refused);
+    RUN_TEST(test_taking_the_gateways_own_address_is_refused);
+    RUN_TEST(test_a_static_address_with_no_dns_is_refused_while_a_name_is_configured);
+    RUN_TEST(test_no_dns_is_fine_when_nothing_is_configured_by_name);
+    RUN_TEST(test_static_addressing_round_trips_through_storage_and_patch);
+    RUN_TEST(test_changing_the_address_requires_a_restart);
     RUN_TEST(test_overlong_strings_are_refused_at_the_boundary);
     RUN_TEST(test_no_credentials_means_portal);
     RUN_TEST(test_a_few_failures_keep_trying_rather_than_open_a_portal);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -413,6 +413,40 @@ static void test_the_device_manager_refuses_past_its_cap() {
 // The settings page stops offering "Add a device" at this number, so it is a contract between
 // the firmware and the page, not a decoration. Nothing guarded it: renaming or dropping the
 // field would have degraded the UI to its hardcoded fallback with every test still green.
+/// ip_mode says how the address was ASKED FOR; ip_address says what the interface ended up
+/// with. Both, because on a bridge whose static address was refused they disagree -- and that
+/// disagreement is the only visible sign of it. Reporting only the configuration would state an
+/// intention as if it were a fact.
+static void test_the_status_payload_reports_the_address_and_how_it_was_obtained() {
+    Rig         r;
+    const auto  state = r.poll();
+    std::string json;
+
+    auto bridge      = makeBridge();
+    bridge.ipAddress = "192.168.1.50";
+    bridge.staticIp  = true;
+    TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", bridge,
+                                              r.diagnostics.snapshot(),
+                                              &eversolar::descriptor(), g_now, {}, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_STRING("static", doc["bridge"]["ip_mode"].as<const char*>());
+    TEST_ASSERT_EQUAL_STRING("192.168.1.50", doc["bridge"]["ip_address"].as<const char*>());
+
+    bridge.staticIp = false;
+    TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", bridge,
+                                              r.diagnostics.snapshot(),
+                                              &eversolar::descriptor(), g_now, {}, json));
+    TEST_ASSERT_EQUAL_STRING("dhcp", parse(json)["bridge"]["ip_mode"].as<const char*>());
+
+    // No address yet -- the portal is up, nothing has been assigned. Omitted rather than "",
+    // which would read like an answer.
+    bridge.ipAddress.clear();
+    TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "eversolar_legacy", bridge,
+                                              r.diagnostics.snapshot(),
+                                              &eversolar::descriptor(), g_now, {}, json));
+    TEST_ASSERT_TRUE(parse(json)["bridge"]["ip_address"].isNull());
+}
+
 static void test_the_status_payload_publishes_the_device_cap() {
     Rig         r;
     const auto  state = r.poll();
@@ -2170,6 +2204,7 @@ int main(int, char**) {
     RUN_TEST(test_a_lone_device_without_either_keeps_the_bare_driver_id);
     RUN_TEST(test_re_adding_an_id_returns_the_same_store_rather_than_failing);
     RUN_TEST(test_the_device_manager_refuses_past_its_cap);
+    RUN_TEST(test_the_status_payload_reports_the_address_and_how_it_was_obtained);
     RUN_TEST(test_the_status_payload_publishes_the_device_cap);
     RUN_TEST(test_the_status_payload_totals_every_polled_device);
     RUN_TEST(test_a_device_that_reports_nothing_does_not_count_towards_a_total);


### PR DESCRIPTION
Closes #61 — phase 1. Fallback-to-DHCP on an unreachable gateway is deliberately **not** here; see the bottom.

## Why validation is the feature

A wrong static address does not fail loudly. **The WiFi association still succeeds** — layer 2 comes up regardless — so the bridge joins the network and is simply unreachable, at whatever height it is mounted. There is no error to catch at runtime.

So `validate()` refuses, at the last moment anyone is looking, everything visible from here:

- anything that is not four decimal octets
- a mask with a hole in it, or one not starting at 255
- an address naming the network or the broadcast
- a gateway outside the subnet, or equal to our own address
- leftover gateway/subnet/dns after the address was cleared

…plus two whose failure is an **absence** rather than an error:

- **a static address with no DNS** while an NTP server or MQTT broker is configured by name. The stack resolves nothing: the bridge boots, answers on its address, looks healthy — and never syncs its clock, because `pool.ntp.org` is a name.
- **a static address with NTP enabled and no `ntp.server`**, even with `use_dhcp` on. There is no lease to provide one, so index 0 is never filled and index 1 is never set.

## Two traps read out of the core, not a tutorial

**The mask rule is not style.** `WiFiSTAClass::config()` in core 3.3.9 silently reinterprets its arguments as the ESP8266 ordering `(ip, dns, gw, subnet)` when the mask's first octet is not 255. An odd mask does not fail — it configures a *different gateway*.

**`WiFi.config(INADDR_NONE, ...)` does not mean "go back to DHCP" here.** Every tutorial says it does, and the Arduino layer does treat `INADDR_NONE` as its unset sentinel — but lwip defines it as `0xFFFFFFFF`, while `NetworkInterface::config()` clears and restarts the DHCP client only when the address is **zero**. Written the tutorial way, this branch would have stopped the DHCP client, configured `255.255.255.255` as a static address, and never restarted DHCP — **on the default path every existing bridge takes**. Caught in self-review before it left the branch.

## Structure

`src/network/ipv4.{h,cpp}` — pure, host-tested, the shared notion of a valid address used by `config/` to validate and `network/` to apply. Stricter than `inet_aton` on purpose: every shorthand that accepts `10.1` or reads `010` as octal is a way to type something that looks like the address you meant and configures another.

Applied between `WiFi.mode()` and `WiFi.begin()` — the DHCP client wins the race otherwise.

## A bug the tests caught, and the guard that now prevents its class

The five fields went into `writeCommon` and were **forgotten in the reader**, so a bridge would have saved its static address and come back on DHCP after a reboot. The writer-vs-writer drift check from 0.15.1 could not see it — both documents were correct.

Added a guard that can: serialise, parse, serialise again, require the blobs identical. No per-field maintenance, so it keeps working for fields nobody has thought of yet. Confirmed it fails when the reader drops a field.

## UI

An Addressing card in the Network section. Hidden rather than disabled on DHCP. On DHCP the fields are sent **empty rather than omitted** — clearing is how a bridge goes back from static, and an omitted key means "leave alone". `bridge.ip_mode` and `bridge.ip_address` in the status payload, separate because on a bridge whose address was refused they disagree.

## Verification

767 host tests (13 for ipv4, 14 for the rules, 1 for the payload, 1 round-trip guard); all four firmware envs build; layering 8/8, cppcheck, ruff, web-JS checks.

**Not hardware-tested.** The parse and the rules are host-proven, but nothing here has configured a real interface yet. Worth a deliberate first run: set a static address on a bridge you can reach physically before trusting it on one you cannot.

## Deliberately out of scope

Fallback to DHCP when the gateway does not answer. It needs a reachability probe rather than a link check — association succeeding tells you nothing — and that is its own design with its own failure modes, only really testable on hardware. Validation plus the BOOT-hold factory reset is the escape hatch for now.
