### PR TITLE
fix(eversolar): one device per bridge, and enforce it before begin() runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ picture:
 
 | Inverter family | Connection | Status |
 |---|---|---|
-| EverSolar / Zeversolar legacy (TL series) | RS485 | **Beta** — running in production, in a multi-day soak toward Stable |
+| EverSolar / Zeversolar legacy (TL series) | RS485 | **Beta** — running in production, in a multi-day soak toward Stable. **One inverter per bridge**: the protocol supports several on one loop and eversolar-monitor does it, but this driver does not yet — see [the notes](docs/eversolar-protocol.md#several-inverters-on-one-bus--possible-in-theory-not-implemented) and [#82](https://github.com/Timdebruijn/heliograph/issues/82) |
 | Growatt SPH hybrid (3–6 kW) | Modbus RTU over RS485 | **Experimental** — register map transcribed from documentation, not yet confirmed against real hardware |
 | Growatt MIC TL-X (0.6–3.3 kW, single phase) | Modbus RTU over RS485 | **Experimental** — map cross-checked against two independent sources that agree, not yet confirmed against real hardware; see [docs/growatt-mic-tl-x-protocol.md](docs/growatt-mic-tl-x-protocol.md) |
 | SolaX X1 series (X1 Mini G1/G2/G3) | RS485 | **Experimental** — the first attempt on real hardware (an X1-Mini-G1) returned no data at all. Read [docs/solax-x1-protocol.md](docs/solax-x1-protocol.md) before you buy or wire anything |

--- a/docs/eversolar-protocol.md
+++ b/docs/eversolar-protocol.md
@@ -399,6 +399,48 @@ Our transport layer does it properly: read until the frame is complete (length f
 byte 8), with a response timeout of **1000 ms** and **3** retries. These values are set in the
 driver's `SerialProfile` and are configurable.
 
+## Several inverters on one bus — possible in theory, not implemented
+
+**Heliograph serves one EverSolar inverter per bridge.** A second configured device is refused
+at startup with a reason on the dashboard, rather than being started (#63). This is a limit of
+this driver, not of the protocol — and it is a real gap for anyone coming from
+eversolar-monitor, which does serve several inverters on one loop.
+
+The protocol supports it and the reference shows exactly how, so nothing here needs guessing.
+Read out of `eversolar.pl` (line numbers are that file's):
+
+| Behaviour | Where | Detail |
+|---|---|---|
+| Register **one** inverter per pass | `:599-645` | Its own comment: "register inverter that responds first". One offline query, one serial, one address, then `$next_inverter_address++` |
+| Discovery comes from the **cadence**, not a loop | `:1008`, `:1038` | Tight loop while no inverter is known; once a minute after that. Three inverters take about three minutes |
+| RE_REGISTER is a **bus** operation | `:822`, `:582-590` | Called once from `inverter_connect()`, which also resets the address counter to `0x10`. Broadcast 8 times, despite the comment saying 3 |
+| Inverters keyed by assigned address | `:632-643` | `%inverters` holds id string, serial and counters; the poll loop walks it |
+
+Why the enumeration needs no arbitration: a registered inverter ignores the broadcast offline
+query, so each pass the next unregistered one answers. If two answer at once the serial number
+fails to parse, the pass yields nothing, and the next one tries again. The reference does not
+resolve collisions — it retries past them.
+
+**What stops us adopting it today is not the protocol but the device model**: this project
+builds one driver instance per configured device, while the above needs one driver that owns
+the bus and yields several devices. That is the piece to design.
+
+Three things any implementation must not break for the installs that exist today, all of which
+have exactly one inverter:
+
+- **The device id stays the serial number.** Keying on the assigned address — as the reference
+  does — would change the id of every existing install, orphaning its retained MQTT topics and
+  re-creating its Home Assistant entities. The address is volatile, reset to `0x10` on every
+  reconnect, so two inverters could even swap identities between sessions.
+- **RE_REGISTER stays available as recovery**, not only at bus startup. An inverter holding an
+  address from an earlier session ignores the offline query forever; only the broadcast breaks
+  that deadlock. Observed live, and pinned by a test.
+- **A quiet bus stays quiet.** The reference re-queries every minute forever, even with nothing
+  left to find. On a one-inverter bridge that is new traffic where there is none today.
+
+Untested against two inverters — nobody involved has two. See #82, which stays open for the
+first report from someone who does.
+
 ## What we still don't know
 
 | Unknown | Impact | Approach |

--- a/src/drivers/eversolar_legacy/descriptor.cpp
+++ b/src/drivers/eversolar_legacy/descriptor.cpp
@@ -26,9 +26,20 @@ const DriverDescriptor& descriptor() {
         x.supportLevel            = DriverSupportLevel::Beta;
         x.probePriority           = 10;
         x.supportsAutoDetection   = true;
-        // The protocol assigns addresses to multiple inverters; the MVP allows only one
-        // active device, but that is an application limit, not a driver limit.
-        x.supportsMultipleDevices = true;
+        // False, and not as a limitation of the application: this DRIVER cannot share a bus
+        // with a second instance of itself, in three separate ways (#63).
+        //
+        // begin() broadcasts RE_REGISTER, which tells every inverter on the line to forget its
+        // address -- so a second instance starting up de-registers the first, already-polling
+        // one. registerDevice() runs the enumeration loop exactly once, so a second inverter is
+        // never discovered anyway. And `assignedAddress` has no option wired to it, so both
+        // instances would claim the same bus address regardless.
+        //
+        // The protocol itself does support several inverters; implementing that means repeating
+        // the offline-query/assign loop until silence and giving each discovered serial its own
+        // device. That is real work and needs two inverters on a bench to verify, which is
+        // exactly why this says false today rather than promising it.
+        x.supportsMultipleDevices = false;
         x.supportsRead            = true;
         x.supportsWrite           = false;
         // Declared here, not in Configuration: the payload-length hypothesis is this

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1199,6 +1199,35 @@ void setup() {
         // this exists for: three inverters share one driver id, so all three failures read
         // identically (review, 2026-07-25).
         const std::string row = "device " + std::to_string(plannedIndex + 1);
+
+        // Refused BEFORE create() and begin(), because for a driver that cannot share a bus,
+        // begin() IS the damage. The AA55 handshake opens with a bus-wide RE_REGISTER
+        // broadcast, so a second instance starting up tells the first, already-polling inverter
+        // to forget its address -- and a check that ran afterwards would report the refusal
+        // from the far side of the harm (#63).
+        //
+        // Enforced here rather than in config validation because this is where the registry is:
+        // the answer is a property of the driver, not of the configuration file, and the config
+        // layer deliberately knows nothing about drivers.
+        const auto* descriptor = g_registry.find(p.id);
+        if (descriptor != nullptr && !descriptor->supportsMultipleDevices) {
+            bool alreadyPlanned = false;
+            for (size_t earlier = 0; earlier < plannedIndex; ++earlier) {
+                if (planned[earlier].id == p.id) {
+                    alreadyPlanned = true;
+                    break;
+                }
+            }
+            if (alreadyPlanned) {
+                log::warn("device '%s' skipped: this driver supports only one device per bridge",
+                          p.id.c_str());
+                g_deviceProblems.push_back(row + " ('" + p.id +
+                                           "') was not started: this driver supports only one "
+                                           "device per bridge");
+                continue;
+            }
+        }
+
         auto driver = g_registry.create(p.id, g_transport, *p.options);
         if (!driver || !driver->begin(g_transport)) {
             // Named, and the loop continues: one unconfigurable device must not cost the others

--- a/test/test_eversolar/driver.cpp
+++ b/test/test_eversolar/driver.cpp
@@ -62,6 +62,35 @@ static void test_begin_broadcasts_re_register() {
     }
 }
 
+/// Why the descriptor says one device per bridge (#63).
+///
+/// Not an assertion that a flag is false -- that would pass just as well if the flag were
+/// meaningless. This is the harm itself: a second instance's begin() broadcasts RE_REGISTER,
+/// every inverter on the line forgets its address, and the first one -- registered, polling,
+/// working -- has to start over. On a real bus both then answer the next broadcast offline
+/// query at once, on half duplex, and whether that converges is not knowable without two
+/// inverters on a bench.
+///
+/// Nobody here has two, which is exactly why the honest answer is to refuse the second device
+/// rather than ship the enumeration this driver would need.
+static void test_a_second_instance_would_deregister_the_first() {
+    Rig r;
+    r.begin();
+    DeviceState state;
+    TEST_ASSERT_EQUAL(PollResult::Ok, r.poll(state));
+    TEST_ASSERT_TRUE(r.driver.registered());
+    TEST_ASSERT_TRUE(r.device.registered);
+
+    // A second instance of the same driver on the same bus, as `additional_devices` would build.
+    EversolarDriver second{r.transport};
+    second.begin(r.transport);
+
+    // The inverter that was working is no longer registered -- and it was not asked anything.
+    TEST_ASSERT_FALSE_MESSAGE(r.device.registered,
+                              "begin() no longer de-registers; #63 may be fixable properly now");
+    TEST_ASSERT_FALSE(descriptor().supportsMultipleDevices);
+}
+
 static void test_begin_fails_when_the_line_cannot_be_configured() {
     Rig r;
     r.transport.configureSucceeds = false;
@@ -734,6 +763,7 @@ static void test_snapshots_are_immutable_and_independent() {
 void run_eversolar_driver() {
     RUN_TEST(test_begin_configures_the_only_known_profile);
     RUN_TEST(test_begin_broadcasts_re_register);
+    RUN_TEST(test_a_second_instance_would_deregister_the_first);
     RUN_TEST(test_begin_fails_when_the_line_cannot_be_configured);
     RUN_TEST(test_begin_declares_no_capabilities_it_cannot_deliver);
     RUN_TEST(test_poll_registers_before_reading);


### PR DESCRIPTION
Closes #63. Option 1 of the three listed there — with one correction to the issue's premise.

## The issue assumed the framework enforces the flag. It does not.

`supportsMultipleDevices` was read by **nothing**: not config validation, not REST, not the UI. It appears only in descriptor definitions. So setting the EverSolar flag to `false` — the whole of option 1 as written — would have changed no behaviour whatever. A second EverSolar would still have started, and still de-registered the first.

This PR therefore does both halves: makes the claim honest, and makes it mean something.

## Why one device, stated as harm rather than as a limit

`begin()` broadcasts RE_REGISTER, which tells every inverter on the line to forget its address. A second instance starting up de-registers the first, already-polling one. On a real bus both then answer the next broadcast offline query simultaneously, on half duplex, and whether that converges is not knowable without two inverters on a bench.

Two more, either of which alone would be enough: `registerDevice()` runs its enumeration loop exactly once, so a second inverter is never discovered; and `assignedAddress` has no option wired to it, so both instances would claim the same bus address.

## Enforced before `begin()`, not after

The guard sits in the device-startup loop, ahead of `create()` and `begin()`. That ordering is the point: **for this driver, `begin()` is the damage.** A check that ran afterwards would report the refusal from the far side of the harm it exists to prevent.

It lives there rather than in config validation because the answer is a property of the driver, and the config layer deliberately knows nothing about drivers. The refusal is named in the same device-problems list the heartbeat and the dashboard already surface, so it appears where the other startup refusals do.

## The test asserts the harm, not the flag

A test that checked `supportsMultipleDevices == false` would have passed just as well while the flag meant nothing — which is exactly the state this PR found. So it does the real thing: register a device, poll it, start a second instance, and assert the **first inverter is no longer registered** while nobody asked it anything.

It carries a message for the day that changes: `"begin() no longer de-registers; #63 may be fixable properly now"`. If someone implements proper enumeration, this test fails and says why.

## What is deliberately not here

Options 2 and 3 — an `address` option wired to `assignedAddress`, or repeating the offline-query/assign loop until silence. The protocol genuinely supports several inverters and that is what it is for. It also cannot be verified without two of them, and shipping unverifiable multi-device behaviour into a handshake that can knock out a working inverter is the opposite of what this project does elsewhere.

## Verification

774 native tests (773 + 1), 8 layering rules, firmware builds. Not verified on hardware, and does not need to be: the change refuses a configuration that nobody can currently run correctly.