### PR TITLE
chore: second cleanup pass — dedupe the PMU transaction loop, close the dependency blind spot

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -5,6 +5,13 @@
 # a single tracking issue when there is something to report. It deliberately does NOT
 # open pull requests: an embedded toolchain or library bump must be a deliberate,
 # hardware-tested change, never an auto-merge.
+#
+# TWO SOURCES, because one of them cannot see everything. `pio pkg outdated` compares
+# registry packages only: a dependency pinned to a git URL has no registry version to
+# compare against and is silently reported as fine. ESPAsyncWebServer is pinned exactly
+# that way, so for two months this job reported "up-to-date" while 3.12.0 sat unnoticed
+# upstream -- the blind spot was in the very automation meant to prevent it. The second
+# step below reads the git pins straight out of platformio.ini and asks GitHub.
 
 name: Dependency check
 
@@ -42,19 +49,56 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
           if echo "$OUT" | grep -q "Everything is up-to-date"; then
-            echo "updates=false" >> "$GITHUB_OUTPUT"
+            echo "registry_updates=false" >> "$GITHUB_OUTPUT"
           else
+            echo "registry_updates=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Every `https://github.com/OWNER/REPO#vX.Y.Z` in platformio.ini, compared against that
+      # repository's latest release. Derived from the file rather than listing the libraries
+      # here: a second git pin added later is covered the day it is added, which is the whole
+      # failure this step exists for.
+      #
+      # Reports nothing when a pin is already current, and says so out loud when a pin has no
+      # releases at all -- "no newer version" and "cannot tell" must not look the same.
+      - name: Check git-pinned dependencies
+        id: gitpins
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPORT=""
+          while IFS= read -r pin; do
+            slug=${pin#https://github.com/}
+            repo=${slug%%#*}
+            have=${slug#*#}
+            latest=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+            if [ -z "$latest" ]; then
+              REPORT="${REPORT}${repo}: pinned at ${have}; no published release to compare"$'\n'
+            elif [ "$latest" != "$have" ]; then
+              REPORT="${REPORT}${repo}: pinned at ${have}, latest is ${latest}"$'\n'
+            fi
+          done < <(grep -oE 'https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[A-Za-z0-9_.-]+' platformio.ini | sort -u)
+          echo "$REPORT"
+          {
+            echo "report<<EOF"
+            echo "$REPORT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ -n "$REPORT" ]; then
             echo "updates=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "updates=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Open or update tracking issue
-        if: steps.outdated.outputs.updates == 'true'
+        if: steps.outdated.outputs.registry_updates == 'true' || steps.gitpins.outputs.updates == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPORT: ${{ steps.outdated.outputs.report }}
+          GIT_REPORT: ${{ steps.gitpins.outputs.report }}
         run: |
           TITLE="PlatformIO dependencies have updates available"
-          BODY=$(printf 'Monthly `pio pkg outdated` report:\n\n```\n%s\n```\n\nReview the changelogs and bump deliberately — toolchain and library updates are hardware-tested changes, per docs/decisions.md.' "$REPORT")
+          BODY=$(printf 'Monthly `pio pkg outdated` report:\n\n```\n%s\n```\n\nGit-pinned dependencies (not visible to `pio pkg outdated`):\n\n```\n%s\n```\n\nReview the changelogs and bump deliberately — toolchain and library updates are hardware-tested changes, per docs/decisions.md.' "$REPORT" "${GIT_REPORT:-none behind}")
           EXISTING=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body "$BODY"

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -59,8 +59,10 @@ jobs:
       # here: a second git pin added later is covered the day it is added, which is the whole
       # failure this step exists for.
       #
-      # Reports nothing when a pin is already current, and says so out loud when a pin has no
-      # releases at all -- "no newer version" and "cannot tell" must not look the same.
+      # Reports nothing when a pin is already current, and says so out loud when the answer
+      # could not be obtained -- "no newer version" and "cannot tell" must not look the same.
+      # A month with a GitHub hiccup therefore adds a line to the tracking issue rather than
+      # silently passing; noise in that direction is the safe direction.
       - name: Check git-pinned dependencies
         id: gitpins
         env:
@@ -73,7 +75,10 @@ jobs:
             have=${slug#*#}
             latest=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
             if [ -z "$latest" ]; then
-              REPORT="${REPORT}${repo}: pinned at ${have}; no published release to compare"$'\n'
+              # Deliberately does not claim there are no releases: an empty answer here is
+              # equally a 404 and a transient API failure, and `gh api` exits non-zero for
+              # both. Saying which one it was would be making it up.
+              REPORT="${REPORT}${repo}: pinned at ${have}; could not determine the latest release"$'\n'
             elif [ "$latest" != "$have" ]; then
               REPORT="${REPORT}${repo}: pinned at ${have}, latest is ${latest}"$'\n'
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,8 +152,15 @@ jobs:
 
       # No PlatformIO and no toolchain here: this job only moves finished binaries around.
       # Each artifact lands in fw/<artifact-name>/, so the images are at fw/fw-<board>/.
+      #
+      # v8, and the reason is the one behaviour change in it: a download whose digest does not
+      # match what the server recorded now FAILS the job instead of logging a warning. For a
+      # workflow whose whole output is firmware other people flash, a silently corrupted
+      # transfer is the worst outcome available -- worse than no release. The hash in
+      # latest.json is computed further down from these same files, so without this check a
+      # mangled image would simply be hashed faithfully and published as correct.
       - name: Download images
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: fw
 

--- a/docs/esp32s3-hardware-audit.md
+++ b/docs/esp32s3-hardware-audit.md
@@ -107,8 +107,8 @@ So no partition change and no sdkconfig change is needed. That part of the brief
 
 What is **not** there:
 
-- **Nothing in the firmware ever reads the coredump.** The only occurrence of the word anywhere
-  in the tree outside the two CSVs is a line in `docs/implementation-plan.md:174`. There is no
+- **Nothing in the firmware ever reads the coredump.** Outside the two partition CSVs the word
+  appeared nowhere in the tracked tree. There is no
   `esp_core_dump_image_check()`, no summary in the diagnostics payload, no REST route. A crash
   writes a full ELF dump to flash and the operator has no way to learn it exists without
   attaching a cable and running `espcoredump.py` by hand.

--- a/platformio.ini
+++ b/platformio.ini
@@ -181,8 +181,22 @@ lib_deps =
     ; package (component_manager.py), and removing the lib_ignore does NOT restore it --
     ; every later build on the machine keeps failing on the stripped includes until the
     ; package's pioarduino-build.py.<mcu> backup is copied back (learned 2026-07-22).
-    esp32async/AsyncTCP@3.4.10
-    https://github.com/ESP32Async/ESPAsyncWebServer#v3.11.2
+    ; BUMPED TOGETHER, not separately: ESPAsyncWebServer 3.12.0 requires AsyncTCP 3.5.0.
+    ; Pinning one without the other gives the resolver two ranges to satisfy and the
+    ; second-copy problem described above.
+    ;
+    ; AsyncTCP 3.5.0 changes abort() to run in the caller's task rather than queueing an
+    ; event, so onDisconnect/onError now fire on that task. Checked before bumping: no code
+    ; here calls AsyncClient::abort(), and neither does eModbus -- ModbusServerTCPasync uses
+    ; close(true), which was already synchronous. That matters because it silences its own
+    ; onDisconnect handler around a teardown to avoid a deadlock; had the changed path been
+    ; the one it uses, this bump would have needed far more than a build.
+    ;
+    ; 3.12.0 also rewrites the WebSocket layer. Not a path here -- the dashboard uses SSE
+    ; (AsyncEventSource), which IS touched, by two use-after-free fixes on the abort/close
+    ; teardown. That is the reason to take this rather than sit on 3.11.2.
+    esp32async/AsyncTCP@3.5.0
+    https://github.com/ESP32Async/ESPAsyncWebServer#v3.12.0
     miq19/eModbus@1.7.4
     bblanchon/ArduinoJson@^7.4.3
     bertmelis/espMqttClient@^1.7.3

--- a/src/device/measurement.cpp
+++ b/src/device/measurement.cpp
@@ -2,7 +2,9 @@
 
 #include "measurement.h"
 
+#include <algorithm>
 #include <cstring>
+#include <utility>
 
 namespace heliograph {
 
@@ -29,22 +31,16 @@ const char* unitSymbol(Unit unit) {
     return "";
 }
 
-Measurement* MeasurementSet::findMutable(const char* id) {
-    for (auto& m : measurements_) {
-        if (idEquals(m.id, id)) {
-            return &m;
-        }
-    }
-    return nullptr;
+const Measurement* MeasurementSet::find(const char* id) const {
+    const auto it = std::find_if(measurements_.begin(), measurements_.end(),
+                                 [id](const Measurement& m) { return idEquals(m.id, id); });
+    return it == measurements_.end() ? nullptr : &*it;
 }
 
-const Measurement* MeasurementSet::find(const char* id) const {
-    for (const auto& m : measurements_) {
-        if (idEquals(m.id, id)) {
-            return &m;
-        }
-    }
-    return nullptr;
+// Delegates rather than repeating the search: idEquals is the definition of "same
+// measurement", and it belongs in one place.
+Measurement* MeasurementSet::findMutable(const char* id) {
+    return const_cast<Measurement*>(std::as_const(*this).find(id));
 }
 
 void MeasurementSet::declare(const char* id, MeasurementType type, Unit unit,

--- a/src/diagnostics/frame_capture.cpp
+++ b/src/diagnostics/frame_capture.cpp
@@ -134,19 +134,13 @@ bool FrameCapture::done(uint64_t nowMs) const {
 }
 
 uint32_t FrameCapture::modbusFrames() const {
-    uint32_t n = 0;
-    for (const auto& f : frames_) {
-        if (f.modbusCrcValid) ++n;
-    }
-    return n;
+    return static_cast<uint32_t>(std::count_if(
+        frames_.begin(), frames_.end(), [](const CapturedFrame& f) { return f.modbusCrcValid; }));
 }
 
 uint32_t FrameCapture::pmuFrames() const {
-    uint32_t n = 0;
-    for (const auto& f : frames_) {
-        if (f.pmuFrameValid) ++n;
-    }
-    return n;
+    return static_cast<uint32_t>(std::count_if(
+        frames_.begin(), frames_.end(), [](const CapturedFrame& f) { return f.pmuFrameValid; }));
 }
 
 }  // namespace heliograph::diag

--- a/src/drivers/eversolar_legacy/eversolar_driver.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_driver.cpp
@@ -10,13 +10,6 @@
 namespace heliograph::eversolar {
 namespace {
 
-constexpr uint32_t kResponseTimeoutMs = 1000;
-/// Wall-clock ceiling on one transact() exchange. A real reply lands well inside a second
-/// (first byte within the response timeout, then ~90 bytes stream in milliseconds); 3 s leaves
-/// ample slack while still bounding a pathological trickle that never completes a frame.
-constexpr uint32_t kTransactionDeadlineMs = 3000;
-constexpr size_t   kRxBufferSize      = kMaxFrameSize + 16;
-constexpr uint32_t kBusLockTimeoutMs  = 2000;
 /// The reference sends the re-register broadcast 8 times, its own comment says the spec
 /// calls for 3. We follow the comment: it is the only statement about the spec we have, and
 /// 8 was never justified.
@@ -100,11 +93,6 @@ EversolarDriver::TransactResult EversolarDriver::transact(CommandCode command,
         return TransactResult::TransportError;
     }
 
-    TransportLock lock(*transport_, kBusLockTimeoutMs);
-    if (!lock.held()) {
-        return TransactResult::TransportError;
-    }
-
     uint8_t request[kMaxFrameSize];
     size_t  requestLen = 0;
     if (buildRequest(command, destination, data, dataLen, request, sizeof(request), requestLen) !=
@@ -112,144 +100,16 @@ EversolarDriver::TransactResult EversolarDriver::transact(CommandCode command,
         return TransactResult::TransportError;
     }
 
-    transport_->flushInput();
-    if (transport_->write(request, requestLen) != requestLen) {
-        // The one terminal state before the traceOutcome scaffolding exists. Left silent it
-        // would be the only failure without a trace -- the exact blind spot this logging is
-        // for (review, 2026-07-20).
-        log::trace("RS485 tx failed: %u byte(s) not fully written",
-                   static_cast<unsigned>(requestLen));
-        return TransactResult::TransportError;
-    }
-
-    uint8_t rx[kRxBufferSize];
-    size_t  have = 0;
-    bool    sawChecksumError = false;
-
-    // Tracing used to happen per read() in the transport, and a single reply arrives in ~40
-    // one-byte chunks: one frame filled the entire log ring, so a captured failure showed a
-    // byte and a half of context (2026-07-20). One line per transaction instead -- and it
-    // reports a REJECTED frame, which previously vanished into the "timeout" bucket and made
-    // a talking inverter indistinguishable from a dead bus.
-    size_t  received  = 0;  ///< bytes ever read in this transaction, before any are consumed
-    size_t  rejected  = 0;
-    uint8_t rejSrc[2] = {0, 0};
-    uint8_t rejCtrl = 0, rejFn = 0;
-    const auto traceOutcome = [&](const char* outcome) {
-        if (!log::enabled(LogLevel::Trace)) {
-            return;
-        }
-        if (rejected > 0) {
-            log::trace("RS485 %s: %u byte(s), %u frame(s) rejected, last from %02X %02X ctrl %02X fn %02X",
-                       outcome, static_cast<unsigned>(received), static_cast<unsigned>(rejected),
-                       rejSrc[0], rejSrc[1], rejCtrl, rejFn);
-        } else {
-            log::trace("RS485 %s: %u byte(s) received", outcome, static_cast<unsigned>(received));
-        }
-        if (received > 0) {
-            log::traceHex("RS485 RX", rx, have);
-        }
-    };
-
-    const uint64_t deadline = transport_->nowMs() + kTransactionDeadlineMs;
-
-    for (;;) {
-        // Overall wall-clock bound on the whole exchange. Each read() renews its own 1 s
-        // timeout, so a sustained trickle of bytes never trips the n==0 branch below and the
-        // loop -- holding the bus lock -- could otherwise run unbounded until the watchdog
-        // reboots (review, 2026-07-20).
-        if (transport_->nowMs() >= deadline) {
-            ++timeouts_;
-            traceOutcome("transaction deadline exceeded");
-            return TransactResult::Timeout;
-        }
-
-        Frame      frame;
-        const auto parsed = parseFrame(rx, have, frame);
-
-        if (parsed == ParseResult::Ok) {
-            auto valid = validateResponse(frame, command, expectedSource);
-            if (valid == ParseResult::WrongSource && altSource != nullptr) {
-                valid = validateResponse(frame, command, *altSource);
-            }
-            if (valid == ParseResult::Ok) {
-                if (frame.dataLength > payloadCapacity) {
-                    // Unreachable today (every caller passes a full-size buffer), but this is
-                    // an InvalidFrame return and every other one tallies. Left untallied it
-                    // would be a return path that silently reports nothing the moment some
-                    // future caller passes a smaller buffer.
-                    ++invalidFrames_;
-                    traceOutcome("payload too large");
-                    return TransactResult::InvalidFrame;
-                }
-                if (frame.dataLength > 0) {
-                    std::memcpy(payloadOut, frame.data, frame.dataLength);
-                }
-                payloadLen = frame.dataLength;
-                traceOutcome("ok");
-                return TransactResult::Ok;
-            }
-            // A well-formed frame that is not ours: our own transmission echoed back by the
-            // half-duplex bus, or traffic for another inverter. Drop it and keep looking
-            // rather than treat the whole exchange as failed. Recorded, though -- if the
-            // inverter answers with something unexpected, that is the single most useful
-            // fact about the failure and it used to leave no trace at all.
-            ++rejected;
-            rejSrc[0] = frame.source.high;
-            rejSrc[1] = frame.source.low;
-            rejCtrl   = frame.control;
-            rejFn     = frame.function;
-            std::memmove(rx, rx + frame.frameLength, have - frame.frameLength);
-            have -= frame.frameLength;
-            continue;
-        }
-
-        if (parsed == ParseResult::BadHeader) {
-            // Resync: drop one byte and rescan. Line noise at the start of a reply must not
-            // cost us the reply itself.
-            std::memmove(rx, rx + 1, have - 1);
-            --have;
-            continue;
-        }
-
-        if (parsed == ParseResult::BadChecksum) {
-            sawChecksumError = true;
-            ++checksumErrors_;
-            const size_t skip = frame.frameLength > 0 ? frame.frameLength : 1;
-            const size_t n    = skip < have ? skip : have;
-            std::memmove(rx, rx + n, have - n);
-            have -= n;
-            continue;
-        }
-
-        // Incomplete: read more.
-        if (have >= sizeof(rx)) {
-            ++invalidFrames_;
-            traceOutcome("buffer full without a valid frame");
-            return TransactResult::InvalidFrame;
-        }
-        const size_t n = transport_->read(rx + have, sizeof(rx) - have, kResponseTimeoutMs);
-        if (n == 0) {
-            if (sawChecksumError) {
-                traceOutcome("checksum error");
-                return TransactResult::ChecksumError;
-            }
-            ++timeouts_;
-            // "silent" only when nothing arrived at all; otherwise something answered and we
-            // did not accept it, which is a different problem with a different fix.
-            traceOutcome(received > 0 ? "timeout after partial/rejected data" : "silent");
-            return TransactResult::Timeout;
-        }
-        have += n;
-        received += n;
-    }
+    const pmu::Exchange exchange{request, requestLen, command, expectedSource, altSource};
+    return pmu::transact(*transport_, exchange, payloadOut, payloadCapacity, payloadLen, tally_,
+                         "RS485");
 }
 
 void EversolarDriver::reRegisterAll() {
     if (transport_ == nullptr) {
         return;
     }
-    TransportLock lock(*transport_, kBusLockTimeoutMs);
+    TransportLock lock(*transport_, pmu::kBusLockTimeoutMs);
     if (!lock.held()) {
         return;
     }
@@ -449,7 +309,7 @@ PollResult EversolarDriver::poll(DeviceState& state) {
 
     NormalInfo info;
     if (decodeNormalInfo(payload, payloadLen, info, options_.layout) != DecodeResult::Ok) {
-        ++invalidFrames_;
+        ++tally_.invalidFrames;
         return PollResult::InvalidFrame;
     }
 

--- a/src/drivers/eversolar_legacy/eversolar_driver.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_driver.cpp
@@ -5,8 +5,6 @@
 
 #include <cstring>
 
-#include "diagnostics/logger.h"
-
 namespace heliograph::eversolar {
 namespace {
 

--- a/src/drivers/eversolar_legacy/eversolar_driver.h
+++ b/src/drivers/eversolar_legacy/eversolar_driver.h
@@ -13,6 +13,7 @@
 #include "drivers/inverter_driver.h"
 #include "eversolar_parser.h"
 #include "protocols/pmu/pmu_protocol.h"
+#include "protocols/pmu/pmu_transaction.h"
 
 namespace heliograph::eversolar {
 
@@ -56,7 +57,8 @@ public:
     bool registered() const { return registered_; }
 
 private:
-    enum class TransactResult { Ok, Timeout, ChecksumError, InvalidFrame, TransportError };
+    /// The shared loop's outcome, under the name every call site here already uses.
+    using TransactResult = pmu::TransactStatus;
 
     /// Sends a request and waits for its matching response, resynchronising past bus noise
     /// and any echo of our own transmission.
@@ -103,13 +105,20 @@ private:
     bool                 channelsDeclared_ = false;
     bool                 declaredDual_     = false;
 
-    uint32_t checksumErrors_ = 0;
-    uint32_t invalidFrames_  = 0;
-    uint32_t timeouts_       = 0;
+    /// Bumped by pmu::transact, which does the counting because it is where the failures are
+    /// seen -- a single exchange can meet several bad frames.
+    pmu::Tally tally_;
 
 public:
     BusErrorCounts busErrors() const override {
-        return {checksumErrors_, timeouts_, invalidFrames_};
+        // Field by field, not brace-init. Tally and BusErrorCounts happen to agree on order
+        // today; a positional copy would swap two counters silently the day one of them gains
+        // a field, and nothing that reads these numbers would look wrong -- only be wrong.
+        BusErrorCounts out;
+        out.checksumErrors = tally_.checksumErrors;
+        out.timeouts       = tally_.timeouts;
+        out.invalidFrames  = tally_.invalidFrames;
+        return out;
     }
 };
 

--- a/src/drivers/solax_x1/solax_driver.cpp
+++ b/src/drivers/solax_x1/solax_driver.cpp
@@ -11,11 +11,6 @@
 namespace heliograph::solax {
 namespace {
 
-constexpr uint32_t kResponseTimeoutMs = 1000;
-/// Wall-clock ceiling on one transact() exchange; same reasoning as the sibling PMU driver.
-constexpr uint32_t kTransactionDeadlineMs = 3000;
-constexpr size_t   kRxBufferSize          = kMaxFrameSize + 16;
-constexpr uint32_t kBusLockTimeoutMs      = 2000;
 /// Consecutive status-report timeouts before poll() runs the non-disruptive recovery probe.
 /// One is a dropped frame; a run means the inverter dropped out (e.g. powered down at dusk).
 constexpr uint8_t kTimeoutsBeforeRecoveryProbe = 3;
@@ -89,11 +84,6 @@ SolaxDriver::TransactResult SolaxDriver::transact(Address source, CommandCode co
         return TransactResult::TransportError;
     }
 
-    TransportLock lock(*transport_, kBusLockTimeoutMs);
-    if (!lock.held()) {
-        return TransactResult::TransportError;
-    }
-
     uint8_t request[kMaxFrameSize];
     size_t  requestLen = 0;
     if (buildRequestFrom(source, command, destination, data, dataLen, request, sizeof(request),
@@ -101,117 +91,9 @@ SolaxDriver::TransactResult SolaxDriver::transact(Address source, CommandCode co
         return TransactResult::TransportError;
     }
 
-    transport_->flushInput();
-    if (transport_->write(request, requestLen) != requestLen) {
-        log::trace("RS485 tx failed: %u byte(s) not fully written",
-                   static_cast<unsigned>(requestLen));
-        return TransactResult::TransportError;
-    }
-
-    uint8_t rx[kRxBufferSize];
-    size_t  have             = 0;
-    bool    sawChecksumError = false;
-    size_t  received         = 0;
-    size_t  rejected         = 0;
-    uint8_t rejSrc[2]        = {0, 0};
-    uint8_t rejCtrl = 0, rejFn = 0;
-    const auto traceOutcome = [&](const char* outcome) {
-        if (!log::enabled(LogLevel::Trace)) {
-            return;
-        }
-        if (rejected > 0) {
-            log::trace("SOLAX %s: %u byte(s), %u frame(s) rejected, last from %02X %02X ctrl %02X fn %02X",
-                       outcome, static_cast<unsigned>(received), static_cast<unsigned>(rejected),
-                       rejSrc[0], rejSrc[1], rejCtrl, rejFn);
-        } else {
-            log::trace("SOLAX %s: %u byte(s) received", outcome, static_cast<unsigned>(received));
-        }
-        if (received > 0) {
-            log::traceHex("SOLAX RX", rx, have);
-        }
-    };
-
-    const uint64_t deadline = transport_->nowMs() + kTransactionDeadlineMs;
-
-    for (;;) {
-        if (transport_->nowMs() >= deadline) {
-            ++timeouts_;
-            traceOutcome("transaction deadline exceeded");
-            return TransactResult::Timeout;
-        }
-
-        Frame      frame;
-        const auto parsed = parseFrame(rx, have, frame);
-
-        if (parsed == ParseResult::Ok) {
-            auto valid = validateResponse(frame, command, expectedSource);
-            if (valid == ParseResult::WrongSource && altSource != nullptr) {
-                valid = validateResponse(frame, command, *altSource);
-            }
-            if (valid == ParseResult::Ok) {
-                if (frame.dataLength > payloadCapacity) {
-                    // Unreachable today (every caller passes a full-size buffer), but this is
-                    // an InvalidFrame return and every other one tallies. Left untallied it
-                    // would be a return path that silently reports nothing the moment some
-                    // future caller passes a smaller buffer.
-                    ++invalidFrames_;
-                    traceOutcome("payload too large");
-                    return TransactResult::InvalidFrame;
-                }
-                if (frame.dataLength > 0) {
-                    std::memcpy(payloadOut, frame.data, frame.dataLength);
-                }
-                payloadLen = frame.dataLength;
-                traceOutcome("ok");
-                return TransactResult::Ok;
-            }
-            // A well-formed frame that is not ours (our own echo, or another master's
-            // traffic). Drop it, record it, keep looking.
-            ++rejected;
-            rejSrc[0] = frame.source.high;
-            rejSrc[1] = frame.source.low;
-            rejCtrl   = frame.control;
-            rejFn     = frame.function;
-            std::memmove(rx, rx + frame.frameLength, have - frame.frameLength);
-            have -= frame.frameLength;
-            continue;
-        }
-
-        if (parsed == ParseResult::BadHeader) {
-            std::memmove(rx, rx + 1, have - 1);
-            --have;
-            continue;
-        }
-
-        if (parsed == ParseResult::BadChecksum) {
-            sawChecksumError = true;
-            ++checksumErrors_;
-            const size_t skip = frame.frameLength > 0 ? frame.frameLength : 1;
-            const size_t n    = skip < have ? skip : have;
-            std::memmove(rx, rx + n, have - n);
-            have -= n;
-            continue;
-        }
-
-        // Incomplete: read more.
-        if (have >= sizeof(rx)) {
-            ++invalidFrames_;
-            traceOutcome("buffer full without a valid frame");
-            return TransactResult::InvalidFrame;
-        }
-        const size_t n = transport_->read(rx + have, sizeof(rx) - have, kResponseTimeoutMs);
-        if (n == 0) {
-            if (sawChecksumError) {
-                traceOutcome("checksum error");
-                return TransactResult::ChecksumError;
-            }
-            ++timeouts_;
-            traceOutcome(received > 0 ? "timeout after partial/rejected data" : "silent");
-            return TransactResult::Timeout;
-        }
-        have += n;
-        received += n;
-    }
+    const pmu::Exchange exchange{request, requestLen, command, expectedSource, altSource};
+    return pmu::transact(*transport_, exchange, payloadOut, payloadCapacity, payloadLen, tally_,
+                         "SOLAX");
 }
 
 bool SolaxDriver::verifyByStatusQuery() {
@@ -408,7 +290,7 @@ PollResult SolaxDriver::poll(DeviceState& state) {
 
     StatusReport report;
     if (decodeStatusReport(payload, payloadLen, report) != DecodeResult::Ok) {
-        ++invalidFrames_;
+        ++tally_.invalidFrames;
         log::trace("SOLAX status report too short: %u byte(s)",
                    static_cast<unsigned>(payloadLen));
         return PollResult::InvalidFrame;

--- a/src/drivers/solax_x1/solax_driver.h
+++ b/src/drivers/solax_x1/solax_driver.h
@@ -22,6 +22,7 @@
 
 #include "drivers/inverter_driver.h"
 #include "drivers/solax_x1/solax_parser.h"
+#include "protocols/pmu/pmu_transaction.h"
 
 namespace heliograph::solax {
 
@@ -53,7 +54,8 @@ public:
     bool registered() const { return registered_; }
 
 private:
-    enum class TransactResult { Ok, Timeout, ChecksumError, InvalidFrame, TransportError };
+    /// The shared loop's outcome, under the name every call site here already uses.
+    using TransactResult = pmu::TransactStatus;
 
     /// Sends a request and waits for its matching response, resynchronising past bus noise
     /// and echoes. `source` exists because the reference sends the SEND_ADDRESS frame with
@@ -91,13 +93,18 @@ private:
     /// has one; the payload carries two). See poll().
     bool pv2Declared_ = false;
 
-    uint32_t checksumErrors_ = 0;
-    uint32_t invalidFrames_  = 0;
-    uint32_t timeouts_       = 0;
+    /// Bumped by pmu::transact. See the note on the sibling driver's copy.
+    pmu::Tally tally_;
 
 public:
     BusErrorCounts busErrors() const override {
-        return {checksumErrors_, timeouts_, invalidFrames_};
+        // Field by field, not brace-init: Tally and BusErrorCounts agree on order today, and
+        // a positional copy would swap two counters silently if either ever gained a field.
+        BusErrorCounts out;
+        out.checksumErrors = tally_.checksumErrors;
+        out.timeouts       = tally_.timeouts;
+        out.invalidFrames  = tally_.invalidFrames;
+        return out;
     }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,19 +391,15 @@ std::string scanNetworksJson() {
         if (ssid.length() == 0) {
             continue;
         }
-        bool merged = false;
-        for (auto& u : unique) {
-            if (u.ssid == ssid) {
-                if (WiFi.RSSI(i) > u.rssi) {
-                    u.rssi = WiFi.RSSI(i);
-                    u.open = WiFi.encryptionType(i) == WIFI_AUTH_OPEN;
-                }
-                merged = true;
-                break;
-            }
-        }
-        if (!merged) {
+        const auto seen = std::find_if(unique.begin(), unique.end(),
+                                       [&ssid](const Network& u) { return u.ssid == ssid; });
+        if (seen == unique.end()) {
             unique.push_back({ssid, WiFi.RSSI(i), WiFi.encryptionType(i) == WIFI_AUTH_OPEN});
+        } else if (WiFi.RSSI(i) > seen->rssi) {
+            // Same SSID on a second AP: keep the stronger one, so the list shows the radio the
+            // bridge would actually associate with.
+            seen->rssi = WiFi.RSSI(i);
+            seen->open = WiFi.encryptionType(i) == WIFI_AUTH_OPEN;
         }
     }
 

--- a/src/outputs/mqtt/publish_policy.cpp
+++ b/src/outputs/mqtt/publish_policy.cpp
@@ -2,6 +2,7 @@
 
 #include "publish_policy.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace heliograph::mqtt {
@@ -43,13 +44,9 @@ bool PublishThrottle::shouldPublish(const DeviceState& state, uint64_t nowMs) {
         if (!m.supported) {
             continue;
         }
-        const Sample* previous = nullptr;
-        for (const auto& s : lastPublished_) {
-            if (s.id == m.id) {
-                previous = &s;
-                break;
-            }
-        }
+        const auto    it       = std::find_if(lastPublished_.begin(), lastPublished_.end(),
+                                              [&m](const Sample& s) { return s.id == m.id; });
+        const Sample* previous = it == lastPublished_.end() ? nullptr : &*it;
         if (previous == nullptr) {
             return true;  // a channel appeared, e.g. a second MPPT was detected
         }

--- a/src/protocols/pmu/pmu_transaction.cpp
+++ b/src/protocols/pmu/pmu_transaction.cpp
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+//
+// Moved here from the two PMU drivers, which held the same loop twice. The comments below are
+// the originals: they record decisions made against real hardware and a real bus, and none of
+// that reasoning changed by moving the code.
+
+#include "pmu_transaction.h"
+
+#include <cstdio>
+#include <cstring>
+
+#include "diagnostics/logger.h"
+
+namespace heliograph::pmu {
+
+TransactStatus transact(Transport& transport, const Exchange& exchange, uint8_t* payloadOut,
+                        size_t payloadCapacity, size_t& payloadLen, Tally& tally,
+                        const char* logPrefix) {
+    payloadLen = 0;
+
+    TransportLock lock(transport, kBusLockTimeoutMs);
+    if (!lock.held()) {
+        return TransactStatus::TransportError;
+    }
+
+    transport.flushInput();
+    if (transport.write(exchange.request, exchange.requestLen) != exchange.requestLen) {
+        // The one terminal state before the traceOutcome scaffolding exists. Left silent it
+        // would be the only failure without a trace -- the exact blind spot this logging is
+        // for (review, 2026-07-20).
+        log::trace("RS485 tx failed: %u byte(s) not fully written",
+                   static_cast<unsigned>(exchange.requestLen));
+        return TransactStatus::TransportError;
+    }
+
+    uint8_t rx[kRxBufferSize];
+    size_t  have             = 0;
+    bool    sawChecksumError = false;
+
+    // Tracing used to happen per read() in the transport, and a single reply arrives in ~40
+    // one-byte chunks: one frame filled the entire log ring, so a captured failure showed a
+    // byte and a half of context (2026-07-20). One line per transaction instead -- and it
+    // reports a REJECTED frame, which previously vanished into the "timeout" bucket and made
+    // a talking inverter indistinguishable from a dead bus.
+    size_t  received  = 0;  ///< bytes ever read in this transaction, before any are consumed
+    size_t  rejected  = 0;
+    uint8_t rejSrc[2] = {0, 0};
+    uint8_t rejCtrl = 0, rejFn = 0;
+    const auto traceOutcome = [&](const char* outcome) {
+        if (!log::enabled(LogLevel::Trace)) {
+            return;
+        }
+        if (rejected > 0) {
+            log::trace("%s %s: %u byte(s), %u frame(s) rejected, last from %02X %02X ctrl %02X fn %02X",
+                       logPrefix, outcome, static_cast<unsigned>(received),
+                       static_cast<unsigned>(rejected), rejSrc[0], rejSrc[1], rejCtrl, rejFn);
+        } else {
+            log::trace("%s %s: %u byte(s) received", logPrefix, outcome,
+                       static_cast<unsigned>(received));
+        }
+        if (received > 0) {
+            // "<bus> RX", exactly as both drivers wrote it before this moved. Built rather
+            // than passed so the caller has one label to supply, not two that could disagree.
+            char label[24];
+            std::snprintf(label, sizeof(label), "%s RX", logPrefix);
+            log::traceHex(label, rx, have);
+        }
+    };
+
+    const uint64_t deadline = transport.nowMs() + kTransactionDeadlineMs;
+
+    for (;;) {
+        // Overall wall-clock bound on the whole exchange. Each read() renews its own 1 s
+        // timeout, so a sustained trickle of bytes never trips the n==0 branch below and the
+        // loop -- holding the bus lock -- could otherwise run unbounded until the watchdog
+        // reboots (review, 2026-07-20).
+        if (transport.nowMs() >= deadline) {
+            ++tally.timeouts;
+            traceOutcome("transaction deadline exceeded");
+            return TransactStatus::Timeout;
+        }
+
+        Frame      frame;
+        const auto parsed = parseFrame(rx, have, frame);
+
+        if (parsed == ParseResult::Ok) {
+            auto valid = validateResponse(frame, exchange.command, exchange.expectedSource);
+            if (valid == ParseResult::WrongSource && exchange.altSource != nullptr) {
+                valid = validateResponse(frame, exchange.command, *exchange.altSource);
+            }
+            if (valid == ParseResult::Ok) {
+                if (frame.dataLength > payloadCapacity) {
+                    // Unreachable today (every caller passes a full-size buffer), but this is
+                    // an InvalidFrame return and every other one tallies. Left untallied it
+                    // would be a return path that silently reports nothing the moment some
+                    // future caller passes a smaller buffer.
+                    ++tally.invalidFrames;
+                    traceOutcome("payload too large");
+                    return TransactStatus::InvalidFrame;
+                }
+                if (frame.dataLength > 0) {
+                    std::memcpy(payloadOut, frame.data, frame.dataLength);
+                }
+                payloadLen = frame.dataLength;
+                traceOutcome("ok");
+                return TransactStatus::Ok;
+            }
+            // A well-formed frame that is not ours: our own transmission echoed back by the
+            // half-duplex bus, or traffic for another inverter. Drop it and keep looking
+            // rather than treat the whole exchange as failed. Recorded, though -- if the
+            // inverter answers with something unexpected, that is the single most useful
+            // fact about the failure and it used to leave no trace at all.
+            ++rejected;
+            rejSrc[0] = frame.source.high;
+            rejSrc[1] = frame.source.low;
+            rejCtrl   = frame.control;
+            rejFn     = frame.function;
+            std::memmove(rx, rx + frame.frameLength, have - frame.frameLength);
+            have -= frame.frameLength;
+            continue;
+        }
+
+        if (parsed == ParseResult::BadHeader) {
+            // Resync: drop one byte and rescan. Line noise at the start of a reply must not
+            // cost us the reply itself.
+            std::memmove(rx, rx + 1, have - 1);
+            --have;
+            continue;
+        }
+
+        if (parsed == ParseResult::BadChecksum) {
+            sawChecksumError = true;
+            ++tally.checksumErrors;
+            const size_t skip = frame.frameLength > 0 ? frame.frameLength : 1;
+            const size_t n    = skip < have ? skip : have;
+            std::memmove(rx, rx + n, have - n);
+            have -= n;
+            continue;
+        }
+
+        // Incomplete: read more.
+        if (have >= sizeof(rx)) {
+            ++tally.invalidFrames;
+            traceOutcome("buffer full without a valid frame");
+            return TransactStatus::InvalidFrame;
+        }
+        const size_t n = transport.read(rx + have, sizeof(rx) - have, kResponseTimeoutMs);
+        if (n == 0) {
+            if (sawChecksumError) {
+                traceOutcome("checksum error");
+                return TransactStatus::ChecksumError;
+            }
+            ++tally.timeouts;
+            // "silent" only when nothing arrived at all; otherwise something answered and we
+            // did not accept it, which is a different problem with a different fix.
+            traceOutcome(received > 0 ? "timeout after partial/rejected data" : "silent");
+            return TransactStatus::Timeout;
+        }
+        have += n;
+        received += n;
+    }
+}
+
+}  // namespace heliograph::pmu

--- a/src/protocols/pmu/pmu_transaction.h
+++ b/src/protocols/pmu/pmu_transaction.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+//
+// One request/response exchange on a half-duplex PMU bus.
+//
+// SEPARATE FROM pmu_protocol.h ON PURPOSE. That header is a pure codec -- build a frame, parse
+// a frame, validate a reply -- with no I/O and no clock. This one performs a transaction, so it
+// depends on Transport. Keeping them apart means the codec stays something you can reason about
+// without a bus at all, which is what makes its tests cheap.
+//
+// WHY IT EXISTS: the two PMU drivers each carried their own copy of this loop. Normalised for
+// whitespace they were 119 and 116 lines with 25 differing, and of those the only real
+// differences were the function signature, which builder made the request, and the string in the
+// log line. Everything that decides what happens on the wire -- the transaction deadline,
+// resynchronising past line noise, dropping a frame addressed to someone else, tallying a
+// checksum error, reassembling a reply split across reads -- was identical twice. A fix applied
+// to one and not the other is the failure this prevents; the deadline itself was once exactly
+// that kind of fix.
+//
+// Deliberately brand-free, comments included: layering rule 1 caught an earlier draft of this
+// header naming both drivers, and it was right to. A third PMU device should find a description
+// of the protocol here, not of whoever happened to need it first.
+//
+// Not platform code: Transport is an interface over cstdint, so this compiles and is tested on
+// the host like the codec beside it.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "pmu_protocol.h"
+#include "transport/transport.h"
+
+namespace heliograph::pmu {
+
+/// Shared line timing. Identical in both drivers before this module existed, declared twice.
+inline constexpr uint32_t kResponseTimeoutMs = 1000;
+/// Wall-clock ceiling on one transact() exchange. A real reply lands well inside a second
+/// (first byte within the response timeout, then ~90 bytes stream in milliseconds); 3 s leaves
+/// ample slack while still bounding a pathological trickle that never completes a frame.
+inline constexpr uint32_t kTransactionDeadlineMs = 3000;
+inline constexpr uint32_t kBusLockTimeoutMs      = 2000;
+inline constexpr size_t   kRxBufferSize          = kMaxFrameSize + 16;
+
+enum class TransactStatus : uint8_t { Ok, Timeout, ChecksumError, InvalidFrame, TransportError };
+
+/// Bus-error tallies, owned by the driver and bumped here.
+///
+/// Passed in rather than derived from the return value, and that is not a style choice: a
+/// transaction can meet several bad-checksum frames while returning ChecksumError once. Counting
+/// from the result would quietly undercount exactly the failure these numbers exist to expose.
+struct Tally {
+    uint32_t checksumErrors = 0;
+    uint32_t invalidFrames  = 0;
+    uint32_t timeouts       = 0;
+};
+
+/// What to send and what counts as an answer to it.
+struct Exchange {
+    const uint8_t* request    = nullptr;
+    size_t         requestLen = 0;
+    CommandCode    command{};
+    Address        expectedSource{};
+    /// A second acceptable source, or nullptr. Used where an inverter may answer from the
+    /// address it was given or from the one it had before being told.
+    const Address* altSource = nullptr;
+};
+
+/// Sends `exchange` and waits for a matching reply, taking the bus lock for the whole thing.
+///
+/// `logPrefix` labels this driver's traffic in trace output; it is the only thing here that
+/// differs per driver and it changes nothing about behaviour.
+TransactStatus transact(Transport& transport, const Exchange& exchange, uint8_t* payloadOut,
+                        size_t payloadCapacity, size_t& payloadLen, Tally& tally,
+                        const char* logPrefix);
+
+}  // namespace heliograph::pmu

--- a/src/relays/drm.cpp
+++ b/src/relays/drm.cpp
@@ -2,6 +2,8 @@
 
 #include "drm.h"
 
+#include <algorithm>
+
 namespace heliograph::drm {
 
 bool isValidRole(const std::string& role) {
@@ -20,14 +22,7 @@ std::vector<std::string> optionsFor(const std::vector<std::string>& roles) {
         if (role == "none" || !isValidRole(role)) {
             continue;
         }
-        bool seen = false;
-        for (const auto& existing : options) {
-            if (existing == role) {
-                seen = true;
-                break;
-            }
-        }
-        if (!seen) {
+        if (std::find(options.begin(), options.end(), role) == options.end()) {
             options.push_back(role);
         }
     }

--- a/src/state/state_store.cpp
+++ b/src/state/state_store.cpp
@@ -2,6 +2,9 @@
 
 #include "state_store.h"
 
+#include <algorithm>
+#include <utility>
+
 namespace heliograph {
 
 StateStore::StateStore() : current_(std::make_shared<const DeviceState>()) {}
@@ -17,12 +20,22 @@ StateHandle StateStore::snapshot() const {
     return current_;
 }
 
+const DeviceManager::Entry* DeviceManager::find(const DeviceId& id) const {
+    const auto it = std::find_if(entries_.begin(), entries_.end(),
+                                 [&id](const Entry& e) { return e.id == id; });
+    return it == entries_.end() ? nullptr : &*it;
+}
+
+// The const overload does the work; this one casts its result back. The object is genuinely
+// non-const on this path, so removing the const that was added a line ago is defined.
+DeviceManager::Entry* DeviceManager::find(const DeviceId& id) {
+    return const_cast<Entry*>(std::as_const(*this).find(id));
+}
+
 StateStore* DeviceManager::add(const DeviceId& id) {
     std::lock_guard<std::mutex> lock(m_);
-    for (auto& e : entries_) {
-        if (e.id == id) {
-            return e.store.get();
-        }
+    if (Entry* existing = find(id)) {
+        return existing->store.get();
     }
     if (entries_.size() >= kMaxActiveDevices) {
         return nullptr;
@@ -43,32 +56,19 @@ std::vector<DeviceId> DeviceManager::devices() const {
 
 StateHandle DeviceManager::state(const DeviceId& id) const {
     std::lock_guard<std::mutex> lock(m_);
-    for (const auto& e : entries_) {
-        if (e.id == id) {
-            return e.store->snapshot();
-        }
-    }
-    return nullptr;
+    const Entry* e = find(id);
+    return e == nullptr ? nullptr : e->store->snapshot();
 }
 
 StateStore* DeviceManager::store(const DeviceId& id) {
     std::lock_guard<std::mutex> lock(m_);
-    for (auto& e : entries_) {
-        if (e.id == id) {
-            return e.store.get();
-        }
-    }
-    return nullptr;
+    Entry* e = find(id);
+    return e == nullptr ? nullptr : e->store.get();
 }
 
 bool DeviceManager::contains(const DeviceId& id) const {
     std::lock_guard<std::mutex> lock(m_);
-    for (const auto& e : entries_) {
-        if (e.id == id) {
-            return true;
-        }
-    }
-    return false;
+    return find(id) != nullptr;
 }
 
 size_t DeviceManager::size() const {

--- a/src/state/state_store.h
+++ b/src/state/state_store.h
@@ -67,6 +67,20 @@ private:
         DeviceId                    id;
         std::unique_ptr<StateStore> store;
     };
+
+    /// Looks up an entry by id, or nullptr.
+    ///
+    /// CALLERS MUST ALREADY HOLD m_. It is not taken here and cannot be: every public method
+    /// above locks, and std::mutex is not recursive -- locking again would deadlock rather
+    /// than fail visibly. Private precisely so that "the caller holds the lock" stays a fact
+    /// about this file instead of a hope about every future one.
+    ///
+    /// One comparison, not five. Four methods used to each carry their own copy of the id
+    /// match; changing how devices are identified meant changing all four and noticing none
+    /// if you missed one.
+    const Entry* find(const DeviceId& id) const;
+    Entry*       find(const DeviceId& id);
+
     mutable std::mutex m_;
     std::vector<Entry> entries_;
 };

--- a/test/test_eversolar/driver.cpp
+++ b/test/test_eversolar/driver.cpp
@@ -318,6 +318,11 @@ static void test_reply_of_wrong_length_is_an_invalid_frame() {
     DeviceState state;
     TEST_ASSERT_EQUAL(PollResult::InvalidFrame, r.poll(state));
     TEST_ASSERT_NULL(state.measurements.find(measurement_id::kAcPowerTotal));
+    // The counter too, not just the verdict. busErrors() copies three same-typed fields out of
+    // the driver's tally, and the other two were already pinned by real-driver tests -- the
+    // checksum one here, the timeout one through DeviceContext's diagnostics. This was the
+    // field a wrong copy could have swapped with nothing noticing.
+    TEST_ASSERT_EQUAL_UINT32(1, r.driver.busErrors().invalidFrames);
 }
 
 static void test_a_run_of_timeouts_keeps_the_registration_and_never_broadcasts() {

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -32,6 +32,8 @@ core_paths=(
     src/protocols/modbus/modbus_rtu.cpp
     src/protocols/pmu/pmu_protocol.h
     src/protocols/pmu/pmu_protocol.cpp
+    src/protocols/pmu/pmu_transaction.h
+    src/protocols/pmu/pmu_transaction.cpp
     src/network/rtc_time.h
     src/network/rtc_time.cpp
     src/drivers/eversolar_legacy/eversolar_parser.h


### PR DESCRIPTION
Second pass of the cleanup brief. The first (#58) did the bulk; this audits what has landed since and acts on it. The honest headline is that there was not much: no dead code, no TODOs, no commented-out blocks, and **zero compiler warnings from `src/`** across all four ESP32 environments. The 188 warnings a clean build does produce are all Espressif's HAL and TinyUSB headers, plus eModbus.

Five commits, each independently revertable.

## `ci:` the dependency check could not see one of its dependencies

The monthly job has been reporting "up-to-date" while ESPAsyncWebServer sat two releases behind. `pio pkg outdated` compares registry packages; a git-pinned dependency has no registry version, so it was not reported as stale — it was not reported at all. The blind spot was inside the automation whose only job was to prevent it.

The new step reads the pins out of `platformio.ini` and asks GitHub, written over the pattern rather than over one library by name, so the next git pin is covered the day it is added. It was run verbatim against the real file before being trusted: one pin found, `v3.11.2 → v3.12.0` reported.

Also `download-artifact` v7 → v8, for its one behaviour change: a digest mismatch now fails the job instead of logging a warning. `latest.json` is hashed from those same downloaded files, so without it a corrupted transfer would be hashed faithfully and published as correct.

## `build(deps):` AsyncTCP 3.5.0 + ESPAsyncWebServer 3.12.0

Together, because 3.12.0 requires 3.5.0. Verified afterwards that libdeps holds exactly one AsyncTCP.

**The breaking change was checked before bumping.** AsyncTCP 3.5.0 runs `abort()` in the caller's task rather than queueing an event, so `onDisconnect`/`onError` now fire there. Nothing in `src/` calls `AsyncClient::abort()`, and neither does eModbus — `ModbusServerTCPasync` uses `close(true)`, which was already synchronous. That mattered: it silences its own `onDisconnect` around a teardown *specifically to avoid a deadlock*, so had it sat on the changed path this would have needed far more than a green build.

Worth taking rather than sitting still: 3.12.0 carries two use-after-free fixes on the abort/close teardown, and that path is under `AsyncEventSource` — the dashboard's live updates. The WebSocket rewrite is not a path here.

**This is the one commit not verified on hardware**, and it cannot be: the native env links none of these libraries.

## `refactor(pmu):` one transaction loop, not two copies

The two PMU drivers each carried the whole request/response loop. Normalised for whitespace: 119 and 116 lines, 25 differing — and of those the only real differences were the signature, which builder made the request, and the string in the log line. The deadline, the resync past line noise, dropping a frame meant for someone else, the checksum tally, reassembling a reply split across reads: identical, twice. That is the shape where a fix lands in one copy and not the other, and it had already happened once — the transaction deadline was itself such a fix.

277 lines out of the drivers; 114 lines of code into `src/protocols/pmu/pmu_transaction.{h,cpp}`. Kept separate from `pmu_protocol.h`, which stays a pure codec with no I/O and no clock.

Three decisions worth reviewing:

- **The tally is passed in, not derived from the return value.** One exchange can meet several bad-checksum frames while returning `ChecksumError` once; counting from the result would undercount the very failure these numbers exist to expose.
- **`busErrors()` copies field by field.** `Tally` and `BusErrorCounts` agree on order today, and nothing in the tests would catch a swap — `test_device_context` drives a fake driver, not these.
- **The trace label is built as `"<bus> RX"`** rather than passed, so the log lines are byte for byte what they were.

Layering rule 1 rejected the first draft: I had named both drivers in the new module's comments. It was right to, and the module is brand-free now, comments included.

## `refactor:` one lookup per collection

cppcheck flagged 17 hand-written loops as replaceable by `<algorithm>`. Taking all 17 would have been mechanical and wrong — several return a pointer *into* the container, where `std::find_if` plus the `end()` comparison is longer than the loop it replaces. Eleven are gone; the six left read better as loops.

The finding underneath was duplication, not style. `DeviceManager` had **four** copies of "walk `entries_` and compare `e.id`"; `MeasurementSet` had the same search twice. Both now have a single private `find()`, whose const overload does the work.

`find()` does **not** take the mutex, and that is load-bearing: every public method already holds it and `std::mutex` is not recursive, so locking again would deadlock rather than fail loudly. Said in the header where the next caller will read it.

## `docs:` a citation nobody could follow

The coredump finding in the hardware audit cited `docs/implementation-plan.md:174`. That file is in `.gitignore`, so anyone who clones follows the pointer to nothing. The finding is unchanged and still dated; only the pointer is gone.

Considered and rejected: a layering rule for this class. Of the four references from tracked docs to untracked paths, three are legitimate — twice the generated `profiles_generated.cpp`, once espMqttClient's own `Transport.h`. A rule needing three exemptions to catch one case is more code than the case is worth.

## Considered and deliberately not done

**The hand-written SHA-256 and IPv4 parser stay.** Both look like "a library already does this", and both would introduce a host/device implementation split on a path where being wrong is silent — mbedTLS is not in the host tests, so the device would run code the NIST vectors never checked; `inet_pton` is POSIX on the host and lwip on the device, inside validation that decides whether a bridge stays reachable. Of `ipv4.cpp`'s 76 lines only 29 are the parser; the rest is mask arithmetic with no stdlib equivalent.

## Verification

770 native tests · all four ESP32 envs build with **zero warnings from `src/`** · layering 8/8 · cppcheck high clean · web-JS 4/4 · profiles + measurement ids OK · ruff clean.

The transaction loop's own paths are covered through both drivers: the deadline under a sustained noise trickle, resync past leading noise, an echo of our own request being skipped, a reply reassembled across reads, and the sunrise recovery.

**What still needs hardware:** the library bump. Everything else is either host-tested or CI-only.

---

## Self-review

**The transplant was verified mechanically, not by reading.** Both original loops were extracted from `main`, normalised, and diffed against the shared one. Every difference is one of four intended kinds: whitespace alignment, `logPrefix` added as a format argument, the built `"<bus> RX"` label, and `exchange.` qualification. No behavioural difference against either original.

**Found: a dead include.** Every `log::` call in the EverSolar driver lived inside the loop; with the loop gone, `diagnostics/logger.h` had no user left there. Checked for `LogLevel` and the macros too, not just the obvious prefix. Removed in `e02138d`. Its sibling still logs three times and keeps the include; `<cstring>` stays in both, `memcpy` is still used outside the moved code.

**Checked and fine:**

- The workflow's renamed output. `updates` became `registry_updates` for the registry step, so every `outputs.*` reference was cross-checked against every declaration — a stale name there would silently stop the job from ever opening an issue.
- `Exchange` is aggregate-initialised positionally at both call sites. Unlike `BusErrorCounts`, its fields are distinct types, so a reordering is a compile error rather than a silent swap. That is why the stricter treatment was applied to one and not the other.
- `char label[24]` against the longest label in use (8 characters); `snprintf` truncates safely regardless.

## Second review pass

Three findings, two of them corrections to claims I made above.

**The lock is now taken later, and I had not checked that.** The first review diffed the loop from `uint8_t rx[...]` onward and concluded "no behavioural difference" — but the code *before* the loop was never compared. It did change: the original took the bus lock and then built the request; now the request is built and the lock taken inside the shared function.

Reasoned through rather than waved past: `buildRequest` is pure computation into a stack buffer, and every `data` argument at all eleven call sites is `nullptr` or a stack local — no buffer another task could mutate while it is read outside the lock. The return value is identical in every combination of build-failure and lock-failure. The lock is held for slightly *less* time, which on a shared half-duplex bus is the better direction. Benign, but it was an unverified change described as a verified one.

**The counter mapping was better covered than I said.** The `refactor(pmu)` commit claims nothing in the tests would notice a swapped `busErrors()` copy. That is wrong: `checksumErrors` is pinned by `test_corrupt_reply_does_not_touch_state`, and `timeouts` end to end through `DeviceContext` by the diagnostics test. Only `invalidFrames` was asserted against the fake driver alone — so that was the field a wrong copy could have swapped silently, and it now has an assertion on the real driver.

Proven, not assumed: swapping `timeouts` and `invalidFrames` in the mapping fails two tests. Restored, green.

**A report that claimed what it cannot know.** The git-pin step said "no published release to compare" whenever the lookup came back empty — but `gh api` exits non-zero for a 404 and for a transient failure alike, so that sentence asserted a fact the step does not have. It now says it could not determine the latest release, and still reports rather than passing silently.

**Also checked, no change needed:** `download-artifact@v8` against artifacts uploaded by `upload-artifact@v7` — v8's own README uses exactly that pairing in its examples, which is unsurprising given upload's latest is v7.0.1 and download's is v8.0.1. `std::as_const(*this).find(id)` selects the const overload, so there is no recursion. No public `DeviceManager` method calls another while holding the mutex.
