### PR TITLE
feat(web): show more than watts per inverter

### DIFF
--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -67,6 +67,13 @@ DeviceSummary summariseDevice(const DeviceState& state, const std::string& devic
     take(measurement_id::kAcPowerTotal, s.hasAcPower, s.acPowerW);
     take(measurement_id::kEnergyToday, s.hasEnergyToday, s.energyTodayKwh);
     take(measurement_id::kEnergyTotal, s.hasEnergyTotal, s.energyTotalKwh);
+    // L1 specifically, not "the AC voltage": a three-phase inverter has three, and picking one
+    // to stand for all of them would be a quiet lie. L1 is the phase every supported driver
+    // reports, and the Device tab remains the place to see all of them.
+    take(measurement_id::kAcL1Voltage, s.hasAcVoltage, s.acVoltageV);
+    take(measurement_id::kTemperature, s.hasTemperature, s.temperatureC);
+    take(measurement_id::kBatterySoc, s.hasBatterySoc, s.batterySocPct);
+    take(measurement_id::kBatteryPower, s.hasBatteryPower, s.batteryPowerW);
     return s;
 }
 
@@ -201,6 +208,33 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
         }
         // Absent channels stay null rather than 0: "this inverter reports no power" and
         // "this inverter reports 0 W" are different answers and look identical as a number.
+        // Same absent-is-null rule for every channel below: a driver that does not report
+        // temperature and one reporting 0 degrees are different answers.
+        if (f.hasEnergyToday) {
+            o["energy_today_kwh"] = f.energyTodayKwh;
+        } else {
+            o["energy_today_kwh"] = nullptr;
+        }
+        if (f.hasAcVoltage) {
+            o["ac_voltage_v"] = f.acVoltageV;
+        } else {
+            o["ac_voltage_v"] = nullptr;
+        }
+        if (f.hasTemperature) {
+            o["temperature_c"] = f.temperatureC;
+        } else {
+            o["temperature_c"] = nullptr;
+        }
+        if (f.hasBatterySoc) {
+            o["battery_soc_pct"] = f.batterySocPct;
+        } else {
+            o["battery_soc_pct"] = nullptr;
+        }
+        if (f.hasBatteryPower) {
+            o["battery_power_w"] = f.batteryPowerW;
+        } else {
+            o["battery_power_w"] = nullptr;
+        }
         if (f.hasAcPower) {
             o["ac_power_w"] = f.acPowerW;
         } else {

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -67,6 +67,21 @@ struct DeviceSummary {
     double      energyTodayKwh   = 0.0;
     bool        hasEnergyTotal   = false;
     double      energyTotalKwh   = 0.0;
+    /// Per-device only: these two are never summed. A household total of volts is meaningless
+    /// and a total of temperatures worse, so unlike the three above they exist purely so the
+    /// fleet strip can show whether one inverter sits at a different voltage or runs hotter
+    /// than its neighbours -- which on a shared bus is the interesting comparison.
+    bool        hasAcVoltage     = false;
+    double      acVoltageV       = 0.0;
+    bool        hasTemperature   = false;
+    double      temperatureC     = 0.0;
+    /// Hybrids only, and absent on every string inverter. `batteryPowerW` keeps the project's
+    /// sign convention (measurement.h): positive charging, negative discharging -- so direction
+    /// and magnitude travel as one number rather than as a flag that can disagree with it.
+    bool        hasBatterySoc    = false;
+    double      batterySocPct    = 0.0;
+    bool        hasBatteryPower  = false;
+    double      batteryPowerW    = 0.0;
 };
 
 /// Reduces one device's state to the row above.

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -349,9 +349,12 @@ function fleetStrip(fleet){
   // Battery power says the direction in words rather than as a sign. The payload follows the
   // project's convention (positive charging, negative discharging), but a reader should not
   // have to know it to answer "is it charging?" -- and a bare -800 W invites the wrong guess.
+  // The word is derived from the number as DISPLAYED, not from the raw value: a trickle of
+  // 0.4 W rounds to 0 at this precision, and "charging 0 W" is a cell that argues with itself.
   const batt=v=>{
-    if(v===0) return 'idle';
-    return (v>0?'charging ':'discharging ')+fmt(Math.abs(v),0)+' W';
+    const w=fmt(Math.abs(v),0);
+    if(Number(w)===0) return 'idle';
+    return (v>0?'charging ':'discharging ')+w+' W';
   };
   const all=[{k:'ac_power_w',t:'AC power',d:0,u:'W'},
              {k:'energy_today_kwh',t:'Today',d:2,u:'kWh'},

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -342,6 +342,24 @@ function fleetTiles(fleet,tot,expected){
 /// Deliberately not a second copy of the Device tab: id, whether it is answering, what it is
 /// producing, and how long ago it last replied. Anything more belongs where there is room.
 function fleetStrip(fleet){
+  // Only columns some inverter can actually fill. A driver that does not report temperature
+  // makes a whole column of em dashes, which reads as "broken" rather than "not applicable" --
+  // and a bus of identical inverters means it is all of them or none. Decided per render from
+  // the payload, so adding a device with more channels widens the table by itself.
+  // Battery power says the direction in words rather than as a sign. The payload follows the
+  // project's convention (positive charging, negative discharging), but a reader should not
+  // have to know it to answer "is it charging?" -- and a bare -800 W invites the wrong guess.
+  const batt=v=>{
+    if(v===0) return 'idle';
+    return (v>0?'charging ':'discharging ')+fmt(Math.abs(v),0)+' W';
+  };
+  const all=[{k:'ac_power_w',t:'AC power',d:0,u:'W'},
+             {k:'energy_today_kwh',t:'Today',d:2,u:'kWh'},
+             {k:'ac_voltage_v',t:'AC voltage',d:1,u:'V'},
+             {k:'temperature_c',t:'Temp',d:1,u:'°C'},
+             {k:'battery_soc_pct',t:'SOC',d:0,u:'%'},
+             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt}];
+  const cols=all.filter(c=>fleet.some(f=>f[c.k]!==null&&f[c.k]!==undefined));
   const rows=fleet.map(f=>{
     const answering=f.online&&f.data_valid&&!f.data_stale;
     const ago=f.last_successful_poll_seconds_ago;
@@ -349,12 +367,18 @@ function fleetStrip(fleet){
     // two are indistinguishable in `online:false` alone.
     const when=(ago===null||ago===undefined)?'<span class="tag" style="background:var(--bad)">never answered</span>'
       :`<span class="tag">${f.data_stale?'stale — ':''}replied ${esc(ago)} s ago</span>`;
-    const w=(f.ac_power_w===null||f.ac_power_w===undefined)?'—':fmt(f.ac_power_w,0)+' W';
+    // Em dash, not 0 and not blank: this driver does not report the channel, which is a
+    // different statement from "reports zero" and must not be readable as a measurement.
+    const num=(v,c)=>(v===null||v===undefined)?'—':(c.fn?c.fn(v):fmt(v,c.d)+' '+c.u);
     return `<tr><td><span class="dot ${answering?'ok':'bad'}"></span>${esc(f.id)}</td>
-      <td class="n">${esc(w)}</td><td class="n">${when}</td></tr>`;
+      ${cols.map(c=>`<td class="n">${esc(num(f[c.k],c))}</td>`).join('')}
+      <td class="n">${when}</td></tr>`;
   }).join('');
-  return `<div class="card" style="margin-top:14px"><table>
-    <tr><th>Inverter</th><th style="text-align:right">AC power</th>
+  // Scrolls rather than squeezes: even four columns do not fit a phone, and hiding them below
+  // a breakpoint means the reading you went looking for is the one that is not there.
+  const width=260+cols.length*100;
+  return `<div class="card" style="margin-top:14px;overflow-x:auto"><table style="min-width:${width}px">
+    <tr><th>Inverter</th>${cols.map(c=>`<th style="text-align:right">${c.t}</th>`).join('')}
     <th style="text-align:right">Last reply</th></tr>${rows}</table></div>`;
 }
 

--- a/test/test_eversolar/driver.cpp
+++ b/test/test_eversolar/driver.cpp
@@ -7,6 +7,8 @@
 
 #include "device/device_context.h"
 #include "diagnostics/diagnostics.h"
+#include "diagnostics/log_buffer.h"
+#include "diagnostics/logger.h"
 #include "drivers/eversolar_legacy/eversolar_driver.h"
 #include "fixtures/eversolar_frames.h"
 #include "state/state_store.h"
@@ -649,6 +651,37 @@ static void test_backoff_is_bounded() {
     TEST_ASSERT_EQUAL_UINT32(policy.maxBackoffMs, ctx.nextDelayMs());
 }
 
+// The trace label is BUILT now, not passed: pmu::transact does snprintf("%s RX", logPrefix)
+// because the shared loop takes one bus name and both drivers used to hardcode two strings.
+// That snprintf is reached only at Trace level during a real transaction, so nothing exercised
+// it -- it was verified once by reading a log off a bridge, which is not a test. A wrong label
+// costs no function, but it is the one piece of output the refactor could quietly change.
+static void test_the_trace_label_names_the_bus_and_the_direction() {
+    // Fully qualified: `log` alone resolves to ::log from <cmath> under the using-directives
+    // at the top of this file.
+    const auto previous = heliograph::log::level();
+    heliograph::log::setLevel(heliograph::LogLevel::Trace);
+    heliograph::log::clearLines();
+
+    Rig r;
+    r.begin();
+    DeviceState state;
+    r.poll(state);
+
+    const auto lines = heliograph::log::recentLines(200);
+    bool       sawRx = false, sawOutcome = false;
+    for (const auto& l : lines) {
+        // Not "contains RS485": the label has to be the prefix of the dump, immediately
+        // followed by hex, which is exactly what a mis-built label would break.
+        if (l.rfind("[T] RS485 RX ", 0) == 0) sawRx = true;
+        if (l.find("RS485 ok: ") != std::string::npos) sawOutcome = true;
+    }
+    TEST_ASSERT_TRUE_MESSAGE(sawRx, "no '[T] RS485 RX <hex>' line from the shared transaction");
+    TEST_ASSERT_TRUE_MESSAGE(sawOutcome, "no 'RS485 ok: ...' outcome line");
+
+    heliograph::log::setLevel(previous);
+}
+
 static void test_diagnostics_track_the_cycle_without_leaking_payload() {
     Rig r;
     r.begin();
@@ -738,6 +771,7 @@ void run_eversolar_driver() {
     RUN_TEST(test_sunrise_recovers_without_intervention);
     RUN_TEST(test_a_single_dropped_frame_does_not_disturb_anything);
     RUN_TEST(test_backoff_is_bounded);
+    RUN_TEST(test_the_trace_label_names_the_bus_and_the_direction);
     RUN_TEST(test_diagnostics_track_the_cycle_without_leaking_payload);
     RUN_TEST(test_snapshots_are_immutable_and_independent);
 }

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -483,9 +483,24 @@ static DeviceState fakeDevice(bool online, bool valid, bool stale, double watts,
                            "AC Power");
     s.measurements.declare(measurement_id::kEnergyToday, MeasurementType::Energy,
                            Unit::KilowattHour, "Energy Today");
+    // Every other channel the summary reads, so the size test below weighs the EXPENSIVE case.
+    // With these absent they serialise as null -- four characters where a full-precision double
+    // is twenty -- and "a full bus still fits" would be measuring the cheapest bus there is.
+    s.measurements.declare(measurement_id::kAcL1Voltage, MeasurementType::Voltage, Unit::Volt,
+                           "AC Voltage");
+    s.measurements.declare(measurement_id::kTemperature, MeasurementType::Temperature,
+                           Unit::Celsius, "Temperature");
+    s.measurements.declare(measurement_id::kBatterySoc, MeasurementType::Ratio,
+                           Unit::Percent, "Battery SOC");
+    s.measurements.declare(measurement_id::kBatteryPower, MeasurementType::Power, Unit::Watt,
+                           "Battery Power");
     if (valid) {
         s.measurements.set(measurement_id::kAcPowerTotal, watts, lastPollMs);
         s.measurements.set(measurement_id::kEnergyToday, today, lastPollMs);
+        s.measurements.set(measurement_id::kAcL1Voltage, 242.13456789, lastPollMs);
+        s.measurements.set(measurement_id::kTemperature, 48.256789, lastPollMs);
+        s.measurements.set(measurement_id::kBatterySoc, 64.5, lastPollMs);
+        s.measurements.set(measurement_id::kBatteryPower, -1523.456789, lastPollMs);
     }
     if (stale) {
         s.measurements.markAllStale();
@@ -612,7 +627,9 @@ static void test_a_full_bus_of_summaries_still_fits() {
     TEST_ASSERT_TRUE(rest::buildStatusPayload(state, "growatt_modbus-1", makeBridge(),
                                               r.diagnostics.snapshot(),
                                               &eversolar::descriptor(), g_now, fleet, json));
-    TEST_ASSERT_TRUE(json.size() < rest::kMaxResponseBytes);
+    // LESS_THAN, not TRUE(<): on failure Unity prints both numbers, so the report says how
+    // far over the cap a new field pushed it instead of only that it did.
+    TEST_ASSERT_LESS_THAN_UINT32(rest::kMaxResponseBytes, json.size());
     TEST_ASSERT_EQUAL_UINT32(kMaxDevices, parse(json)["devices"].size());
 }
 

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -58,6 +58,7 @@ def main() -> int:
                 status |= check_version_compare(script, scratch)
                 status |= check_auth_prompt_reentrancy(script, scratch)
                 status |= check_auth_fetch_race(script, scratch)
+                status |= check_fleet_columns(script, scratch)
     return status
 
 
@@ -159,6 +160,66 @@ process.exit(bad === 0 ? 0 : 1);
     path.write_text(harness)
     result = subprocess.run(["node", str(path)], capture_output=True, text=True)
     print(f"version comparison: {'OK' if result.returncode == 0 else 'FAIL'}")
+    if result.returncode != 0:
+        print(result.stdout + result.stderr)
+        return 1
+    return 0
+
+
+def check_fleet_columns(script, scratch):
+    """A fleet column appears only when some inverter can fill it.
+
+    A string inverter has no battery, and a column of em dashes reads as "broken" rather than
+    "not applicable". The inverse matters just as much: one device reporting a channel must keep
+    the column for all of them, with the em dash marking the device that does not -- absent and
+    zero are different answers and must not look alike.
+
+    Battery direction is checked as words. The payload carries the project's sign convention
+    (positive charging, negative discharging); a reader should not need to know it, and a bare
+    negative in a cell invites exactly the wrong guess.
+    """
+    body = extract_function(script, "fleetStrip")
+    if body is None:
+        print("FAIL: fleetStrip() not found in index_html.h; this check needs updating")
+        return 1
+    harness = (
+        "const esc=s=>String(s);\nconst fmt=(v,d)=>Number(v).toFixed(d);\n"
+        + body
+        + r"""
+const cols = h => (h.match(/<th[^>]*>([^<]*)<\/th>/g)||[]).map(x=>x.replace(/<[^>]*>/g,''));
+const base = {online:true,data_valid:true,data_stale:false,last_successful_poll_seconds_ago:2};
+let bad = 0;
+const check = (cond, msg) => { if (!cond) { console.error(msg); bad++; } };
+
+let h = fleetStrip([{...base,id:'a',ac_power_w:771,energy_today_kwh:9.3,ac_voltage_v:238,
+  temperature_c:48.6,battery_soc_pct:null,battery_power_w:null}]);
+let c = cols(h);
+check(!c.includes('SOC') && !c.includes('Battery'), 'battery columns shown for a device with no battery');
+check(c.includes('Temp') && c.includes('Today'), 'a channel the device reports has no column');
+
+h = fleetStrip([{...base,id:'b',ac_power_w:1200,battery_soc_pct:64,battery_power_w:1500}]);
+check(cols(h).includes('SOC'), 'SOC column missing for a hybrid');
+check(h.includes('charging 1500 W'), 'charging not spelled out');
+check(h.includes('64 %'), 'state of charge not rendered');
+
+h = fleetStrip([{...base,id:'c',battery_soc_pct:20,battery_power_w:-800}]);
+check(h.includes('discharging 800 W'), 'discharging not spelled out');
+check(!h.includes('-800'), 'a raw negative leaked into the cell');
+
+h = fleetStrip([{...base,id:'d',battery_soc_pct:50,battery_power_w:0}]);
+check(h.includes('idle'), 'a resting battery is not reported as idle');
+
+h = fleetStrip([{...base,id:'e',temperature_c:40},{...base,id:'f',temperature_c:null}]);
+check(cols(h).includes('Temp'), 'column dropped although one device reports it');
+check(h.includes('\u2014'), 'the device without the channel is not an em dash');
+
+process.exit(bad === 0 ? 0 : 1);
+"""
+    )
+    path = pathlib.Path(scratch) / "fleet_columns.js"
+    path.write_text(harness)
+    result = subprocess.run(["node", str(path)], capture_output=True, text=True)
+    print(f"fleet columns: {'OK' if result.returncode == 0 else 'FAIL'}")
     if result.returncode != 0:
         print(result.stdout + result.stderr)
         return 1

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -209,6 +209,10 @@ check(!h.includes('-800'), 'a raw negative leaked into the cell');
 h = fleetStrip([{...base,id:'d',battery_soc_pct:50,battery_power_w:0}]);
 check(h.includes('idle'), 'a resting battery is not reported as idle');
 
+h = fleetStrip([{...base,id:'g',battery_soc_pct:50,battery_power_w:0.4}]);
+check(h.includes('idle'), 'a trickle that rounds to 0 W still claims a direction');
+check(!h.includes('charging 0 W'), 'the cell argues with itself: a direction next to zero watts');
+
 h = fleetStrip([{...base,id:'e',temperature_c:40},{...base,id:'f',temperature_c:null}]);
 check(cols(h).includes('Temp'), 'column dropped although one device reports it');
 check(h.includes('\u2014'), 'the device without the channel is not an em dash');


### PR DESCRIPTION
The fleet strip carried AC power and nothing else, so on a bus of several inverters the only comparison available was "who is producing more right now". It now also shows **energy today, AC voltage, temperature, battery SOC and battery power**.

Not just a page change: `/api/v1/status` sent only `ac_power_w` per device. Energy today was already in `DeviceSummary` (it feeds the totals) and simply never serialised; the other four are new there, taken through the same valid-AND-fresh helper every other output uses.

## Columns appear only when some inverter can fill them

A string inverter has no battery, and a column of em dashes reads as "broken" rather than "not applicable". The inverse is kept deliberately: one device reporting a channel keeps the column for all of them, and the device that does not gets the em dash — absent and zero are different answers.

## Battery direction is spelled out

`charging 1500 W`, `discharging 800 W`, `idle` — not a signed number. The payload keeps the project's convention (positive charging, negative discharging), but a reader should not have to know it, and a bare `-800 W` invites the wrong guess.

## Details worth reviewing

**AC voltage is L1 specifically.** A three-phase inverter has three, and picking one to stand for all of them would be a quiet lie. The Device tab still shows each.

**Payload cost was measured, not assumed.** The cap is 8192 bytes; a live four-device bridge sent 3759. Five more fields cost ~70 bytes per device, so eight devices land near 5200 — comfortably inside. That is why absent channels still travel as explicit `null` rather than being omitted.

**The table scrolls horizontally** instead of squeezing. Eight columns do not fit a phone, and hiding them below a breakpoint means the reading you went looking for is the one that is not there.

## Verification

New `check_web_js.py` harness runs `fleetStrip` in node over six cases: a string inverter gets no battery columns, a hybrid does, charge/discharge/idle render as words, a raw negative never reaches a cell, and a channel reported by only one of two devices keeps its column with an em dash for the other.

**Proven to catch its target:** dropping the empty-column filter fails it with `battery columns shown for a device with no battery`.

771 native tests · layering 8/8 · ruff clean · both boards build.

---

## Review

Three findings, two of them fixed here.

**The size test was measuring the cheapest bus that can exist.** `test_a_full_bus_of_summaries_still_fits` guards the payload the page fetches every second — eight devices under 8 KB, or the UI goes dark. It stayed green after this branch added five per-device fields, and that was the problem: `fakeDevice()` declares only AC power and energy today, so the four new channels serialised as `null`. Four characters where a full-precision double is twenty, times four fields, times eight devices. `fakeDevice()` now populates every channel `summariseDevice` reads.

Measured rather than estimated: the expensive case is **4262 bytes against a cap of 8192**. Comfortable, and now permanently guarded. The assertion also became `LESS_THAN` so a future failure prints how far over it went, not just that it did.

**A battery cell that argued with itself.** `batt()` picked "charging" or "discharging" from the raw value, then printed the magnitude rounded to whole watts — so 0.4 W rendered as `charging 0 W`. The word now comes from the number as displayed: if the rounded magnitude is zero, the cell says `idle`. Covered in the harness and proven to catch it.

**Worth knowing, not a defect:** the fleet strip only renders when `expected>1 || polled>1`. A bridge with one inverter keeps the classic single-device dashboard and never shows these columns. That is the existing design — the alternative would be a one-row table restating the tiles above it — but it means this change is invisible on a single-inverter bridge.

**Checked and fine:** `esc()` wraps every formatted cell including the em dash and `°C`; an empty fleet yields no columns and no rows rather than a broken table; the `min-width` grows with the column count so the container scrolls instead of the page; absent channels still travel as explicit `null`, which the measured headroom justifies.
