### PR TITLE
refactor(outputs): one diagnostics payload, not two copies of it

### DIFF
--- a/src/outputs/json_util.h
+++ b/src/outputs/json_util.h
@@ -7,6 +7,7 @@
 
 #include <ArduinoJson.h>
 
+#include <optional>
 #include <string>
 
 #include "json_limits.h"
@@ -15,6 +16,7 @@
 #include "device/capability.h"
 #include "device/command.h"
 #include "device/device_state.h"
+#include "diagnostics/diagnostics.h"
 #include "diagnostics/log_timestamp.h"
 
 namespace heliograph::json_util {
@@ -106,6 +108,100 @@ inline void writeDeviceStatus(JsonObject obj, const DeviceState& state) {
     } else {
         obj["error_code"] = nullptr;
     }
+}
+
+/// Everything both diagnostics payloads report, written once.
+///
+/// They were a copy of each other -- same fields, same order, same null-not-zero rules, right
+/// down to a word-for-word comment. That is the failure mode this header exists to prevent: a
+/// field added to one output and silently missing from the other, with nothing failing to say
+/// so. It escaped the earlier consolidation because the two builders differ in TWO fields, and
+/// two differences were enough to make them look like separate functions.
+///
+/// Those two differences are deliberate and are preserved exactly, which is why they are
+/// parameters rather than something this function decides:
+///   - `boardName` empty omits `board`. MQTT already carries the board as the Home Assistant
+///     device model, so repeating it on the diagnostics topic says nothing new.
+///   - `mqttConnected` unset omits `mqtt_connected`. On a payload that arrived over MQTT the
+///     field can only ever say true; it is a fact worth reporting over REST and a tautology
+///     over MQTT.
+///
+/// Field order is preserved for both callers, so no consumer sees a changed document.
+inline void writeDiagnostics(JsonObject doc, const DiagnosticsSnapshot& d,
+                             const BridgeInfo& bridge, const std::string& boardName,
+                             std::optional<bool> mqttConnected) {
+    doc["uptime_seconds"]   = bridge.uptimeSeconds;
+    doc["firmware_version"] = bridge.firmwareVersion;
+    addOptional(doc, "board", boardName);
+    doc["free_heap_bytes"]         = bridge.freeHeapBytes;
+    doc["minimum_free_heap_bytes"] = bridge.minFreeHeapBytes;
+    doc["max_alloc_heap_bytes"]    = bridge.maxAllocHeapBytes;
+
+    // Absent, not zero, when the board has none -- and 0 is a legitimate reading for
+    // psram_free_bytes on a board that HAS PSRAM and has exhausted it, so the two must not
+    // collapse onto the same value. Reported at all because the three heap figures above are
+    // MALLOC_CAP_INTERNAL and say nothing about it (audit, 2026-07-26).
+    if (bridge.psramSizeBytes > 0) {
+        doc["psram_size_bytes"] = bridge.psramSizeBytes;
+        doc["psram_free_bytes"] = bridge.psramFreeBytes;
+    } else {
+        doc["psram_size_bytes"] = nullptr;
+        doc["psram_free_bytes"] = nullptr;
+    }
+    doc["reset_reason"]    = bridge.resetReason;
+    doc["ota_image_state"] = bridge.otaImageState;
+
+    // Absent, not zero, when no dump is stored: task "" at PC 0 is not a fact about anything,
+    // and `coredump_present` false already carries the whole message.
+    doc["coredump_present"] = bridge.coredumpPresent;
+    if (bridge.coredumpPresent && !bridge.coredumpTask.empty()) {
+        doc["coredump_task"] = bridge.coredumpTask;  // std::string: copied into the document
+    } else {
+        doc["coredump_task"] = nullptr;
+    }
+    if (bridge.coredumpPresent) {
+        doc["coredump_pc"] = bridge.coredumpPc;
+    } else {
+        doc["coredump_pc"] = nullptr;
+    }
+    doc["wifi_connected"] = bridge.wifiConnected;
+    // Only meaningful while associated; 0 dBm would look like an excellent signal.
+    if (bridge.wifiConnected) {
+        doc["wifi_rssi_dbm"] = bridge.wifiRssiDbm;
+    } else {
+        doc["wifi_rssi_dbm"] = nullptr;
+    }
+    if (mqttConnected.has_value()) {
+        doc["mqtt_connected"] = *mqttConnected;
+    }
+    addClockFields(doc, bridge);
+
+    doc["poll_success_total"]              = d.pollSuccessTotal;
+    doc["poll_failure_total"]              = d.pollFailureTotal;
+    doc["consecutive_poll_failures"]       = d.consecutivePollFailures;
+    doc["checksum_error_total"]            = d.checksumErrorTotal;
+    doc["rs485_timeout_total"]             = d.rs485TimeoutTotal;
+    doc["invalid_frame_total"]             = d.invalidFrameTotal;
+    doc["wifi_reconnect_total"]            = d.wifiReconnectTotal;
+    doc["mqtt_reconnect_total"]            = d.mqttReconnectTotal;
+    doc["modbus_client_connections_total"] = d.modbusClientConnections;
+    doc["rest_requests_total"]             = d.restRequestTotal;
+    doc["mqtt_publish_failure_total"]      = d.mqttPublishFailureTotal;
+    doc["last_successful_poll_ms"]         = d.lastSuccessfulPollMs;
+    // Null until the first sample, not 0: a monitoring rule on "stack headroom == 0" must not
+    // fire during the first seconds after boot.
+    if (d.rs485StackFreeBytes > 0) {
+        doc["rs485_stack_free_bytes"] = d.rs485StackFreeBytes;
+    } else {
+        doc["rs485_stack_free_bytes"] = nullptr;
+    }
+    if (d.loopStackFreeBytes > 0) {
+        doc["loop_stack_free_bytes"] = d.loopStackFreeBytes;
+    } else {
+        doc["loop_stack_free_bytes"] = nullptr;
+    }
+    // Set from pollResultName() and friends only. Never carries payload bytes or config.
+    doc["last_error"] = d.lastError;
 }
 
 /// The capabilities document, byte-for-byte the same over MQTT and REST.

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -4,6 +4,8 @@
 
 #include <ArduinoJson.h>
 
+#include <optional>
+
 #include "device/command.h"  // commandTypeName
 #include "outputs/json_util.h"
 

--- a/src/outputs/mqtt/mqtt_payloads.cpp
+++ b/src/outputs/mqtt/mqtt_payloads.cpp
@@ -51,73 +51,10 @@ bool buildStatePayload(const DeviceState& state, std::string& out, size_t maxByt
 bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bridge,
                              std::string& out, size_t maxBytes) {
     JsonDocument doc;
-    doc["uptime_seconds"]            = bridge.uptimeSeconds;
-    doc["firmware_version"]          = bridge.firmwareVersion;
-    doc["free_heap_bytes"]           = bridge.freeHeapBytes;
-    doc["minimum_free_heap_bytes"]   = bridge.minFreeHeapBytes;
-    doc["max_alloc_heap_bytes"]      = bridge.maxAllocHeapBytes;
-
-    // Absent, not zero, when the board has none -- and 0 is a legitimate reading for
-    // psram_free_bytes on a board that HAS PSRAM and has exhausted it, so the two must not
-    // collapse onto the same value. Reported at all because the three heap figures above are
-    // MALLOC_CAP_INTERNAL and say nothing about it (audit, 2026-07-26).
-    if (bridge.psramSizeBytes > 0) {
-        doc["psram_size_bytes"] = bridge.psramSizeBytes;
-        doc["psram_free_bytes"] = bridge.psramFreeBytes;
-    } else {
-        doc["psram_size_bytes"] = nullptr;
-        doc["psram_free_bytes"] = nullptr;
-    }
-    doc["reset_reason"]              = bridge.resetReason;
-    doc["ota_image_state"]           = bridge.otaImageState;
-
-    // Absent, not zero, when no dump is stored: task "" at PC 0 is not a fact about anything,
-    // and `coredump_present` false already carries the whole message. The partition and the
-    // IDF support have existed since the OTA layout was designed; nothing read them until now.
-    doc["coredump_present"] = bridge.coredumpPresent;
-    if (bridge.coredumpPresent && !bridge.coredumpTask.empty()) {
-        doc["coredump_task"] = bridge.coredumpTask;  // std::string: copied into the document
-    } else {
-        doc["coredump_task"] = nullptr;
-    }
-    if (bridge.coredumpPresent) {
-        doc["coredump_pc"] = bridge.coredumpPc;
-    } else {
-        doc["coredump_pc"] = nullptr;
-    }
-    doc["wifi_connected"]            = bridge.wifiConnected;
-    // Only meaningful while associated; 0 dBm would look like an excellent signal.
-    if (bridge.wifiConnected) {
-        doc["wifi_rssi_dbm"] = bridge.wifiRssiDbm;
-    } else {
-        doc["wifi_rssi_dbm"] = nullptr;
-    }
-    json_util::addClockFields(doc.as<JsonObject>(), bridge);
-    doc["poll_success_total"]        = d.pollSuccessTotal;
-    doc["poll_failure_total"]        = d.pollFailureTotal;
-    doc["consecutive_poll_failures"] = d.consecutivePollFailures;
-    doc["checksum_error_total"]      = d.checksumErrorTotal;
-    doc["rs485_timeout_total"]       = d.rs485TimeoutTotal;
-    doc["invalid_frame_total"]       = d.invalidFrameTotal;
-    doc["wifi_reconnect_total"]      = d.wifiReconnectTotal;
-    doc["mqtt_reconnect_total"]      = d.mqttReconnectTotal;
-    doc["modbus_client_connections_total"] = d.modbusClientConnections;
-    doc["rest_requests_total"]       = d.restRequestTotal;
-    doc["mqtt_publish_failure_total"] = d.mqttPublishFailureTotal;
-    doc["last_successful_poll_ms"]   = d.lastSuccessfulPollMs;
-    // Null until the first sample, not 0: same reasoning as the RSSI field above.
-    if (d.rs485StackFreeBytes > 0) {
-        doc["rs485_stack_free_bytes"] = d.rs485StackFreeBytes;
-    } else {
-        doc["rs485_stack_free_bytes"] = nullptr;
-    }
-    if (d.loopStackFreeBytes > 0) {
-        doc["loop_stack_free_bytes"] = d.loopStackFreeBytes;
-    } else {
-        doc["loop_stack_free_bytes"] = nullptr;
-    }
-    // Set from pollResultName() and friends only. Never carries payload bytes or config.
-    doc["last_error"] = d.lastError;
+    // No board name and no mqtt_connected: the board is already the Home Assistant device
+    // model, and a payload that arrived over MQTT cannot report anything but true. See
+    // json_util::writeDiagnostics for why those two are the caller's choice.
+    json_util::writeDiagnostics(doc.to<JsonObject>(), d, bridge, {}, std::nullopt);
     return finish(doc, out, maxBytes);
 }
 

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -371,74 +371,8 @@ bool buildMeasurementsPayload(const DeviceState& state, std::string& out, size_t
 bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bridge,
                              std::string& out, size_t maxBytes) {
     JsonDocument doc;
-    doc["uptime_seconds"]          = bridge.uptimeSeconds;
-    doc["firmware_version"]        = bridge.firmwareVersion;
-    doc["board"]                   = bridge.boardName;
-    doc["free_heap_bytes"]         = bridge.freeHeapBytes;
-    doc["minimum_free_heap_bytes"] = bridge.minFreeHeapBytes;
-    doc["max_alloc_heap_bytes"]    = bridge.maxAllocHeapBytes;
-
-    // Absent, not zero, when the board has none -- and 0 is a legitimate reading for
-    // psram_free_bytes on a board that HAS PSRAM and has exhausted it, so the two must not
-    // collapse onto the same value. Reported at all because the three heap figures above are
-    // MALLOC_CAP_INTERNAL and say nothing about it (audit, 2026-07-26).
-    if (bridge.psramSizeBytes > 0) {
-        doc["psram_size_bytes"] = bridge.psramSizeBytes;
-        doc["psram_free_bytes"] = bridge.psramFreeBytes;
-    } else {
-        doc["psram_size_bytes"] = nullptr;
-        doc["psram_free_bytes"] = nullptr;
-    }
-    doc["reset_reason"]            = bridge.resetReason;
-    doc["ota_image_state"]         = bridge.otaImageState;
-
-    // Absent, not zero, when no dump is stored: task "" at PC 0 is not a fact about anything,
-    // and `coredump_present` false already carries the whole message. The partition and the
-    // IDF support have existed since the OTA layout was designed; nothing read them until now.
-    doc["coredump_present"] = bridge.coredumpPresent;
-    if (bridge.coredumpPresent && !bridge.coredumpTask.empty()) {
-        doc["coredump_task"] = bridge.coredumpTask;  // std::string: copied into the document
-    } else {
-        doc["coredump_task"] = nullptr;
-    }
-    if (bridge.coredumpPresent) {
-        doc["coredump_pc"] = bridge.coredumpPc;
-    } else {
-        doc["coredump_pc"] = nullptr;
-    }
-    doc["wifi_connected"]          = bridge.wifiConnected;
-    if (bridge.wifiConnected) {
-        doc["wifi_rssi_dbm"] = bridge.wifiRssiDbm;
-    } else {
-        doc["wifi_rssi_dbm"] = nullptr;
-    }
-    doc["mqtt_connected"]                  = bridge.mqttConnected;
-    json_util::addClockFields(doc.as<JsonObject>(), bridge);
-    doc["poll_success_total"]              = d.pollSuccessTotal;
-    doc["poll_failure_total"]              = d.pollFailureTotal;
-    doc["consecutive_poll_failures"]       = d.consecutivePollFailures;
-    doc["checksum_error_total"]            = d.checksumErrorTotal;
-    doc["rs485_timeout_total"]             = d.rs485TimeoutTotal;
-    doc["invalid_frame_total"]             = d.invalidFrameTotal;
-    doc["wifi_reconnect_total"]            = d.wifiReconnectTotal;
-    doc["mqtt_reconnect_total"]            = d.mqttReconnectTotal;
-    doc["modbus_client_connections_total"] = d.modbusClientConnections;
-    doc["rest_requests_total"]             = d.restRequestTotal;
-    doc["mqtt_publish_failure_total"] = d.mqttPublishFailureTotal;
-    doc["last_successful_poll_ms"]         = d.lastSuccessfulPollMs;
-    // Null until the first sample, not 0: a monitoring rule on "stack headroom == 0" must
-    // not fire during the first seconds after boot.
-    if (d.rs485StackFreeBytes > 0) {
-        doc["rs485_stack_free_bytes"] = d.rs485StackFreeBytes;
-    } else {
-        doc["rs485_stack_free_bytes"] = nullptr;
-    }
-    if (d.loopStackFreeBytes > 0) {
-        doc["loop_stack_free_bytes"] = d.loopStackFreeBytes;
-    } else {
-        doc["loop_stack_free_bytes"] = nullptr;
-    }
-    doc["last_error"]                      = d.lastError;
+    json_util::writeDiagnostics(doc.to<JsonObject>(), d, bridge, bridge.boardName,
+                                bridge.mqttConnected);
     return finish(doc, out, maxBytes);
 }
 


### PR DESCRIPTION
First of four steps from the codebase audit. Each is its own PR so each stays separately revertable under squash-merge.

## What was wrong

The MQTT and REST diagnostics builders were copies of each other: the same thirty fields, in the same order, under the same null-not-zero rules, down to a **word-for-word duplicated comment** about PSRAM.

`json_util.h` exists precisely to stop this — its opening line reads *"Both the MQTT and REST payload builders had a byte-for-byte copy of these; one definition now."* This block escaped that consolidation because the two builders differ in **two** fields, and two differences were enough to make them look like separate functions rather than one function with parameters.

The cost was never a compile error. It was a field added to one output and silently missing from the other, every test still green, and nothing anywhere to say so.

## What it is now

One `json_util::writeDiagnostics(...)`. Both differences are preserved **exactly**, as parameters rather than as something the shared function decides:

- **`board` is omitted over MQTT.** The board already arrives as the Home Assistant device model, so repeating it on the diagnostics topic says nothing new.
- **`mqtt_connected` is omitted over MQTT.** On a payload that arrived over MQTT the field can only ever read `true` — a fact over REST, a tautology over MQTT.

## No external change, and I checked rather than assumed

Field order was compared **mechanically against `main`, key by key, for both payloads**. Both are identical.

That check mattered: the tests pass either way, because they do not assert every field. Green would not have been evidence.

## Verification

- 811 native tests
- `check_layering.sh` (8 rules), `check_web_js.py`
- `waveshare-rs485-can` and `mock` build
- 135 lines removed, 102 added, and one place left to edit when a diagnostic is added

## Risk

Low. No behavioural change, no API change, and the one thing that could have gone wrong — a field or an ordering quietly shifting — is the thing that was explicitly verified.