### PR TITLE
ci: a docs-only PR has nothing to build, which is not a failure

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -10,9 +10,18 @@
 #
 # The board list is computed, not static. `changes` emits the full list only when the PR touches
 # something the image is built from, and an empty list otherwise; fromJSON turns it into the
-# build matrix. An empty array expands to zero matrix jobs, so a docs-only PR compiles nothing
-# and shows no build check -- without a job-level `if`, which is precisely the skip that would
-# render `${{ matrix.env }}` as a check name.
+# build matrix.
+#
+# An empty array does NOT quietly expand to zero jobs, which this comment claimed until a
+# docs-only PR was checked against reality: GitHub Actions FAILS a job whose matrix vector has
+# no values. So every documentation PR ended with a red Firmware check for having nothing to
+# build -- #77 and #68 both did -- and the workflow's own comment said the opposite.
+#
+# Hence the job-level `if` below, which the original note went out of its way to avoid because
+# a skipped matrix job reports its check name un-interpolated. That cosmetic cost is real, and
+# it is worth paying: a neutral "skipped" check on a docs PR beats a red one that means nothing.
+# It also only ever shows up on exactly the PRs that build nothing, because this workflow does
+# not trigger on push at all.
 
 name: Firmware
 
@@ -66,6 +75,9 @@ jobs:
   build:
     name: Build (${{ matrix.env }})
     needs: changes
+    # Nothing to build is not a failure. Without this the empty matrix errors out; see the note
+    # at the top of this file.
+    if: needs.changes.outputs.envs != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Closes #78.

## The workflow's comment described the intent, not the behaviour

`firmware.yml` said an empty matrix array expands to zero jobs, so a documentation PR would compile nothing and show no check. It does not — GitHub Actions **fails** a job whose matrix vector has no values. Every docs-only PR therefore ended red for having nothing to build.

That is how it survived: the comment documented what was supposed to happen as though it were what did happen, and nothing tests a comment.

## Verified, not assumed

The premise was checked against the run history before changing anything:

| Branch | Result |
|---|---|
| `docs/hardware-three-boards` (#77, docs-only) | **failure** |
| every code branch since | success |

## The fix, and the cost it accepts

A job-level `if: needs.changes.outputs.envs != '[]'` — which the original note went out of its way to avoid, for a real reason: a skipped matrix job reports its check name un-interpolated, so it shows as `Build (${{ matrix.env }})`.

That cost is worth paying. A neutral *skipped* check beats a red one that means nothing, and it can only ever appear on a PR that builds nothing — this workflow does not trigger on push at all, so it never touches main.

The header comment now says what actually happens, including why the ugly name is tolerated.

## Verification

The proof is this PR itself: it touches only `.github/`, so the Firmware check should come back **skipped** rather than red. That is the whole behaviour under test, and it cannot be verified any other way.