### PR TITLE
fix(eversolar): the assigned address must never be a discovery sweep target

### DIFF
--- a/src/drivers/eversolar_legacy/descriptor.cpp
+++ b/src/drivers/eversolar_legacy/descriptor.cpp
@@ -65,9 +65,18 @@ const DriverDescriptor& descriptor() {
             "16",
             {},
             kFirstInverterAddress, 254}};
-        // Named the same as the sibling drivers' address option, which is what lets the
-        // settings page warn when two configured devices would share one.
-        x.addressOptionKey = "address";
+        // Deliberately NOT addressOptionKey, for the same reason the SolaX driver spells out:
+        // this is the address the bridge HANDS the inverter at registration, not one the
+        // inverter already answers at. Sweeping it would discover nothing -- it would assign a
+        // string of addresses in a row and leave the device on the last one while the report
+        // named the first. A PMU device is found by its broadcast offline query, which needs no
+        // address at all.
+        //
+        // It was set here briefly, on the belief that the settings page reads it to warn about
+        // two devices sharing an address. It does not: extended discovery is the only consumer.
+        // The mistake was harmless only by accident -- the sweep runs over 1-8 and this option
+        // starts at 16, so every candidate fell outside the bounds and was skipped. Widening
+        // the sweep would have made a discovery run broadcast RE_REGISTER at a working bus.
         return x;
     }();
     return d;

--- a/test/test_eversolar/driver.cpp
+++ b/test/test_eversolar/driver.cpp
@@ -100,6 +100,28 @@ static void test_the_first_address_still_broadcasts_re_register() {
     TEST_ASSERT_TRUE(descriptor().supportsMultipleDevices);
 }
 
+/// The address option must never become a discovery sweep target.
+///
+/// It is the address the bridge HANDS the inverter at registration, not one the inverter
+/// already answers at. Sweeping it discovers nothing: it assigns a string of addresses in a row
+/// and leaves the device on the last one while the report names the first. Worse for this
+/// driver specifically -- each swept candidate is a fresh registration attempt, and a failed one
+/// can broadcast RE_REGISTER at a bus with a working inverter on it.
+///
+/// Asserted on the property, not on the sweep range. The field was briefly set here and did no
+/// damage purely by accident: extended discovery sweeps 1-8 and this option starts at 16, so
+/// every candidate fell outside the bounds. Pinning "no overlap with today's sweep" would be
+/// pinning the coincidence; this pins the rule.
+static void test_the_assigned_address_is_never_swept_by_discovery() {
+    TEST_ASSERT_FALSE_MESSAGE(descriptor().hasSweepableAddress(),
+                              "the assigned address must not be a discovery sweep target");
+    TEST_ASSERT_TRUE_MESSAGE(descriptor().addressOptionKey.empty(),
+                             "addressOptionKey is read by extended discovery and nothing else");
+    // The option itself stays, because a second inverter needs it -- it is only discovery that
+    // must not touch it.
+    TEST_ASSERT_NOT_NULL(descriptor().findOption("address"));
+}
+
 static void test_begin_fails_when_the_line_cannot_be_configured() {
     Rig r;
     r.transport.configureSucceeds = false;
@@ -774,6 +796,7 @@ void run_eversolar_driver() {
     RUN_TEST(test_begin_broadcasts_re_register);
     RUN_TEST(test_a_second_instance_leaves_the_first_inverter_registered);
     RUN_TEST(test_the_first_address_still_broadcasts_re_register);
+    RUN_TEST(test_the_assigned_address_is_never_swept_by_discovery);
     RUN_TEST(test_begin_fails_when_the_line_cannot_be_configured);
     RUN_TEST(test_begin_declares_no_capabilities_it_cannot_deliver);
     RUN_TEST(test_poll_registers_before_reading);


### PR DESCRIPTION
Found by the self-review #85 should have had before it was merged. Tim's feedback — that I sometimes skip reviewing my own PRs — was right, and this is what it cost.

## What went wrong

#85 set `x.addressOptionKey = "address"` on the EverSolar descriptor, with a comment claiming the settings page reads it to warn when two devices share an address. **It does not.** Extended discovery is the only consumer, and the field's own documentation says so:

> Extended discovery sweeps this option; nothing else reads it.

That documentation also names this precise hazard:

> an option may be an address the bridge HANDS OUT rather than one the device has. The registration protocols work that way, and sweeping such an option would assign nine addresses in a row rather than discover anything.

The SolaX driver — identical semantics, an address handed out at registration — **deliberately refuses** the field, with that reasoning spelled out in its descriptor. This driver was given it anyway, against an established decision sitting in a sibling file.

## Why it matters more here than for SolaX

Every swept candidate is a fresh registration attempt, and a failed one can broadcast **RE_REGISTER** — at a bus with a working inverter on it. A discovery run would have disturbed the device it was meant to find, which is the exact failure #63 was filed about.

## It was safe only by coincidence

The sweep runs over addresses **1–8**. This option's declared range starts at **16**. So every sweep candidate fell outside the bounds and was skipped, leaving one probe at the default — discovery behaved exactly as before.

That is a coincidence, not a safeguard. Nothing connects the two numbers, nothing tests the relationship, and widening the sweep would have removed the protection silently.

## The test pins the rule, not the coincidence

It asserts the address is **not sweepable at all** — not that today's sweep range happens to miss it. Pinning "no overlap with 1–8" would have pinned the accident and passed right up until someone changed the sweep.

Verified against the merged code: it fails there, with the message it was given.

The option itself stays. A second inverter needs it; it is only discovery that must not touch it, and the test asserts both halves.

## Verification

796 native tests (795 + 1), all 8 layering rules, firmware builds.