### PR TITLE
feat(sunspec): active power limit via model 123 (immediate controls)

### DIFF
--- a/docs/sunspec.md
+++ b/docs/sunspec.md
@@ -10,6 +10,12 @@ standard — no per-vendor file, no per-model file.
 implemented and host-tested against a simulated device; nothing has met real hardware. See
 [Compatibility](#compatibility) for what that means for your inverter.
 
+That warning carries more weight now that this driver can **write**. A read path that is wrong
+publishes a wrong number; a write path that is wrong changes somebody's inverter. Nothing writes
+by itself — the power limit is a capability the device must publish and a caller must invoke —
+but if you are the first to point this at a real inverter, watch what it does before you trust
+it, and please say so on the issue either way.
+
 ## How it works
 
 A SunSpec device places a marker and then a self-describing chain in its holding registers:
@@ -54,6 +60,45 @@ layout, verified against the official definitions, so all three are handled iden
 | DC power | `DCW` | `dc.power.total` |
 | Temperature | `TmpCab` | `inverter.temperature` |
 | Operating state | `St` | status code |
+
+## What can be controlled today
+
+**Model 123 (immediate controls)** — read on every poll, and writable when the device publishes
+it. This is the one control surface here that needed no per-vendor research: the device says
+where its own registers are, so the addresses come from the standard and from the chain rather
+than from a transcribed vendor table. A wrong address in a power-limit map does not cost yield,
+it lands in grid protection.
+
+| Control | SunSpec point | Offset | Exposed as |
+|---|---|---|---|
+| Active power limit | `WMaxLimPct` | 5 | `control.active_power_limit` (%), writable |
+| Limit on/off | `WMaxLim_Ena` | 9 | `control.active_power_limit_enabled` |
+| Connect / disconnect | `Conn` | 4 | start / stop |
+| Limit resolution | `WMaxLimPct_SF` | 23 | the step of the control above |
+
+Rules this follows, all of them the kind that only bite in production:
+
+- **The capability is absent, not refused,** on a device that publishes no model 123 — and also
+  on one that publishes it without a usable `WMaxLimPct_SF`, because the percentage cannot then
+  be encoded and a control with invented limits is worse than none.
+- **The bounds are the device's.** 0–100% because `WMaxLimPct` is a percentage of nameplate, and
+  the *step* is whatever the device's scale factor buys: `sf = -1` accepts 62.5%, `sf = 0` does
+  not.
+- **A setpoint out of range is refused, never clamped.** Silently running at 100% when 150% was
+  asked for hides the caller's mistake behind a successful command.
+- **The value is written before the limit is armed.** The other order applies whatever limit the
+  register was holding for however long the two writes are apart.
+- **The echo is the confirmation.** A write whose echoed address or value disagrees is reported
+  as a failure, not success. On a control register the difference is between an inverter that is
+  limited and one everybody believes is limited.
+- **What is published is what the device holds**, re-read every poll — not what was last written.
+  Those differ when a second controller is on the bus, or when the inverter's own revert timer
+  fires, which model 123 defines and several devices implement.
+
+Note the spelling of the enable point: it is `WMaxLim_Ena`, **not** `WMaxLimPct_Ena`. Its
+neighbours all carry the `Pct` infix, so the natural guess is one register off — and one
+register off is `WMaxLimPct_RmpTms`, a ramp time that would accept the 1 meant as "enabled"
+and leave the limit switched off.
 
 Not read yet: nameplate and settings (120–122), and the storage/battery models (124, 160,
 802–804). Those are a separate step — battery semantics vary far more between vendors than
@@ -157,8 +202,10 @@ entries, one whose lengths walk off the address space stops, and one that simply
 answering keeps whatever was mapped — several devices do not serve the terminator at all. None
 of those fail the device outright.
 
-Read-only. SunSpec does define writable models; enabling one needs a hardware-verified map and
-a deliberate write path, and neither exists.
+Model 123 is the only writable model implemented, and the write path is single-register (0x06)
+with the echo verified, never a span. That is not caution for its own sake: the points somebody
+wants to set are interleaved with window, revert and ramp times they did not ask about, and a
+block write cannot express the difference.
 
 Sources: the official SunSpec model definitions (<https://github.com/sunspec/models>) for every
 offset used here, and the SunSpec Alliance information model for the marker, chain structure

--- a/src/device/measurement.h
+++ b/src/device/measurement.h
@@ -121,6 +121,16 @@ inline constexpr const char* kBatteryDischargePower = "battery.discharge_power";
 inline constexpr const char* kGridImportPower = "grid.import_power";
 inline constexpr const char* kGridExportPower = "grid.export_power";
 
+/// What the inverter is currently limited TO, as a percentage of its nameplate maximum, and
+/// whether that limit is switched on at all.
+///
+/// A control that is written must also be readable, or nobody can tell what the device is doing
+/// -- only what it was last asked to do. Those differ whenever a write was refused, a second
+/// controller is on the bus, or the inverter reverted the limit on its own timer, which several
+/// of them do by design.
+inline constexpr const char* kActivePowerLimitPct = "control.active_power_limit";
+inline constexpr const char* kActivePowerLimitEnabled = "control.active_power_limit_enabled";
+
 /// Every id above, in one place.
 ///
 /// Needed because a device removed from the configuration leaves retained Home Assistant
@@ -135,6 +145,7 @@ inline constexpr const char* kAll[] = {
     kTemperature,    kOperatingHours, kBatterySoc,     kBatteryPower,   kBatteryVoltage,
     kBatteryCurrent, kBatteryTemperature, kBatteryEnergyCharged, kBatteryEnergyDischarged,
     kBatteryChargePower, kBatteryDischargePower, kGridImportPower, kGridExportPower,
+    kActivePowerLimitPct, kActivePowerLimitEnabled,
 };
 
 }  // namespace measurement_id

--- a/src/drivers/sunspec/descriptor.cpp
+++ b/src/drivers/sunspec/descriptor.cpp
@@ -17,9 +17,10 @@ const DriverDescriptor& descriptor() {
         x.description =
             "Any inverter implementing the SunSpec Modbus standard (models 101/102/103). The "
             "device describes its own register layout at runtime, so no per-vendor map is "
-            "needed. Read-only. Not yet confirmed against physical hardware -- see "
-            "docs/sunspec.md for which devices are expected to work and which have actually "
-            "been tested.";
+            "needed. A device that also publishes model 123 gains an active power limit, "
+            "bounded by the scale factor it publishes for it. Not yet confirmed against "
+            "physical hardware -- see docs/sunspec.md for which devices are expected to work "
+            "and which have actually been tested.";
         x.supportedTransports = {TransportType::Rs485, TransportType::Mock};
         // SunSpec does not mandate a line speed; 9600 and 19200 are both common, so both are
         // offered and discovery tries them in order.
@@ -32,7 +33,11 @@ const DriverDescriptor& descriptor() {
         x.supportsAutoDetection   = true;
         x.supportsMultipleDevices = false;
         x.supportsRead            = true;
-        x.supportsWrite           = false;
+        // The driver has a write path; whether a given DEVICE has one is a separate question,
+        // answered by capabilities() after model 123 has been read. This flag is the static
+        // claim about the driver, so it says yes -- a UI that hid the control surface here
+        // would hide it for the devices that do publish 123 as well.
+        x.supportsWrite           = true;
         x.addressOptionKey        = "unit_id";
         x.options                 = {
             DriverOption{"unit_id", "Modbus unit id",

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -69,6 +69,12 @@ bool SunspecDriver::walkChain(PollResult& outFailure) {
     chain_.clear();
     inverterEntry_ = nullptr;
     commonEntry_   = nullptr;
+    controlsEntry_ = nullptr;
+    // Dropped with the chain, not kept across it: a re-walk happens because the device stopped
+    // answering mid-chain, and one that came back with a different layout must not be written
+    // into using bounds read from the layout it had before.
+    controlsRead_  = false;
+    controls_      = ControlsReadings{};
     walked_        = false;
 
     uint16_t   marker[2] = {};
@@ -136,6 +142,19 @@ bool SunspecDriver::walkChain(PollResult& outFailure) {
         if (inverterEntry_ == nullptr && isInverterModel(e.modelId)) {
             inverterEntry_ = &e;
         }
+        if (controlsEntry_ == nullptr && e.modelId == kModelControls) {
+            // Only accept a block long enough to hold the points that will be written. A device
+            // advertising a truncated 123 is not one to write into on the assumption that the
+            // missing tail is where we think it is: the enable point sits at offset 9 and the
+            // scale factor at 23, so a short block puts a control write into whatever follows.
+            if (static_cast<size_t>(kHeaderRegisters + e.length) >= controls::kMinRegisters) {
+                controlsEntry_ = &e;
+            } else {
+                log::warn("SUNSPEC model 123 at %u is %u registers, needs %u -- controls ignored",
+                          e.address, static_cast<unsigned>(kHeaderRegisters + e.length),
+                          static_cast<unsigned>(controls::kMinRegisters));
+            }
+        }
     }
 
     // Identity is read here rather than only in probe(): a driver selected by hand never gets
@@ -193,6 +212,9 @@ bool SunspecDriver::begin(Transport& transport) {
     transport_ = &transport;
     chain_.clear();
     walked_                = false;
+    controlsEntry_         = nullptr;
+    controlsRead_          = false;
+    controls_              = ControlsReadings{};
     identity_              = DeviceIdentity{};
     identity_.driverId     = descriptor().id;
     identity_.instanceKey  = std::to_string(options_.unitId);
@@ -326,7 +348,49 @@ PollResult SunspecDriver::poll(DeviceState& state) {
         state.statusCode          = r.state;
         state.statusCodeSupported = true;
     }
+
+    // Read on every poll, not once: the limit is a control somebody else can also change --
+    // another controller on the bus, the installer's app, or the inverter's own revert timer,
+    // which model 123 defines and several devices implement. Reporting what we last WROTE
+    // rather than what the device currently holds would make those changes invisible.
+    if (controlsEntry_ != nullptr && refreshControls()) {
+        m.declare(measurement_id::kActivePowerLimitPct, MeasurementType::Ratio, Unit::Percent,
+                  "Active Power Limit");
+        // Both channels, because either alone misleads: a stored limit of 50% that is switched
+        // off means the inverter is not limited at all, and "enabled" without the value does
+        // not say limited to what.
+        m.declare(measurement_id::kActivePowerLimitEnabled, MeasurementType::Generic, Unit::None,
+                  "Active Power Limit Enabled");
+        if (controls_.hasPowerLimit) {
+            m.set(measurement_id::kActivePowerLimitPct, controls_.powerLimitPct, ts);
+        }
+        if (controls_.hasLimitEnabled) {
+            m.set(measurement_id::kActivePowerLimitEnabled, controls_.limitEnabled ? 1.0 : 0.0,
+                  ts);
+        }
+    }
     return PollResult::Ok;
+}
+
+bool SunspecDriver::refreshControls() {
+    if (controlsEntry_ == nullptr) {
+        return false;
+    }
+    std::vector<uint16_t> regs;
+    PollResult            ignored = PollResult::Timeout;
+    // Best-effort, like the identity read: a controls block that does not answer must not fail
+    // a poll whose inverter readings arrived intact. It costs the control surface for this
+    // round, which the absent measurement already says.
+    if (!readModel(*controlsEntry_, regs, ignored)) {
+        return false;
+    }
+    ControlsReadings fresh;
+    if (!decodeControls(regs.data(), regs.size(), fresh)) {
+        return false;
+    }
+    controls_     = fresh;
+    controlsRead_ = true;
+    return true;
 }
 
 InverterCapabilities SunspecDriver::capabilities() const {
@@ -341,14 +405,104 @@ InverterCapabilities SunspecDriver::capabilities() const {
     c.addRead(InverterCapability::ReadDcPower);
     c.addRead(InverterCapability::ReadEnergyTotal);
     c.addRead(InverterCapability::ReadTemperature);
+
+    // Write capabilities are the device's, not this driver's. They appear only once model 123
+    // has actually been READ -- not merely advertised on the chain -- because the bounds come
+    // from the scale factor inside it. A capability offered before that would be a control
+    // surface with invented limits, and the first thing anybody does with a power limit is
+    // drag it to a number.
+    if (!controlsRead_) {
+        return c;
+    }
+    const LimitBounds bounds = limitBounds(controls_.limitScale);
+    if (bounds.usable) {
+        c.addRead(InverterCapability::SetActivePowerLimit);
+        c.addWrite(InverterCapability::SetActivePowerLimit);
+        auto& n    = c.numeric[static_cast<size_t>(InverterCommandType::SetActivePowerLimitPercent)];
+        n.supported = true;
+        n.writable  = true;
+        n.minimum   = bounds.minimum;
+        n.maximum   = bounds.maximum;
+        n.step      = bounds.step;
+        n.unit      = Unit::Percent;
+    }
+    // Conn is a separate point with its own sentinel: a device may implement the limit and not
+    // the disconnect, or the other way round, so they are advertised independently rather than
+    // as one "controls" capability.
+    if (controls_.hasConnection) {
+        c.addRead(InverterCapability::StartStop);
+        c.addWrite(InverterCapability::StartStop);
+    }
     return c;
 }
 
+CommandResult SunspecDriver::writeControl(size_t pointOffset, uint16_t value) {
+    if (transport_ == nullptr || controlsEntry_ == nullptr) {
+        return CommandResult::Unsupported;
+    }
+    const uint16_t address = static_cast<uint16_t>(controlsEntry_->address + pointOffset);
+    const auto     outcome =
+        modbus::writeSingleRegister(*transport_, options_.unitId, address, value);
+    switch (outcome.status) {
+        case modbus::TransactionStatus::Ok:
+            return CommandResult::Ok;
+        case modbus::TransactionStatus::Exception:
+            // The device answered and refused. Distinct from a bus failure: the write reached
+            // it, so retrying the same value will be refused again.
+            log::warn("SUNSPEC write %u = %u refused, exception %u", address, value,
+                      static_cast<unsigned>(outcome.exceptionCode));
+            return CommandResult::Rejected;
+        case modbus::TransactionStatus::Crc:
+            ++busErrors_.checksumErrors;
+            return CommandResult::DriverError;
+        case modbus::TransactionStatus::Timeout:
+            ++busErrors_.timeouts;
+            return CommandResult::Timeout;
+        default:
+            // Protocol / TransportError. Includes the echo not matching what was sent, which is
+            // the one failure a write has and a read does not.
+            ++busErrors_.invalidFrames;
+            log::warn("SUNSPEC write %u = %u was not confirmed", address, value);
+            return CommandResult::DriverError;
+    }
+}
+
 CommandResult SunspecDriver::execute(const InverterCommand& command) {
-    (void)command;
-    // Read-only, like every driver here. SunSpec does define writable models, but enabling one
-    // needs a hardware-verified map and a deliberate write path -- neither exists yet.
-    return CommandResult::Unsupported;
+    // Every gate is a real one: the capability set above is what the dispatcher checks, and it
+    // is absent unless this device published a model 123 that could be read. The checks here
+    // are the driver's own, for a caller that reached execute() another way.
+    if (controlsEntry_ == nullptr || !controlsRead_) {
+        return CommandResult::Unsupported;
+    }
+
+    switch (command.type) {
+        case InverterCommandType::SetActivePowerLimitPercent: {
+            if (!command.numericValue.has_value()) {
+                return CommandResult::Rejected;
+            }
+            uint16_t raw = 0;
+            if (!encodePowerLimitPct(*command.numericValue, controls_.limitScale, raw)) {
+                // Refused rather than clamped: see encodePowerLimitPct. A caller that asked for
+                // 150% has made a mistake, and running the inverter at 100% instead would hide
+                // it behind an apparently successful command.
+                return CommandResult::OutOfRange;
+            }
+            // Value first, enable second. The other order arms whatever limit the register
+            // happened to be holding -- possibly one set by somebody else, possibly the 0% that
+            // a device ships with -- for however long the two writes are apart.
+            const CommandResult set = writeControl(controls::kWMaxLimPct, raw);
+            if (set != CommandResult::Ok) {
+                return set;
+            }
+            return writeControl(controls::kWMaxLim_Ena, controls::kEnabled);
+        }
+        case InverterCommandType::Start:
+            return writeControl(controls::kConn, controls::kConnect);
+        case InverterCommandType::Stop:
+            return writeControl(controls::kConn, controls::kDisconnect);
+        default:
+            return CommandResult::Unsupported;
+    }
 }
 
 }  // namespace heliograph::sunspec

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -29,10 +29,11 @@ modbus::ReadOutcome SunspecDriver::read(uint16_t address, uint16_t count, uint16
     const auto outcome = modbus::readRegisters(*transport_, options_.unitId,
                                                modbus::kReadHoldingRegisters, address, count, out,
                                                capacity, timing);
-    // Every read on the wire passes through here. Note that a steady-state poll is ONE
-    // transaction: the chain walk is gated on walked_ and runs once per session, and model 103
-    // fits inside a single chunk. The dozen-transaction case is the walk itself, where only the
-    // read that stopped it ever reached the old poll-verdict counter.
+    // Every read on the wire passes through here. A steady-state poll is ONE transaction on a
+    // device without model 123 and TWO on a device with it: the chain walk is gated on walked_
+    // and runs once per session, and model 103 and model 123 each fit inside a single chunk.
+    // The dozen-transaction case is the walk itself, where only the read that stopped it ever
+    // reached the old poll-verdict counter.
     tallyModbusRead(busErrors_, outcome.status);
     return outcome;
 }
@@ -381,17 +382,31 @@ bool SunspecDriver::refreshControls() {
     // Best-effort, like the identity read: a controls block that does not answer must not fail
     // a poll whose inverter readings arrived intact. It costs the control surface for this
     // round, which the absent measurement already says.
-    if (!readModel(*controlsEntry_, regs, ignored)) {
-        return false;
-    }
+    const bool ok = readModel(*controlsEntry_, regs, ignored);
     ControlsReadings fresh;
-    if (!decodeControls(regs.data(), regs.size(), fresh)) {
-        return false;
+    if (ok && decodeControls(regs.data(), regs.size(), fresh)) {
+        controls_     = fresh;
+        controlsRead_ = true;
+        return true;
     }
-    controls_     = fresh;
-    controlsRead_ = true;
-    return true;
+
+    // Give up on a device that advertises the model and has NEVER served it -- but keep
+    // retrying one that has.
+    //
+    // Without this, such a device costs a failed transaction on every poll, forever: the full
+    // response timeout added to each cycle, and every one of those failures tallied into the
+    // bus error counters that the alerting rules watch. The inverter read still succeeds, so
+    // the poll reports Ok while the counters climb -- a healthy bus made to look like a
+    // degrading one, by a control surface nobody is using. A device that has answered before
+    // is a different case: that is a real control surface and a glitch is worth riding out.
+    if (!controlsRead_) {
+        log::warn("SUNSPEC model 123 at %u advertised but unreadable -- controls disabled",
+                  controlsEntry_->address);
+        controlsEntry_ = nullptr;
+    }
+    return false;
 }
+
 
 InverterCapabilities SunspecDriver::capabilities() const {
     // Declared from what the decoder can actually produce, not from what SunSpec defines:

--- a/src/drivers/sunspec/sunspec_driver.h
+++ b/src/drivers/sunspec/sunspec_driver.h
@@ -79,6 +79,14 @@ private:
     bool readModel(const ChainEntry& entry, std::vector<uint16_t>& out, PollResult& outFailure);
     modbus::ReadOutcome read(uint16_t address, uint16_t count, uint16_t* out, uint16_t capacity);
 
+    /// Reads model 123 and refreshes controls_. Returns false when the device has no controls
+    /// block or the read failed; the caller decides whether that is fatal, because a device
+    /// that reads fine and simply offers no controls is not a broken device.
+    bool refreshControls();
+    /// One control register, written and its echo verified. Refuses before touching the bus
+    /// when there is no controls block to write into.
+    CommandResult writeControl(size_t pointOffset, uint16_t value);
+
     Transport*     transport_ = nullptr;
     SunspecOptions options_;
     BusErrorCounts busErrors_{};
@@ -86,8 +94,19 @@ private:
     std::vector<ChainEntry> chain_;
     const ChainEntry*       inverterEntry_ = nullptr;  ///< into chain_
     const ChainEntry*       commonEntry_   = nullptr;
+    const ChainEntry*       controlsEntry_ = nullptr;
     DeviceIdentity          identity_;
     bool                    walked_ = false;
+
+    /// Last read of model 123, and whether it has ever been read.
+    ///
+    /// Cached because capabilities() is const and is asked what this device can do before any
+    /// caller would think to poll -- and the answer is not a property of the driver, it is a
+    /// property of the device in front of it. The bounds of the power limit come from the
+    /// device's own scale factor, so until the block has been read there is nothing honest to
+    /// advertise and the capability stays absent.
+    ControlsReadings controls_{};
+    bool             controlsRead_ = false;
 };
 
 const DriverDescriptor&         descriptor();

--- a/src/drivers/sunspec/sunspec_parser.cpp
+++ b/src/drivers/sunspec/sunspec_parser.cpp
@@ -13,6 +13,11 @@ namespace {
 constexpr int kMinExponent = -10;
 constexpr int kMaxExponent = 10;
 
+/// WMaxLimPct is a percentage of the nameplate maximum, so 100 is the whole machine. Not the
+/// widest value the register could hold: above 100 the standard defines nothing, and a device
+/// asked for 300% is being sent a number rather than an instruction.
+constexpr double kMaxLimitPercent = 100.0;
+
 double powerOfTen(int exponent) {
     double result = 1.0;
     if (exponent >= 0) {
@@ -131,6 +136,73 @@ bool decodeInverter(const uint16_t* regs, size_t count, InverterReadings& out) {
         out.hasState = true;
         out.state    = st;
     }
+    return true;
+}
+
+bool decodeControls(const uint16_t* regs, size_t count, ControlsReadings& out) {
+    if (regs == nullptr || count < controls::kMinRegisters) {
+        return false;
+    }
+    out = ControlsReadings{};
+
+    out.limitScale = decodeScaleFactor(regs[controls::kWMaxLimPct_SF]);
+    out.hasPowerLimit =
+        applyScale(regs[controls::kWMaxLimPct], /*isSigned=*/false, out.limitScale,
+                   out.powerLimitPct);
+
+    // The two enums carry no scale factor, so only the sentinel can make them absent. Read
+    // strictly: anything that is neither 0 nor 1 is a value this decoder has no meaning for,
+    // and guessing that "not zero means on" is how a disconnected inverter gets reported as
+    // connected.
+    const uint16_t ena = regs[controls::kWMaxLim_Ena];
+    if (ena == controls::kDisabled || ena == controls::kEnabled) {
+        out.hasLimitEnabled = true;
+        out.limitEnabled    = ena == controls::kEnabled;
+    }
+    const uint16_t conn = regs[controls::kConn];
+    if (conn == controls::kDisconnect || conn == controls::kConnect) {
+        out.hasConnection = true;
+        out.connected     = conn == controls::kConnect;
+    }
+    return true;
+}
+
+LimitBounds limitBounds(const ScaleFactor& sf) {
+    LimitBounds b;
+    if (!sf.valid) {
+        return b;  // no usable exponent: nothing can be encoded, so nothing may be offered
+    }
+    const double step = powerOfTen(sf.exponent);
+    // A device whose exponent is coarser than the whole range cannot express a limit at all --
+    // sf = 3 means the smallest step is 1000%, and offering a 0-100 control with a step it
+    // cannot honour would accept setpoints that round to nothing.
+    if (step > kMaxLimitPercent) {
+        return b;
+    }
+    b.usable  = true;
+    b.minimum = 0.0;
+    b.maximum = kMaxLimitPercent;
+    b.step    = step;
+    return b;
+}
+
+bool encodePowerLimitPct(double percent, const ScaleFactor& sf, uint16_t& raw) {
+    const LimitBounds b = limitBounds(sf);
+    if (!b.usable || !(percent >= b.minimum) || !(percent <= b.maximum)) {
+        // `!(x >= min)` rather than `x < min` so a NaN setpoint is refused too, instead of
+        // sailing through both comparisons and being cast to whatever the conversion yields.
+        return false;
+    }
+    const double scaled = percent / powerOfTen(sf.exponent);
+    // Round rather than truncate: at sf = 0 a request for 49.9% is far better served by 50 than
+    // by 49, and truncation biases every setpoint downwards.
+    const double rounded = std::floor(scaled + 0.5);
+    if (rounded < 0.0 || rounded >= static_cast<double>(kNotImplementedU16)) {
+        // The top of the uint16 range is the not-implemented sentinel, so a value that lands on
+        // it would tell the device "no value" while the caller believes it set a limit.
+        return false;
+    }
+    raw = static_cast<uint16_t>(rounded);
     return true;
 }
 

--- a/src/drivers/sunspec/sunspec_parser.h
+++ b/src/drivers/sunspec/sunspec_parser.h
@@ -47,6 +47,12 @@ inline constexpr uint16_t kModelInverterThreePhase  = 103;
 
 bool isInverterModel(uint16_t modelId);
 
+/// Immediate controls. The one writable model this driver implements, and the reason it can be
+/// implemented at all: it is published and vendor-neutral, so the addresses come from the
+/// standard and from the device's own chain rather than from a transcribed vendor table. A
+/// wrong address in a power-limit map does not cost yield, it lands in grid protection.
+inline constexpr uint16_t kModelControls = 123;
+
 /// Not-implemented sentinels, straight from the specification.
 inline constexpr uint16_t kNotImplementedU16 = 0xFFFF;
 inline constexpr uint16_t kNotImplementedS16 = 0x8000;  // also the not-implemented scale factor
@@ -96,6 +102,31 @@ inline constexpr size_t kSt     = 38;
 inline constexpr size_t kMinRegisters = 39;
 }  // namespace inverter
 
+/// Model 123, transcribed from the official definition (sunspec/models, json/model_123.json).
+///
+/// Only the points this driver touches are named. The gaps are not padding: 2/3 are the connect
+/// timing window, 6/7/8 the limit's window, revert and ramp times, and 10-22 the power-factor
+/// and reactive-power controls. All of them are writable, and writing one by accident changes
+/// how the inverter behaves under a control it was never asked about -- which is why the write
+/// path below writes single registers by name and never a span.
+///
+/// Note the spelling: the enable point is `WMaxLim_Ena`, NOT `WMaxLimPct_Ena`. The neighbouring
+/// points all carry the `Pct` infix, so the obvious guess is one register off -- and one
+/// register off here is `WMaxLimPct_RmpTms`, a ramp time that would silently accept the 1 meant
+/// as "enabled" and leave the limit disabled.
+namespace controls {
+inline constexpr size_t kConn          = 4;   ///< enum16: 0 disconnect, 1 connect
+inline constexpr size_t kWMaxLimPct    = 5;   ///< uint16, scaled by kWMaxLimPct_SF
+inline constexpr size_t kWMaxLim_Ena   = 9;   ///< enum16: 0 disabled, 1 enabled
+inline constexpr size_t kWMaxLimPct_SF = 23;  ///< sunssf
+/// Every point above must exist before the block can be decoded.
+inline constexpr size_t kMinRegisters = 26;
+inline constexpr uint16_t kDisconnect = 0;
+inline constexpr uint16_t kConnect    = 1;
+inline constexpr uint16_t kDisabled   = 0;
+inline constexpr uint16_t kEnabled    = 1;
+}  // namespace controls
+
 namespace common {
 inline constexpr size_t kMn = 2;   // manufacturer, 16 registers
 inline constexpr size_t kMd = 18;  // model, 16
@@ -129,6 +160,50 @@ struct InverterReadings {
 /// block is too short to be one -- a truncated read must never be decoded from whatever
 /// happened to be in the buffer.
 bool decodeInverter(const uint16_t* regs, size_t count, InverterReadings& out);
+
+/// What one model 123 block yielded.
+///
+/// The scale factor is carried out rather than consumed, because a WRITE needs it too: the
+/// percentage has to be encoded with the device's own exponent, and re-deriving it at the write
+/// site is how the read and the write end up disagreeing about what "50%" means.
+struct ControlsReadings {
+    ScaleFactor limitScale;      ///< invalid when the device published no usable WMaxLimPct_SF
+    bool   hasPowerLimit  = false;
+    double powerLimitPct  = 0;   ///< the limit currently in the register, scaled
+    bool   hasLimitEnabled = false;
+    bool   limitEnabled    = false;
+    bool   hasConnection   = false;
+    bool   connected       = false;
+};
+
+/// Decodes a model 123 block. `regs` starts at the model id. Returns false when the block is
+/// too short -- a truncated read must never be decoded from whatever was in the buffer.
+///
+/// Returning true does NOT mean the device implements the limit: a device may carry the model
+/// and publish the not-implemented sentinel for every point in it. The `has*` flags say which.
+bool decodeControls(const uint16_t* regs, size_t count, ControlsReadings& out);
+
+/// Smallest and largest percentage the device can be asked for, given its scale factor.
+///
+/// The ceiling is SunSpec's own (100% of nameplate), not the widest number the register could
+/// hold: WMaxLimPct is a percentage of WMax, and asking for 300% is not a bigger limit, it is a
+/// value the standard does not define. The floor is 0. `step` is the resolution the exponent
+/// buys -- a device with sf = -1 accepts 12.3%, one with sf = 0 rounds it, and telling a
+/// control surface otherwise invites a setpoint that silently does not arrive.
+struct LimitBounds {
+    bool   usable  = false;
+    double minimum = 0.0;
+    double maximum = 0.0;
+    double step    = 0.0;
+};
+LimitBounds limitBounds(const ScaleFactor& sf);
+
+/// Encodes a percentage into the raw register value, using the DEVICE's scale factor.
+///
+/// Refuses rather than clamps when the value is out of range or cannot be represented. A
+/// silently clamped setpoint is the failure mode that matters here: the caller believes it
+/// asked for one thing, the inverter is doing another, and nothing anywhere says so.
+bool encodePowerLimitPct(double percent, const ScaleFactor& sf, uint16_t& raw);
 
 struct CommonIdentity {
     std::string manufacturer;

--- a/src/protocols/modbus/modbus_client.cpp
+++ b/src/protocols/modbus/modbus_client.cpp
@@ -89,4 +89,73 @@ ReadOutcome readRegisters(Transport& transport, uint8_t unitId, uint8_t function
     }
 }
 
+TransactionOutcome writeSingleRegister(Transport& transport, uint8_t unitId, uint16_t address,
+                                       uint16_t value, const ReadTiming& timing) {
+    TransactionOutcome outcome;
+
+    uint8_t req[8];
+    size_t  reqLen = 0;
+    if (buildWriteSingleRegister(unitId, address, value, req, sizeof(req), reqLen) !=
+        BuildResult::Ok) {
+        outcome.status = TransactionStatus::Protocol;
+        return outcome;
+    }
+
+    transport.flushInput();
+    if (transport.write(req, reqLen) != reqLen) {
+        outcome.status = TransactionStatus::TransportError;
+        return outcome;
+    }
+
+    uint8_t        rx[kMaxAdu];
+    size_t         have     = 0;
+    const uint64_t deadline = transport.nowMs() + timing.transactionDeadlineMs;
+    for (;;) {
+        if (transport.nowMs() >= deadline) {
+            outcome.status = TransactionStatus::Timeout;
+            return outcome;
+        }
+
+        WriteResponse resp;
+        switch (parseWriteResponse(rx, have, unitId, kWriteSingleRegister, resp)) {
+            case ParseResult::Ok:
+                // The echo is the confirmation. A device that answers with a different address
+                // or a different value has not done what was asked, however well-formed the
+                // frame is -- and treating that as success is how a setpoint silently does not
+                // arrive.
+                if (resp.address != address || resp.value != value) {
+                    outcome.status = TransactionStatus::Protocol;
+                    return outcome;
+                }
+                outcome.status = TransactionStatus::Ok;
+                return outcome;
+            case ParseResult::Exception:
+                // The ordinary answer to a control write that is refused: read-only register,
+                // out-of-range value, or a device that wants an unlock first.
+                outcome.status        = TransactionStatus::Exception;
+                outcome.exceptionCode = resp.exceptionCode;
+                return outcome;
+            case ParseResult::Incomplete:
+                break;  // fall through and read more
+            case ParseResult::BadCrc:
+                outcome.status = TransactionStatus::Crc;
+                return outcome;
+            default:
+                outcome.status = TransactionStatus::Protocol;
+                return outcome;
+        }
+
+        if (have >= sizeof(rx)) {
+            outcome.status = TransactionStatus::Protocol;
+            return outcome;
+        }
+        const size_t n = transport.read(rx + have, sizeof(rx) - have, timing.responseTimeoutMs);
+        if (n == 0) {
+            outcome.status = TransactionStatus::Timeout;
+            return outcome;
+        }
+        have += n;
+    }
+}
+
 }  // namespace heliograph::modbus

--- a/src/protocols/modbus/modbus_client.h
+++ b/src/protocols/modbus/modbus_client.h
@@ -69,4 +69,29 @@ ReadOutcome readRegisters(Transport& transport, uint8_t unitId, uint8_t function
                           uint16_t start, uint16_t count, uint16_t* out, uint16_t outCapacity,
                           const ReadTiming& timing = {});
 
+/// The outcomes of a Modbus transaction, whichever direction it went.
+///
+/// Aliases rather than a parallel enum for writes: a write fails in exactly the same ways a read
+/// does -- silence, a mangled CRC, an exception, a frame that is not the answer to our question
+/// -- and two lists would be two things to keep in step. The names below are the ones to use in
+/// new code; the Read* spellings stay because they are what every existing driver says.
+using TransactionStatus  = ReadStatus;
+using TransactionOutcome = ReadOutcome;
+
+/// Writes one holding register (0x06) and confirms the device's echo.
+///
+/// Success means the device echoed BOTH the address and the value we sent. That check is the
+/// whole reason this returns something other than "the bytes went out": a write whose echo is
+/// not verified is a request, not a setting, and on a control register the difference is
+/// between an inverter that is limited and one that everybody believes is limited.
+///
+/// A mismatched echo reports Protocol -- the documented meaning of "the frame was intact but
+/// not what we asked for" -- rather than Ok.
+///
+/// Deliberately single-register only. Write-multiple exists in the codec, but a control model
+/// interleaves the points somebody wants to set with timing and ramp registers they do not, and
+/// a span write cannot express that difference.
+TransactionOutcome writeSingleRegister(Transport& transport, uint8_t unitId, uint16_t address,
+                                       uint16_t value, const ReadTiming& timing = {});
+
 }  // namespace heliograph::modbus

--- a/test/support/fake_sunspec_device.h
+++ b/test/support/fake_sunspec_device.h
@@ -75,6 +75,14 @@ public:
         return block;
     }
 
+    /// A model 123 block with every point at its not-implemented sentinel, for a test to fill
+    /// in only what it is about. Indices are offsets from the model id, like the inverter block.
+    static std::vector<uint16_t> blankControlsPayload() {
+        std::vector<uint16_t> block(sunspec::controls::kMinRegisters, sunspec::kNotImplementedU16);
+        block[sunspec::controls::kWMaxLimPct_SF] = sunspec::kNotImplementedS16;
+        return block;
+    }
+
     /// Strips the two header registers off a block built with the offsets above, which is what
     /// addModel() wants.
     static std::vector<uint16_t> asPayload(const std::vector<uint16_t>& block) {
@@ -106,6 +114,31 @@ public:
         }
         ++reads;
 
+        if (fn == modbus::kWriteSingleRegister) {
+            // `count` holds the VALUE for 0x06, not a register count -- same two bytes, a
+            // different meaning, which is exactly the confusion the echo is there to catch.
+            const uint16_t value = count;
+            if (registers.find(start) == registers.end() || refuseWrites) {
+                reply = {unit, static_cast<uint8_t>(fn | 0x80),
+                         static_cast<uint8_t>(refuseWrites ? 0x04 : 0x02)};
+                appendCrc(reply);
+                return true;
+            }
+            registers[start] = value;
+            ++writes;
+            lastWriteAddress = start;
+            lastWriteValue   = value;
+            // A real device echoes the request back verbatim. `echoWrongValue` makes it lie,
+            // which is the only way to test that the caller checks the echo rather than
+            // treating a well-formed reply as confirmation.
+            reply = {unit, fn, request[2], request[3]};
+            const uint16_t echoed = echoWrongValue ? static_cast<uint16_t>(value ^ 0xFFFF) : value;
+            reply.push_back(static_cast<uint8_t>(echoed >> 8));
+            reply.push_back(static_cast<uint8_t>(echoed & 0xFF));
+            appendCrc(reply);
+            return true;
+        }
+
         std::vector<uint16_t> values;
         values.reserve(count);
         for (uint16_t i = 0; i < count; ++i) {
@@ -131,6 +164,19 @@ public:
 
     bool     asleep = false;
     uint32_t reads  = 0;  ///< how many requests were answered, for round-trip assertions
+
+    /// Writes that landed, and the last one, so a test can assert WHICH register was written
+    /// rather than only that the command reported success. A control write to the right value
+    /// at the wrong address is the failure worth catching.
+    uint32_t writes           = 0;
+    uint16_t lastWriteAddress = 0;
+    uint16_t lastWriteValue   = 0;
+    /// Answer every write with exception 4 (device failure), as an inverter does for a register
+    /// it will not accept -- locked, out of range, or wanting an installer code first.
+    bool refuseWrites = false;
+    /// Echo a value other than the one written. A device doing this is not doing what it was
+    /// asked while looking, on the wire, like it did.
+    bool echoWrongValue = false;
 
     /// Answer with a wrecked checksum, as a bus with a missing ground or no termination does.
     /// Distinct from `asleep`: the device is talking, the wire is mangling it -- and those two

--- a/test/test_sunspec/driver.cpp
+++ b/test/test_sunspec/driver.cpp
@@ -55,6 +55,30 @@ void buildTypical(FakeSunspecDevice& dev, double watts = 1500.0) {
     dev.terminate(at);
 }
 
+/// The same healthy device, plus a model 123 it actually implements.
+///
+/// `sf` is the exponent the device publishes for the limit, which is what decides both the
+/// resolution offered and how a percentage is encoded on the wire.
+uint16_t buildWithControls(FakeSunspecDevice& dev, int sf = -1, uint16_t limitRaw = 1000,
+                           uint16_t enabled = sunspec::controls::kDisabled) {
+    uint16_t at = dev.placeMarker();
+    at = dev.addModel(at, sunspec::kModelCommon,
+                      FakeSunspecDevice::commonPayload("Acme Solar", "AS-5000", "SN12345"));
+    at = dev.addModel(at, sunspec::kModelInverterThreePhase,
+                      FakeSunspecDevice::asPayload(FakeSunspecDevice::blankInverterPayload()));
+
+    const uint16_t controlsAt = at;
+    auto block = FakeSunspecDevice::blankControlsPayload();
+    block[sunspec::controls::kWMaxLimPct]    = limitRaw;
+    block[sunspec::controls::kWMaxLim_Ena]   = enabled;
+    block[sunspec::controls::kConn]          = sunspec::controls::kConnect;
+    block[sunspec::controls::kWMaxLimPct_SF] = static_cast<uint16_t>(static_cast<int16_t>(sf));
+    at = dev.addModel(at, sunspec::kModelControls, FakeSunspecDevice::asPayload(block));
+
+    dev.terminate(at);
+    return controlsAt;  ///< so a test can assert the ADDRESS a control write landed on
+}
+
 }  // namespace
 
 static void test_probe_identifies_the_device_from_the_common_model() {
@@ -377,15 +401,201 @@ static void test_a_silent_device_does_not_poll() {
     TEST_ASSERT_NOT_EQUAL(PollResult::Ok, d.poll(state));
 }
 
-static void test_the_driver_is_read_only() {
+/// A device that publishes no model 123 must not merely refuse a write -- the capability has to
+/// be ABSENT, so nothing upstream ever offers a control that cannot exist.
+static void test_a_device_without_model_123_offers_no_controls() {
     Rig r;
     buildTypical(r.device);
     r.arm();
     auto d = r.makeDriver();
 
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::Ok, d.poll(state));
+
+    TEST_ASSERT_TRUE(d.capabilities().isReadOnly());
+    TEST_ASSERT_FALSE(d.capabilities().canWrite(InverterCapability::SetActivePowerLimit));
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 50.0;
+    TEST_ASSERT_EQUAL(CommandResult::Unsupported, d.execute(cmd));
+    TEST_ASSERT_EQUAL_UINT32(0, r.device.writes);
+}
+
+/// The capability is not a property of the driver but of the device in front of it, and its
+/// bounds come from the scale factor that device published -- not from a constant here.
+static void test_model_123_grants_a_power_limit_bounded_by_the_devices_scale_factor() {
+    Rig r;
+    buildWithControls(r.device, /*sf=*/-1);
+    r.arm();
+    auto d = r.makeDriver();
+
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::Ok, d.poll(state));
+
+    const auto caps = d.capabilities();
+    TEST_ASSERT_FALSE(caps.isReadOnly());
+    TEST_ASSERT_TRUE(caps.canWrite(InverterCapability::SetActivePowerLimit));
+
+    const auto& n =
+        caps.numeric[static_cast<size_t>(InverterCommandType::SetActivePowerLimitPercent)];
+    TEST_ASSERT_TRUE(n.supported);
+    TEST_ASSERT_TRUE(n.writable);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0, n.minimum);
+    TEST_ASSERT_EQUAL_DOUBLE(100.0, n.maximum);
+    // sf = -1 buys one decimal. A control surface told otherwise would accept 12.34% and the
+    // device would round it, silently.
+    TEST_ASSERT_DOUBLE_WITHIN(1e-9, 0.1, n.step);
+    TEST_ASSERT_EQUAL(Unit::Percent, n.unit);
+}
+
+/// Before the block has been read there is no scale factor, and therefore no honest bounds to
+/// advertise. A capability offered at that point is a control with invented limits.
+static void test_the_capability_is_absent_until_the_controls_block_has_been_read() {
+    Rig r;
+    buildWithControls(r.device);
+    r.arm();
+    auto d = r.makeDriver();
+
     TEST_ASSERT_TRUE(d.capabilities().isReadOnly());
     InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 50.0;
     TEST_ASSERT_EQUAL(CommandResult::Unsupported, d.execute(cmd));
+}
+
+/// The whole write path, on the wire: the right registers, the right values, in the right order.
+static void test_setting_a_limit_writes_the_value_before_it_arms_the_limit() {
+    Rig            r;
+    const uint16_t controlsAt = buildWithControls(r.device, /*sf=*/-1);
+    r.arm();
+    auto d = r.makeDriver();
+
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::Ok, d.poll(state));
+
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 62.5;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, d.execute(cmd));
+
+    // Two writes, not one span: the registers between the value and the enable are ramp and
+    // revert times nobody asked to change.
+    TEST_ASSERT_EQUAL_UINT32(2, r.device.writes);
+    // 62.5% at sf = -1 is 625 raw.
+    TEST_ASSERT_EQUAL_UINT16(
+        625, r.device.registers[static_cast<uint16_t>(controlsAt + sunspec::controls::kWMaxLimPct)]);
+    // And the enable is the LAST thing written -- arming first would apply whatever limit the
+    // register happened to hold until the second write landed.
+    TEST_ASSERT_EQUAL_UINT16(static_cast<uint16_t>(controlsAt + sunspec::controls::kWMaxLim_Ena),
+                             r.device.lastWriteAddress);
+    TEST_ASSERT_EQUAL_UINT16(sunspec::controls::kEnabled, r.device.lastWriteValue);
+}
+
+/// Out of range is refused, not clamped, and nothing goes onto the bus. A caller that asked for
+/// 150% has made a mistake; running at 100% instead hides it behind a successful command.
+static void test_a_limit_outside_the_devices_range_never_reaches_the_bus() {
+    Rig r;
+    buildWithControls(r.device);
+    r.arm();
+    auto d = r.makeDriver();
+
+    DeviceState state;
+    d.poll(state);
+    const uint32_t before = r.device.writes;
+
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 150.0;
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, d.execute(cmd));
+    cmd.numericValue = -1.0;
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, d.execute(cmd));
+    TEST_ASSERT_EQUAL_UINT32(before, r.device.writes);
+}
+
+/// A device that answers with an exception has refused. Distinct from a bus failure: the write
+/// arrived, so the same value will be refused again.
+static void test_a_refused_write_is_reported_as_a_refusal() {
+    Rig r;
+    buildWithControls(r.device);
+    r.arm();
+    auto d = r.makeDriver();
+
+    DeviceState state;
+    d.poll(state);
+    r.device.refuseWrites = true;
+
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 40.0;
+    TEST_ASSERT_EQUAL(CommandResult::Rejected, d.execute(cmd));
+}
+
+/// The echo IS the confirmation. A device that answers with a well-formed frame carrying a
+/// different value has not done what it was asked, and reporting Ok would leave everybody
+/// believing in a limit that was never set.
+static void test_a_write_whose_echo_disagrees_is_not_success() {
+    Rig r;
+    buildWithControls(r.device);
+    r.arm();
+    auto d = r.makeDriver();
+
+    DeviceState state;
+    d.poll(state);
+    r.device.echoWrongValue = true;
+
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 40.0;
+    TEST_ASSERT_EQUAL(CommandResult::DriverError, d.execute(cmd));
+}
+
+/// What is published is what the DEVICE holds, not what was last written -- the two differ
+/// whenever someone else changed it or the inverter's own revert timer fired.
+static void test_the_published_limit_comes_from_the_device_not_from_the_last_write() {
+    Rig r;
+    // 45.0% stored, and switched OFF: an inverter holding a limit it is not applying.
+    buildWithControls(r.device, /*sf=*/-1, /*limitRaw=*/450, sunspec::controls::kDisabled);
+    r.arm();
+    auto d = r.makeDriver();
+
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::Ok, d.poll(state));
+
+    const auto* limit = state.measurements.find(measurement_id::kActivePowerLimitPct);
+    TEST_ASSERT_NOT_NULL(limit);
+    TEST_ASSERT_TRUE(limit->valid);
+    TEST_ASSERT_DOUBLE_WITHIN(0.01, 45.0, limit->value);
+
+    // And the flag that stops that 45% being read as "the inverter is limited to 45%".
+    const auto* on = state.measurements.find(measurement_id::kActivePowerLimitEnabled);
+    TEST_ASSERT_NOT_NULL(on);
+    TEST_ASSERT_TRUE(on->valid);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0, on->value);
+}
+
+/// A device carrying model 123 with no usable scale factor can be read but not written: the
+/// percentage cannot be encoded, so offering the control would be offering a guess.
+static void test_a_controls_block_without_a_scale_factor_grants_no_limit() {
+    Rig      r;
+    uint16_t at = r.device.placeMarker();
+    at = r.device.addModel(at, sunspec::kModelInverterThreePhase,
+                           FakeSunspecDevice::asPayload(FakeSunspecDevice::blankInverterPayload()));
+    // Every point at its sentinel, including WMaxLimPct_SF.
+    at = r.device.addModel(at, sunspec::kModelControls,
+                           FakeSunspecDevice::asPayload(FakeSunspecDevice::blankControlsPayload()));
+    r.device.terminate(at);
+    r.arm();
+
+    auto        d = r.makeDriver();
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::Ok, d.poll(state));
+
+    TEST_ASSERT_FALSE(d.capabilities().canWrite(InverterCapability::SetActivePowerLimit));
+    const auto* limit = state.measurements.find(measurement_id::kActivePowerLimitPct);
+    // Declared, because the model is there -- but carrying no reading, which is the honest
+    // combination for a point the device does not implement.
+    TEST_ASSERT_NOT_NULL(limit);
+    TEST_ASSERT_FALSE(limit->valid);
 }
 
 void run_sunspec_driver() {
@@ -407,5 +617,13 @@ void run_sunspec_driver() {
     RUN_TEST(test_a_marker_with_no_readable_models_is_not_reported_as_a_timeout);
     RUN_TEST(test_an_undecodable_model_counts_an_invalid_frame);
     RUN_TEST(test_a_silent_device_does_not_poll);
-    RUN_TEST(test_the_driver_is_read_only);
+    RUN_TEST(test_a_device_without_model_123_offers_no_controls);
+    RUN_TEST(test_model_123_grants_a_power_limit_bounded_by_the_devices_scale_factor);
+    RUN_TEST(test_the_capability_is_absent_until_the_controls_block_has_been_read);
+    RUN_TEST(test_setting_a_limit_writes_the_value_before_it_arms_the_limit);
+    RUN_TEST(test_a_limit_outside_the_devices_range_never_reaches_the_bus);
+    RUN_TEST(test_a_refused_write_is_reported_as_a_refusal);
+    RUN_TEST(test_a_write_whose_echo_disagrees_is_not_success);
+    RUN_TEST(test_the_published_limit_comes_from_the_device_not_from_the_last_write);
+    RUN_TEST(test_a_controls_block_without_a_scale_factor_grants_no_limit);
 }

--- a/test/test_sunspec/driver.cpp
+++ b/test/test_sunspec/driver.cpp
@@ -573,6 +573,53 @@ static void test_the_published_limit_comes_from_the_device_not_from_the_last_wri
     TEST_ASSERT_EQUAL_DOUBLE(0.0, on->value);
 }
 
+/// A device that advertises model 123 on the chain and then will not serve it must cost ONE
+/// failed transaction, not one per poll forever.
+///
+/// The failure this prevents is quiet: the inverter read still succeeds, so every poll reports
+/// Ok while a full response timeout is added to each cycle and each failure is tallied into the
+/// bus error counters the alerting rules watch. A healthy bus is made to look like a degrading
+/// one, by a control surface nobody is using.
+static void test_a_controls_block_that_never_answers_is_given_up_on() {
+    Rig      r;
+    uint16_t at = r.device.placeMarker();
+    at = r.device.addModel(at, sunspec::kModelInverterThreePhase,
+                           FakeSunspecDevice::asPayload(FakeSunspecDevice::blankInverterPayload()));
+    // Advertised on the chain at its full length, but the payload registers are absent, so the
+    // device answers the read with "illegal data address" -- exactly what a slave does for a
+    // model it lists and does not implement.
+    const uint16_t controlsAt = at;
+    at = r.device.addModel(at, sunspec::kModelControls,
+                           FakeSunspecDevice::asPayload(FakeSunspecDevice::blankControlsPayload()));
+    // From the PAYLOAD onwards only. The model id and its length have to stay, or the chain walk
+    // stops at this block and never records it -- which would make this a test about a truncated
+    // chain, and it would pass whether or not the retry is bounded.
+    for (uint16_t i = 2; i < sunspec::controls::kMinRegisters; ++i) {
+        r.device.registers.erase(static_cast<uint16_t>(controlsAt + i));
+    }
+    r.device.terminate(at);
+    r.arm();
+
+    auto        d = r.makeDriver();
+    DeviceState first;
+    TEST_ASSERT_EQUAL(PollResult::Ok, d.poll(first));
+    const uint32_t afterFirst = r.device.reads;
+
+    // The ABSOLUTE cost of a steady-state poll, not a comparison between two later polls:
+    // consecutive polls cost the same whether the block is retried forever or given up on, so
+    // comparing them proves nothing. One transaction is the inverter model. Two would be the
+    // inverter model plus another doomed attempt at the controls.
+    DeviceState second;
+    TEST_ASSERT_EQUAL(PollResult::Ok, d.poll(second));
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, r.device.reads - afterFirst,
+                                     "the unreadable controls block is still being retried");
+
+    DeviceState third;
+    TEST_ASSERT_EQUAL(PollResult::Ok, d.poll(third));
+    TEST_ASSERT_EQUAL_UINT32(2, r.device.reads - afterFirst);
+    TEST_ASSERT_FALSE(d.capabilities().canWrite(InverterCapability::SetActivePowerLimit));
+}
+
 /// A device carrying model 123 with no usable scale factor can be read but not written: the
 /// percentage cannot be encoded, so offering the control would be offering a guess.
 static void test_a_controls_block_without_a_scale_factor_grants_no_limit() {
@@ -625,5 +672,6 @@ void run_sunspec_driver() {
     RUN_TEST(test_a_refused_write_is_reported_as_a_refusal);
     RUN_TEST(test_a_write_whose_echo_disagrees_is_not_success);
     RUN_TEST(test_the_published_limit_comes_from_the_device_not_from_the_last_write);
+    RUN_TEST(test_a_controls_block_that_never_answers_is_given_up_on);
     RUN_TEST(test_a_controls_block_without_a_scale_factor_grants_no_limit);
 }

--- a/test/test_sunspec/parser.cpp
+++ b/test/test_sunspec/parser.cpp
@@ -7,6 +7,7 @@
 
 #include <unity.h>
 
+#include <limits>
 #include <vector>
 
 #include "drivers/sunspec/sunspec_parser.h"
@@ -168,6 +169,99 @@ static void test_common_model_too_short_is_refused() {
     TEST_ASSERT_FALSE(decodeCommon(b.data(), b.size(), id));
 }
 
+// --- model 123, immediate controls ---------------------------------------------------------
+
+namespace {
+std::vector<uint16_t> controlsBlock(int sf, uint16_t limit, uint16_t ena, uint16_t conn) {
+    std::vector<uint16_t> b(controls::kMinRegisters, kNotImplementedU16);
+    b[controls::kWMaxLimPct]    = limit;
+    b[controls::kWMaxLim_Ena]   = ena;
+    b[controls::kConn]          = conn;
+    b[controls::kWMaxLimPct_SF] = static_cast<uint16_t>(static_cast<int16_t>(sf));
+    return b;
+}
+}  // namespace
+
+static void test_controls_decode_with_the_scale_factor() {
+    const auto       b = controlsBlock(-1, 875, controls::kEnabled, controls::kConnect);
+    ControlsReadings c;
+    TEST_ASSERT_TRUE(decodeControls(b.data(), b.size(), c));
+    TEST_ASSERT_TRUE(c.hasPowerLimit);
+    TEST_ASSERT_DOUBLE_WITHIN(0.01, 87.5, c.powerLimitPct);
+    TEST_ASSERT_TRUE(c.hasLimitEnabled);
+    TEST_ASSERT_TRUE(c.limitEnabled);
+    TEST_ASSERT_TRUE(c.hasConnection);
+    TEST_ASSERT_TRUE(c.connected);
+}
+
+/// The enums carry no scale factor, so only their sentinel can make them absent -- and anything
+/// that is neither 0 nor 1 has no defined meaning. Guessing "non-zero is on" is how a
+/// disconnected inverter gets reported as connected.
+static void test_an_out_of_range_enum_is_absent_rather_than_true() {
+    auto b = controlsBlock(0, 50, 7, 9);
+    ControlsReadings c;
+    TEST_ASSERT_TRUE(decodeControls(b.data(), b.size(), c));
+    TEST_ASSERT_FALSE(c.hasLimitEnabled);
+    TEST_ASSERT_FALSE(c.hasConnection);
+}
+
+static void test_a_truncated_controls_block_is_refused() {
+    std::vector<uint16_t> b(controls::kMinRegisters - 1, 0);
+    ControlsReadings      c;
+    TEST_ASSERT_FALSE(decodeControls(b.data(), b.size(), c));
+}
+
+static void test_the_limit_is_bounded_by_the_standard_not_by_the_register() {
+    ScaleFactor sf = decodeScaleFactor(0);  // exponent 0
+    const auto  b  = limitBounds(sf);
+    TEST_ASSERT_TRUE(b.usable);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0, b.minimum);
+    // A uint16 could carry 65534, but WMaxLimPct is a percentage of nameplate: above 100 the
+    // standard defines nothing.
+    TEST_ASSERT_EQUAL_DOUBLE(100.0, b.maximum);
+    TEST_ASSERT_EQUAL_DOUBLE(1.0, b.step);
+}
+
+static void test_a_scale_factor_coarser_than_the_range_grants_nothing() {
+    // sf = 3 means the smallest step the device can express is 1000%.
+    const auto b = limitBounds(decodeScaleFactor(3));
+    TEST_ASSERT_FALSE(b.usable);
+    uint16_t raw = 0;
+    TEST_ASSERT_FALSE(encodePowerLimitPct(50.0, decodeScaleFactor(3), raw));
+}
+
+static void test_encoding_rounds_rather_than_truncates() {
+    uint16_t raw = 0;
+    // At sf = 0 a request for 49.9% is far better served by 50 than by 49; truncation would
+    // bias every setpoint downwards.
+    TEST_ASSERT_TRUE(encodePowerLimitPct(49.9, decodeScaleFactor(0), raw));
+    TEST_ASSERT_EQUAL_UINT16(50, raw);
+    TEST_ASSERT_TRUE(encodePowerLimitPct(62.5, decodeScaleFactor(-1), raw));
+    TEST_ASSERT_EQUAL_UINT16(625, raw);
+}
+
+static void test_encoding_refuses_what_it_cannot_represent() {
+    uint16_t raw = 0;
+    TEST_ASSERT_FALSE(encodePowerLimitPct(100.1, decodeScaleFactor(0), raw));
+    TEST_ASSERT_FALSE(encodePowerLimitPct(-0.1, decodeScaleFactor(0), raw));
+    // No usable exponent: nothing can be encoded at all.
+    TEST_ASSERT_FALSE(encodePowerLimitPct(50.0, decodeScaleFactor(kNotImplementedS16), raw));
+    // NaN must not sail through the comparisons and be cast to whatever the conversion yields.
+    TEST_ASSERT_FALSE(
+        encodePowerLimitPct(std::numeric_limits<double>::quiet_NaN(), decodeScaleFactor(0), raw));
+}
+
+/// The value that would land on the not-implemented sentinel must never be written: it would
+/// tell the device "no value" while the caller believes a limit was set.
+static void test_encoding_never_produces_the_not_implemented_sentinel() {
+    uint16_t raw = 0;
+    // sf = -3 puts 65.535% at exactly 65535.
+    TEST_ASSERT_FALSE(encodePowerLimitPct(65.535, decodeScaleFactor(-3), raw));
+    // The neighbour below is fine.
+    TEST_ASSERT_TRUE(encodePowerLimitPct(65.534, decodeScaleFactor(-3), raw));
+    TEST_ASSERT_EQUAL_UINT16(65534, raw);
+}
+
 void run_sunspec_parser() {
     RUN_TEST(test_model_ids);
     RUN_TEST(test_scale_factor_is_applied_with_its_sign);
@@ -180,4 +274,12 @@ void run_sunspec_parser() {
     RUN_TEST(test_a_truncated_block_is_refused);
     RUN_TEST(test_common_model_strings);
     RUN_TEST(test_common_model_too_short_is_refused);
+    RUN_TEST(test_controls_decode_with_the_scale_factor);
+    RUN_TEST(test_an_out_of_range_enum_is_absent_rather_than_true);
+    RUN_TEST(test_a_truncated_controls_block_is_refused);
+    RUN_TEST(test_the_limit_is_bounded_by_the_standard_not_by_the_register);
+    RUN_TEST(test_a_scale_factor_coarser_than_the_range_grants_nothing);
+    RUN_TEST(test_encoding_rounds_rather_than_truncates);
+    RUN_TEST(test_encoding_refuses_what_it_cannot_represent);
+    RUN_TEST(test_encoding_never_produces_the_not_implemented_sentinel);
 }


### PR DESCRIPTION
Closes #20.

Every driver here is read-only, for the reason #20 states: a write path needs a register map confirmed against real hardware, and power-limit registers sit next to grid protection and country-code settings. Model 123 is the exception worth taking, because the device announces its own addresses on the chain. Nothing is transcribed from a vendor table and nothing is guessed.

## The shape of it

**The capability belongs to the device, not to the driver.** It appears only after model 123 has actually been *read* — not merely seen on the chain — because the bounds come from the scale factor inside it. A device without the model, or with one whose `WMaxLimPct_SF` is the not-implemented sentinel, has the capability **absent** rather than refused. That is what #20 asked for, and it means nothing upstream can offer a control that cannot exist.

**The bounds are the device's own.** 0–100%, because `WMaxLimPct` is a percentage of nameplate and above 100 the standard defines nothing — not the 65534 the register could physically hold. The *step* is whatever the exponent buys: `sf = -1` accepts 62.5%, `sf = 0` does not, and a control surface told otherwise would accept setpoints that silently round away.

**Writes are single-register, echo verified.** Model 123 interleaves the points you want to set with window, revert and ramp times you did not ask about, so a span write cannot express the difference. The value is written *before* the limit is armed — the other order applies whatever limit the register was holding for as long as the two writes are apart, possibly one somebody else set. An echo that disagrees on address or value is reported as a failure: on a control register that is the difference between an inverter that is limited and one everybody believes is limited.

**Out of range is refused, never clamped.** Running at 100% when 150% was asked for hides the caller's mistake behind a successful command.

**What is published is what the device holds,** re-read every poll rather than echoed back from the last write. Those differ when a second controller is on the bus, or when the inverter's own revert timer fires — model 123 defines one and several devices implement it. Two channels, because either alone misleads: a stored 50% that is switched off means the inverter is not limited at all.

## On not guessing

The offsets were **fetched from the official definition** (`sunspec/models`, `json/model_123.json`), not recalled. That turned up something worth flagging: #20's own table says `WMaxLimPct_Ena`, but the real point is **`WMaxLim_Ena`** — no `Pct` infix, unlike every neighbour. The natural guess is one register off, and one register off is `WMaxLimPct_RmpTms`, a ramp time that would happily accept the `1` meant as "enabled" and leave the limit switched off.

A short block is also rejected rather than trusted: a device advertising a truncated 123 would put a control write into whatever follows it.

## Also here

`writeSingleRegister` joins `readRegisters` in the Modbus client, sharing its outcome type via aliases instead of growing a parallel enum — a write fails in the same ways a read does, and two lists would be two things to keep in step.

## Verification

789 native tests (773 + 16), all 8 layering rules, 35 measurement ids, web checks, firmware builds.

The new tests cover the parts that only bite in production: the capability absent before the block is read, absent without a scale factor, the two writes landing on the right registers **in the right order**, an out-of-range setpoint never reaching the bus, an exception reported as a refusal rather than a bus fault, a lying echo not counting as success, and the published limit coming from the device rather than from what was written. The fake device learned to answer 0x06 — including refusing, and echoing the wrong value on purpose, which is the only way to test that the echo is actually checked.

## What this does not do

**Nothing can invoke it yet.** `CommandDispatcher` is still not wired to any output, and nothing outside the drivers calls `execute()`. This is the driver-side half; a control in Home Assistant needs the dispatcher connected to REST/MQTT and a `number` entity in discovery. Worth its own PR.

**Still unverified against hardware** — the blocker #20 names, unchanged. `docs/sunspec.md` now says so louder, because the warning carries more weight for a driver that can write than for one that could only read.