### PR TITLE
docs(ci): stop citing a version that does not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@
 # that file for the reasoning.
 #
 # Checks only. The ESP32 toolchain cache is warmed by cache-warm.yml, which runs on main for
-# the cache-scoping reason documented there -- it lived here until 0.16.1 and made this run take
+# the cache-scoping reason documented there -- it lived here until PR #67 and made this run take
 # twice as long as the checks it reports on, which mattered because tagging a release waits for
 # that conclusion.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@
 # downloads redirect to a host that sends no CORS headers, and ESP Web Tools
 # fetches the image with fetch(), which that would break.
 #
-# THREE JOBS, NOT ONE, since 0.16.1. The boards used to be built one after another inside a
+# THREE JOBS, NOT ONE (PR #67). The boards used to be built one after another inside a
 # single job: 161 s of the ~296 s a release took, more than half of it spent waiting for one
 # compile to finish so an identical compile could start. They now run as a matrix, and the
 # checks moved into their own job because they need no ESP32 toolchain and so have no business


### PR DESCRIPTION
Two workflow comments dated the release-pipeline split as **0.16.1**. No such release exists — and none should: the only thing on main since v0.16.0 is that CI change, so cutting a tag would publish firmware byte-identical to what every bridge already runs, and show them an update badge for it, purely to make a comment true.

They point at **PR #67** instead. A merged PR number is stable in a way an anticipated version number is not, and the repo already cites issues this way.

Same failure mode as the line-number references `check_layering.sh` rule 8 catches: correct-looking, unverifiable, and wrong the moment the plan changes.

Worth noting that this is the second time this session I wrote a version number into a comment before deciding to release it. The first (0.16.0, in the NVS-budget test) happened to come true; this one would only have come true if I let a comment drive a release.

Comments only — no workflow behaviour changes. All four workflows still parse.
