### PR TITLE
Release 0.18.1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,10 +115,17 @@ namespace {
 // implements model 123 can be curtailed from Home Assistant, which is the first write path in
 // this firmware and stays behind the read-only kill switch. And the legacy PMU driver can put
 // several inverters on one bus, one device each -- untested against real hardware, since nobody
-// involved has two, so the pitfalls are written down rather than claimed away.
+// involved has two, so the pitfalls are written down rather than claimed away. 0.18.1 repairs
+// the per-inverter strip, which 0.18.0 broke the moment a battery appeared in it: the columns
+// were allowed a flat width that no longer held once a cell contained words instead of a
+// number, so every row wrapped and the table stopped lining up. Columns now declare what they
+// need. While it was open, the battery cell also stopped spelling out its direction and started
+// showing it -- a down arrow in red for charging, an up arrow in green for discharging, with a
+// legend under the table, and the word kept in the cell's title for anyone reading by anything
+// other than eye.
 #define HELIOGRAPH_VERSION_MAJOR 0
 #define HELIOGRAPH_VERSION_MINOR 18
-#define HELIOGRAPH_VERSION_PATCH 0
+#define HELIOGRAPH_VERSION_PATCH 1
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Version bump only. No behaviour change beyond the number the firmware reports about itself.

## Why this is a blocking step, not a formality

The release workflow derives its version from the **tag name**; the firmware reports `kFirmwareVersion`, built from the `#define`s in `src/main.cpp`. **Nothing checks that the two agree.** Tagging without this bump ships a firmware reporting 0.18.0 while `latest.json` says 0.18.1 — and the dashboard's update check compares exactly those two numbers, so every bridge would be offered the same update forever.

## What 0.18.1 fixes

[#91](https://github.com/Timdebruijn/heliograph/pull/91) — the per-inverter strip, which 0.18.0 broke the moment a battery appeared in it. The columns were allowed a flat width that stopped holding once a cell contained words instead of a number, so every row wrapped and the table lost its alignment. Caught by eye on the four-device bench within minutes of the 0.18.0 flash.

While that was open, the battery cell also stopped spelling out its direction and started showing it: `↓` red for charging, `↑` green for discharging, a legend under the table, and the word kept in the cell's `title` for anyone reading by something other than eye.

## Verified on this exact tree

- 810 native tests
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py`
- All four targets build; the binary reports `0.18.1`, confirmed from the binary itself rather than the source