### PR TITLE
fix(config): the device label limit counted bytes, not characters

### DIFF
--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -149,15 +149,30 @@ bool checkLength(const std::string& value, size_t max, const char* field, Config
 /// or truncates the name at a point nobody chose. Everything printable is allowed, accents and
 /// emoji included -- "Schuur" and "Balkon achter" are the point of the feature.
 bool checkLabel(const std::string& value, const char* field, ConfigError& error) {
-    if (!checkLength(value, 32, field, error)) return false;
+    // Counted in CHARACTERS, not bytes, because that is what the message promises and what the
+    // person typing sees. checkLength counts bytes, which is right for an SSID or a hostname --
+    // those are ASCII by specification -- and wrong here: this field exists to hold names like
+    // "Schuur" and "Zonnepaneel achter", and a review found "at most 32 characters" refusing a
+    // name of 20 once accents brought it past 32 bytes.
+    //
+    // A UTF-8 continuation byte is 0b10xxxxxx; every other byte starts a character. Counting
+    // the non-continuation bytes is the whole rule, and needs no decoder.
+    size_t characters = 0;
     for (const unsigned char c : value) {
-        // < 0x20 and 0x7F are the C0 controls and DEL. Bytes above 0x7F are left alone: they are
-        // UTF-8 continuation bytes, not characters, and judging them one byte at a time would
-        // reject every accented name.
+        // < 0x20 and 0x7F are the C0 controls and DEL. Everything printable is allowed,
+        // including multi-byte UTF-8 -- a newline would split a log line in two and truncate a
+        // Home Assistant device name at a point nobody chose, an accent would not.
         if (c < 0x20 || c == 0x7F) {
             error = {field, "must not contain control characters"};
             return false;
         }
+        if ((c & 0xC0) != 0x80) {
+            ++characters;
+        }
+    }
+    if (characters > 32) {
+        error = {field, "must be at most 32 characters"};
+        return false;
     }
     return true;
 }

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -999,6 +999,30 @@ static void test_a_label_may_not_carry_control_characters() {
     TEST_ASSERT_EQUAL_STRING("Schuur achter", c.driver.label.c_str());
 }
 
+// The limit is in characters, which is what the error message promises and what the person
+// typing sees. Counting bytes -- correct for an SSID, which is ASCII by specification --
+// refused a 20-character name once accents pushed it past 32 bytes (release review).
+static void test_the_label_limit_counts_characters_not_bytes() {
+    Configuration c;
+    ConfigError   e;
+    // 24 characters, 48 bytes: every one of these is two bytes in UTF-8.
+    const std::string accented(24, 'x');
+    std::string       twoByteEach;
+    for (int i = 0; i < 24; ++i) {
+        twoByteEach += "\xC3\xA9";  // e-acute
+    }
+    TEST_ASSERT_EQUAL_size_t(48, twoByteEach.size());
+    TEST_ASSERT_TRUE(applyConfigPatch(R"({"driver":{"label":")" + twoByteEach + R"("}})", c, e));
+
+    // And the limit still bites at 33 characters.
+    std::string tooMany;
+    for (int i = 0; i < 33; ++i) {
+        tooMany += "\xC3\xA9";
+    }
+    TEST_ASSERT_FALSE(applyConfigPatch(R"({"driver":{"label":")" + tooMany + R"("}})", c, e));
+    TEST_ASSERT_EQUAL_STRING("driver.label", e.field.c_str());
+}
+
 static void test_renaming_a_device_needs_a_restart() {
     // The label is applied when the device is created in setup() and announced to Home Assistant
     // at connect. A page that said "applied immediately" would show the old name until reboot.
@@ -2433,6 +2457,7 @@ int main(int, char**) {
     RUN_TEST(test_no_label_means_no_key_at_all);
     RUN_TEST(test_the_fleet_entry_carries_the_label);
     RUN_TEST(test_a_label_may_not_carry_control_characters);
+    RUN_TEST(test_the_label_limit_counts_characters_not_bytes);
     RUN_TEST(test_renaming_a_device_needs_a_restart);
     RUN_TEST(test_diagnostics_unit_id_must_differ_from_the_inverter);
     RUN_TEST(test_max_clients_is_bounded_at_both_ends);


### PR DESCRIPTION
**This fix was written during the pre-release review and never reached main.** It was pushed to `feat/device-labels` after [#88](https://github.com/Timdebruijn/heliograph/pull/88) had already been squash-merged, so it sat on a dead branch while 0.18.0 and 0.18.1 were tagged. The bug is in both releases.

Recovered here as a straight cherry-pick of `779a49c`.

## The bug

`checkLabel` promised "at most 32 characters" in its error message and then called `checkLength`, which counts `value.size()` — **bytes**.

Every accented character is two bytes in UTF-8 and an emoji is four. So a name like `Zonnepaneel achter` with accents is refused well under the length the message names, with nothing explaining why. The field's own comment says accents and emoji are the point of the feature.

`checkLength` is right everywhere else it is used: an SSID and a hostname are ASCII by specification, so bytes and characters are the same thing there. They are not the same thing in the one field meant to hold a name in someone's own language.

## The fix

Count non-continuation bytes. A UTF-8 continuation byte is `0b10xxxxxx`; every other byte starts a character. That is the whole rule and it needs no decoder.

## Verification

- 811 native tests pass, including a new one asserting a 24-character / 48-byte label is accepted and a 33-character one is not.
- Mutation-tested: put the byte check back and the new test fails.
- `check_layering.sh`, `check_web_js.py` pass.

## Worth noting

Nothing caught this. A commit pushed to a branch whose PR is already merged is invisible — no CI runs against main, no PR shows it, and `gh pr list` is empty. The only reason it surfaced is that Tim asked why the branch was still there.