### PR TITLE
feat(eversolar): several inverters on one bus, one device each

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ picture:
 
 | Inverter family | Connection | Status |
 |---|---|---|
-| EverSolar / Zeversolar legacy (TL series) | RS485 | **Beta** — running in production, in a multi-day soak toward Stable. **One inverter per bridge**: the protocol supports several on one loop and eversolar-monitor does it, but this driver does not yet — see [the notes](docs/eversolar-protocol.md#several-inverters-on-one-bus--possible-in-theory-not-implemented) and [#82](https://github.com/Timdebruijn/heliograph/issues/82) |
+| EverSolar / Zeversolar legacy (TL series) | RS485 | **Beta** — running in production, in a multi-day soak toward Stable. Several inverters on one loop are supported but **not yet confirmed on hardware** — read [the pitfalls](docs/eversolar-protocol.md#several-inverters-on-one-bus) first, and report what happens on [#82](https://github.com/Timdebruijn/heliograph/issues/82) |
 | Growatt SPH hybrid (3–6 kW) | Modbus RTU over RS485 | **Experimental** — register map transcribed from documentation, not yet confirmed against real hardware |
 | Growatt MIC TL-X (0.6–3.3 kW, single phase) | Modbus RTU over RS485 | **Experimental** — map cross-checked against two independent sources that agree, not yet confirmed against real hardware; see [docs/growatt-mic-tl-x-protocol.md](docs/growatt-mic-tl-x-protocol.md) |
 | SolaX X1 series (X1 Mini G1/G2/G3) | RS485 | **Experimental** — the first attempt on real hardware (an X1-Mini-G1) returned no data at all. Read [docs/solax-x1-protocol.md](docs/solax-x1-protocol.md) before you buy or wire anything |

--- a/docs/eversolar-protocol.md
+++ b/docs/eversolar-protocol.md
@@ -399,47 +399,68 @@ Our transport layer does it properly: read until the frame is complete (length f
 byte 8), with a response timeout of **1000 ms** and **3** retries. These values are set in the
 driver's `SerialProfile` and are configurable.
 
-## Several inverters on one bus — possible in theory, not implemented
+## Several inverters on one bus
 
-**Heliograph serves one EverSolar inverter per bridge.** A second configured device is refused
-at startup with a reason on the dashboard, rather than being started (#63). This is a limit of
-this driver, not of the protocol — and it is a real gap for anyone coming from
-eversolar-monitor, which does serve several inverters on one loop.
+**Supported, and untested against real hardware.** Nobody involved has two EverSolar inverters,
+so everything below is reasoned from the protocol and from the reference implementation, which
+does serve several inverters on one loop. Read the pitfalls before you wire a second one.
 
-The protocol supports it and the reference shows exactly how, so nothing here needs guessing.
-Read out of `eversolar.pl` (line numbers are that file's):
+### How to configure it
 
-| Behaviour | Where | Detail |
-|---|---|---|
-| Register **one** inverter per pass | `:599-645` | Its own comment: "register inverter that responds first". One offline query, one serial, one address, then `$next_inverter_address++` |
-| Discovery comes from the **cadence**, not a loop | `:1008`, `:1038` | Tight loop while no inverter is known; once a minute after that. Three inverters take about three minutes |
-| RE_REGISTER is a **bus** operation | `:822`, `:582-590` | Called once from `inverter_connect()`, which also resets the address counter to `0x10`. Broadcast 8 times, despite the comment saying 3 |
-| Inverters keyed by assigned address | `:632-643` | `%inverters` holds id string, serial and counters; the poll loop walks it |
+Give each inverter its own **assigned bus address**, counting up from 16 (`0x10`): the first
+device keeps the default, the second gets 17, and so on. The address is not stored in the
+inverter — it is handed out at registration and forgotten on power loss.
 
-Why the enumeration needs no arbitration: a registered inverter ignores the broadcast offline
-query, so each pass the next unregistered one answers. If two answer at once the serial number
-fails to parse, the pass yields nothing, and the next one tries again. The reference does not
-resolve collisions — it retries past them.
+### How the enumeration works, and why it needs no loop
 
-**What stops us adopting it today is not the protocol but the device model**: this project
-builds one driver instance per configured device, while the above needs one driver that owns
-the bus and yields several devices. That is the piece to design.
+A registered inverter **ignores the broadcast offline query**. So when the second driver
+instance sends that query, the first inverter stays silent and the next unregistered one
+answers. Instances start sequentially from the configuration, and that ordering is the whole
+mechanism.
 
-Three things any implementation must not break for the installs that exist today, all of which
-have exactly one inverter:
+The reference does the same thing from a timer instead of from a config list: `register_inverter()`
+handles exactly one inverter per pass — its own comment says *"register inverter that responds
+first"* (`eversolar.pl:599-645`) — and is called once a minute (`:1038`). We call it once per
+configured device instead.
 
-- **The device id stays the serial number.** Keying on the assigned address — as the reference
-  does — would change the id of every existing install, orphaning its retained MQTT topics and
-  re-creating its Home Assistant entities. The address is volatile, reset to `0x10` on every
-  reconnect, so two inverters could even swap identities between sessions.
-- **RE_REGISTER stays available as recovery**, not only at bus startup. An inverter holding an
-  address from an earlier session ignores the offline query forever; only the broadcast breaks
-  that deadlock. Observed live, and pinned by a test.
-- **A quiet bus stays quiet.** The reference re-queries every minute forever, even with nothing
-  left to find. On a one-inverter bridge that is new traffic where there is none today.
+**RE_REGISTER is a bus operation, not a device one.** It tells every inverter on the line to
+forget its address, so only the instance holding the first address (16) broadcasts it. The
+reference is the same: one call, from `inverter_connect()` (`:822`). An unconditional broadcast
+per instance is what made a second device knock out the first (#63).
 
-Untested against two inverters — nobody involved has two. See #82, which stays open for the
-first report from someone who does.
+### Pitfalls
+
+**A cold start has both inverters answering at once.** After RE_REGISTER nothing on the line has
+an address, so the first offline query is answered by every inverter simultaneously — on half
+duplex. Our parser rejects the result (checksum, header and destination are all checked), and the
+poll retries. The protocol defines no backoff, so if two inverters answer with identical timing
+this could in principle repeat. The reference has exactly the same exposure and works in the
+field, which suggests real devices differ enough in response latency for the frames to queue
+rather than overlap; `flushInput()` before each request discards the surplus. **This is the one
+behaviour that genuinely needs two inverters to confirm.**
+
+**Which config row gets which inverter is not fixed across reboots.** Whichever answers first
+gets address 16. Device ids are derived from the serial number, so they stay stable per inverter
+— but anything keyed on the *configuration slot* can swap. The Modbus TCP unit ids are keyed
+that way. If you poll those, do not assume unit 1 is the same physical inverter after a restart.
+
+**Two devices sharing one address will not work**, and will look like an intermittent inverter
+rather than a configuration mistake. The settings page warns when two configured devices share
+an address, which is why the option is named the same as the sibling drivers'.
+
+**Discovery still assigns 16.** The wizard configures one device. A second inverter is added by
+hand afterwards, with its own address.
+
+**Recovery still needs the broadcast.** An inverter holding an address from an earlier session
+ignores the offline query forever; only RE_REGISTER breaks that deadlock. That is why the first
+instance still sends it on every start, and why a single-inverter bridge behaves exactly as it
+did before this change.
+
+### If you have two
+
+Please report what happens on #82 — including "it did not work". The startup logs and the
+`checksum_error_total` / `invalid_frame_total` counters say immediately whether the cold-start
+collision above is real.
 
 ## What we still don't know
 

--- a/src/drivers/eversolar_legacy/descriptor.cpp
+++ b/src/drivers/eversolar_legacy/descriptor.cpp
@@ -34,12 +34,17 @@ const DriverDescriptor& descriptor() {
         // one. registerDevice() runs the enumeration loop exactly once, so a second inverter is
         // never discovered anyway. And `assignedAddress` has no option wired to it, so both
         // instances would claim the same bus address regardless.
+        // True, with one device per inverter and each holding its own bus address.
         //
-        // The protocol itself does support several inverters; implementing that means repeating
-        // the offline-query/assign loop until silence and giving each discovered serial its own
-        // device. That is real work and needs two inverters on a bench to verify, which is
-        // exactly why this says false today rather than promising it.
-        x.supportsMultipleDevices = false;
+        // The enumeration needs no loop of its own: a registered inverter ignores the broadcast
+        // offline query, so the second instance's query is answered by the next unregistered
+        // one. Instances start sequentially from the configuration, which is the ordering that
+        // makes that work -- the same mechanism the reference implementation drives from a
+        // timer instead (eversolar.pl:1038).
+        //
+        // NOT verified against two physical inverters; nobody involved has two. See #82 and
+        // the pitfalls in docs/eversolar-protocol.md before wiring a second one.
+        x.supportsMultipleDevices = true;
         x.supportsRead            = true;
         x.supportsWrite           = false;
         // Declared here, not in Configuration: the payload-length hypothesis is this
@@ -50,7 +55,19 @@ const DriverDescriptor& descriptor() {
             "How to interpret the measurement payload. 'auto' derives it from the frame "
             "length (28 bytes = 1 string, 32 = 2). Force one only if a device contradicts "
             "that.",
-            "auto", {"auto", "single", "dual"}}};
+            "auto", {"auto", "single", "dual"}},
+            DriverOption{
+            "address", "Assigned bus address",
+            "Address this bridge hands to its inverter at registration. Leave at 16 unless you "
+            "have more than one inverter on the same RS485 loop; then give each its own, "
+            "counting up (16, 17, 18...). The inverter does not store it -- it is handed out "
+            "at registration and forgotten on power loss. Range 16-254.",
+            "16",
+            {},
+            kFirstInverterAddress, 254}};
+        // Named the same as the sibling drivers' address option, which is what lets the
+        // settings page warn when two configured devices would share one.
+        x.addressOptionKey = "address";
         return x;
     }();
     return d;

--- a/src/drivers/eversolar_legacy/eversolar_driver.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_driver.cpp
@@ -30,6 +30,16 @@ EversolarOptions optionsFrom(const heliograph::DriverOptions& values) {
     } else {
         out.layout = LayoutSelection::Auto;
     }
+    long addr = 0;
+    if (eversolar::descriptor().numericOption(values, "address", addr)) {
+        out.assignedAddress = static_cast<uint8_t>(addr);
+    } else {
+        // Not an error: the option is absent on every install that predates it, and its
+        // default IS kFirstInverterAddress -- so a single-inverter bridge keeps handing out
+        // 0x10 exactly as before, and keeps sending the RE_REGISTER that only the holder of
+        // that address sends.
+        out.assignedAddress = kFirstInverterAddress;
+    }
     return out;
 }
 
@@ -74,7 +84,20 @@ bool EversolarDriver::begin(Transport& transport) {
     identity_.driverId      = eversolar::descriptor().id;
     identity_.instanceKey   = std::to_string(options_.assignedAddress);
 
-    reRegisterAll();
+    // Only the holder of the first address broadcasts it.
+    //
+    // RE_REGISTER tells EVERY inverter on the line to forget its address, so an unconditional
+    // broadcast here made a second instance's startup de-register the first, already-polling
+    // one (#63). It is a BUS operation, not a device one -- the reference implementation calls
+    // it once from inverter_connect() and never again (eversolar.pl:822).
+    //
+    // Derived from the address rather than configured, so there is no extra knob to get wrong
+    // and no ordering contract between instances to honour. It also keeps a single-inverter
+    // bridge byte-identical: its address is the default 0x10, so it still broadcasts exactly as
+    // it always has.
+    if (options_.assignedAddress == kFirstInverterAddress) {
+        reRegisterAll();
+    }
     return true;
 }
 

--- a/test/test_eversolar/driver.cpp
+++ b/test/test_eversolar/driver.cpp
@@ -62,33 +62,42 @@ static void test_begin_broadcasts_re_register() {
     }
 }
 
-/// Why the descriptor says one device per bridge (#63).
+/// The property that makes a second inverter possible at all (#63, #82).
 ///
-/// Not an assertion that a flag is false -- that would pass just as well if the flag were
-/// meaningless. This is the harm itself: a second instance's begin() broadcasts RE_REGISTER,
-/// every inverter on the line forgets its address, and the first one -- registered, polling,
-/// working -- has to start over. On a real bus both then answer the next broadcast offline
-/// query at once, on half duplex, and whether that converges is not knowable without two
-/// inverters on a bench.
-///
-/// Nobody here has two, which is exactly why the honest answer is to refuse the second device
-/// rather than ship the enumeration this driver would need.
-static void test_a_second_instance_would_deregister_the_first() {
+/// RE_REGISTER tells EVERY inverter on the line to forget its address. It is a bus operation,
+/// not a device one, so only the instance holding the first address may send it -- otherwise
+/// starting device 2 knocks out device 1, which is what this driver used to do.
+static void test_a_second_instance_leaves_the_first_inverter_registered() {
     Rig r;
     r.begin();
     DeviceState state;
     TEST_ASSERT_EQUAL(PollResult::Ok, r.poll(state));
     TEST_ASSERT_TRUE(r.driver.registered());
     TEST_ASSERT_TRUE(r.device.registered);
+    const uint32_t broadcastsBefore = r.device.reRegisterCount;
 
-    // A second instance of the same driver on the same bus, as `additional_devices` would build.
-    EversolarDriver second{r.transport};
+    // A second instance, as `additional_devices` would build it: same bus, its own address.
+    EversolarOptions opts;
+    opts.assignedAddress = static_cast<uint8_t>(kFirstInverterAddress + 1);
+    EversolarDriver second{r.transport, opts};
     second.begin(r.transport);
 
-    // The inverter that was working is no longer registered -- and it was not asked anything.
-    TEST_ASSERT_FALSE_MESSAGE(r.device.registered,
-                              "begin() no longer de-registers; #63 may be fixable properly now");
-    TEST_ASSERT_FALSE(descriptor().supportsMultipleDevices);
+    // Not one extra broadcast, and the working inverter still holds its address.
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(broadcastsBefore, r.device.reRegisterCount,
+                                     "a second instance broadcast RE_REGISTER");
+    TEST_ASSERT_TRUE_MESSAGE(r.device.registered,
+                             "starting a second device de-registered the first inverter");
+}
+
+/// The other half: a single-inverter bridge must be byte-identical to what it was. Its address
+/// is the default, so it still broadcasts -- and that broadcast is what recovers an inverter
+/// holding a stale address from an earlier session.
+static void test_the_first_address_still_broadcasts_re_register() {
+    Rig r;
+    r.begin();
+    TEST_ASSERT_EQUAL_UINT32(3, r.device.reRegisterCount);
+    TEST_ASSERT_EQUAL_UINT8(kFirstInverterAddress, EversolarOptions{}.assignedAddress);
+    TEST_ASSERT_TRUE(descriptor().supportsMultipleDevices);
 }
 
 static void test_begin_fails_when_the_line_cannot_be_configured() {
@@ -763,7 +772,8 @@ static void test_snapshots_are_immutable_and_independent() {
 void run_eversolar_driver() {
     RUN_TEST(test_begin_configures_the_only_known_profile);
     RUN_TEST(test_begin_broadcasts_re_register);
-    RUN_TEST(test_a_second_instance_would_deregister_the_first);
+    RUN_TEST(test_a_second_instance_leaves_the_first_inverter_registered);
+    RUN_TEST(test_the_first_address_still_broadcasts_re_register);
     RUN_TEST(test_begin_fails_when_the_line_cannot_be_configured);
     RUN_TEST(test_begin_declares_no_capabilities_it_cannot_deliver);
     RUN_TEST(test_poll_registers_before_reading);


### PR DESCRIPTION
Addresses #82. Replaces #83, which GitHub auto-closed when its base branch (#81) was merged and deleted — the stacked-PR trap. Same commit, rebased onto main; the two #81 commits dropped out cleanly as already-upstream.

**The blocker I claimed in #82 did not exist, and it is worth saying why.**

I read the reference implementation as owning the bus and serving N inverters from one process, and concluded that needed a framework change — one driver yielding several devices. That was backwards. The reference *has* to repeat registration because it has one process for all inverters. We have **one instance per inverter**, so registering exactly one per instance is not a limitation, it is the right granularity. Obstacle 1 of #63 dissolves entirely under that reading.

## How it works

A registered inverter **ignores the broadcast offline query**, so the second instance's query is answered by the next unregistered one. Instances start sequentially from the configuration, and that ordering is the whole mechanism — the reference drives the same thing from a timer (`eversolar.pl:1038`).

Most of the plumbing already existed (`assignedAddress`, `address_`, `instanceKey`). Two changes:

- **An `address` option** wired to `assignedAddress`, exactly as `solax_driver.cpp` already does.
- **RE_REGISTER only from the holder of the first address.** It is a bus operation, not a device one — the reference calls it once from `inverter_connect()` (`:822`) — and broadcasting it per instance is what made a second device knock out the first.

Derived from the address rather than configured: no extra knob, no ordering contract between instances.

## Single-inverter setups stay byte-identical

The hard requirement, and it falls out rather than being bolted on. An existing bridge's address is the default `0x10`, so it is the first-address holder and still broadcasts RE_REGISTER exactly as before — which is also the only thing that recovers an inverter holding a stale address from an earlier session. That live-observed case has a test, and it still passes. Device ids stay serial-derived, so no MQTT topic or Home Assistant entity moves.

## The test asserts the fix it was written to fail against

#81 added a test asserting the *harm*, carrying a message for the day it changed: `"begin() no longer de-registers; #63 may be fixable properly now"`. This is that day. It failed exactly as designed and was replaced by the two properties that matter — a second instance adds no broadcast, and leaves the first inverter registered.

## Not verified against two inverters

`docs/eversolar-protocol.md` documents the pitfalls. The one that genuinely needs hardware: after RE_REGISTER nothing has an address, so the first offline query is answered by every inverter at once, on half duplex. Our parser rejects the collision and the poll retries, but the protocol defines no backoff. The reference has identical exposure and works in the field — evidence, not proof.

Also documented: which config row gets which inverter is **not fixed across reboots**. Device ids stay stable (serial-derived), but Modbus TCP unit ids are keyed on the configuration slot and can swap between physical inverters across a restart.

## Verification

795 native tests and all 8 layering rules on the rebased branch, against the post-merge main.