### PR TITLE
feat(devices): give each inverter a name an operator recognises

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -99,8 +99,8 @@ once a driver has write capabilities.
     "ac.power.total": { "value": 1842.0, "unit": "W", "valid": true, "stale": false }
   },
   "devices": [
-    { "id": "growatt_modbus-1", "online": true, "data_valid": true, "data_stale": false,
-      "last_successful_poll_seconds_ago": 3, "ac_power_w": 1240.0 },
+    { "id": "growatt_modbus-1", "label": "Schuur", "online": true, "data_valid": true,
+      "data_stale": false, "last_successful_poll_seconds_ago": 3, "ac_power_w": 1240.0 },
     { "id": "growatt_modbus-2", "online": false, "data_valid": false, "data_stale": false,
       "last_successful_poll_seconds_ago": null, "ac_power_w": null }
   ],
@@ -112,6 +112,12 @@ once a driver has write capabilities.
   }
 }
 ```
+
+`label` is the name an operator gave the device on the settings page. It is **optional and
+additional**: absent when nothing was set, and never a replacement for `id`. `id` is the key —
+it addresses `/api/v1/devices/<id>`, the MQTT topic tree and the Modbus unit mapping — so a
+client that followed the label would 404 the first time somebody renamed an inverter. Show the
+label, address by the id. Renaming is safe precisely because nothing keys on it.
 
 `device` and `measurements` describe the **first** device and always will — that is what existing
 clients read; `devices[0]` is built from the same snapshot, so the two cannot contradict each
@@ -188,7 +194,7 @@ authenticate must ask the user for it rather than read it back; the factory valu
   "serial": { "override": false, "baud_rate": 9600, "parity": "none",
               "data_bits": 8, "stop_bits": 1 },
   "security": { "password_set": true, "read_only_mode": false },
-  "driver": { "id": "eversolar_legacy", "auto_detect": false },
+  "driver": { "id": "eversolar_legacy", "auto_detect": false, "label": "Schuur" },
   "logging": { "level": "info" }
 }
 ```

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -142,6 +142,26 @@ bool checkLength(const std::string& value, size_t max, const char* field, Config
     return true;
 }
 
+/// A device label is free text, with one restriction: no control characters.
+///
+/// Not squeamishness. The label is announced to Home Assistant as a device name, written into
+/// log lines and rendered on the dashboard, and a stray newline or NUL splits a log line in two
+/// or truncates the name at a point nobody chose. Everything printable is allowed, accents and
+/// emoji included -- "Schuur" and "Balkon achter" are the point of the feature.
+bool checkLabel(const std::string& value, const char* field, ConfigError& error) {
+    if (!checkLength(value, 32, field, error)) return false;
+    for (const unsigned char c : value) {
+        // < 0x20 and 0x7F are the C0 controls and DEL. Bytes above 0x7F are left alone: they are
+        // UTF-8 continuation bytes, not characters, and judging them one byte at a time would
+        // reject every accented name.
+        if (c < 0x20 || c == 0x7F) {
+            error = {field, "must not contain control characters"};
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace
 
 namespace {
@@ -271,6 +291,7 @@ bool validate(const Configuration& config, ConfigError& error) {
     if (!checkLength(config.mqtt.baseTopic, 64, "mqtt.base_topic", error)) return false;
     if (!checkLength(config.mqtt.discoveryPrefix, 64, "mqtt.discovery_prefix", error)) return false;
     if (!checkLength(config.driver.id, 64, "driver.id", error)) return false;
+    if (!checkLabel(config.driver.label, "driver.label", error)) return false;
     if (!checkLength(config.security.adminUsername, 32, "security.admin_username", error)) return false;
     if (!checkLength(config.security.adminPassword, 64, "security.admin_password", error)) return false;
     // Driver options are free-form, so bound them too rather than trust the driver.
@@ -377,6 +398,7 @@ bool validate(const Configuration& config, ConfigError& error) {
             return false;
         }
         if (!checkLength(d.id, 64, (where + ".driver_id").c_str(), error)) return false;
+        if (!checkLabel(d.label, (where + ".label").c_str(), error)) return false;
         for (const auto& [key, value] : d.options) {
             if (!checkLength(key, 32, (where + ".options").c_str(), error)) return false;
             if (!checkLength(value, 128, (where + ".options").c_str(), error)) return false;
@@ -472,6 +494,7 @@ void writeCommon(JsonDocument& doc, const Configuration& config) {
     JsonObject driver     = doc["driver"].to<JsonObject>();
     driver["id"]          = config.driver.id;
     driver["auto_detect"] = config.driver.autoDetect;
+    driver["label"]       = config.driver.label;
     JsonObject options    = driver["options"].to<JsonObject>();
     for (const auto& [key, value] : config.driver.options) {
         options[key] = value;
@@ -483,6 +506,7 @@ void writeCommon(JsonDocument& doc, const Configuration& config) {
     for (const auto& d : config.additionalDevices) {
         JsonObject e   = extra.add<JsonObject>();
         e["driver_id"] = d.id;
+        e["label"]     = d.label;
         JsonObject o   = e["options"].to<JsonObject>();
         for (const auto& [key, value] : d.options) {
             o[key] = value;
@@ -579,6 +603,12 @@ bool configChangeRequiresReboot(const Configuration& a, const Configuration& b) 
            a.modbus.diagnosticsUnitId != b.modbus.diagnosticsUnitId ||
            a.polling.intervalSeconds != b.polling.intervalSeconds ||
            a.driver.id != b.driver.id || a.driver.options != b.driver.options ||
+           // Field by field here, NOT via DriverSettings::operator==, so a new field on that
+           // struct does not silently join this list. The label is applied when the device is
+           // created in setup(), so it belongs -- and a test caught that adding it to
+           // operator== alone was not enough, because additionalDevices uses the operator and
+           // `driver` does not.
+           a.driver.label != b.driver.label ||
            // The drivers and their poll contexts are built once, in setup(). Adding or
            // removing an inverter therefore changes nothing until the next boot.
            a.additionalDevices != b.additionalDevices ||
@@ -654,6 +684,7 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
     if (JsonObjectConst driver = doc["driver"]; !driver.isNull()) {
         if (!patchString(driver["id"], merged.driver.id, "driver.id", error)) return false;
         if (!patchBool(driver["auto_detect"], merged.driver.autoDetect, "driver.auto_detect", error)) return false;
+        if (!patchString(driver["label"], merged.driver.label, "driver.label", error)) return false;
         if (JsonObjectConst options = driver["options"]; !options.isNull()) {
             for (JsonPairConst kv : options) {
                 if (!kv.value().is<const char*>()) {
@@ -782,6 +813,8 @@ bool applyConfigPatch(const std::string& json, Configuration& config, ConfigErro
             JsonObjectConst obj = item.as<JsonObjectConst>();
             DriverSettings  d;
             if (!patchString(obj["driver_id"], d.id, (where + ".driver_id").c_str(), error))
+                return false;
+            if (!patchString(obj["label"], d.label, (where + ".label").c_str(), error))
                 return false;
             if (JsonObjectConst options = obj["options"]; !options.isNull()) {
                 for (JsonPairConst kv : options) {

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -82,9 +82,27 @@ struct DriverSettings {
     /// Driver-specific settings, opaque here. The driver declares which keys exist and what
     /// they accept (DriverDescriptor::options); validateDriverOptions checks them against it.
     DriverOptions options;
+    /// What the operator calls this inverter: "Schuur", "Balkon". Optional, and empty means
+    /// exactly what it means today -- every surface falls back to the registered id.
+    ///
+    /// DISPLAY ONLY. It must never reach an identifier: not the registered device id, not a
+    /// REST path, not an MQTT topic, not a Home Assistant unique_id. Those are keys, and a
+    /// rename would silently strand every entity's history behind a new one. It is stored here,
+    /// beside the device row, rather than on DeviceIdentity for the same reason -- deviceId()
+    /// lives on that struct, and a label in scope there is one line away from ending up in it.
+    ///
+    /// Home Assistant is the exception that proves the rule: discovery announces it as the
+    /// device NAME, which HA is free to change on an existing device, while the unique_id it
+    /// keys entities by stays derived from the id (#76).
+    std::string label;
 
     friend bool operator==(const DriverSettings& a, const DriverSettings& b) {
-        return a.id == b.id && a.autoDetect == b.autoDetect && a.options == b.options;
+        // label included deliberately: it is applied when the device is created in setup() and
+        // announced to Home Assistant at connect, so a changed label needs a restart like every
+        // other property of a device row. Leaving it out would make the settings page report no
+        // restart needed and then show the old name until the next reboot anyway.
+        return a.id == b.id && a.autoDetect == b.autoDetect && a.label == b.label &&
+               a.options == b.options;
     }
     friend bool operator!=(const DriverSettings& a, const DriverSettings& b) { return !(a == b); }
 };

--- a/src/config/configuration_store.cpp
+++ b/src/config/configuration_store.cpp
@@ -199,6 +199,7 @@ LoadResult deserializeConfigFromStorage(const std::string& json, Configuration& 
     if (JsonObjectConst driver = doc["driver"]; !driver.isNull()) {
         if (driver["id"].is<const char*>())    parsed.driver.id = driver["id"].as<const char*>();
         if (driver["auto_detect"].is<bool>())  parsed.driver.autoDetect = driver["auto_detect"].as<bool>();
+        if (driver["label"].is<const char*>()) parsed.driver.label = driver["label"].as<const char*>();
         if (JsonObjectConst options = driver["options"]; !options.isNull()) {
             for (JsonPairConst kv : options) {
                 if (kv.value().is<const char*>()) {
@@ -218,6 +219,7 @@ LoadResult deserializeConfigFromStorage(const std::string& json, Configuration& 
         for (JsonObjectConst e : extra) {
             DriverSettings d;
             if (e["driver_id"].is<const char*>()) d.id = e["driver_id"].as<const char*>();
+            if (e["label"].is<const char*>()) d.label = e["label"].as<const char*>();
             if (JsonObjectConst o = e["options"]; !o.isNull()) {
                 for (JsonPairConst kv : o) {
                     if (kv.value().is<const char*>()) {

--- a/src/device/device_context.cpp
+++ b/src/device/device_context.cpp
@@ -5,13 +5,17 @@
 namespace heliograph {
 
 DeviceContext::DeviceContext(InverterDriver& driver, StateStore& store, Diagnostics& diagnostics,
-                             ClockFn clock, const PollPolicy& policy)
+                             ClockFn clock, const PollPolicy& policy, std::string label)
     : driver_(driver),
       store_(store),
       diagnostics_(diagnostics),
       clock_(std::move(clock)),
       policy_(policy) {
     state_.bridgeOnline = true;
+    // Set once and then carried by every published snapshot: pollOnce() works on a copy of
+    // state_ and moves it back, so the label survives each poll without the driver knowing it
+    // exists. A driver has no business naming the thing an operator named.
+    state_.label        = std::move(label);
     state_.identity     = driver_.identity();
     state_.capabilities = driver_.capabilities();
     // Read the driver's tally rather than assuming zero. Today it always IS zero -- main.cpp

--- a/src/device/device_context.h
+++ b/src/device/device_context.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <functional>
+#include <string>
 
 #include "device/clock.h"
 #include "device/device_state.h"
@@ -28,8 +29,13 @@ struct PollPolicy {
 
 class DeviceContext {
 public:
+    /// `label` is the operator's name for this device, or empty. Taken at construction rather
+    /// than through a setter because the constructor publishes a first snapshot, and rs485Task
+    /// is already running by the time setup() gets here: a setter called afterwards would race
+    /// the poll task for state_, which is exactly what the missing workingState() accessor
+    /// below exists to prevent.
     DeviceContext(InverterDriver& driver, StateStore& store, Diagnostics& diagnostics,
-                  ClockFn clock, const PollPolicy& policy = {});
+                  ClockFn clock, const PollPolicy& policy = {}, std::string label = {});
 
     /// One poll attempt. Publishes a new snapshot either way, so that consumers always see
     /// current liveness even while the device is unreachable.

--- a/src/device/device_state.h
+++ b/src/device/device_state.h
@@ -39,6 +39,15 @@ struct DeviceState {
     uint32_t consecutiveFailures  = 0;
 
     DeviceIdentity       identity;
+    /// What the operator calls this inverter ("Schuur"), from the configured device row.
+    /// Empty means unlabelled, and every surface then shows the registered id, exactly as
+    /// before the field existed.
+    ///
+    /// DISPLAY ONLY, and separate from `identity` on purpose. `identity` is what the device
+    /// told us and it carries deviceId(), the key behind REST paths, MQTT topics and Home
+    /// Assistant unique_ids. A label that leaked into any of those would move an operator's
+    /// whole history the moment they renamed an inverter (#76).
+    std::string          label;
     InverterCapabilities capabilities;
     MeasurementSet       measurements;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1176,13 +1176,13 @@ void setup() {
     // Device 1 comes from `driver`, the rest from `additional_devices`, in that order. One list
     // so the poll loop has one thing to walk, and so a bring-up log reads in the same order the
     // settings page shows.
-    struct Planned { std::string id; const DriverOptions* options; };
+    struct Planned { std::string id; const DriverOptions* options; std::string label; };
     std::vector<Planned> planned;
     if (!driverId.empty()) {
-        planned.push_back({driverId, &g_config.driver.options});
+        planned.push_back({driverId, &g_config.driver.options, g_config.driver.label});
     }
     for (const auto& d : g_config.additionalDevices) {
-        planned.push_back({d.id, &d.options});
+        planned.push_back({d.id, &d.options, d.label});
     }
     g_devicesConfigured = planned.size();
     // One slot per CONFIGURED device, filled in as each one starts. The Modbus unit ids are
@@ -1198,7 +1198,14 @@ void setup() {
         // settings page numbers them. Naming only the driver id was useless on the very bus
         // this exists for: three inverters share one driver id, so all three failures read
         // identically (review, 2026-07-25).
-        const std::string row = "device " + std::to_string(plannedIndex + 1);
+        // The label goes in the PROBLEM text too. "device 2 could not be started" sends someone
+        // to count rows on the settings page; "device 2 (Schuur) could not be started" sends
+        // them to the shed. The row number stays, because that is what the settings page shows
+        // and an unlabelled bridge still needs to be told which row.
+        const std::string row = p.label.empty()
+                                    ? "device " + std::to_string(plannedIndex + 1)
+                                    : "device " + std::to_string(plannedIndex + 1) + " (" +
+                                          p.label + ")";
 
         // Refused BEFORE create() and begin(), because for a driver that cannot share a bus,
         // begin() IS the damage. The AA55 handshake opens with a bus-wide RE_REGISTER
@@ -1264,7 +1271,7 @@ void setup() {
         PollPolicy policy;
         policy.intervalMs = g_config.polling.intervalSeconds * 1000;
         g_contexts.push_back(std::make_unique<DeviceContext>(*driver, *store, g_diagnostics,
-                                                             nowMs, policy));
+                                                             nowMs, policy, p.label));
         g_deviceIds.push_back(id);
         g_configSlotIds[plannedIndex] = id;
         // `planned` is in configuration order and `p` is the entry being started, so this is
@@ -1432,12 +1439,13 @@ void loop() {
                     const char* why = !f.online          ? "offline"
                                       : f.dataStale      ? "stale"
                                                          : "no valid reading";
-                    log::info("state:   %s not answering (%s, last reply %us ago)", f.id.c_str(),
-                              why, static_cast<unsigned>(f.lastPollSecondsAgo));
+                    log::info("state:   %s not answering (%s, last reply %us ago)",
+                              rest::displayName(f).c_str(), why,
+                              static_cast<unsigned>(f.lastPollSecondsAgo));
                 } else {
                     // Never a byte since boot: a bus or addressing fault, not an inverter that
                     // went quiet, and the two need different things done about them.
-                    log::info("state:   %s has never answered", f.id.c_str());
+                    log::info("state:   %s has never answered", rest::displayName(f).c_str());
                 }
             }
             // A device that never STARTED is not in the fleet at all -- it has no driver, so it

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -95,7 +95,8 @@ std::string humanise(const std::string& id) {
 }
 
 void addDeviceBlock(JsonObject entity, const BridgeInfo& bridge, const DeviceIdentity& identity,
-                    bool isBridgeEntity, const std::string& uniqueBase) {
+                    bool isBridgeEntity, const std::string& uniqueBase,
+                    const std::string& label = {}) {
     JsonObject device = entity["device"].to<JsonObject>();
     if (isBridgeEntity) {
         device["identifiers"].to<JsonArray>().add(bridge.bridgeId);
@@ -119,7 +120,19 @@ void addDeviceBlock(JsonObject entity, const BridgeInfo& bridge, const DeviceIde
     const std::string& descriptor = !identity.model.empty()          ? identity.model
                                     : !identity.manufacturer.empty() ? identity.manufacturer
                                                                      : kUnknownInverterName;
-    std::string name = bridge.name.empty() ? descriptor : bridge.name + " - " + descriptor;
+    // A label replaces the derived name outright, bridge prefix and all. Somebody who types
+    // "Schuur" wants to read "Schuur" in Home Assistant, not "Heliograph - TL3000-20 #17", and
+    // prefixing it would only put the bridge's name back in front of the one thing they chose.
+    //
+    // Only the NAME. identifiers, unique_id and the retained config topic are all derived from
+    // uniqueBase and are untouched, which is what makes renaming safe: Home Assistant matches
+    // the device it already has, updates its name, and every entity keeps its history. (An
+    // operator who renamed the device inside HA keeps their own name -- HA treats that as
+    // name_by_user and does not let discovery overrule it.)
+    std::string name = !label.empty() ? label
+                       : bridge.name.empty()
+                           ? descriptor
+                           : bridge.name + " - " + descriptor;
     // Three identical inverters on one bus produce three identical model strings and no serial
     // number, so without this Home Assistant lists three devices called exactly the same thing
     // and twelve entities each called "AC Power". The address is the only thing that tells them
@@ -127,8 +140,12 @@ void addDeviceBlock(JsonObject entity, const BridgeInfo& bridge, const DeviceIde
     //
     // Only for devices 2..N: the primary keeps the name it has always had, like its topics and
     // its unique ids. Same reasoning, same test.
+    //
+    // And never when a label is set: the label already tells the devices apart -- that is what
+    // it is for -- so appending "#17" to "Schuur" would put the address back into the one name
+    // the operator chose to be free of it.
     const bool primary = uniqueBase == bridge.bridgeId;
-    if (!primary && !identity.instanceKey.empty()) {
+    if (label.empty() && !primary && !identity.instanceKey.empty()) {
         name += " #" + identity.instanceKey;
     }
     device["name"] = name;
@@ -255,7 +272,7 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         if (const int precision = displayPrecisionFor(m.type); precision >= 0) {
             e["suggested_display_precision"] = precision;
         }
-        addDeviceBlock(e, bridge, state.identity, /*isBridgeEntity=*/false, uniqueBase);
+        addDeviceBlock(e, bridge, state.identity, /*isBridgeEntity=*/false, uniqueBase, state.label);
 
         DiscoveryEntity entity;
         entity.uniqueId    = e["unique_id"].as<std::string>();
@@ -279,7 +296,7 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         e["value_template"] = "{{ value_json.status_text }}";
         e["availability_topic"] = availabilityTopic;
         e["icon"]           = "mdi:information-outline";
-        addDeviceBlock(e, bridge, state.identity, false, uniqueBase);
+        addDeviceBlock(e, bridge, state.identity, false, uniqueBase, state.label);
 
         DiscoveryEntity entity;
         entity.uniqueId    = e["unique_id"].as<std::string>();
@@ -301,7 +318,7 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         e["availability_topic"] = availabilityTopic;
         e["device_class"]   = "connectivity";
         e["entity_category"] = "diagnostic";
-        addDeviceBlock(e, bridge, state.identity, false, uniqueBase);
+        addDeviceBlock(e, bridge, state.identity, false, uniqueBase, state.label);
 
         DiscoveryEntity entity;
         entity.uniqueId = e["unique_id"].as<std::string>();

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -36,6 +36,10 @@ bool buildProvisionPayload(const std::string& hostname, std::string& out, size_t
     return finish(doc, out, maxBytes);
 }
 
+const std::string& displayName(const DeviceSummary& device) {
+    return device.label.empty() ? device.id : device.label;
+}
+
 FleetTotals totalsFor(const std::vector<DeviceSummary>& fleet) {
     FleetTotals t;
     t.polled = static_cast<unsigned>(fleet.size());
@@ -63,6 +67,7 @@ DeviceSummary summariseDevice(const DeviceState& state, const std::string& devic
                               uint64_t nowMs) {
     DeviceSummary s;
     s.id        = deviceId;
+    s.label     = state.label;
     s.online    = state.inverterOnline;
     s.dataValid = state.dataValid;
     s.dataStale = state.dataStale;
@@ -176,6 +181,7 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
 
     JsonObject d = doc["device"].to<JsonObject>();
     d["id"]      = deviceId;  // the registered id, not identity.deviceId() -- see the header
+    addOptional(d, "label", state.label);
     addOptional(d, "driver_id", state.identity.driverId);
     if (driver != nullptr) {
         d["support_level"] = supportLevelName(driver->supportLevel);
@@ -216,6 +222,7 @@ bool buildStatusPayload(const DeviceState& state, const std::string& deviceId,
     for (const auto& f : fleet) {
         JsonObject o    = devices.add<JsonObject>();
         o["id"]         = f.id;
+        addOptional(o, "label", f.label);
         o["online"]     = f.online;
         o["data_valid"] = f.dataValid;
         o["data_stale"] = f.dataStale;
@@ -306,7 +313,11 @@ bool buildDevicePayload(const DeviceState& state, const std::string& deviceId,
                         const DriverDescriptor* driver, uint64_t nowMs, std::string& out,
                         size_t maxBytes) {
     JsonDocument doc;
-    doc["id"] = deviceId;
+    JsonObject   root = doc.to<JsonObject>();
+    root["id"]        = deviceId;
+    // Outside `identity`, deliberately: identity is what the DEVICE reported, and a name the
+    // operator typed does not belong in it.
+    addOptional(root, "label", state.label);
 
     JsonObject identity = doc["identity"].to<JsonObject>();
     addOptional(identity, "manufacturer", state.identity.manufacturer);

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -51,6 +51,11 @@ bool buildProvisionPayload(const std::string& hostname, std::string& out,
 /// report energy must not contribute a zero to a total.
 struct DeviceSummary {
     std::string id;
+    /// The operator's name for this device, or empty. Reported BESIDE the id, never in place
+    /// of it: `id` keys /api/v1/devices/<id>, the MQTT topic tree and the Modbus unit mapping,
+    /// and a client that followed a label would 404 the moment somebody renamed an inverter.
+    /// A client chooses which to show; the firmware refuses to choose for it.
+    std::string label;
     /// The Modbus TCP unit id this device is served at, or 0 when Modbus is off or this device
     /// is past the end of the served run. Reported because otherwise the only way to learn it
     /// is to read modbus.unit_id, fetch the device list and count positions -- and on a bus of
@@ -105,6 +110,14 @@ struct FleetTotals {
 /// rather than by two people remembering the same rule -- the heartbeat used to describe the
 /// first device only, and there was no shared definition of "answering" for it to use (#74).
 FleetTotals totalsFor(const std::vector<DeviceSummary>& fleet);
+
+/// What to CALL this device in a line meant for a human: the label when there is one, the
+/// registered id otherwise.
+///
+/// One function so every human-facing surface makes the same choice. Never use it where an
+/// identifier is wanted -- it deliberately returns something that is not stable across a
+/// rename, which is the whole point on one side and a bug on the other.
+const std::string& displayName(const DeviceSummary& device);
 
 /// Reduces one device's state to the row above.
 ///

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1506,8 +1506,8 @@ async function renderConfig(){
         <div style="display:flex;justify-content:space-between;align-items:baseline">
           <b>Device ${i+2}</b>
           <a href="#" onclick="removeExtraDevice(${i});return false">Remove</a></div>
-        <label for="xd${i}_name">Name</label>
-        <input id="xd${i}_name" value="${esc(row.label||'')}" placeholder="Schuur"
+        <label for="xdname${i}">Name</label>
+        <input id="xdname${i}" value="${esc(row.label||'')}" placeholder="Schuur"
           oninput="setExtraLabel(${i},this.value)">
         <div class="dim" style="font-size:12px">Optional. Shown on the dashboard and in Home
         Assistant instead of the technical id. Renaming is safe: it never changes the id, so

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -373,7 +373,12 @@ function fleetStrip(fleet){
     // Em dash, not 0 and not blank: this driver does not report the channel, which is a
     // different statement from "reports zero" and must not be readable as a measurement.
     const num=(v,c)=>(v===null||v===undefined)?'—':(c.fn?c.fn(v):fmt(v,c.d)+' '+c.u);
-    return `<tr><td><span class="dot ${answering?'ok':'bad'}"></span>${esc(f.id)}</td>
+    // The label when there is one, the id underneath it in small type -- not INSTEAD of it.
+    // The id is what /api/v1/devices/<id>, the MQTT topics and the Modbus unit mapping use, so
+    // someone debugging still needs to read it off the screen they are already looking at.
+    const named=f.label?`${esc(f.label)}<div class="dim" style="font-size:11px">${esc(f.id)}</div>`
+                       :esc(f.id);
+    return `<tr><td><span class="dot ${answering?'ok':'bad'}"></span>${named}</td>
       ${cols.map(c=>`<td class="n">${esc(num(f[c.k],c))}</td>`).join('')}
       <td class="n">${when}</td></tr>`;
   }).join('');
@@ -568,7 +573,8 @@ async function renderDevices(b){
         : (dev.data_stale?`<span class="tag">stale — last reply ${esc(ago)} s ago</span>`
                          :`<span class="tag">replied ${esc(ago)} s ago</span>`);
       cards.push(`<div class="card"><div style="display:flex;justify-content:space-between;
-        align-items:baseline;gap:10px"><b>${esc(id)}</b>${live}</div>
+        align-items:baseline;gap:10px"><b>${esc(dev.label||id)}</b>${
+        dev.label?`<span class="dim" style="font-size:12px">${esc(id)}</span>`:''}${live}</div>
         <table>${deviceTable(ident,devCache[id],m)}</table></div>`);
     }
     if(ids.length&&!problems.length&&configured===ids.length){
@@ -1203,7 +1209,7 @@ const RESTART_NEEDED={
   'mqtt.base_topic':'MQTT base topic','mqtt.discovery_enabled':'Home Assistant discovery',
   'modbus.enabled':'Modbus on/off','modbus.port':'Modbus port','modbus.unit_id':'Modbus unit ID',
   'polling.interval_seconds':'Polling interval',
-  'driver.id':'Active driver','driver.options':'Driver options',
+  'driver.id':'Active driver','driver.label':'Device 1 name','driver.options':'Driver options',
   'ntp.enabled':'NTP on/off','ntp.use_dhcp':'NTP via DHCP','ntp.server':'NTP server',
   'ntp.timezone':'Timezone',
   'serial.override':'RS485 line override','serial.baud_rate':'RS485 baud rate',
@@ -1442,7 +1448,7 @@ async function renderConfig(){
   // Deliberately NOT pre-filled with anything when a row is added: an extra device that names
   // no driver is refused by the firmware, and an address silently defaulting to the same one
   // the primary uses would collide and be skipped at boot with only a log line to say so.
-  let xdevs = ((c.additional_devices)||[]).map(d=>({id:d.driver_id||'',options:{...(d.options||{})}}));
+  let xdevs = ((c.additional_devices)||[]).map(d=>({id:d.driver_id||'',label:d.label||'',options:{...(d.options||{})}}));
 
   // Fills a row's model with the driver's declared defaults. Called when a row is added or its
   // driver changes, so the model always holds what the fields SHOW.
@@ -1500,6 +1506,12 @@ async function renderConfig(){
         <div style="display:flex;justify-content:space-between;align-items:baseline">
           <b>Device ${i+2}</b>
           <a href="#" onclick="removeExtraDevice(${i});return false">Remove</a></div>
+        <label for="xd${i}_name">Name</label>
+        <input id="xd${i}_name" value="${esc(row.label||'')}" placeholder="Schuur"
+          oninput="setExtraLabel(${i},this.value)">
+        <div class="dim" style="font-size:12px">Optional. Shown on the dashboard and in Home
+        Assistant instead of the technical id. Renaming is safe: it never changes the id, so
+        history is kept.</div>
         <label for="xd${i}_drv">Driver</label>
         <select id="xd${i}_drv" onchange="setExtraDriver(${i},this.value)">
           <option value="" ${row.id?'':'selected'}>— choose —</option>${
@@ -1514,17 +1526,21 @@ async function renderConfig(){
     const add=$('#xdevadd');
     if(add)add.disabled=xdevs.length+1>=(window.g_maxDevices||8);
   };
-  window.addExtraDevice=()=>{xdevs.push({id:'',options:{}});renderExtraDevices()};
+  window.addExtraDevice=()=>{xdevs.push({id:'',label:'',options:{}});renderExtraDevices()};
   window.removeExtraDevice=i=>{xdevs.splice(i,1);renderExtraDevices()};
   window.setExtraDriver=(i,id)=>{
     // Options belong to a driver, so switching driver drops the old one's values rather than
     // carrying keys the new driver never declared -- which the firmware would refuse anyway.
-    xdevs[i]={id,options:{}};
+    // The name is the operator's, not the driver's: switching driver keeps it. Clearing it
+    // here would silently discard something they typed for a device that is still the same
+    // physical inverter in the same shed.
+    xdevs[i]={id,label:xdevs[i].label,options:{}};
     seedRowOptions(xdevs[i]);
     renderExtraDevices();
   };
   window.setExtraOption=(i,key,value)=>{xdevs[i].options[key]=value};
-  window.extraDevicesBody=()=>xdevs.map(d=>({driver_id:d.id,options:{...d.options}}));
+  window.setExtraLabel=(i,value)=>{xdevs[i].label=value};
+  window.extraDevicesBody=()=>xdevs.map(d=>({driver_id:d.id,label:d.label||'',options:{...d.options}}));
 
   // What the firmware would refuse, or accept and then quietly skip at boot -- said here, next
   // to the row, instead of as `additional_devices[2].driver_id: ...` under the Save button,
@@ -1662,6 +1678,11 @@ async function renderConfig(){
     <label for="c_sersb">Stop bits</label>
     <input id="c_sersb" type="number" value="${c.serial.stop_bits}"></div>
   <div class="card"><b>Driver</b> <span class="tag" style="font-weight:400">needs restart</span>
+    <label for="c_drvname">Name</label>
+    <input id="c_drvname" value="${esc(c.driver.label||'')}" placeholder="Schuur">
+    <div class="dim" style="font-size:12px">Optional name for device 1, shown on the dashboard
+    and in Home Assistant instead of the technical id. Renaming is safe: the id never changes,
+    so history is kept.</div>
     <label for="c_drv">Active driver</label>
     <select id="c_drv" onchange="reloadDriverOpts()">${
       // A stored id that matches no option selects nothing, so the browser silently shows the
@@ -1782,7 +1803,7 @@ async function saveConfig(){
          ...(v('c_ntptz')==='__custom'
              ?{timezone:v('c_ntptzc'),timezone_name:''}
              :{timezone:TZBYNAME[v('c_ntptz')],timezone_name:v('c_ntptz')})},
-    driver:{id:v('c_drv'),options:{}},
+    driver:{id:v('c_drv'),label:v('c_drvname'),options:{}},
     // read_only_mode is rendered from the stored value, so the generic per-key diff below is
     // enough: no rendered default to mistake for a change (unlike driver options / relay roles).
     // admin_username is added below only when typed, like the other credential fields.

--- a/test/test_config_backup/test_main.cpp
+++ b/test/test_config_backup/test_main.cpp
@@ -41,9 +41,10 @@ static Configuration populated() {
     c.modbus.diagnosticsUnitId = 240;
     c.polling.intervalSeconds = 30;
     c.driver.id              = "mock";
+    c.driver.label           = "Schuur";
     c.driver.autoDetect      = true;
     c.driver.options["unit_id"] = "3";
-    c.additionalDevices.push_back({"mock", false, {{"unit_id", "4"}}});
+    c.additionalDevices.push_back({"mock", false, {{"unit_id", "4"}}, "Balkon"});
     c.relays.enabled         = true;
     c.relays.roles           = {"drm0", "none"};
     c.ntp.enabled            = false;
@@ -98,6 +99,11 @@ static void test_round_trip_with_secrets_is_lossless() {
     TEST_ASSERT_EQUAL_UINT8(240, restored.modbus.diagnosticsUnitId);
     TEST_ASSERT_EQUAL_UINT32(30, restored.polling.intervalSeconds);
     TEST_ASSERT_TRUE(original.driver == restored.driver);
+    // Named explicitly rather than left to operator==: a label that failed to round-trip would
+    // come back empty, every surface would silently fall back to the id, and the operator would
+    // find their inverters renamed to serial numbers after a restore.
+    TEST_ASSERT_EQUAL_STRING("Schuur", restored.driver.label.c_str());
+    TEST_ASSERT_EQUAL_STRING("Balkon", restored.additionalDevices[0].label.c_str());
     TEST_ASSERT_EQUAL_size_t(1, restored.additionalDevices.size());
     TEST_ASSERT_EQUAL_STRING("4", restored.additionalDevices[0].options.at("unit_id").c_str());
     TEST_ASSERT_TRUE(restored.relays.enabled);

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -953,6 +953,64 @@ static void test_devices_beyond_the_first_carry_their_address_in_the_name() {
     TEST_ASSERT_TRUE(nameA.find('#') == std::string::npos);
 }
 
+// A label becomes the Home Assistant device NAME and nothing else. This is the assertion the
+// whole feature rests on: unique_id and the retained config topic stay derived from the id, so
+// renaming an inverter updates the name of the device Home Assistant already has instead of
+// creating a second one and stranding every entity's history behind the first (#76).
+static void test_a_label_renames_the_ha_device_without_touching_its_unique_id() {
+    Rig              r;
+    DeviceState      state  = r.poll();
+    const BridgeInfo bridge = makeBridge();
+    const MqttTopics t(kDefaultBaseTopic, bridge.bridgeId);
+
+    const auto unlabelled = buildDiscoveryEntities(state, bridge, t, t.availability(),
+                                                   kDefaultDiscoveryPrefix, bridge.bridgeId);
+    state.label           = "Schuur";
+    const auto labelled   = buildDiscoveryEntities(state, bridge, t, t.availability(),
+                                                   kDefaultDiscoveryPrefix, bridge.bridgeId);
+
+    TEST_ASSERT_EQUAL_size_t(unlabelled.size(), labelled.size());
+    for (size_t i = 0; i < labelled.size(); ++i) {
+        // The two things a rename must never move.
+        TEST_ASSERT_EQUAL_STRING(unlabelled[i].uniqueId.c_str(), labelled[i].uniqueId.c_str());
+        TEST_ASSERT_EQUAL_STRING(unlabelled[i].configTopic.c_str(),
+                                 labelled[i].configTopic.c_str());
+    }
+
+    JsonDocument doc;
+    deserializeJson(doc, labelled.front().payload);
+    // Bare, with no bridge prefix: somebody who types "Schuur" wants to read "Schuur".
+    TEST_ASSERT_EQUAL_STRING("Schuur", doc["device"]["name"]);
+    // Identifiers are keys too, and they are what Home Assistant matches an existing device on.
+    JsonDocument before;
+    deserializeJson(before, unlabelled.front().payload);
+    TEST_ASSERT_EQUAL_STRING(before["device"]["identifiers"][0].as<const char*>(),
+                             doc["device"]["identifiers"][0].as<const char*>());
+    // State topics follow the id, not the name.
+    if (!doc["state_topic"].isNull()) {
+        TEST_ASSERT_EQUAL_STRING(before["state_topic"].as<const char*>(),
+                                 doc["state_topic"].as<const char*>());
+    }
+}
+
+// The address suffix exists to tell identical inverters apart. A label already does that, so
+// appending "#2" to it would put the address back into the one name chosen to be free of it.
+static void test_a_label_replaces_the_address_suffix_rather_than_carrying_it() {
+    Rig         r;
+    DeviceState state          = r.poll();
+    state.identity.instanceKey = "2";
+    state.label                = "Balkon";
+    const BridgeInfo bridge    = makeBridge();
+    const MqttTopics t(kDefaultBaseTopic, bridge.bridgeId, "growatt_modbus-2");
+
+    const auto entities = buildDiscoveryEntities(state, bridge, t, t.availability(),
+                                                 kDefaultDiscoveryPrefix,
+                                                 bridge.bridgeId + "_growatt_modbus-2");
+    JsonDocument doc;
+    deserializeJson(doc, entities.front().payload);
+    TEST_ASSERT_EQUAL_STRING("Balkon", doc["device"]["name"]);
+}
+
 static void test_two_devices_produce_distinct_unique_ids_and_ha_devices() {
     Rig               r;
     const DeviceState state  = r.poll();
@@ -1087,6 +1145,8 @@ int main(int, char**) {
     RUN_TEST(test_every_device_tracks_the_bridge_availability_topic);
     RUN_TEST(test_devices_beyond_the_first_carry_their_address_in_the_name);
     RUN_TEST(test_further_devices_get_their_own_subtree);
+    RUN_TEST(test_a_label_renames_the_ha_device_without_touching_its_unique_id);
+    RUN_TEST(test_a_label_replaces_the_address_suffix_rather_than_carrying_it);
     RUN_TEST(test_two_devices_produce_distinct_unique_ids_and_ha_devices);
     RUN_TEST(test_topics_are_built_consistently);
     RUN_TEST(test_state_payload_is_valid_json_with_the_expected_values);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -943,6 +943,77 @@ static void test_modbus_write_cannot_be_enabled() {
     TEST_ASSERT_EQUAL_STRING("modbus.write_enabled", e.field.c_str());
 }
 
+// --- Device labels (#76) -------------------------------------------------------------------
+
+// The whole feature rests on this: a label is additional, never a rename. `id` keys
+// /api/v1/devices/<id>, the state store, the MQTT topic tree and the Modbus unit mapping, and
+// rest_payloads.h already carries a note about a payload that reported a different id there and
+// sent clients to a path that 404s.
+static void test_a_label_is_reported_beside_the_id_never_instead_of_it() {
+    DeviceState state;
+    state.identity.driverId = "mock_inverter";
+    state.label             = "Schuur";
+
+    std::string out;
+    TEST_ASSERT_TRUE(rest::buildDevicePayload(state, "mock_inverter-1", nullptr, 1000, out, 4096));
+    auto doc = parse(out);
+    TEST_ASSERT_EQUAL_STRING("mock_inverter-1", doc["id"].as<const char*>());
+    TEST_ASSERT_EQUAL_STRING("Schuur", doc["label"].as<const char*>());
+}
+
+// An unlabelled bridge must be byte-identical to before the field existed, so a client that
+// never heard of labels cannot start seeing an empty string where it expects a missing key.
+static void test_no_label_means_no_key_at_all() {
+    DeviceState state;
+    state.identity.driverId = "mock_inverter";
+
+    std::string out;
+    TEST_ASSERT_TRUE(rest::buildDevicePayload(state, "mock_inverter-1", nullptr, 1000, out, 4096));
+    auto doc = parse(out);
+    TEST_ASSERT_TRUE(doc["label"].isNull());
+}
+
+static void test_the_fleet_entry_carries_the_label() {
+    DeviceState state;
+    state.label = "Balkon";
+    const auto summary = rest::summariseDevice(state, "mock_inverter-2", 1000);
+    TEST_ASSERT_EQUAL_STRING("Balkon", summary.label.c_str());
+    // displayName is what every human-facing line uses. Label when set, id otherwise.
+    TEST_ASSERT_EQUAL_STRING("Balkon", rest::displayName(summary).c_str());
+
+    DeviceState plain;
+    TEST_ASSERT_EQUAL_STRING("mock_inverter-3",
+                             rest::displayName(rest::summariseDevice(plain, "mock_inverter-3", 1000)).c_str());
+}
+
+// A label is free text on purpose -- "Schuur", "Balkon achter" -- but it is announced to Home
+// Assistant as a device name and written into log lines, and a newline there splits one log
+// line into two with the second one unattributed.
+static void test_a_label_may_not_carry_control_characters() {
+    Configuration c;
+    ConfigError   e;
+    TEST_ASSERT_FALSE(applyConfigPatch("{\"driver\":{\"label\":\"Schuur\\nBalkon\"}}", c, e));
+    TEST_ASSERT_EQUAL_STRING("driver.label", e.field.c_str());
+    // Accented and non-ASCII names are fine: they are multi-byte UTF-8, not control bytes.
+    TEST_ASSERT_TRUE(applyConfigPatch("{\"driver\":{\"label\":\"Schuur achter\"}}", c, e));
+    TEST_ASSERT_EQUAL_STRING("Schuur achter", c.driver.label.c_str());
+}
+
+static void test_renaming_a_device_needs_a_restart() {
+    // The label is applied when the device is created in setup() and announced to Home Assistant
+    // at connect. A page that said "applied immediately" would show the old name until reboot.
+    Configuration a;
+    Configuration b = a;
+    b.driver.label  = "Schuur";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(a, b));
+
+    Configuration c = a;
+    c.additionalDevices.push_back(DriverSettings{"mock_inverter", false, {}, "Balkon"});
+    Configuration d = c;
+    d.additionalDevices[0].label = "Garage";
+    TEST_ASSERT_TRUE(configChangeRequiresReboot(c, d));
+}
+
 static void test_diagnostics_unit_id_must_differ_from_the_inverter() {
     Configuration c;
     ConfigError   e;
@@ -2284,6 +2355,11 @@ int main(int, char**) {
     RUN_TEST(test_invalid_json_is_refused);
     RUN_TEST(test_out_of_range_values_are_refused);
     RUN_TEST(test_modbus_write_cannot_be_enabled);
+    RUN_TEST(test_a_label_is_reported_beside_the_id_never_instead_of_it);
+    RUN_TEST(test_no_label_means_no_key_at_all);
+    RUN_TEST(test_the_fleet_entry_carries_the_label);
+    RUN_TEST(test_a_label_may_not_carry_control_characters);
+    RUN_TEST(test_renaming_a_device_needs_a_restart);
     RUN_TEST(test_diagnostics_unit_id_must_differ_from_the_inverter);
     RUN_TEST(test_a_value_too_large_for_the_field_is_refused_not_wrapped);
     RUN_TEST(test_driver_options_are_opaque_to_the_config_model);


### PR DESCRIPTION
Closes #76.

## What it does

Each configured device row gets an optional name — *Schuur*, *Balkon*, *Garage* — shown wherever the device is displayed, with the technical id still available where it matters. Empty behaves exactly as today, so a single-inverter bridge is unchanged everywhere.

Surfaces: settings page (device 1 and every extra row), fleet strip, Device tab, `/api/v1/status`, `/api/v1/devices/<id>`, the heartbeat's not-answering lines, `device_problems`, and Home Assistant discovery.

## The one rule the design turns on

**A label is additional, never a rename.**

The registered id keys `/api/v1/devices/<id>`, the state store, the MQTT topic tree, the Modbus unit mapping and the Home Assistant `unique_id`. Every one of those is a key, and moving a key strands an operator's history behind the old one. Concretely:

- The label lives on the **device row** in configuration and on `DeviceState` — deliberately **not** on `DeviceIdentity`. That struct carries `deviceId()`, and a label in scope there is one line away from ending up in the key. It reaches `DeviceState` through the `DeviceContext` constructor, which is the only place that can set it without racing `rs485Task` for `state_`.
- REST reports it **beside** the id and omits the key entirely when unset, so an unlabelled bridge's payload is byte-identical to before.
- Home Assistant gets it as the device **name** only. `unique_id`, `identifiers`, the retained config topic and the state topics all stay derived from the id — which is what makes renaming safe: HA matches the device it already has and updates its name in place. No orphaned retained topics, and an operator who renamed the device inside HA keeps their own name (HA treats that as `name_by_user`).

That last point is the one the issue flagged as needing thought rather than a quick patch, so it has its own test and the test is mutation-tested.

## Two smaller decisions

**A label replaces the `#2` address suffix rather than carrying it.** The suffix exists to tell identical inverters apart; a label already does that, so appending it would put the address back into the one name chosen to be free of it. Mutation-tested — reverting the guard fails with `Expected 'Balkon' Was 'Balkon #2'`.

**Renaming needs a restart, and the page says so.** The device is created in `setup()` and announced at connect. Writing that test caught a real gap: adding `label` to `DriverSettings::operator==` covered `additional_devices` but not `driver`, because `configChangeRequiresReboot` compares that one field by field. Fixed, with a comment saying why the list is explicit.

## Validation

32 characters, no control characters. Everything printable is allowed — accents and non-ASCII included, since multi-byte UTF-8 is not control bytes and "Schuur achter" is the point of the feature. A newline would split a log line in two and truncate an HA device name at a point nobody chose.

## Verification

- 803 native tests pass, including 7 new ones across `test_rest`, `test_mqtt` and `test_config_backup`.
- Mutation-tested: the HA suffix guard and the restart-required diff both fail when broken.
- Backup/restore round-trips both labels, asserted by name rather than left to `operator==`.
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py` pass.
- `waveshare-rs485-can`, `waveshare-relay-6ch` and `mock` all build.
- Not hardware-tested. The Home Assistant rename path in particular deserves a look on a real HA instance before this ships.

## Note on ordering

`DriverSettings::label` is declared **after** `options`, not in the middle of the struct. Aggregate initialisers like `DriverSettings{"growatt_modbus", false, {{"unit_id", "300"}}}` exist in the tests, and inserting a field ahead of `options` silently changes what they mean.