### PR TITLE
fix(eversolar): pin the upgrade path, and say which branch actually handles it

### DIFF
--- a/src/drivers/eversolar_legacy/eversolar_driver.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_driver.cpp
@@ -30,14 +30,20 @@ EversolarOptions optionsFrom(const heliograph::DriverOptions& values) {
     } else {
         out.layout = LayoutSelection::Auto;
     }
+    // An install that predates this option has no "address" key stored, and that case is
+    // handled by the TRUE branch, not the false one: numericOption falls back to the option's
+    // DECLARED default when the key is absent (optionOr in driver_descriptor.h), and that
+    // default is "16" -- kFirstInverterAddress. So a single-inverter bridge upgrading from an
+    // older firmware keeps handing out 0x10 exactly as before, and keeps sending the
+    // RE_REGISTER that only the holder of that address sends.
+    //
+    // The else below is therefore reached only when the descriptor and this code disagree --
+    // no such option, not numeric, or a stored value outside the declared range. Restating the
+    // same default there is deliberate: this driver must never end up with address 0.
     long addr = 0;
     if (eversolar::descriptor().numericOption(values, "address", addr)) {
         out.assignedAddress = static_cast<uint8_t>(addr);
     } else {
-        // Not an error: the option is absent on every install that predates it, and its
-        // default IS kFirstInverterAddress -- so a single-inverter bridge keeps handing out
-        // 0x10 exactly as before, and keeps sending the RE_REGISTER that only the holder of
-        // that address sends.
         out.assignedAddress = kFirstInverterAddress;
     }
     return out;

--- a/test/test_eversolar/driver.cpp
+++ b/test/test_eversolar/driver.cpp
@@ -50,6 +50,32 @@ static void test_begin_configures_the_only_known_profile() {
     TEST_ASSERT_EQUAL_UINT8(1, r.transport.profile().stopBits);
 }
 
+// The exact shape a bridge has after an OTA update from a firmware that predates the "address"
+// option: the key is simply not in the stored configuration. This is the case the whole
+// single-inverter upgrade path rests on, and until now nothing asserted it -- the other tests
+// all construct EversolarOptions directly and so never exercise optionsFrom() at all.
+//
+// Note WHICH branch answers it. numericOption() does not fail on an absent key: optionOr()
+// falls back to the option's declared default ("16"), so the value arrives through the success
+// path. A reviewer reading the else branch would conclude otherwise, which is why this is
+// pinned rather than left to inspection.
+static void test_a_config_without_the_address_option_still_gets_the_first_address() {
+    const heliograph::DriverOptions stored;  // exactly what a pre-0.18 bridge has
+    const EversolarOptions          options = optionsFrom(stored);
+    TEST_ASSERT_EQUAL_UINT8(kFirstInverterAddress, options.assignedAddress);
+}
+
+// And a stored value the descriptor would refuse must not leave the driver at address 0, which
+// is the PMU broadcast address -- it would answer for every inverter on the line.
+static void test_an_out_of_range_stored_address_falls_back_rather_than_to_zero() {
+    heliograph::DriverOptions stored;
+    stored["address"] = "999";  // above the declared maximum of 254
+    TEST_ASSERT_EQUAL_UINT8(kFirstInverterAddress, optionsFrom(stored).assignedAddress);
+
+    stored["address"] = "not a number";
+    TEST_ASSERT_EQUAL_UINT8(kFirstInverterAddress, optionsFrom(stored).assignedAddress);
+}
+
 static void test_begin_broadcasts_re_register() {
     Rig r;
     r.begin();
@@ -793,6 +819,8 @@ static void test_snapshots_are_immutable_and_independent() {
 
 void run_eversolar_driver() {
     RUN_TEST(test_begin_configures_the_only_known_profile);
+    RUN_TEST(test_a_config_without_the_address_option_still_gets_the_first_address);
+    RUN_TEST(test_an_out_of_range_stored_address_falls_back_rather_than_to_zero);
     RUN_TEST(test_begin_broadcasts_re_register);
     RUN_TEST(test_a_second_instance_leaves_the_first_inverter_registered);
     RUN_TEST(test_the_first_address_still_broadcasts_re_register);


### PR DESCRIPTION
Findings from the pre-release review of `v0.17.0..main`. **Neither is a regression** — a bridge upgrading from an older firmware does get address `0x10` and does still broadcast `RE_REGISTER` — but both are worth closing before a tag.

## The comment was wrong about its own code

`optionsFrom()` explained, in the `else` branch, that an absent `"address"` option lands there. It does not. `numericOption()` falls back to the option's **declared default** when the key is missing (`optionOr`, [driver_descriptor.h:144](src/drivers/driver_descriptor.h:144)), and that default is `"16"` — so the value arrives through the *success* branch.

Same result, wrong explanation. The cost is real but deferred: somebody changing the default later would have edited the branch that never runs.

The `else` is now documented for what it actually catches — a disagreement between this code and the descriptor — and why restating the default there is still deliberate: this driver must never end up on address 0, which is the PMU broadcast address.

## And nothing tested it

Every other test in `test_eversolar` constructs `EversolarOptions` directly, so `optionsFrom()` — the function that actually sees a stored configuration — had **no coverage at all**. The one config shape this release depends on is the one a pre-0.18 bridge has: no `"address"` key whatsoever.

Now pinned, together with the out-of-range and non-numeric cases, because a fallback that produced `0` would put the driver on the broadcast address and make it answer for every inverter on the line.

## Verification

- 106 tests in `test_eversolar`, all pass.
- The new tests fail against a mutated `optionsFrom()` that returns 0 on the fallback path.