### PR TITLE
Release 0.18.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,9 +106,18 @@ namespace {
 // inverter that is not answering, why, and how long ago it last replied. Underneath: the two
 // PMU drivers stop carrying the same hundred-line transaction loop twice, and AsyncTCP and
 // ESPAsyncWebServer move up for two use-after-free fixes on the teardown path the dashboard's
-// live updates run over.
+// live updates run over. 0.18.0 lets an operator name their inverters -- "Schuur", "Balkon"
+// instead of XH30006011550619 -- everywhere a device is shown, including as the Home Assistant
+// device name, while every identifier keys on the id exactly as before, so renaming one keeps
+// its history. The Modbus TCP client limit and idle timeout become settings rather than header
+// constants nothing ever assigned; six clients came back as four on hardware with nothing
+// anywhere saying a limit had been hit, and the bridge now says so. A SunSpec inverter that
+// implements model 123 can be curtailed from Home Assistant, which is the first write path in
+// this firmware and stays behind the read-only kill switch. And the legacy PMU driver can put
+// several inverters on one bus, one device each -- untested against real hardware, since nobody
+// involved has two, so the pitfalls are written down rather than claimed away.
 #define HELIOGRAPH_VERSION_MAJOR 0
-#define HELIOGRAPH_VERSION_MINOR 17
+#define HELIOGRAPH_VERSION_MINOR 18
 #define HELIOGRAPH_VERSION_PATCH 0
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)


### PR DESCRIPTION
Version bump only. No behaviour change beyond the number the firmware reports about itself.

## Why this is a separate, blocking step

The release workflow derives its version from the **tag name** (`GITHUB_REF_NAME`), but the firmware reports `kFirmwareVersion`, built from the `#define`s in [main.cpp:119](src/main.cpp:119). **Nothing checks that the two agree.** Tagging without this bump ships a firmware that reports 0.17.0 while `latest.json` says 0.18.0 — and the dashboard's update check compares exactly those two numbers, so every bridge would be offered the same update forever.

## Verified on this exact tree

- 810 native tests pass
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py` pass
- All four targets build: `waveshare-rs485-can`, `waveshare-relay-1ch`, `waveshare-relay-6ch`, `mock`

The layering check caught the first draft of the release note: it named a manufacturer outside `src/drivers/`, which rule 1 forbids in comments too. Reworded.

## What 0.18.0 contains

- #76 — names per inverter, display-only, never in an identifier
- #71 — Modbus TCP client limit and idle timeout as settings
- #20 — SunSpec model 123 curtailment, the first write path in this firmware
- #63 / #82 — several PMU inverters on one bus, one device each (not hardware-tested)
- #79 — mock energy counters and battery power
- Plus the pre-release review fixes in #89