### PR TITLE
fix(dashboard): the fleet strip broke its rows once a hybrid appeared, and now says which way the battery is going

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -351,10 +351,24 @@ function fleetStrip(fleet){
   // have to know it to answer "is it charging?" -- and a bare -800 W invites the wrong guess.
   // The word is derived from the number as DISPLAYED, not from the raw value: a trickle of
   // 0.4 W rounds to 0 at this precision, and "charging 0 W" is a cell that argues with itself.
+  // Colour REINFORCES the word, it never replaces it. The cell still reads "charging" or
+  // "discharging" in full, so a colourblind reader loses nothing and a screenshot pasted into
+  // a chat still says what it means. Colour alone carrying the meaning would be the bug.
+  //
+  // Red for charging, green for discharging, which is the household reading rather than the
+  // battery's: discharging means the house is running on its own stored sun instead of buying
+  // it, and charging means power is going in. Both readings are defensible -- somebody could
+  // just as well see green as "filling up" -- which is exactly why the legend below exists
+  // rather than leaving it to be guessed.
+  const battState=v=>{
+    if(Number(fmt(Math.abs(v),0))===0) return 'idle';
+    return v>0?'charging':'discharging';
+  };
+  const battColour={charging:'var(--bad)',discharging:'var(--ok)',idle:'var(--dim)'};
   const batt=v=>{
-    const w=fmt(Math.abs(v),0);
-    if(Number(w)===0) return 'idle';
-    return (v>0?'charging ':'discharging ')+w+' W';
+    const state=battState(v);
+    if(state==='idle') return 'idle';
+    return state+' '+fmt(Math.abs(v),0)+' W';
   };
   // Each column declares what it actually needs. A flat allowance per column was fine while
   // the widest cell was a number; it stopped being fine the moment a hybrid appeared, because
@@ -383,8 +397,16 @@ function fleetStrip(fleet){
     // someone debugging still needs to read it off the screen they are already looking at.
     const named=f.label?`${esc(f.label)}<div class="dim" style="font-size:11px">${esc(f.id)}</div>`
                        :esc(f.id);
+    // Only the battery column is coloured, and only when it holds a reading. Colouring a value
+    // that is merely present would turn the strip into a traffic light nobody asked for.
+    const cell=c=>{
+      const v=f[c.k];
+      const style=(c.k==='battery_power_w'&&v!==null&&v!==undefined)
+        ? ` style="color:${battColour[battState(v)]}"` : '';
+      return `<td class="n"${style}>${esc(num(v,c))}</td>`;
+    };
     return `<tr><td><span class="dot ${answering?'ok':'bad'}"></span>${named}</td>
-      ${cols.map(c=>`<td class="n">${esc(num(f[c.k],c))}</td>`).join('')}
+      ${cols.map(cell).join('')}
       <td class="n">${when}</td></tr>`;
   }).join('');
   // Scrolls rather than squeezes: even four columns do not fit a phone, and hiding them below
@@ -394,9 +416,19 @@ function fleetStrip(fleet){
   // nowrap is the other half: without it the table honours min-width and then wraps the text
   // inside the cells anyway, which is the worst of both -- a scrollbar AND broken rows.
   const width=260+cols.reduce((a,c)=>a+c.w,0)+150;
-  return `<div class="card" style="margin-top:14px;overflow-x:auto"><table style="min-width:${width}px;white-space:nowrap">
+  // Only when there is a battery column to explain. A legend for a column that is not on
+  // screen is noise, and this strip already filters columns no inverter can fill.
+  const swatch=(colour,text)=>`<span style="display:inline-flex;align-items:center;gap:5px">
+    <span class="dot" style="background:${colour};margin-right:0"></span>${text}</span>`;
+  const legend=cols.some(c=>c.k==='battery_power_w')
+    ? `<div class="dim" style="font-size:12px;margin-top:10px;display:flex;flex-wrap:wrap;gap:14px">
+       ${swatch('var(--bad)','charging — power going into the battery')}
+       ${swatch('var(--ok)','discharging — the house is running on it')}
+       ${swatch('var(--dim)','idle')}</div>`
+    : '';
+  return `<div class="card" style="margin-top:14px"><div style="overflow-x:auto"><table style="min-width:${width}px;white-space:nowrap">
     <tr><th>Inverter</th>${cols.map(c=>`<th style="text-align:right">${c.t}</th>`).join('')}
-    <th style="text-align:right">Last reply</th></tr>${rows}</table></div>`;
+    <th style="text-align:right">Last reply</th></tr>${rows}</table></div>${legend}</div>`;
 }
 
 function render(s){

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -356,12 +356,17 @@ function fleetStrip(fleet){
     if(Number(w)===0) return 'idle';
     return (v>0?'charging ':'discharging ')+w+' W';
   };
-  const all=[{k:'ac_power_w',t:'AC power',d:0,u:'W'},
-             {k:'energy_today_kwh',t:'Today',d:2,u:'kWh'},
-             {k:'ac_voltage_v',t:'AC voltage',d:1,u:'V'},
-             {k:'temperature_c',t:'Temp',d:1,u:'°C'},
-             {k:'battery_soc_pct',t:'SOC',d:0,u:'%'},
-             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt}];
+  // Each column declares what it actually needs. A flat allowance per column was fine while
+  // the widest cell was a number; it stopped being fine the moment a hybrid appeared, because
+  // the battery cell holds a SENTENCE ("discharging 400 W") and the header "AC voltage" is two
+  // words. At 100px each they wrapped mid-column and the rows lost their alignment -- seen on
+  // a four-device bench the moment the mock started publishing battery power (0.18.0).
+  const all=[{k:'ac_power_w',t:'AC power',d:0,u:'W',w:110},
+             {k:'energy_today_kwh',t:'Today',d:2,u:'kWh',w:110},
+             {k:'ac_voltage_v',t:'AC voltage',d:1,u:'V',w:115},
+             {k:'temperature_c',t:'Temp',d:1,u:'°C',w:90},
+             {k:'battery_soc_pct',t:'SOC',d:0,u:'%',w:80},
+             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt,w:170}];
   const cols=all.filter(c=>fleet.some(f=>f[c.k]!==null&&f[c.k]!==undefined));
   const rows=fleet.map(f=>{
     const answering=f.online&&f.data_valid&&!f.data_stale;
@@ -384,8 +389,12 @@ function fleetStrip(fleet){
   }).join('');
   // Scrolls rather than squeezes: even four columns do not fit a phone, and hiding them below
   // a breakpoint means the reading you went looking for is the one that is not there.
-  const width=260+cols.length*100;
-  return `<div class="card" style="margin-top:14px;overflow-x:auto"><table style="min-width:${width}px">
+  //
+  // Summed from what the columns declare, plus the name and the "Last reply" tag at either end.
+  // nowrap is the other half: without it the table honours min-width and then wraps the text
+  // inside the cells anyway, which is the worst of both -- a scrollbar AND broken rows.
+  const width=260+cols.reduce((a,c)=>a+c.w,0)+150;
+  return `<div class="card" style="margin-top:14px;overflow-x:auto"><table style="min-width:${width}px;white-space:nowrap">
     <tr><th>Inverter</th>${cols.map(c=>`<th style="text-align:right">${c.t}</th>`).join('')}
     <th style="text-align:right">Last reply</th></tr>${rows}</table></div>`;
 }

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -346,20 +346,26 @@ function fleetStrip(fleet){
   // makes a whole column of em dashes, which reads as "broken" rather than "not applicable" --
   // and a bus of identical inverters means it is all of them or none. Decided per render from
   // the payload, so adding a device with more channels widens the table by itself.
-  // Battery power says the direction in words rather than as a sign. The payload follows the
-  // project's convention (positive charging, negative discharging), but a reader should not
-  // have to know it to answer "is it charging?" -- and a bare -800 W invites the wrong guess.
-  // The word is derived from the number as DISPLAYED, not from the raw value: a trickle of
-  // 0.4 W rounds to 0 at this precision, and "charging 0 W" is a cell that argues with itself.
-  // Colour REINFORCES the word, it never replaces it. The cell still reads "charging" or
-  // "discharging" in full, so a colourblind reader loses nothing and a screenshot pasted into
-  // a chat still says what it means. Colour alone carrying the meaning would be the bug.
+  // Battery power says its direction, rather than leaving it in the sign of a number. The
+  // payload follows the project's convention (positive charging, negative discharging), but a
+  // reader should not have to know that to answer "is it charging?" -- a bare -800 W invites
+  // the wrong guess. The direction is derived from the number as DISPLAYED, not from the raw
+  // value: a trickle of 0.4 W rounds to 0 at this precision, and a direction next to zero watts
+  // is a cell that argues with itself.
   //
-  // Red for charging, green for discharging, which is the household reading rather than the
-  // battery's: discharging means the house is running on its own stored sun instead of buying
-  // it, and charging means power is going in. Both readings are defensible -- somebody could
-  // just as well see green as "filling up" -- which is exactly why the legend below exists
-  // rather than leaving it to be guessed.
+  // TWO carriers, and this is the whole of it: an ARROW and a COLOUR. Down is power going into
+  // the battery, up is power coming out of it; red is charging, green is discharging. The word
+  // used to be spelled out in the cell and no longer is -- the arrow says it, and that column
+  // was the widest in the table by a distance, which is what broke the layout to begin with.
+  //
+  // The arrow is not decoration. It is a SHAPE, so it survives a reader who cannot tell the red
+  // from the green, and it is why the colour may never become the only carrier. The word itself
+  // reaches assistive technology and a hover through the cell's title, rather than being
+  // dropped outright.
+  //
+  // Red for charging is the household reading rather than the battery's: discharging means the
+  // house is running on its own stored sun instead of buying it. Somebody could just as well
+  // see green as "filling up", which is exactly why the legend below is not optional.
   const battState=v=>{
     if(Number(fmt(Math.abs(v),0))===0) return 'idle';
     return v>0?'charging':'discharging';
@@ -388,7 +394,7 @@ function fleetStrip(fleet){
              {k:'ac_voltage_v',t:'AC voltage',d:1,u:'V',w:115},
              {k:'temperature_c',t:'Temp',d:1,u:'°C',w:90},
              {k:'battery_soc_pct',t:'SOC',d:0,u:'%',w:80},
-             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt,w:110}];
+             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt,w:110,state:battState}];
   const cols=all.filter(c=>fleet.some(f=>f[c.k]!==null&&f[c.k]!==undefined));
   const rows=fleet.map(f=>{
     const answering=f.online&&f.data_valid&&!f.data_stale;
@@ -405,13 +411,21 @@ function fleetStrip(fleet){
     // someone debugging still needs to read it off the screen they are already looking at.
     const named=f.label?`${esc(f.label)}<div class="dim" style="font-size:11px">${esc(f.id)}</div>`
                        :esc(f.id);
-    // Only the battery column is coloured, and only when it holds a reading. Colouring a value
-    // that is merely present would turn the strip into a traffic light nobody asked for.
+    // Only a column that asks for it is coloured, and only when it holds a reading. Colouring
+    // every value that happens to be present would turn the strip into a traffic light nobody
+    // asked for. Keyed off the column definition rather than a literal column name, so the rule
+    // travels with the column instead of a second place having to know which one is special.
+    //
+    // title carries the word the cell stopped spelling out. A screen reader announcing
+    // "down arrow 2450 watts" is not an answer to "is it charging?", and the legend that
+    // answers it lives elsewhere in the document. Costs nothing on screen.
     const cell=c=>{
       const v=f[c.k];
-      const style=(c.k==='battery_power_w'&&v!==null&&v!==undefined)
-        ? ` style="color:${battColour[battState(v)]}"` : '';
-      return `<td class="n"${style}>${esc(num(v,c))}</td>`;
+      const has=v!==null&&v!==undefined;
+      if(!c.state||!has) return `<td class="n">${esc(num(v,c))}</td>`;
+      const state=c.state(v);
+      return `<td class="n" title="${esc(state)}" style="color:${battColour[state]}">${
+        esc(num(v,c))}</td>`;
     };
     return `<tr><td><span class="dot ${answering?'ok':'bad'}"></span>${named}</td>
       ${cols.map(cell).join('')}

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -365,10 +365,18 @@ function fleetStrip(fleet){
     return v>0?'charging':'discharging';
   };
   const battColour={charging:'var(--bad)',discharging:'var(--ok)',idle:'var(--dim)'};
+  // An arrow on top of the word and the colour, so the meaning survives losing any one of the
+  // three: down is power going INTO the battery, up is power coming out of it. Idle gets no
+  // arrow, because nothing is moving and an arrow would have to point somewhere.
+  const battArrow={charging:'\u2193',discharging:'\u2191',idle:''};
+  // Arrow and number only. The word came out because the arrow already says it and the column
+  // was the widest in the table by a distance -- which is what broke the layout in the first
+  // place. That makes the legend load-bearing rather than supplementary: it is now the only
+  // place the arrows are spelled out, so it renders whenever the column does, never optionally.
   const batt=v=>{
     const state=battState(v);
     if(state==='idle') return 'idle';
-    return state+' '+fmt(Math.abs(v),0)+' W';
+    return battArrow[state]+' '+fmt(Math.abs(v),0)+' W';
   };
   // Each column declares what it actually needs. A flat allowance per column was fine while
   // the widest cell was a number; it stopped being fine the moment a hybrid appeared, because
@@ -380,7 +388,7 @@ function fleetStrip(fleet){
              {k:'ac_voltage_v',t:'AC voltage',d:1,u:'V',w:115},
              {k:'temperature_c',t:'Temp',d:1,u:'°C',w:90},
              {k:'battery_soc_pct',t:'SOC',d:0,u:'%',w:80},
-             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt,w:170}];
+             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt,w:110}];
   const cols=all.filter(c=>fleet.some(f=>f[c.k]!==null&&f[c.k]!==undefined));
   const rows=fleet.map(f=>{
     const answering=f.online&&f.data_valid&&!f.data_stale;
@@ -418,13 +426,15 @@ function fleetStrip(fleet){
   const width=260+cols.reduce((a,c)=>a+c.w,0)+150;
   // Only when there is a battery column to explain. A legend for a column that is not on
   // screen is noise, and this strip already filters columns no inverter can fill.
-  const swatch=(colour,text)=>`<span style="display:inline-flex;align-items:center;gap:5px">
-    <span class="dot" style="background:${colour};margin-right:0"></span>${text}</span>`;
+  // Shows the cell itself, not an abstraction of it: same arrow, same colour, same word. A
+  // legend that renders differently from the thing it explains is one more thing to decode.
+  const key=(state,text)=>`<span style="display:inline-flex;align-items:center;gap:6px">
+    <span style="color:${battColour[state]}">${battArrow[state]||'\u2014'} ${state}</span>${text}</span>`;
   const legend=cols.some(c=>c.k==='battery_power_w')
-    ? `<div class="dim" style="font-size:12px;margin-top:10px;display:flex;flex-wrap:wrap;gap:14px">
-       ${swatch('var(--bad)','charging — power going into the battery')}
-       ${swatch('var(--ok)','discharging — the house is running on it')}
-       ${swatch('var(--dim)','idle')}</div>`
+    ? `<div class="dim" style="font-size:12px;margin-top:10px;display:flex;flex-wrap:wrap;gap:18px">
+       ${key('charging','power going into the battery')}
+       ${key('discharging','the house is running on it')}
+       ${key('idle','')}</div>`
     : '';
   return `<div class="card" style="margin-top:14px"><div style="overflow-x:auto"><table style="min-width:${width}px;white-space:nowrap">
     <tr><th>Inverter</th>${cols.map(c=>`<th style="text-align:right">${c.t}</th>`).join('')}

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -209,11 +209,15 @@ h = fleetStrip([{...base,id:'b',ac_power_w:1200,battery_soc_pct:64,battery_power
 check(cols(h).includes('SOC'), 'SOC column missing for a hybrid');
 check(h.includes('\u2193 1500 W'), 'charging is not marked with a down arrow');
 check(h.includes('var(--bad)'), 'charging is not coloured');
+// The word left the cell but not the document. A screen reader announcing "down arrow 2450
+// watts" cannot answer "is it charging?", and the legend that answers it is elsewhere.
+check(h.includes('title="charging"'), 'the cell does not carry the word for assistive tech');
 check(h.includes('64 %'), 'state of charge not rendered');
 
 h = fleetStrip([{...base,id:'c',battery_soc_pct:20,battery_power_w:-800}]);
 check(h.includes('\u2191 800 W'), 'discharging is not marked with an up arrow');
 check(h.includes('var(--ok)'), 'discharging is not coloured');
+check(h.includes('title="discharging"'), 'the cell does not carry the word for assistive tech');
 check(!h.includes('-800'), 'a raw negative leaked into the cell');
 
 // The legend became load-bearing the moment the word came out of the cell: it is the only

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -197,14 +197,32 @@ let c = cols(h);
 check(!c.includes('SOC') && !c.includes('Battery'), 'battery columns shown for a device with no battery');
 check(c.includes('Temp') && c.includes('Today'), 'a channel the device reports has no column');
 
+// The direction is carried by an ARROW now, not by the word it used to spell out. What the
+// rule protects has not changed: a reader must be able to answer "is it charging?" without
+// knowing this project's sign convention, and a bare -800 does not let them.
+//
+// Two carriers, deliberately, and both are checked. The arrow is a SHAPE, so it survives being
+// read by someone who cannot distinguish the red from the green; the colour is the second cue,
+// not the only one. Asserting only the colour would let a future change drop the arrow and
+// leave the meaning in a hue.
 h = fleetStrip([{...base,id:'b',ac_power_w:1200,battery_soc_pct:64,battery_power_w:1500}]);
 check(cols(h).includes('SOC'), 'SOC column missing for a hybrid');
-check(h.includes('charging 1500 W'), 'charging not spelled out');
+check(h.includes('\u2193 1500 W'), 'charging is not marked with a down arrow');
+check(h.includes('var(--bad)'), 'charging is not coloured');
 check(h.includes('64 %'), 'state of charge not rendered');
 
 h = fleetStrip([{...base,id:'c',battery_soc_pct:20,battery_power_w:-800}]);
-check(h.includes('discharging 800 W'), 'discharging not spelled out');
+check(h.includes('\u2191 800 W'), 'discharging is not marked with an up arrow');
+check(h.includes('var(--ok)'), 'discharging is not coloured');
 check(!h.includes('-800'), 'a raw negative leaked into the cell');
+
+// The legend became load-bearing the moment the word came out of the cell: it is the only
+// place the arrows are explained. A strip that renders the column without it is undecodable.
+check(h.includes('power going into the battery') && h.includes('the house is running on it'),
+      'the battery column renders without the legend that explains its arrows');
+h = fleetStrip([{...base,id:'h',ac_power_w:500,battery_power_w:null,battery_soc_pct:null}]);
+check(!h.includes('power going into the battery'),
+      'a legend for a battery column that is not on screen');
 
 h = fleetStrip([{...base,id:'d',battery_soc_pct:50,battery_power_w:0}]);
 check(h.includes('idle'), 'a resting battery is not reported as idle');


### PR DESCRIPTION
Two things, both in the per-inverter strip. The first is a regression that shipped in 0.18.0; the second is what Tim asked for on top of it.

## 1. The bug

Found on hardware minutes after 0.18.0 went on the four-device bench: the strip scrolls sideways **and** breaks its cells onto a second line, so the rows stop lining up.

**The column allowance was a flat 100px.** Fine while the widest cell was a number. #79 made the mock publish `battery.power`, so the **Battery column rendered for the first time** — and that cell held a *sentence*, `discharging 400 W`. At 100px it wrapped, and dragged `AC voltage`, `25.0 °C` and `12.50 kWh` with it.

**Nothing said `nowrap`.** The table honoured `min-width`, produced a scrollbar, and then wrapped the text inside the cells anyway — a scrollbar *and* broken rows.

This is not a bug in #79. #79 is correct; it exposed a sizing rule that only held while no driver reported a battery. Columns now declare what they need and the width is summed from that. The horizontal scroll **stays** — it is deliberate, and hiding columns below a breakpoint would hide the reading someone went looking for.

## 2. Direction, said three ways and then two

`↓` red for charging, `↑` green for discharging, `idle` in grey, with a legend under the table.

Red for charging is the *household* reading rather than the battery's: discharging means the house is running on its own stored sun instead of buying it. Somebody could just as reasonably read green as "filling up" — which is exactly why the legend is not optional.

The word `charging` / `discharging` **came out of the cell** at Tim's request: the arrow says it, and that column was the widest in the table by a distance. Two consequences, both handled:

- **The legend became load-bearing.** It is now the only place the arrows are explained, so it renders whenever the column does — and, asserted separately, *not* when the column is absent.
- **The word went to `title`, not to nothing.** A screen reader announcing "down arrow 2450 watts" does not answer "is it charging?". `title="charging"` costs no pixels and adds a hover.

The arrow is the point, not decoration: it is a **shape**, so it survives a reader who cannot tell the red from the green. The colour is the second cue and may never become the only one.

## What the self-review caught

A comment I had written an hour earlier: *"Colour REINFORCES the word, it never replaces it. The cell still reads 'charging' or 'discharging' in full."* The word came out two commits later and the comment survived, asserting something the code had stopped doing. Rewritten, and it is what led to the `title` fix.

Also: the cell no longer tests for a literal column name to decide what to colour — the column declares its own state function.

## Verification

- **CI caught a real break**: `check_web_js` asserts `charging not spelled out`. Taking the word out broke it, and I had run that checker after the two edits *before* the one that changed what it asserts. The rule is updated rather than removed — what it protects is unchanged: a reader must answer "is it charging?" without knowing this project's sign convention.
- The checker now guards **arrow, colour, title, and the legend's presence and absence**. The title assertion is mutation-tested: remove the attribute and it fails.
- Rendered old vs new against the **live payload** from the bench at 192.168.20.153 at a deliberately narrow viewport — not by reasoning about CSS.
- 810 native tests, `check_layering.sh`, `check_web_js.py` all pass.

## Note for the next release

This regression shipped in a tag and was caught by eye. Nothing in the suite renders the dashboard, so no automated check could have caught the *layout* — only the content assertions in `check_web_js` exist. Worth considering whether the screenshot pipeline in `docs/images/` should run against the mock build in CI; it already does everything needed except assert.