### PR TITLE
fix(mock): publish battery.power, and make the energy counters count

### DIFF
--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -383,8 +383,11 @@ PollResult MockDriver::poll(DeviceState& state) {
     // no register for the combined value, so that output is unchanged by this.
     m.declare(measurement_id::kBatteryPower, MeasurementType::Power, Unit::Watt, "Battery Power");
     const double soc = 40.0 + 40.0 * fraction;
-    // `<= 0.0` rather than `== 0.0`: night is the only case meant here, and an exact float
-    // compare also catches sunrise, where the sine is a true zero in broad daylight.
+    // `<= 0.0` rather than `== 0.0` only to avoid resting on an exact float compare; it does
+    // NOT change which samples count as night, since both forms are true at exactly zero.
+    // Sunrise, where the sine is a genuine zero in daylight, therefore still reads as night for
+    // the one sample that lands on it -- harmless in a simulation, and cheaper to say than to
+    // carry a phase check down here for.
     const double chargeW    = fraction > 0.3 ? 1000.0 : 0.0;
     const double dischargeW = fraction <= 0.0 ? 400.0 : 0.0;
     m.set(measurement_id::kBatterySoc, soc, ts);

--- a/src/drivers/mock/mock_driver.cpp
+++ b/src/drivers/mock/mock_driver.cpp
@@ -27,9 +27,25 @@ uint64_t defaultClock() {
 
 constexpr double kPi          = 3.14159265358979323846;
 constexpr double kPeakDcWatts = 6000.0;
+/// One simulated day's yield, and where the lifetime counter starts. Named rather than written
+/// out at the point of use because three channels have to agree on them: today integrates to
+/// exactly kDailyYieldKwh by sunset, and the lifetime total is that yield times the days behind
+/// us plus whatever today has produced so far.
+constexpr double kDailyYieldKwh   = 12.5;
+constexpr double kInitialTotalKwh = 24680.0;
 
-/// Bell-shaped output over the middle half of the day, zero at night. Zero here is a real
-/// measurement, exactly as it is for a real inverter after sunset.
+/// Where an instance sits in its simulated day.
+struct SimDay {
+    /// Whole simulated days behind us. Only the lifetime counter needs this, and it needs it to
+    /// keep climbing across a midnight instead of restarting.
+    uint64_t completed = 0;
+    /// 0.0 = midnight, 0.25 = sunrise, 0.5 = midday, 0.75 = sunset.
+    double phase = 0.0;
+};
+
+/// The one place the simulated clock is turned into a position in the day. The curve and both
+/// energy counters read it, so they cannot drift apart -- the counters have to roll over at
+/// exactly the moment the curve calls it midnight, or the lifetime total jumps at the seam.
 ///
 /// The cycle starts at midday rather than midnight. The phase origin is arbitrary in a
 /// simulation, and starting at midnight means a freshly booted bridge reports 0 W until a
@@ -55,18 +71,55 @@ constexpr double kPeakDcWatts = 6000.0;
 /// rose and set in unison would never reach that state at all.
 ///
 /// Instance 1 gets no offset, so the single-mock case is bit-for-bit what it always was.
-double solarFraction(uint64_t nowMs, uint64_t dayLengthMs, uint8_t instance) {
+SimDay simulatedDay(uint64_t nowMs, uint64_t dayLengthMs, uint8_t instance) {
     if (dayLengthMs == 0) {
-        return 0.0;
+        return {};  // midnight forever: no curve, no yield, lifetime total left at its start
     }
     const uint64_t offset = (instance > 0 ? instance - 1u : 0u) * (dayLengthMs / 32ULL);
-    nowMs += offset;
-    const double raw = static_cast<double>(nowMs % dayLengthMs) / static_cast<double>(dayLengthMs);
-    const double phase = raw < 0.5 ? raw + 0.5 : raw - 0.5;  // shift midnight -> midday
+    // Half a cycle forward, rather than folding the phase afterwards. Both express the same
+    // midday origin, but shifting the input is what lets the day count and the phase fall out
+    // of one division and therefore agree at the rollover.
+    const uint64_t t = nowMs + offset + dayLengthMs / 2;
+    return {t / dayLengthMs, static_cast<double>(t % dayLengthMs) / static_cast<double>(dayLengthMs)};
+}
+
+/// Bell-shaped output over the middle half of the day, zero at night. Zero here is a real
+/// measurement, exactly as it is for a real inverter after sunset.
+double solarFraction(double phase) {
     if (phase < 0.25 || phase > 0.75) {
         return 0.0;  // night
     }
     return std::sin((phase - 0.25) * 2.0 * kPi);
+}
+
+/// Energy generated since the simulated midnight -- the INTEGRAL of the curve above, not a
+/// scaled copy of it.
+///
+/// This used to be `12.5 * fraction`, which meant "today" climbed until midday and then fell
+/// back to zero by sunset. A daily counter that decreases is not merely a wrong number, it is a
+/// different kind of number: every consumer downstream treats a drop as a meter reset, Home
+/// Assistant's `total_increasing` classes included. Because it is the integral, its slope is
+/// the instantaneous power -- so the two channels now describe the same inverter.
+double energyToday(double phase) {
+    if (phase <= 0.25) {
+        return 0.0;  // between midnight and sunrise the new day has produced nothing yet
+    }
+    if (phase >= 0.75) {
+        return kDailyYieldKwh;  // after sunset: the day's total, held until midnight
+    }
+    const double daylight = (phase - 0.25) / 0.5;  // 0 at sunrise, 1 at sunset
+    return kDailyYieldKwh * (1.0 - std::cos(daylight * kPi)) / 2.0;
+}
+
+/// Lifetime yield: a fixed starting point plus every day behind us plus today's progress.
+///
+/// Continuous across midnight by construction -- `completed` gains the day at the same instant
+/// `energyToday` drops it -- which is the property that makes it safe to hand to a counter that
+/// may never go backwards. It was a hardcoded 24680 that never moved at all, so nothing
+/// downstream that accumulates or rate-limits on this channel was ever exercised.
+double energyTotal(const SimDay& day) {
+    return kInitialTotalKwh + static_cast<double>(day.completed) * kDailyYieldKwh
+           + energyToday(day.phase);
 }
 
 DriverDescriptor makeDescriptor(bool writable) {
@@ -247,7 +300,8 @@ PollResult MockDriver::poll(DeviceState& state) {
     }
 
     const uint64_t now      = clock_ ? clock_() : 0;
-    const double   fraction = solarFraction(now, options_.dayLengthMs, options_.instance);
+    const SimDay   day      = simulatedDay(now, options_.dayLengthMs, options_.instance);
+    const double   fraction = solarFraction(day.phase);
     const double   dcPower  = kPeakDcWatts * fraction;
     const double   acPower  = dcPower * 0.97;
 
@@ -320,17 +374,30 @@ PollResult MockDriver::poll(DeviceState& state) {
               "Battery Charge Power");
     m.declare(measurement_id::kBatteryDischargePower, MeasurementType::Power, Unit::Watt,
               "Battery Discharge Power");
+    // The combined channel as well as the two rails. measurement.h asks a driver that reads
+    // them separately to publish this one too, and the only driver that reads them separately
+    // was the one ignoring that -- so the sign convention itself went untested, and everything
+    // keyed on battery.power (the dashboard's charge/discharge column, the Home Assistant
+    // entity, the MQTT topic) had nothing to show on the one device anybody can run without
+    // hardware. Modbus TCP is the exception: its map carries the two rails at 304/306 and has
+    // no register for the combined value, so that output is unchanged by this.
+    m.declare(measurement_id::kBatteryPower, MeasurementType::Power, Unit::Watt, "Battery Power");
     const double soc = 40.0 + 40.0 * fraction;
+    // `<= 0.0` rather than `== 0.0`: night is the only case meant here, and an exact float
+    // compare also catches sunrise, where the sine is a true zero in broad daylight.
+    const double chargeW    = fraction > 0.3 ? 1000.0 : 0.0;
+    const double dischargeW = fraction <= 0.0 ? 400.0 : 0.0;
     m.set(measurement_id::kBatterySoc, soc, ts);
     m.set(measurement_id::kBatteryVoltage, 48.0 + soc * 0.05, ts);
-    m.set(measurement_id::kBatteryChargePower, fraction > 0.3 ? 1000.0 : 0.0, ts);
-    m.set(measurement_id::kBatteryDischargePower, fraction == 0.0 ? 400.0 : 0.0, ts);
+    m.set(measurement_id::kBatteryChargePower, chargeW, ts);
+    m.set(measurement_id::kBatteryDischargePower, dischargeW, ts);
+    m.set(measurement_id::kBatteryPower, chargeW - dischargeW, ts);  // + charging, - discharging
 
     m.set(measurement_id::kAcPowerTotal, acPower, ts);
     m.set(measurement_id::kAcFrequency, 50.0, ts);
     m.set(measurement_id::kDcPowerTotal, dcPower, ts);
-    m.set(measurement_id::kEnergyToday, 12.5 * fraction, ts);
-    m.set(measurement_id::kEnergyTotal, 24680.0, ts);
+    m.set(measurement_id::kEnergyToday, energyToday(day.phase), ts);
+    m.set(measurement_id::kEnergyTotal, energyTotal(day), ts);
     m.set(measurement_id::kTemperature, 25.0 + 20.0 * fraction, ts);
 
     state.statusCode          = fraction > 0.0 ? 1 : 0;

--- a/test/test_driver_registry/test_main.cpp
+++ b/test/test_driver_registry/test_main.cpp
@@ -552,6 +552,153 @@ static void test_an_instance_beyond_the_device_table_is_refused() {
                                            DriverOptions{{"unit_id", "8"}}, error));
 }
 
+// --- the mock's counters and battery -----------------------------------------------------
+
+#if ENABLE_DRIVER_MOCK
+/// A mock on a clock the test moves by hand, so a whole simulated day fits in one loop.
+///
+/// `dayLengthMs` of 1000 makes a tick a thousandth of a day; the day boundary then sits at
+/// now = 500, because the curve's origin is midday rather than midnight.
+namespace {
+constexpr uint64_t kDay      = 1000;   ///< one simulated day, in ticks
+constexpr uint64_t kMidnight = 500;    ///< the tick at which a simulated day begins
+constexpr double   kDailyYieldKwh = 12.5;
+
+struct SteppedMock {
+    uint64_t         now = kMidnight;
+    MockTransport    transport;
+    mock::MockDriver driver;
+
+    SteppedMock() : driver([this] { return now; }, [] {
+        mock::MockOptions o;
+        o.dayLengthMs = kDay;
+        return o;
+    }()) {
+        driver.begin(transport);
+    }
+
+    /// One poll at the current tick, returning the value of a channel. Fails the test rather
+    /// than dereferencing null, so a channel that stops being published is a named failure.
+    double read(const char* id) {
+        DeviceState state;
+        state.lastPollAttemptMs = now + 1;
+        TEST_ASSERT_EQUAL(PollResult::Ok, driver.poll(state));
+        const auto* m = state.measurements.find(id);
+        TEST_ASSERT_NOT_NULL_MESSAGE(m, id);
+        return m->value;
+    }
+};
+}  // namespace
+#endif
+
+/// The defect: `energy.today` was the power curve scaled, so it climbed to midday and then fell
+/// back to zero by sunset. The afternoon is where that shows -- at equal power either side of
+/// noon the old code returned equal energy, which is only true if the morning produced nothing.
+static void test_energy_today_only_ever_climbs_within_a_day() {
+#if ENABLE_DRIVER_MOCK
+    SteppedMock m;
+
+    m.now = kMidnight;
+    TEST_ASSERT_TRUE_MESSAGE(m.read(measurement_id::kEnergyToday) == 0.0,
+                             "a day must start at zero");
+
+    double previous = 0.0;
+    for (uint64_t tick = kMidnight; tick < kMidnight + kDay; ++tick) {
+        m.now              = tick;
+        const double today = m.read(measurement_id::kEnergyToday);
+        TEST_ASSERT_TRUE_MESSAGE(today >= previous, "energy.today went backwards");
+        previous = today;
+    }
+
+    // Morning and afternoon at the same instantaneous power: the same reading under the old
+    // code, and necessarily different once it is an integral.
+    m.now                 = kMidnight + 375;  // phase 0.375, climbing
+    const double morning  = m.read(measurement_id::kEnergyToday);
+    m.now                 = kMidnight + 625;  // phase 0.625, same power, falling
+    const double afternoon = m.read(measurement_id::kEnergyToday);
+    TEST_ASSERT_TRUE_MESSAGE(afternoon > morning, "the afternoon must add to the day, not undo it");
+
+    m.now = kMidnight + 750;  // sunset
+    TEST_ASSERT_TRUE(std::fabs(m.read(measurement_id::kEnergyToday) - kDailyYieldKwh) < 1e-9);
+    m.now = kMidnight + 900;  // after dark, held rather than decaying
+    TEST_ASSERT_TRUE(std::fabs(m.read(measurement_id::kEnergyToday) - kDailyYieldKwh) < 1e-9);
+#else
+    TEST_IGNORE_MESSAGE("mock driver not compiled in");
+#endif
+}
+
+/// The lifetime counter has to survive the seam that resets the daily one -- the moment the two
+/// disagree it either jumps or goes backwards, and a total that goes backwards is a meter reset
+/// to everything downstream. It used to be a constant, so nothing here was exercised at all.
+static void test_energy_total_crosses_midnight_without_a_step() {
+#if ENABLE_DRIVER_MOCK
+    SteppedMock m;
+
+    double previous = 0.0;
+    for (uint64_t tick = kMidnight; tick <= kMidnight + 2 * kDay; ++tick) {
+        m.now              = tick;
+        const double total = m.read(measurement_id::kEnergyTotal);
+        TEST_ASSERT_TRUE_MESSAGE(total >= previous, "energy.total went backwards");
+        previous = total;
+    }
+
+    // Two days on: exactly two days' yield richer. Asserted as a difference, not against an
+    // absolute figure -- the absolute one also encodes where the simulation's epoch happens to
+    // fall (it starts at midday, so a day is already banked by the first midnight), which is
+    // incidental and would make this test fail for the wrong reason.
+    m.now                = kMidnight;
+    const double atStart = m.read(measurement_id::kEnergyTotal);
+    m.now                = kMidnight + 2 * kDay;
+    TEST_ASSERT_TRUE(std::fabs((m.read(measurement_id::kEnergyTotal) - atStart)
+                               - 2 * kDailyYieldKwh) < 1e-9);
+
+    // Either side of a single tick across midnight: continuous, not a jump of a day's yield.
+    m.now              = kMidnight + kDay - 1;
+    const double before = m.read(measurement_id::kEnergyTotal);
+    m.now              = kMidnight + kDay;
+    const double after  = m.read(measurement_id::kEnergyTotal);
+    TEST_ASSERT_TRUE_MESSAGE(std::fabs(after - before) < 0.01, "the day rolled over with a step");
+#else
+    TEST_IGNORE_MESSAGE("mock driver not compiled in");
+#endif
+}
+
+/// measurement.h asks a driver reading separate charge/discharge rails to publish the combined
+/// `battery.power` as well. The mock read them separately and published only the rails, so the
+/// sign convention had no test and every consumer of the combined channel -- the dashboard
+/// column, the Home Assistant entity, the MQTT topic -- had nothing to show on the one
+/// device that runs without hardware.
+static void test_the_mock_publishes_combined_battery_power() {
+#if ENABLE_DRIVER_MOCK
+    SteppedMock m;
+    bool sawCharging = false, sawDischarging = false, sawIdle = false;
+
+    for (uint64_t tick = kMidnight; tick < kMidnight + kDay; tick += 5) {
+        m.now                  = tick;
+        const double power     = m.read(measurement_id::kBatteryPower);
+        const double charge    = m.read(measurement_id::kBatteryChargePower);
+        const double discharge = m.read(measurement_id::kBatteryDischargePower);
+        TEST_ASSERT_TRUE_MESSAGE(std::fabs(power - (charge - discharge)) < 1e-9,
+                                 "battery.power must agree with the rails it is made of");
+        if (power > 0.0) {
+            sawCharging = true;
+        } else if (power < 0.0) {
+            sawDischarging = true;
+        } else {
+            sawIdle = true;
+        }
+    }
+
+    // All three states within one simulated day: a column that can only ever render one of them
+    // is not a demonstration of anything.
+    TEST_ASSERT_TRUE_MESSAGE(sawCharging, "never charged");
+    TEST_ASSERT_TRUE_MESSAGE(sawDischarging, "never discharged");
+    TEST_ASSERT_TRUE_MESSAGE(sawIdle, "never idle");
+#else
+    TEST_IGNORE_MESSAGE("mock driver not compiled in");
+#endif
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_a_numeric_option_out_of_range_is_refused);
@@ -587,5 +734,8 @@ int main(int, char**) {
     RUN_TEST(test_instances_are_staggered_so_they_do_not_report_in_lockstep);
     RUN_TEST(test_a_running_fleet_ends_up_part_producing_and_part_dark);
     RUN_TEST(test_an_instance_beyond_the_device_table_is_refused);
+    RUN_TEST(test_energy_today_only_ever_climbs_within_a_day);
+    RUN_TEST(test_energy_total_crosses_midnight_without_a_step);
+    RUN_TEST(test_the_mock_publishes_combined_battery_power);
     return UNITY_END();
 }


### PR DESCRIPTION
Reported from the 6CH running four mocks: the dashboard showed no charge/discharge column, and `today` never climbed. Both are real, and both are in the mock rather than in the dashboard.

## What was wrong

**No `battery.power`.** All four devices reported `"battery_power_w": null`. The strip hides a column when no inverter has a value for it, so the filter was doing its job — the data genuinely was not there. The mock sets `battery.charge_power` and `battery.discharge_power` and never the combined channel, while `measurement.h` asks a driver reading separate rails to publish it:

> a driver that reads separate charge/discharge rails combines them into this

The only driver that reads separate rails was the one not doing it. So the sign convention (positive charging, negative discharging) had no test anywhere, and every consumer keyed on `battery.power` had nothing to show on the one device anybody can run without hardware. A real Growatt SPH publishes it directly and was unaffected.

**`energy.today` was not a counter.** It was `12.5 * fraction` — the power curve scaled — so it rose to midday and fell back to zero by sunset. Measured live, staggered across the fleet: 1.05 / 3.49 / 5.80 / 7.87 kWh, all four heading back down within minutes. A daily counter that decreases is not merely a wrong number; a `total_increasing` sensor reads the drop as a meter reset. `energy.total` is family: a hardcoded 24680 that never moved, so nothing downstream that accumulates on that channel was ever exercised.

## What changed

`energy.today` is now the integral of the curve, so its slope is the instantaneous power and the two channels describe the same inverter. It holds at the day's total after sunset and resets at midnight. `energy.total` is the starting figure plus whole days behind us plus today — continuous across the rollover by construction, since the day count gains what today drops at the same instant.

The phase of the simulated day now comes from one place. The counters have to roll over at exactly the moment the curve calls it midnight, or the lifetime total steps at the seam; deriving both from one division is what makes that structural instead of a coincidence.

Also drops an exact float compare (`fraction == 0.0`) that treated sunrise — a true zero in broad daylight — as night.

## Verification

- 776 native tests pass (773 + 3), all 8 layering rules, `relay-6ch` builds.
- The three new tests were run against the unmodified driver and **all three fail**, each for its own reason: `energy.today went backwards`, the lifetime delta over two days is 0 instead of 25 kWh, and `battery.power` is absent.
- One test asserts the total as a *difference* over two days rather than an absolute figure. The absolute one also encodes where the epoch falls — the simulation starts at midday, so a day is already banked by the first midnight — and my first attempt failed on exactly that.

## Effects worth naming

- **A new Home Assistant entity** appears per mock: `Battery Power`. Intended — everything read from an inverter should be visible in HA.
- **Midday now reads 6.25 kWh where it used to read 12.5.** Same daily yield, reached at sunset instead of noon, because it is an integral now.
- **Modbus TCP is unchanged.** Its map has the rails at 304/306 and no register for the combined value. I said otherwise in chat earlier; there is no such register.

## Left alone deliberately

The battery's own internals stay inconsistent: SOC is `40 + 40 * fraction`, so it falls through the afternoon while `charge_power` still reads 1000 W. Making SOC integrate the rails is a larger change than the two defects reported here, and I would rather it be its own PR than ride along in this one. Say the word and I will file it.