### PR TITLE
Release 0.18.2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,9 +123,14 @@ namespace {
 // showing it -- a down arrow in red for charging, an up arrow in green for discharging, with a
 // legend under the table, and the word kept in the cell's title for anyone reading by anything
 // other than eye.
+// 0.18.2 makes the 32-character limit on a device name mean characters. It counted bytes, so
+// an accented name was refused at roughly half the length the error message promised -- in the
+// one field that exists to hold a name in somebody's own language. The fix was written during
+// the 0.18.0 review and pushed to a branch whose pull request had already been merged, where it
+// sat, invisible, through two tags.
 #define HELIOGRAPH_VERSION_MAJOR 0
 #define HELIOGRAPH_VERSION_MINOR 18
-#define HELIOGRAPH_VERSION_PATCH 1
+#define HELIOGRAPH_VERSION_PATCH 2
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Version bump only.

## Why this is blocking, not a formality

The release workflow derives its version from the **tag name**; the firmware reports the `#define`s in `src/main.cpp`. **Nothing checks that the two agree.** Ship them apart and the dashboard offers every bridge the same update forever.

## What 0.18.2 fixes

[#93](https://github.com/Timdebruijn/heliograph/pull/93) — the 32-character limit on a device name counted **bytes**. Every accented character is two bytes in UTF-8, so a name was refused at roughly half the length the error message promised, in the one field that exists to hold a name in somebody's own language.

The fix was written during the 0.18.0 review and pushed to a branch whose PR had already been squash-merged. It sat there, invisible to CI and to `gh pr list`, through **both** v0.18.0 and v0.18.1.

## Verified on this exact tree

- 811 native tests
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py`
- All four targets build; the binary reports `0.18.2`, read from the binary rather than the source