### PR TITLE
fix: the state heartbeat describes the fleet, not the first inverter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,7 @@
 #include "outputs/modbus_tcp/modbus_tcp_server.h"
 #include "outputs/mqtt/mqtt_output.h"
 #include "outputs/rest/rest_api.h"
+#include "outputs/rest/rest_payloads.h"
 #include "relays/drm.h"
 #include "relays/relay_controller.h"
 #include "status/boot_button.h"
@@ -1348,16 +1349,49 @@ void loop() {
         // Same per-task self-report as rs485Task; see the note there.
         g_diagnostics.recordLoopStackFree(
             static_cast<uint32_t>(uxTaskGetStackHighWaterMark(nullptr)));
-        if (g_state) {
-            const auto  s = g_state->snapshot();
-            const auto* p = s->measurements.find(measurement_id::kAcPowerTotal);
-            // Through the logger, not a raw print: the heartbeat then carries the same
-            // wall-clock stamp as everything else, which is what makes an unattended capture
-            // legible after the fact.
-            log::info("state: wifi=%s inverter=%d valid=%d stale=%d power=%s heap=%lu",
-                      provisioningStateName(g_wifi.state()), s->inverterOnline, s->dataValid,
-                      s->dataStale, (p && p->valid) ? String(p->value, 1).c_str() : "unknown",
+        // THE WHOLE FLEET, not the first device (#74). This used to read g_state, which is
+        // assigned once while starting devices and then holds device 1 forever: on a bus of
+        // four, three could be dead and this line would report the healthy one every ten
+        // seconds. It also printed `inverter=%d` from a bool, so "1" meant online and read as
+        // a count -- identical output for one inverter and for eight.
+        //
+        // Summed by rest::totalsFor so the heartbeat and /api/v1/status cannot disagree about
+        // what "answering" means.
+        //
+        // Through the logger, not a raw print: the heartbeat then carries the same wall-clock
+        // stamp as everything else, which is what makes an unattended capture legible.
+        {
+            const uint64_t                   now = nowMs();
+            std::vector<rest::DeviceSummary> fleet;
+            fleet.reserve(g_deviceIds.size());
+            for (const auto& id : g_deviceIds) {
+                if (StateHandle h = g_devices.state(id)) {
+                    fleet.push_back(rest::summariseDevice(*h, id, now));
+                }
+            }
+            const auto t = rest::totalsFor(fleet);
+            log::info("state: wifi=%s devices=%u/%u answering power=%s heap=%lu",
+                      provisioningStateName(g_wifi.state()), t.answering,
+                      static_cast<unsigned>(g_devicesConfigured),
+                      t.acCount != 0 ? String(t.acPowerW, 1).c_str() : "unknown",
                       static_cast<unsigned long>(ESP.getFreeHeap()));
+            // One line each for the devices that are NOT answering, and none at all when the
+            // fleet is healthy. A capture from a working bridge stays one line per heartbeat;
+            // a sick one names the inverter instead of leaving it to be deduced from a count.
+            // Bounded by kMaxDevices, so this can never be more than eight lines.
+            for (const auto& f : fleet) {
+                if (f.online && f.dataValid && !f.dataStale) {
+                    continue;
+                }
+                if (f.everPolled) {
+                    log::info("state:   %s not answering (last reply %us ago)", f.id.c_str(),
+                              static_cast<unsigned>(f.lastPollSecondsAgo));
+                } else {
+                    // Never a byte since boot: a bus or addressing fault, not an inverter that
+                    // went quiet, and the two need different things done about them.
+                    log::info("state:   %s has never answered", f.id.c_str());
+                }
+            }
         }
     }
     delay(100);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1392,6 +1392,14 @@ void loop() {
                     log::info("state:   %s has never answered", f.id.c_str());
                 }
             }
+            // A device that never STARTED is not in the fleet at all -- it has no driver, so it
+            // has no id to print (see the reconciliation note above). Without this the count
+            // would read "3/4" with nothing named, which is the one case a reader cannot tell
+            // apart from a bug in the count. Said at boot too, but a capture taken hours later
+            // has long since lost that line out of the ring.
+            for (const auto& p : g_deviceProblems) {
+                log::info("state:   %s", p.c_str());
+            }
         }
     }
     delay(100);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1384,8 +1384,15 @@ void loop() {
                     continue;
                 }
                 if (f.everPolled) {
-                    log::info("state:   %s not answering (last reply %us ago)", f.id.c_str(),
-                              static_cast<unsigned>(f.lastPollSecondsAgo));
+                    // WHY, not just that. The old line carried valid= and stale= for the first
+                    // device, and folding three causes into one phrase would have dropped what
+                    // those flags were for. Offline before stale: a device that drops is marked
+                    // offline AND stale by markAllStale(), and the offline is the cause.
+                    const char* why = !f.online          ? "offline"
+                                      : f.dataStale      ? "stale"
+                                                         : "no valid reading";
+                    log::info("state:   %s not answering (%s, last reply %us ago)", f.id.c_str(),
+                              why, static_cast<unsigned>(f.lastPollSecondsAgo));
                 } else {
                     // Never a byte since boot: a bus or addressing fault, not an inverter that
                     // went quiet, and the two need different things done about them.

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -36,6 +36,29 @@ bool buildProvisionPayload(const std::string& hostname, std::string& out, size_t
     return finish(doc, out, maxBytes);
 }
 
+FleetTotals totalsFor(const std::vector<DeviceSummary>& fleet) {
+    FleetTotals t;
+    t.polled = static_cast<unsigned>(fleet.size());
+    for (const auto& f : fleet) {
+        if (f.online && f.dataValid && !f.dataStale) {
+            ++t.answering;
+        }
+        if (f.hasAcPower) {
+            t.acPowerW += f.acPowerW;
+            ++t.acCount;
+        }
+        if (f.hasEnergyToday) {
+            t.energyTodayKwh += f.energyTodayKwh;
+            ++t.todayCount;
+        }
+        if (f.hasEnergyTotal) {
+            t.energyTotalKwh += f.energyTotalKwh;
+            ++t.lifetimeCount;
+        }
+    }
+    return t;
+}
+
 DeviceSummary summariseDevice(const DeviceState& state, const std::string& deviceId,
                               uint64_t nowMs) {
     DeviceSummary s;
@@ -187,8 +210,9 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     // bridge's health may be built from it: on a bus of three, one dead inverter left the
     // header indicator green and the Dashboard reporting a healthy day (#38).
     JsonArray devices = doc["devices"].to<JsonArray>();
-    double    acTotal = 0.0, todayTotal = 0.0, lifetimeTotal = 0.0;
-    unsigned  acCount = 0, todayCount = 0, lifetimeCount = 0, answering = 0;
+    // Summed by the shared helper, not here: the log heartbeat reports the same fleet and must
+    // not carry its own copy of what "answering" means (#74).
+    const FleetTotals totals = totalsFor(fleet);
     for (const auto& f : fleet) {
         JsonObject o    = devices.add<JsonObject>();
         o["id"]         = f.id;
@@ -240,28 +264,13 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
         } else {
             o["ac_power_w"] = nullptr;
         }
-        if (f.online && f.dataValid && !f.dataStale) {
-            ++answering;
-        }
-        if (f.hasAcPower) {
-            acTotal += f.acPowerW;
-            ++acCount;
-        }
-        if (f.hasEnergyToday) {
-            todayTotal += f.energyTodayKwh;
-            ++todayCount;
-        }
-        if (f.hasEnergyTotal) {
-            lifetimeTotal += f.energyTotalKwh;
-            ++lifetimeCount;
-        }
     }
     JsonObject t = doc["totals"].to<JsonObject>();
     // "Answering" is the strict reading: started, online, holding data that is valid and not
     // stale. A device that started and never returned a byte is not answering, and neither is
     // one whose last reading has aged out.
-    t["devices_answering"] = answering;
-    t["devices_polled"]    = static_cast<unsigned>(fleet.size());
+    t["devices_answering"] = totals.answering;
+    t["devices_polled"]    = totals.polled;
     // A total over none is unknown, not zero. The count travels with it so a client can say
     // "2 of 3 inverters" instead of implying the sum covers everything.
     const auto total = [&t](const char* key, unsigned count, double sum) {
@@ -271,12 +280,12 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
             t[key] = nullptr;
         }
     };
-    total("ac_power_w", acCount, acTotal);
-    t["ac_power_devices"] = acCount;
-    total("energy_today_kwh", todayCount, todayTotal);
-    t["energy_today_devices"] = todayCount;
-    total("energy_total_kwh", lifetimeCount, lifetimeTotal);
-    t["energy_total_devices"] = lifetimeCount;
+    total("ac_power_w", totals.acCount, totals.acPowerW);
+    t["ac_power_devices"] = totals.acCount;
+    total("energy_today_kwh", totals.todayCount, totals.energyTodayKwh);
+    t["energy_today_devices"] = totals.todayCount;
+    total("energy_total_kwh", totals.lifetimeCount, totals.energyTotalKwh);
+    t["energy_total_devices"] = totals.lifetimeCount;
 
     doc["poll_success_total"] = diagnostics.pollSuccessTotal;
     doc["poll_failure_total"] = diagnostics.pollFailureTotal;

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -84,6 +84,28 @@ struct DeviceSummary {
     double      batteryPowerW    = 0.0;
 };
 
+/// What a fleet adds up to.
+///
+/// A count travels with every sum because a total over none is unknown, not zero -- and a total
+/// over two of three inverters must not read as the household figure.
+struct FleetTotals {
+    unsigned polled        = 0;
+    /// Started, online, holding data that is valid and NOT stale. The strict reading: a device
+    /// that never returned a byte is not answering, and neither is one whose reading aged out.
+    unsigned answering     = 0;
+    unsigned acCount       = 0;
+    double   acPowerW      = 0.0;
+    unsigned todayCount    = 0;
+    double   energyTodayKwh = 0.0;
+    unsigned lifetimeCount = 0;
+    double   energyTotalKwh = 0.0;
+};
+
+/// Sums a fleet. Pure, so the status payload and the log heartbeat can agree by construction
+/// rather than by two people remembering the same rule -- the heartbeat used to describe the
+/// first device only, and there was no shared definition of "answering" for it to use (#74).
+FleetTotals totalsFor(const std::vector<DeviceSummary>& fleet);
+
 /// Reduces one device's state to the row above.
 ///
 /// A reading counts only while it is valid AND fresh -- the same rule every other output uses.

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -518,6 +518,42 @@ static JsonDocument statusOf(const std::vector<rest::DeviceSummary>& fleet) {
     return parse(json);
 }
 
+// totalsFor is now the ONE definition of "answering" -- the status payload and the ten-second
+// log heartbeat both call it, so a disagreement between the dashboard and the logs is no longer
+// possible by construction (#74). Tested directly rather than only through the payload: the
+// heartbeat has no JSON to assert on.
+static void test_only_a_device_that_is_online_valid_and_fresh_is_answering() {
+    const auto ok = rest::summariseDevice(fakeDevice(true, true, false, 100.0, 1.0, g_now - 1000),
+                                          "a", g_now);
+    // Offline AND stale: that is how the firmware leaves a device that stopped answering, and
+    // (false, true, false) is a combination the state machine cannot produce -- my first version
+    // of this test built exactly that and asserted the wrong count, which is the trap fakeDevice
+    // documents above.
+    const auto offline  = rest::summariseDevice(fakeDevice(false, true, true, 100.0, 1.0, g_now - 1000),
+                                                "b", g_now);
+    const auto invalid  = rest::summariseDevice(fakeDevice(true, false, false, 100.0, 1.0, g_now - 1000),
+                                                "c", g_now);
+    const auto stale    = rest::summariseDevice(fakeDevice(true, true, true, 100.0, 1.0, g_now - 1000),
+                                                "d", g_now);
+
+    const auto t = rest::totalsFor({ok, offline, invalid, stale});
+    TEST_ASSERT_EQUAL_UINT32(4, t.polled);
+    TEST_ASSERT_EQUAL_UINT32(1, t.answering);
+    // Only the answering device contributes a reading. A stale one still holds valid==true, so
+    // without the freshness rule a dead inverter's last daylight value keeps being summed.
+    TEST_ASSERT_EQUAL_UINT32(1, t.acCount);
+    TEST_ASSERT_EQUAL_DOUBLE(100.0, t.acPowerW);
+}
+
+// A fleet with nothing in it has no readings, not zero readings: the count is what tells the
+// heartbeat to print "unknown" rather than "0.0 W" on a bridge whose inverters are all dark.
+static void test_an_empty_fleet_reports_no_readings_rather_than_zero() {
+    const auto t = rest::totalsFor({});
+    TEST_ASSERT_EQUAL_UINT32(0, t.polled);
+    TEST_ASSERT_EQUAL_UINT32(0, t.answering);
+    TEST_ASSERT_EQUAL_UINT32(0, t.acCount);
+}
+
 static void test_the_status_payload_totals_every_polled_device() {
     const auto a = rest::summariseDevice(fakeDevice(true, true, false, 1200.0, 5.0, g_now - 2000),
                                          "growatt_modbus-1", g_now);
@@ -2223,6 +2259,8 @@ int main(int, char**) {
     RUN_TEST(test_the_device_manager_refuses_past_its_cap);
     RUN_TEST(test_the_status_payload_reports_the_address_and_how_it_was_obtained);
     RUN_TEST(test_the_status_payload_publishes_the_device_cap);
+    RUN_TEST(test_only_a_device_that_is_online_valid_and_fresh_is_answering);
+    RUN_TEST(test_an_empty_fleet_reports_no_readings_rather_than_zero);
     RUN_TEST(test_the_status_payload_totals_every_polled_device);
     RUN_TEST(test_a_device_that_reports_nothing_does_not_count_towards_a_total);
     RUN_TEST(test_a_stale_reading_leaves_the_total_and_the_device_is_not_answering);


### PR DESCRIPTION
Closes #74.

Every ten seconds a bridge logged one line about device 1 and called it the state:

```
state: wifi=connected inverter=1 valid=1 stale=0 power=5818.6 heap=134848   ← four inverters
state: wifi=connected devices=4/4 answering power=5818.6 heap=134848        ← now
```

`g_state` is assigned inside `if (g_driver == nullptr)` while devices start, so it holds whichever device started first and is never revisited. On the bus of four this was found on, three could be dead and the line would keep reporting the healthy one.

The second half was worse: `inverter=%d` printed `DeviceState::inverterOnline`, a **bool**. `inverter=1` meant "online" while reading as a count — identical output for one inverter and for eight. The first defect hid devices; this one denied they existed.

## What it does now

A healthy fleet is still one line. A device that is not answering gets a line of its own, naming it:

```
state: wifi=connected devices=3/4 answering power=2100.0 heap=153704
state:   growatt_modbus-2 not answering (last reply 245s ago)
```

A device that has **never** answered says so differently — never a byte since boot is a bus or addressing fault, not an inverter that went quiet, and they need different things done about them. Bounded by `kMaxDevices`, so at most eight extra lines.

## `rest::totalsFor` is new and shared

The status payload computed these sums inline. The heartbeat needed the same "online AND valid AND NOT stale" rule, and writing it a second time in `main.cpp` is exactly how the dashboard and the logs come to disagree about which inverters are working.

`buildStatusPayload` now calls it too, so the extraction is behaviour-preserving by construction — **122 existing REST tests pass unchanged**.

## Verification

Tested directly rather than only through the payload, because the heartbeat has no JSON to assert on: an offline, an invalid and a stale device each fail to count, and an empty fleet reports no readings rather than zero readings.

**Worth recording:** my first version of that test built `(online=false, stale=false)` and asserted the wrong count. That combination is unreachable — the firmware calls `markAllStale()` when a device drops — and it is the exact trap `fakeDevice`'s own comment documents. The fixture caught me with it.

773 native tests · layering 8/8 · three boards build with zero warnings from `src/`.