### PR TITLE
feat(mqtt): record which topic tree was announced, and say when it moves (#41)

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -259,3 +259,50 @@ discovers that half the outputs ignored it. Now the behavior is enforced by test
 Exponential back-off 1 s → 2 s → 4 s → … → max 60 s. After connecting: availability `online`,
 then identity/capabilities/discovery, then state. The poll cycle keeps running in the
 meantime — `mqttTask` and `rs485Task` share nothing but the `StateStore`.
+
+## Changing the base topic or the discovery prefix
+
+Both need a restart, and both leave the previous topic tree behind on the broker. **The bridge
+does not clear it**, and the two fields do not strand the same things.
+
+### `mqtt.base_topic`
+
+The Home Assistant discovery configs do **not** move. Their topics are built from the bridge id,
+not from the base topic, so the next announcement overwrites them in place with `state_topic`
+pointing at the new tree. Your entities keep working and keep their history.
+
+What is stranded is the retained data under the old tree — `state`, `identity`, `capabilities`,
+`diagnostics`, `availability`, and the same three for every extra device. Invisible in Home
+Assistant, clutter on the broker.
+
+### `mqtt.discovery_prefix`
+
+Here the configs really do move. The old ones stay retained, so Home Assistant keeps a full set
+of stale entities beside the new ones — reporting online forever with their last value, because
+availability is bridge-scoped and nothing publishes to the old tree any more.
+
+**Deleting the device in Home Assistant does not fix this.** The retained config is still on the
+broker, so it is rediscovered on the next Home Assistant restart. It has to be cleared at the
+broker.
+
+### Clearing it
+
+The bridge logs the old and new prefixes when it notices the change, so the tree to clear is
+named in the boot log rather than left for you to work out. With mosquitto's tools:
+
+```bash
+mosquitto_sub -h BROKER -t 'OLD_BASE/BRIDGE_ID/#' -v --retained-only -W 2   | cut -d' ' -f1 | xargs -I{} mosquitto_pub -h BROKER -t {} -r -n
+```
+
+Same shape for an old discovery prefix, with `-t 'OLD_PREFIX/+/BRIDGE_ID*/#'`. `-r -n` publishes
+an empty retained payload, which is how a retained message is deleted.
+
+### Why the firmware does not do it for you
+
+An automatic sweep on boot has to get the distinction above exactly right, and the failure mode
+of getting it wrong is deleting the discovery configs that were just correctly rewritten —
+turning broker clutter into a device that vanishes from someone's dashboard, unattended. No
+comparable project does this in firmware either: ESPHome ships `esphome clean-mqtt` and Tasmota
+points at Tasmota Device Manager, both host-side tools a human runs deliberately.
+
+Tracked in [#41](https://github.com/Timdebruijn/heliograph/issues/41).

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -288,14 +288,36 @@ broker.
 ### Clearing it
 
 The bridge logs the old and new prefixes when it notices the change, so the tree to clear is
-named in the boot log rather than left for you to work out. With mosquitto's tools:
+named in the boot log rather than left for you to work out.
+
+Retained messages are deleted by publishing an empty payload to the same topic with the retain
+flag set. With mosquitto's tools, for a base topic that moved:
 
 ```bash
-mosquitto_sub -h BROKER -t 'OLD_BASE/BRIDGE_ID/#' -v --retained-only -W 2   | cut -d' ' -f1 | xargs -I{} mosquitto_pub -h BROKER -t {} -r -n
+mosquitto_sub -h BROKER -t 'OLD_BASE/BRIDGE_ID/#' -v --retained-only -W 2 \
+  | cut -d' ' -f1 \
+  | xargs -I{} mosquitto_pub -h BROKER -t {} -r -n
 ```
 
-Same shape for an old discovery prefix, with `-t 'OLD_PREFIX/+/BRIDGE_ID*/#'`. `-r -n` publishes
-an empty retained payload, which is how a retained message is deleted.
+For a discovery prefix that moved, the entities live under several component types
+(`sensor`, `binary_sensor`, `switch`, `select`) and under two id shapes — `BRIDGE_ID` for the
+first device and the bridge's own entities, `BRIDGE_ID_DEVICEID` for every other. **MQTT has no
+wildcard within a topic level** — `+` matches exactly one whole level and `#` the rest, so
+`BRIDGE_ID*` matches nothing. Subscribe to the whole prefix and filter:
+
+```bash
+mosquitto_sub -h BROKER -t 'OLD_PREFIX/#' -v --retained-only -W 2 \
+  | grep "BRIDGE_ID" \
+  | cut -d' ' -f1 \
+  | xargs -I{} mosquitto_pub -h BROKER -t {} -r -n
+```
+
+Two things about `--retained-only`: it exits as soon as a **non**-retained message arrives, which
+on an orphaned tree never happens (nothing publishes there any more) but will cut the listing
+short if you point it at a live one. And `-W 2` is the safety net — without a timeout the client
+waits forever on a quiet tree.
+
+Check what would be deleted before deleting it: drop the `xargs` line and read the list first.
 
 ### Why the firmware does not do it for you
 

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -329,38 +329,74 @@ bool ConfigurationStore::save(const Configuration& config) {
     return backend_.write(kStorageKeyConfig, blob);
 }
 
-std::vector<mqtt::AnnouncedDevice> ConfigurationStore::announcedDevices() {
-    std::lock_guard<std::mutex>        lock(mutex_);
-    std::vector<mqtt::AnnouncedDevice> out;
-    std::string                        raw;
-    if (!backend_.read(kStorageKeyAnnounced, raw) || raw.empty()) {
-        return out;
-    }
-    JsonDocument doc;
-    if (deserializeJson(doc, raw) != DeserializationError::Ok || !doc.is<JsonArray>()) {
-        return out;  // unreadable bookkeeping is simply forgotten, never fatal
-    }
-    for (JsonVariantConst v : doc.as<JsonArrayConst>()) {
-        // A bare string is the shape this key had before it carried the topic tree. Read as
-        // non-primary, which is what it always meant: the flag was added when the primary's
-        // tree turned out to need different handling, not to reinterpret old entries.
+namespace {
+
+/// Reads the device list out of whichever shape this key is in.
+///
+/// Two legacy shapes, both still readable. A bare string is the oldest: it predates the primary
+/// flag and always meant non-primary, which is how it is read. An object with `id`/`primary` is
+/// the second. Neither carries the topic tree it was announced under, which is what the
+/// enclosing object adds.
+void readDeviceArray(JsonArrayConst arr, std::vector<mqtt::AnnouncedDevice>& out) {
+    for (JsonVariantConst v : arr) {
         if (v.is<const char*>()) {
             out.push_back({v.as<const char*>(), false});
         } else if (v.is<JsonObjectConst>() && v["id"].is<const char*>()) {
             out.push_back({v["id"].as<const char*>(), v["primary"].as<bool>()});
         }
     }
+}
+
+}  // namespace
+
+mqtt::AnnouncementRecord ConfigurationStore::announcement() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    mqtt::AnnouncementRecord    out;
+    std::string                 raw;
+    if (!backend_.read(kStorageKeyAnnounced, raw) || raw.empty()) {
+        return out;
+    }
+    JsonDocument doc;
+    if (deserializeJson(doc, raw) != DeserializationError::Ok) {
+        return out;  // unreadable bookkeeping is simply forgotten, never fatal
+    }
+    // A bare array is the pre-0.16 shape: the ids were recorded, the tree they went to was not.
+    // Left with empty prefixes, which means UNKNOWN rather than "the default" -- nothing may
+    // conclude from such a record that the topics did or did not move.
+    if (doc.is<JsonArray>()) {
+        readDeviceArray(doc.as<JsonArrayConst>(), out.devices);
+        return out;
+    }
+    if (!doc.is<JsonObject>()) {
+        return out;
+    }
+    if (doc["base"].is<const char*>())   out.baseTopic       = doc["base"].as<const char*>();
+    if (doc["prefix"].is<const char*>()) out.discoveryPrefix = doc["prefix"].as<const char*>();
+    if (doc["devices"].is<JsonArrayConst>()) {
+        readDeviceArray(doc["devices"].as<JsonArrayConst>(), out.devices);
+    }
     return out;
 }
 
-bool ConfigurationStore::setAnnouncedDevices(const std::vector<mqtt::AnnouncedDevice>& devices) {
+std::vector<mqtt::AnnouncedDevice> ConfigurationStore::announcedDevices() {
+    return announcement().devices;
+}
+
+bool ConfigurationStore::setAnnouncement(const mqtt::AnnouncementRecord& record) {
     std::lock_guard<std::mutex> lock(mutex_);
     JsonDocument doc;
-    JsonArray    arr = doc.to<JsonArray>();
-    for (const auto& d : devices) {
-        JsonObject o  = arr.add<JsonObject>();
-        o["id"]       = d.id;
-        o["primary"]  = d.primary;
+    JsonObject   root = doc.to<JsonObject>();
+    // The tree these ids were announced under. Recorded because every topic MqttOutput builds
+    // comes from the CURRENT configuration: once base_topic or discovery_prefix changes, nothing
+    // is left that knows where the previous tree was, and its retained payloads are stranded
+    // with no way to name them. Written here so that a later boot can at least SAY so.
+    root["base"]      = record.baseTopic;
+    root["prefix"]    = record.discoveryPrefix;
+    JsonArray devices = root["devices"].to<JsonArray>();
+    for (const auto& d : record.devices) {
+        JsonObject o = devices.add<JsonObject>();
+        o["id"]      = d.id;
+        o["primary"] = d.primary;
     }
     std::string raw;
     serializeJson(doc, raw);

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -378,9 +378,6 @@ mqtt::AnnouncementRecord ConfigurationStore::announcement() {
     return out;
 }
 
-std::vector<mqtt::AnnouncedDevice> ConfigurationStore::announcedDevices() {
-    return announcement().devices;
-}
 
 bool ConfigurationStore::setAnnouncement(const mqtt::AnnouncementRecord& record) {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/config/configuration_store.h
+++ b/src/config/configuration_store.h
@@ -102,8 +102,12 @@ public:
     /// re-addressed leaves its entities behind -- and because availability is bridge-scoped they
     /// report ONLINE forever with their last value, straight into an energy dashboard. Clearing
     /// them needs the one fact nothing else survives a reboot with: what we announced last time.
+    /// What was last successfully announced, and the tree it went to. An older record carries
+    /// the ids with empty prefixes -- unknown, not "the default".
+    mqtt::AnnouncementRecord announcement();
+    /// The device list alone, for callers that do not care where it was announced.
     std::vector<mqtt::AnnouncedDevice> announcedDevices();
-    bool setAnnouncedDevices(const std::vector<mqtt::AnnouncedDevice>& devices);
+    bool setAnnouncement(const mqtt::AnnouncementRecord& record);
 
     /// Copies the stored configuration into the rollback slot, so the restore about to
     /// overwrite it can be undone. Call immediately before a restore, and nowhere else: doing

--- a/src/config/configuration_store.h
+++ b/src/config/configuration_store.h
@@ -104,9 +104,13 @@ public:
     /// them needs the one fact nothing else survives a reboot with: what we announced last time.
     /// What was last successfully announced, and the tree it went to. An older record carries
     /// the ids with empty prefixes -- unknown, not "the default".
+    ///
+    /// Deliberately the only accessor. A convenience that returned the device list alone existed
+    /// briefly and had no caller outside its own tests: every real user of this needs to know
+    /// WHERE the ids were announced, because that is the fact nothing else survives a reboot
+    /// with. Handing out the list without it invites exactly the reasoning this record exists to
+    /// prevent.
     mqtt::AnnouncementRecord announcement();
-    /// The device list alone, for callers that do not care where it was announced.
-    std::vector<mqtt::AnnouncedDevice> announcedDevices();
     bool setAnnouncement(const mqtt::AnnouncementRecord& record);
 
     /// Copies the stored configuration into the rollback slot, so the restore about to

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -791,21 +791,48 @@ void reconcileAnnouncedDevices(const BridgeInfo& bridge) {
         return;
     }
 
-    std::vector<mqtt::AnnouncedDevice> record;
-    record.reserve(g_deviceIds.size());
+    const auto previous = g_store.announcement();
+    // Say it, once, if the tree moved. Nothing is cleared automatically: the retained payloads
+    // under an old base topic are litter, but the discovery configs under an old prefix are the
+    // live Home Assistant entities if only the base topic changed -- deviceUniqueBase() does not
+    // include it, so those configs are OVERWRITTEN in place rather than orphaned. An automatic
+    // sweep that gets that distinction wrong deletes a working device from someone's dashboard
+    // while nobody is watching, which is why no comparable project does this in firmware either
+    // (ESPHome ships `esphome clean-mqtt`, Tasmota points at its Device Manager -- both host-side
+    // tools a human runs). What the bridge CAN do that an external script cannot is know where
+    // its own topics used to be, so it names them. See docs/mqtt.md and issue #41.
+    if (previous.prefixesKnown()) {
+        if (previous.baseTopic != g_config.mqtt.baseTopic) {
+            log::warn("MQTT: base topic changed %s -> %s; retained payloads under "
+                      "%s/%s/... are no longer updated (docs/mqtt.md explains how to clear them)",
+                      previous.baseTopic.c_str(), g_config.mqtt.baseTopic.c_str(),
+                      previous.baseTopic.c_str(), bridge.bridgeId.c_str());
+        }
+        if (previous.discoveryPrefix != g_config.mqtt.discoveryPrefix) {
+            log::warn("MQTT: discovery prefix changed %s -> %s; Home Assistant will keep the old "
+                      "entities until the retained configs under %s/ are cleared",
+                      previous.discoveryPrefix.c_str(), g_config.mqtt.discoveryPrefix.c_str(),
+                      previous.discoveryPrefix.c_str());
+        }
+    }
+
+    mqtt::AnnouncementRecord record;
+    record.baseTopic       = g_config.mqtt.baseTopic;
+    record.discoveryPrefix = g_config.mqtt.discoveryPrefix;
+    record.devices.reserve(g_deviceIds.size());
     for (const auto& id : g_deviceIds) {
-        record.push_back({id, id == g_primaryDeviceId});
+        record.devices.push_back({id, id == g_primaryDeviceId});
     }
 
     bool allCleared = true;
     for (const auto& id :
-         mqtt::devicesToForget(g_store.announcedDevices(), g_deviceIds, g_primaryDeviceId)) {
+         mqtt::devicesToForget(previous.devices, g_deviceIds, g_primaryDeviceId)) {
         if (!g_mqtt->forgetDevice(id, bridge)) {
             allCleared = false;
             // Kept in the record even though it is gone from the configuration: dropping it
             // here would be the last time anything knew it existed, and its entities would then
             // be orphaned for good.
-            record.push_back({id, false});
+            record.devices.push_back({id, false});
         }
     }
     if (!allCleared && ++g_announcedAttempts < 5) {
@@ -814,7 +841,7 @@ void reconcileAnnouncedDevices(const BridgeInfo& bridge) {
     if (!allCleared) {
         log::warn("MQTT: could not clear every removed device's topics; will retry next boot");
     }
-    if (!g_store.setAnnouncedDevices(record)) {
+    if (!g_store.setAnnouncement(record)) {
         log::warn("MQTT: could not record which devices were announced; removing one later will "
                   "leave its Home Assistant entities behind");
     }

--- a/src/outputs/mqtt/announced_devices.h
+++ b/src/outputs/mqtt/announced_devices.h
@@ -18,6 +18,29 @@ struct AnnouncedDevice {
     bool        primary = false;
 };
 
+/// What was last SUCCESSFULLY announced, and the tree it went to.
+///
+/// The prefixes are recorded with the ids because without them nothing can find the old tree
+/// after a rename: every topic MqttOutput builds comes from the CURRENT config, so once the
+/// setting changes there is no longer anything that knows where the previous one was.
+///
+/// "Successfully" is the whole design of the retry question. The record is updated only after a
+/// publish that actually left, so it always names the last tree that received anything -- which
+/// is the only tree with something to clear. Two renames in a row with a broker outage between
+/// them need no list of previous prefixes to resolve: the second rename finds the record still
+/// naming the first tree, because the middle one never published.
+///
+/// Empty prefixes mean UNKNOWN, not "the default". A record written before this bridge tracked
+/// them says nothing about where its topics went, and guessing would risk clearing the live
+/// tree.
+struct AnnouncementRecord {
+    std::string                  baseTopic;
+    std::string                  discoveryPrefix;
+    std::vector<AnnouncedDevice> devices;
+
+    bool prefixesKnown() const { return !baseTopic.empty() && !discoveryPrefix.empty(); }
+};
+
 /// Which previously announced devices left a DEVICE-SCOPED topic tree that nothing publishes to
 /// any more, and whose retained payloads therefore have to be cleared.
 ///

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -1165,14 +1165,14 @@ static void test_older_announcement_records_still_read_with_unknown_prefixes() {
 static void test_announced_devices_round_trip_and_start_empty() {
     MemoryBackend      backend;
     ConfigurationStore store(backend);
-    TEST_ASSERT_TRUE(store.announcedDevices().empty());
+    TEST_ASSERT_TRUE(store.announcement().devices.empty());
 
     mqtt::AnnouncementRecord announced;
     announced.baseTopic       = "heliograph";
     announced.discoveryPrefix = "homeassistant";
     announced.devices         = {{"growatt_modbus-1", true}, {"growatt_modbus-2", false}};
     TEST_ASSERT_TRUE(store.setAnnouncement(announced));
-    const auto back = store.announcedDevices();
+    const auto back = store.announcement().devices;
     TEST_ASSERT_EQUAL_UINT32(2, back.size());
     TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", back[1].id.c_str());
     // Which tree a device was announced on is half the fact: without it, a device promoted into
@@ -1183,7 +1183,7 @@ static void test_announced_devices_round_trip_and_start_empty() {
 
     // Removing the last device must be storable as such, not indistinguishable from "never set".
     TEST_ASSERT_TRUE(store.setAnnouncement({}));
-    TEST_ASSERT_TRUE(store.announcedDevices().empty());
+    TEST_ASSERT_TRUE(store.announcement().devices.empty());
 }
 
 // The key first shipped as a plain array of ids. Reading one back as non-primary is not a
@@ -1194,7 +1194,7 @@ static void test_announced_bookkeeping_reads_the_flat_id_list() {
     ConfigurationStore store(backend);
     backend.write(kStorageKeyAnnounced, R"(["eversolar-1","growatt_modbus-2"])");
 
-    const auto back = store.announcedDevices();
+    const auto back = store.announcement().devices;
     TEST_ASSERT_EQUAL_UINT32(2, back.size());
     TEST_ASSERT_EQUAL_STRING("eversolar-1", back[0].id.c_str());
     TEST_ASSERT_FALSE(back[0].primary);
@@ -1207,7 +1207,7 @@ static void test_corrupt_announced_bookkeeping_is_not_fatal() {
     MemoryBackend      backend;
     ConfigurationStore store(backend);
     backend.write(kStorageKeyAnnounced, "{not json");
-    TEST_ASSERT_TRUE(store.announcedDevices().empty());
+    TEST_ASSERT_TRUE(store.announcement().devices.empty());
 
     auto c = provisionedConfig();
     TEST_ASSERT_TRUE(store.save(c));
@@ -1222,7 +1222,7 @@ static void test_a_factory_reset_forgets_what_was_announced() {
     ConfigurationStore store(backend);
     store.setAnnouncement({"heliograph", "homeassistant", {{"growatt_modbus-1", true}}});
     TEST_ASSERT_TRUE(store.factoryReset());
-    TEST_ASSERT_TRUE(store.announcedDevices().empty());
+    TEST_ASSERT_TRUE(store.announcement().devices.empty());
 }
 
 static void test_ota_rejects_a_non_firmware_upload_before_writing() {

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -1109,14 +1109,69 @@ static void test_a_nameless_stored_device_is_dropped_not_fatal() {
 // knowing -- and without it a removed device's retained Home Assistant entities can never be
 // cleared. Kept out of Configuration on purpose: it is not a user setting, must not appear in
 // GET /config, and must not take part in the reboot-required diff.
+/// The prefixes are recorded WITH the ids, because every topic MqttOutput builds comes from the
+/// current configuration: once base_topic or discovery_prefix changes there is nothing left that
+/// knows where the previous tree was. Recording it after the fact is impossible, which is why
+/// this lands before anything that uses it.
+static void test_the_announcement_records_the_tree_it_went_to() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+
+    mqtt::AnnouncementRecord record;
+    record.baseTopic       = "solarbridge";
+    record.discoveryPrefix = "homeassistant";
+    record.devices         = {{"eversolar_legacy-16", true}, {"growatt_modbus-2", false}};
+    TEST_ASSERT_TRUE(store.setAnnouncement(record));
+
+    ConfigurationStore reloaded(backend);
+    const auto         back = reloaded.announcement();
+    TEST_ASSERT_TRUE(back.prefixesKnown());
+    TEST_ASSERT_EQUAL_STRING("solarbridge", back.baseTopic.c_str());
+    TEST_ASSERT_EQUAL_STRING("homeassistant", back.discoveryPrefix.c_str());
+    TEST_ASSERT_EQUAL_UINT32(2, back.devices.size());
+    TEST_ASSERT_TRUE(back.devices[0].primary);
+    TEST_ASSERT_FALSE(back.devices[1].primary);
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", back.devices[1].id.c_str());
+}
+
+/// Both older shapes still read. Their ids survive; their prefixes are UNKNOWN rather than
+/// assumed to be the defaults -- a record that never said where its topics went must not be
+/// read as saying they were somewhere in particular, or a later cleanup would aim at the tree
+/// that is live right now.
+static void test_older_announcement_records_still_read_with_unknown_prefixes() {
+    MemoryBackend      backend;
+    ConfigurationStore store(backend);
+
+    // Oldest: bare strings, before the primary flag existed.
+    backend.write(kStorageKeyAnnounced, R"(["eversolar_legacy-16","growatt_modbus-2"])");
+    auto bare = store.announcement();
+    TEST_ASSERT_FALSE(bare.prefixesKnown());
+    TEST_ASSERT_EQUAL_UINT32(2, bare.devices.size());
+    TEST_ASSERT_FALSE_MESSAGE(bare.devices[0].primary, "a bare string always meant non-primary");
+
+    // Second: objects with the flag, still no tree.
+    backend.write(kStorageKeyAnnounced,
+                  R"([{"id":"eversolar_legacy-16","primary":true}])");
+    auto flagged = store.announcement();
+    TEST_ASSERT_FALSE(flagged.prefixesKnown());
+    TEST_ASSERT_EQUAL_UINT32(1, flagged.devices.size());
+    TEST_ASSERT_TRUE(flagged.devices[0].primary);
+
+    // Unreadable bookkeeping is forgotten, never fatal.
+    backend.write(kStorageKeyAnnounced, "{not json");
+    TEST_ASSERT_EQUAL_UINT32(0, store.announcement().devices.size());
+}
+
 static void test_announced_devices_round_trip_and_start_empty() {
     MemoryBackend      backend;
     ConfigurationStore store(backend);
     TEST_ASSERT_TRUE(store.announcedDevices().empty());
 
-    const std::vector<mqtt::AnnouncedDevice> announced{{"growatt_modbus-1", true},
-                                                       {"growatt_modbus-2", false}};
-    TEST_ASSERT_TRUE(store.setAnnouncedDevices(announced));
+    mqtt::AnnouncementRecord announced;
+    announced.baseTopic       = "heliograph";
+    announced.discoveryPrefix = "homeassistant";
+    announced.devices         = {{"growatt_modbus-1", true}, {"growatt_modbus-2", false}};
+    TEST_ASSERT_TRUE(store.setAnnouncement(announced));
     const auto back = store.announcedDevices();
     TEST_ASSERT_EQUAL_UINT32(2, back.size());
     TEST_ASSERT_EQUAL_STRING("growatt_modbus-2", back[1].id.c_str());
@@ -1127,7 +1182,7 @@ static void test_announced_devices_round_trip_and_start_empty() {
     TEST_ASSERT_FALSE(back[1].primary);
 
     // Removing the last device must be storable as such, not indistinguishable from "never set".
-    TEST_ASSERT_TRUE(store.setAnnouncedDevices({}));
+    TEST_ASSERT_TRUE(store.setAnnouncement({}));
     TEST_ASSERT_TRUE(store.announcedDevices().empty());
 }
 
@@ -1165,7 +1220,7 @@ static void test_corrupt_announced_bookkeeping_is_not_fatal() {
 static void test_a_factory_reset_forgets_what_was_announced() {
     MemoryBackend      backend;
     ConfigurationStore store(backend);
-    store.setAnnouncedDevices(std::vector<mqtt::AnnouncedDevice>{{"growatt_modbus-1", true}});
+    store.setAnnouncement({"heliograph", "homeassistant", {{"growatt_modbus-1", true}}});
     TEST_ASSERT_TRUE(store.factoryReset());
     TEST_ASSERT_TRUE(store.announcedDevices().empty());
 }
@@ -1407,6 +1462,8 @@ int main(int, char**) {
     RUN_TEST(test_extra_devices_survive_a_restart);
     RUN_TEST(test_a_config_without_the_device_list_stays_single_device);
     RUN_TEST(test_a_nameless_stored_device_is_dropped_not_fatal);
+    RUN_TEST(test_the_announcement_records_the_tree_it_went_to);
+    RUN_TEST(test_older_announcement_records_still_read_with_unknown_prefixes);
     RUN_TEST(test_announced_devices_round_trip_and_start_empty);
     RUN_TEST(test_announced_bookkeeping_reads_the_flat_id_list);
     RUN_TEST(test_corrupt_announced_bookkeeping_is_not_fatal);


### PR DESCRIPTION
Scoped down from what #41 proposes, after @Timdebruijn asked the question I should have asked before starting: **is this a problem anyone actually has?**

Mostly, no. Nobody outside this repo has ever flashed the firmware, so the `solarbridge` → `heliograph` case is a sample of one, and a fresh install that never changes these fields never orphans anything.

## What survives that question

- **The trigger is not the rename** — it is changing either field at all. Most likely during setup, and most likely `discovery_prefix`, which people find out is non-default only *after* the bridge has already announced.
- **The recovery is genuinely bad.** Verified while scoping: deleting the device in Home Assistant does **not** stick. The retained config is still on the broker and is rediscovered on the next restart, so it takes broker-level surgery.

So: record the fact, report it, document the fix. **Clear nothing.**

## Recording is the only part that cannot wait

Every topic `MqttOutput` builds comes from the *current* configuration. The moment `base_topic` or `discovery_prefix` changes, nothing is left that knows where the previous tree was — recording it afterwards is impossible. That is why this lands now and the rest does not.

The bookkeeping becomes `{base, prefix, devices[]}`. Both older shapes still read, with prefixes left **UNKNOWN** rather than assumed to be the defaults: a record that never said where its topics went must not be read as saying they were somewhere in particular, or a later cleanup would aim at the tree that is live right now.

Reconcile logs the old and new prefixes when they differ, so the tree to clear is named in the boot log rather than left to be worked out.

## Not clearing is the decision, not an omission

`deviceUniqueBase()` excludes the base topic, so a base-topic rename leaves the discovery configs where they are and the next announcement **overwrites** them, `state_topic` and all. An automatic sweep that misses that distinction deletes the configs it just correctly rewrote — broker clutter becomes a device vanishing from a dashboard, unattended.

No comparable project does this in firmware either: ESPHome ships `esphome clean-mqtt`, Tasmota points at Tasmota Device Manager. Both host-side tools a human runs deliberately.

`docs/mqtt.md` now explains what each field strands, why the two differ, that Home Assistant's own delete does not fix it, and the `mosquitto_pub -r -n` one-liner that does.

## Notes for review

- `setAnnouncedDevices()` became `setAnnouncement()` rather than gaining an overload. A convenience that silently dropped the prefixes is exactly the footgun this removes, and the three compile errors in the tests were the API saying so.
- **A preview-and-clear button was built and then deleted.** It would have been a module with no caller for a problem nobody has yet — the pattern these self-reviews keep finding, one level up. The design analysis is preserved on [#41](https://github.com/Timdebruijn/heliograph/issues/41#issuecomment-5089796000) for whoever needs it.

## Verification

770 host tests (2 new: the record round-trip, and both legacy shapes reading with unknown prefixes). Firmware builds, layering 8/8.
