### PR TITLE
ci: build the release boards in parallel, and stop waiting on a cache

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+#
+# Warms the ESP32 toolchain cache on main. Nothing here validates anything.
+#
+# SPLIT OUT OF ci.yml ON PURPOSE, and the reason is about waiting rather than tidiness. This job
+# takes ~128 s while the checks that actually decide whether a commit is good finish in ~64 s.
+# While it lived in the CI workflow it was the longest job, so the CI run was not "completed"
+# until it was done -- and tagging a release waits for CI to be green. Half of that wait was for
+# a cache.
+#
+# It also could not fail safely there. Its own comment said "the job only warms a cache, so its
+# failure never blocks a release", which was not true while a failure turned the whole CI run
+# red: the release process reads that run's conclusion. Now a failed warm is a failed warm.
+#
+# Everything below is unchanged from where it used to live; the comments are the original ones
+# because the reasoning has not changed, only the file.
+
+name: Cache warm
+
+on:
+  push:
+    branches: [main]
+
+# Never two at once on the same key -- they would race to write the same cache entry and the
+# loser's ~1.7 GB upload is pure waste. Superseding is right here in a way it is not for CI:
+# only the newest tree is worth caching.
+concurrency:
+  group: cache-warm
+  cancel-in-progress: true
+
+jobs:
+  # The ONLY writer of the ESP32 toolchain cache, and the reason it exists on main rather than in
+  # firmware.yml or release.yml where the builds actually are.
+  #
+  # GitHub scopes a cache to the ref that wrote it. A cache written on refs/pull/21/merge is
+  # invisible to refs/tags/v0.12.0 and to every other PR; caches on the DEFAULT BRANCH are the
+  # only ones readable from any ref. Since firmware.yml runs on pull_request and release.yml on
+  # tags, nothing was ever writing to a scope the others could read: every PR build and every
+  # release downloaded the ~1.7 GB toolchain fresh and then saved its own private copy. Five of
+  # those copies were sitting in the 10 GB repo budget, evicting the small useful caches, and
+  # none had ever been restored by anything. A transient 504 on that download broke the 0.12.0
+  # release (2026-07-24), which is what turned this up.
+  #
+  # This job compiles one board and throws the result away. That it BUILDS is the point, not an
+  # accident: pioarduino does not fetch the ~200 MB xtensa toolchain during `pio pkg install`
+  # (that only lands the platform and the tool-esp_install helper). The toolchain is pulled by
+  # a build-time script -- platform.py's _run_idf_tools_install, invoked from `pio run` -- so a
+  # cache warmed by `pkg install` alone would miss the very thing worth caching and every
+  # consumer would still cold-download it. One real build populates ~/.platformio completely.
+  #
+  # One board covers all four esp32 envs: rs485-can, both relay boards and mock share the same
+  # platform, board and toolchain (they differ only in build flags and partitions), so the
+  # packages this build lands are exactly the ones every env restores.
+  warm-toolchain-cache:
+    name: Warm firmware toolchain cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # Restore-and-save. On a hit the packages are already present, so the build below reuses
+      # them and only recompiles; a miss repopulates the entry every consumer depends on.
+      - name: Cache PlatformIO
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-fw-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      # Retried, because a cold run downloads from GitHub release assets and that is exactly
+      # what broke the 0.12.0 release: platform-espressif32.zip returned 504 for several minutes
+      # while GitHub reported all systems operational. Retrying `pio run` also re-attempts a
+      # network failure part-way through the toolchain fetch. A genuine compile error would
+      # retry too, but this same tree already compiled green on its PR, so on main that path is
+      # not expected -- and the job only warms a cache, so its failure never blocks a release.
+      - name: Build one board to populate the toolchain cache
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if pio run -e waveshare-rs485-can; then
+              exit 0
+            fi
+            echo "build failed (attempt ${attempt}); retrying in $((attempt * 20))s"
+            sleep $((attempt * 20))
+          done
+          echo "build still failing after 5 attempts" >&2
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@
 # main posts no firmware check and a release does not rebuild what the PR already built. See
 # that file for the reasoning.
 #
-# This workflow does own one firmware-adjacent job: warming the ESP32 toolchain cache on main.
-# That has to happen on the default branch because of how GitHub scopes caches -- see the
-# comment on the job itself.
+# Checks only. The ESP32 toolchain cache is warmed by cache-warm.yml, which runs on main for
+# the cache-scoping reason documented there -- it lived here until 0.16.1 and made this run take
+# twice as long as the checks it reports on, which mattered because tagging a release waits for
+# that conclusion.
 
 name: CI
 
@@ -97,69 +98,3 @@ jobs:
 
       - name: Native test suite
         run: pio test -e native
-
-  # The ONLY writer of the ESP32 toolchain cache, and the reason it exists here rather than in
-  # firmware.yml or release.yml where the builds actually are.
-  #
-  # GitHub scopes a cache to the ref that wrote it. A cache written on refs/pull/21/merge is
-  # invisible to refs/tags/v0.12.0 and to every other PR; caches on the DEFAULT BRANCH are the
-  # only ones readable from any ref. Since firmware.yml runs on pull_request and release.yml on
-  # tags, nothing was ever writing to a scope the others could read: every PR build and every
-  # release downloaded the ~1.7 GB toolchain fresh and then saved its own private copy. Five of
-  # those copies were sitting in the 10 GB repo budget, evicting the small useful caches, and
-  # none had ever been restored by anything. A transient 504 on that download broke the 0.12.0
-  # release (2026-07-24), which is what turned this up.
-  #
-  # This job compiles one board and throws the result away. That it BUILDS is the point, not an
-  # accident: pioarduino does not fetch the ~200 MB xtensa toolchain during `pio pkg install`
-  # (that only lands the platform and the tool-esp_install helper). The toolchain is pulled by
-  # a build-time script -- platform.py's _run_idf_tools_install, invoked from `pio run` -- so a
-  # cache warmed by `pkg install` alone would miss the very thing worth caching and every
-  # consumer would still cold-download it. One real build populates ~/.platformio completely.
-  #
-  # One board covers all four esp32 envs: rs485-can, both relay boards and mock share the same
-  # platform, board and toolchain (they differ only in build flags and partitions), so the
-  # packages this build lands are exactly the ones every env restores.
-  warm-toolchain-cache:
-    name: Warm firmware toolchain cache
-    # Pushes to main only. On a pull request the build jobs restore this cache but must never
-    # write one -- a PR-scoped copy is the exact waste described above.
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      # Restore-and-save. On a hit the packages are already present, so the build below reuses
-      # them and only recompiles; a miss repopulates the entry every consumer depends on.
-      - name: Cache PlatformIO
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.platformio
-            ~/.cache/pip
-          key: pio-fw-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
-
-      - name: Install PlatformIO
-        run: pip install platformio
-
-      # Retried, because a cold run downloads from GitHub release assets and that is exactly
-      # what broke the 0.12.0 release: platform-espressif32.zip returned 504 for several minutes
-      # while GitHub reported all systems operational. Retrying `pio run` also re-attempts a
-      # network failure part-way through the toolchain fetch. A genuine compile error would
-      # retry too, but this same tree already compiled green on its PR, so on main that path is
-      # not expected -- and the job only warms a cache, so its failure never blocks a release.
-      - name: Build one board to populate the toolchain cache
-        run: |
-          for attempt in 1 2 3 4 5; do
-            if pio run -e waveshare-rs485-can; then
-              exit 0
-            fi
-            echo "build failed (attempt ${attempt}); retrying in $((attempt * 20))s"
-            sleep $((attempt * 20))
-          done
-          echo "build still failing after 5 attempts" >&2
-          exit 1

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -78,8 +78,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Restore-only, on purpose. The writer is the warm-toolchain-cache job in ci.yml, which
-      # runs on main and therefore produces the one cache scope every ref can read. Saving here
+      # Restore-only, on purpose. The writer is the warm-toolchain-cache job in cache-warm.yml,
+      # which runs on main and therefore produces the one cache scope every ref can read. Saving
       # instead would write a ~1.7 GB copy scoped to this PR that no other run could ever use,
       # while crowding the 10 GB repo budget -- and these four matrix jobs would race to write
       # four of them. A miss just means this build downloads the toolchain itself, as before.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,23 @@
 # SPDX-License-Identifier: MIT
 #
-# Push a tag `v*` and this builds the firmware, attaches both images to a
+# Push a tag `v*` and this builds the firmware, attaches every image to a
 # GitHub Release, and redeploys the browser flasher on GitHub Pages so
 # "flash the latest release" needs nothing but a USB cable and Chrome/Edge.
 #
 # The flasher bin is served from Pages, not from the release asset: release
 # downloads redirect to a host that sends no CORS headers, and ESP Web Tools
 # fetches the image with fetch(), which that would break.
+#
+# THREE JOBS, NOT ONE, since 0.16.1. The boards used to be built one after another inside a
+# single job: 161 s of the ~296 s a release took, more than half of it spent waiting for one
+# compile to finish so an identical compile could start. They now run as a matrix, and the
+# checks moved into their own job because they need no ESP32 toolchain and so have no business
+# holding up a build that does.
+#
+# The ordering guarantee is unchanged, and it is the part worth being careful about: nothing is
+# published until every board has built AND every check has passed. `needs` enforces that
+# exactly as running them in sequence did. A release that shipped three good images and one bad
+# one would be far worse than a slow release.
 
 name: Release
 
@@ -19,9 +30,17 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  # One list, read by the staging loop, the flasher site and the update feed. The matrix below
+  # cannot use it -- `strategy` is evaluated before `env` exists -- so that one place repeats
+  # the boards, and it is the only one.
+  BOARDS: rs485-can relay-1ch relay-6ch
+
 jobs:
-  release:
-    name: Build + publish release
+  # The checks, on their own. Everything here is host-side, so this job is finished long before
+  # the builds are and never delays them.
+  verify:
+    name: Verify before shipping
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -30,10 +49,52 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Restore-only. A tag ref cannot read a cache written by a PR or by another tag, so the
-      # save this step used to do produced a ~1.7 GB entry that nothing would ever restore --
-      # including the next release. The writer is now the warm-toolchain-cache job in ci.yml,
-      # running on main, whose scope every ref can read.
+      # The native cache, not the firmware one: a different key and a fraction of the size.
+      # Restore-only, because a tag ref cannot write a cache anything else would ever read.
+      - name: Restore PlatformIO (native)
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-native-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Validate device profiles
+        run: python3 tools/gen_profiles.py --check
+
+      - name: Layering invariants
+        run: bash tools/check_layering.sh
+
+      - name: Embedded JS syntax
+        run: python3 tools/check_web_js.py
+
+      - name: Native test suite
+        run: pio test -e native
+
+  build:
+    name: Build ${{ matrix.board }}
+    runs-on: ubuntu-latest
+    strategy:
+      # STOP on the first failure, unlike firmware.yml which lets every board report. There the
+      # point is telling a contributor which boards broke; here nothing ships unless all of them
+      # work, so the remaining jobs would only burn minutes.
+      fail-fast: true
+      matrix:
+        board: [rs485-can, relay-1ch, relay-6ch]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # Restore-only. A tag ref cannot read a cache written by a PR or by another tag, so a save
+      # here would produce a ~1.7 GB entry that nothing would ever restore -- including the next
+      # release. The writer is the warm-toolchain-cache job in cache-warm.yml, running on main,
+      # whose scope every ref can read.
       - name: Restore PlatformIO toolchain
         uses: actions/cache/restore@v6
         with:
@@ -53,8 +114,7 @@ jobs:
       - name: Install board packages
         run: |
           for attempt in 1 2 3 4 5; do
-            if pio pkg install \
-                 -e waveshare-rs485-can -e waveshare-relay-1ch -e waveshare-relay-6ch; then
+            if pio pkg install -e "waveshare-${{ matrix.board }}"; then
               exit 0
             fi
             echo "package install failed (attempt ${attempt}); retrying in $((attempt * 20))s"
@@ -63,29 +123,61 @@ jobs:
           echo "package install still failing after 5 attempts" >&2
           exit 1
 
-      - name: Verify before shipping
-        run: |
-          python3 tools/gen_profiles.py --check
-          bash tools/check_layering.sh
-          python3 tools/check_web_js.py
-          pio test -e native
+      - name: Build firmware
+        run: pio run -e "waveshare-${{ matrix.board }}"
 
-      - name: Build firmware (all boards)
-        run: |
-          pio run -e waveshare-rs485-can
-          pio run -e waveshare-relay-1ch
-          pio run -e waveshare-relay-6ch
+      # Both images: the OTA one the dashboard installs, and the factory one the browser flasher
+      # writes over USB. Named per board so publish can tell them apart after download.
+      #
+      # if-no-files-found: error rather than the default warning. A silently empty artifact would
+      # surface three steps later as a cp that cannot find its source, in the job that publishes.
+      - name: Upload images
+        uses: actions/upload-artifact@v7
+        with:
+          name: fw-${{ matrix.board }}
+          path: |
+            .pio/build/waveshare-${{ matrix.board }}/firmware.bin
+            .pio/build/waveshare-${{ matrix.board }}/firmware.factory.bin
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    # BOTH. This is the ordering guarantee the single job used to give for free: no image is
+    # attached and no feed is deployed unless every board built and every check passed.
+    needs: [verify, build]
+    steps:
+      - uses: actions/checkout@v7
+
+      # No PlatformIO and no toolchain here: this job only moves finished binaries around.
+      # Each artifact lands in fw/<artifact-name>/, so the images are at fw/fw-<board>/.
+      - name: Download images
+        uses: actions/download-artifact@v7
+        with:
+          path: fw
 
       - name: Stage release assets
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          # The matrix and $BOARDS are two lists of the same fact -- `strategy` is evaluated
+          # before `env` exists, so they cannot be derived from one another. If they ever
+          # disagree, an extra board would be built and silently not published, or a missing one
+          # would fail three lines down with a confusing cp error. Say it here instead.
+          built=$(ls -1 fw | wc -l)
+          want=$(printf '%s\n' $BOARDS | wc -l)
+          if [ "$built" -ne "$want" ]; then
+            echo "built $built board(s) but BOARDS lists $want: $(ls -1 fw | tr '\n' ' ')" >&2
+            echo "the matrix in this workflow and the BOARDS env have drifted apart" >&2
+            exit 1
+          fi
           mkdir -p dist
-          for board in rs485-can relay-1ch relay-6ch; do
-            cp ".pio/build/waveshare-${board}/firmware.bin" \
-               "dist/heliograph-${VERSION}-${board}.bin"
-            cp ".pio/build/waveshare-${board}/firmware.factory.bin" \
+          for board in $BOARDS; do
+            cp "fw/fw-${board}/firmware.bin" "dist/heliograph-${VERSION}-${board}.bin"
+            cp "fw/fw-${board}/firmware.factory.bin" \
                "dist/heliograph-${VERSION}-${board}-factory.bin"
           done
+          ls -l dist
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -99,15 +191,13 @@ jobs:
           mkdir -p site
           sed "s|__REPO_URL__|${{ github.server_url }}/${{ github.repository }}|" \
             flasher/index.html > site/index.html
-          for board in rs485-can relay-1ch relay-6ch; do
-            cp ".pio/build/waveshare-${board}/firmware.factory.bin" \
-               "site/heliograph-${board}-factory.bin"
+          for board in $BOARDS; do
+            cp "fw/fw-${board}/firmware.factory.bin" "site/heliograph-${board}-factory.bin"
             # The OTA image too, not just the factory one. The dashboard's update button
             # fetches this with fetch(), and Pages is the only host in the chain that sends
             # CORS headers -- the release asset redirects to one that does not, which is the
             # same reason the flasher bin is served from here.
-            cp ".pio/build/waveshare-${board}/firmware.bin" \
-               "site/heliograph-${board}.bin"
+            cp "fw/fw-${board}/firmware.bin" "site/heliograph-${board}.bin"
             sed -e "s/__VERSION__/${VERSION}/" -e "s/__BOARD__/${board}/" \
               flasher/manifest.json > "site/manifest-${board}.json"
           done
@@ -131,7 +221,7 @@ jobs:
               "${{ github.server_url }}" "${{ github.repository }}" "${GITHUB_REF_NAME}"
             printf '  "boards": {\n'
             first=1
-            for board in rs485-can relay-1ch relay-6ch; do
+            for board in $BOARDS; do
               file="heliograph-${board}.bin"
               sha=$(sha256sum "site/${file}" | cut -d' ' -f1)
               size=$(stat -c%s "site/${file}")


### PR DESCRIPTION
A release took **~7 minutes** end to end, and neither half of that was work.

| | before | after (expected) |
|---|---|---|
| CI on main | 132 s | ~64 s |
| Release | 296 s | ~155 s |

## Release: 161 s of the 296 was three boards, one after another

Inside a single job — more than half the run spent waiting for one compile to finish so an identical compile could start. Now a matrix.

The checks moved into their own job at the same time: they are all host-side, need no ESP32 toolchain, and had no business holding up a build that does.

## CI: 128 s of the 132 was a job that validates nothing

`warm-toolchain-cache` exists so other refs can read a cache, for the scoping reason its own comment explains. But it was the **longest** job in the run, so it decided when CI was "done" — and tagging a release waits for that conclusion. Half the wait was for a cache.

Moved to `cache-warm.yml`. It also could not fail safely where it was: its comment claimed *"the job only warms a cache, so its failure never blocks a release"*, which was untrue while a failure turned the whole CI run red. Now a failed warm is just a failed warm.

## The ordering guarantee is unchanged

`publish` needs `[verify, build]`. Nothing is attached and no feed is deployed unless **every** board built and **every** check passed — exactly what running them in sequence gave for free. A release that shipped three good images and one bad one would be far worse than a slow release.

## Tested without cutting a release

A real run would overwrite `latest.json` and break the update badge on live bridges, so instead the publish job's shell was extracted from the YAML and run **verbatim** against a faked `download-artifact` layout:

- the six staged asset names are **identical** to what v0.16.0 actually shipped — diffed against the real release, not eyeballed
- the site tree matches what Pages serves today, manifests included
- the feed's `sha256` is 64 chars and hashes the very file published beside it
- the new drift guard fires, with a message naming the cause

## One new guard

`strategy` is evaluated before `env` exists, so the board list genuinely cannot be shared between the matrix and the shell loops — they are two lists of one fact. The mismatch is now checked at release time rather than discovered later as a board that built and was silently never published.

## A version check worth noting

`download-artifact@v7` pairs with `upload-artifact@v7`, checked against the action's own tags rather than assumed. The two are **not** released in lockstep — download is already on v8 — and a wrong major is precisely the kind of thing you find out at the moment you need a release.

## Risk

This is release infrastructure, so the honest caveat: the *build* and *verify* jobs are mechanical (copied steps, one board per job) but have not run for real. The publish job — where the paths actually changed, from `.pio/build/...` to `fw/fw-<board>/...` — is the part that was simulated end to end.

The first real exercise will be the next tag. If it fails it fails before publishing, because `publish` runs last and everything it needs is checked on the way in.
