### PR TITLE
refactor(modbus): one transaction skeleton, not one per function code

### DIFF
--- a/src/protocols/modbus/modbus_client.cpp
+++ b/src/protocols/modbus/modbus_client.cpp
@@ -3,6 +3,95 @@
 #include "protocols/modbus/modbus_client.h"
 
 namespace heliograph::modbus {
+namespace {
+
+/// What a caller's parse step reports back.
+///
+/// `result` is the codec's verdict on the bytes. `accepted` is the caller's own verdict on a
+/// frame the codec decoded cleanly -- the two are not the same question, and collapsing them
+/// is how a well-formed answer to a different question gets recorded as success.
+struct ParseStep {
+    ParseResult result        = ParseResult::Malformed;
+    bool        accepted      = true;
+    uint8_t     exceptionCode = 0;
+};
+
+/// The half of a Modbus transaction that does not depend on what was asked: send, then read
+/// until the answer parses, the deadline passes, or the line stops making sense.
+///
+/// Written once because it WAS written twice. The read path and the write path carried the
+/// same deadline handling, the same incomplete-frame loop, the same full-buffer bail-out and
+/// the same timeout mapping, in two functions that drifted apart only in their comments. Every
+/// one of those rules is a decision about a bus that answers slowly or not at all, and having
+/// two copies meant a fix to one leaving the other exactly as wrong as before.
+///
+/// A template rather than std::function: this runs per poll on a task with a fixed stack, and
+/// there is no reason to pay for an indirect call and a possible allocation to express "the
+/// caller decides how to parse".
+template <typename ParseFn>
+TransactionOutcome runTransaction(Transport& transport, const uint8_t* req, size_t reqLen,
+                                  const ReadTiming& timing, ParseFn parse) {
+    TransactionOutcome outcome;
+
+    transport.flushInput();
+    if (transport.write(req, reqLen) != reqLen) {
+        outcome.status = TransactionStatus::TransportError;
+        return outcome;
+    }
+
+    uint8_t        rx[kMaxAdu];
+    size_t         have     = 0;
+    const uint64_t deadline = transport.nowMs() + timing.transactionDeadlineMs;
+    for (;;) {
+        // Checked before parsing as well as before reading: a device that keeps dribbling
+        // bytes that never form a frame must still hit the ceiling.
+        if (transport.nowMs() >= deadline) {
+            outcome.status = TransactionStatus::Timeout;
+            return outcome;
+        }
+
+        const ParseStep step = parse(rx, have);
+        switch (step.result) {
+            case ParseResult::Ok:
+                // Decoded cleanly is not the same as acceptable. What `accepted` means is the
+                // caller's business -- see the two call sites, where the reasoning lives.
+                outcome.status = step.accepted ? TransactionStatus::Ok
+                                               : TransactionStatus::Protocol;
+                return outcome;
+            case ParseResult::Exception:
+                outcome.status        = TransactionStatus::Exception;
+                outcome.exceptionCode = step.exceptionCode;
+                return outcome;
+            case ParseResult::Incomplete:
+                break;  // fall through and read more
+            case ParseResult::BadCrc:
+                // The one outcome that indicts the cable rather than the configuration. The
+                // codec has always kept it separate; fusing it here is what made a Modbus
+                // driver unable to ever report a checksum error.
+                outcome.status = TransactionStatus::Crc;
+                return outcome;
+            default:
+                // WrongUnit / WrongFunction / Malformed.
+                outcome.status = TransactionStatus::Protocol;
+                return outcome;
+        }
+
+        if (have >= sizeof(rx)) {
+            // A full ADU of bytes that still does not parse: the bus is not speaking Modbus at
+            // us. Reporting Protocol rather than reading forever.
+            outcome.status = TransactionStatus::Protocol;
+            return outcome;
+        }
+        const size_t n = transport.read(rx + have, sizeof(rx) - have, timing.responseTimeoutMs);
+        if (n == 0) {
+            outcome.status = TransactionStatus::Timeout;
+            return outcome;
+        }
+        have += n;
+    }
+}
+
+}  // namespace
 
 ReadOutcome readRegisters(Transport& transport, uint8_t unitId, uint8_t functionCode,
                           uint16_t start, uint16_t count, uint16_t* out, uint16_t outCapacity,
@@ -21,72 +110,24 @@ ReadOutcome readRegisters(Transport& transport, uint8_t unitId, uint8_t function
         return outcome;
     }
 
-    transport.flushInput();
-    if (transport.write(req, reqLen) != reqLen) {
-        outcome.status = ReadStatus::TransportError;
-        return outcome;
-    }
-
-    uint8_t        rx[kMaxAdu];
-    size_t         have     = 0;
-    const uint64_t deadline = transport.nowMs() + timing.transactionDeadlineMs;
-    for (;;) {
-        // Checked before parsing as well as before reading: a device that keeps dribbling
-        // bytes that never form a frame must still hit the ceiling.
-        if (transport.nowMs() >= deadline) {
-            outcome.status = ReadStatus::Timeout;
-            return outcome;
-        }
-
-        ReadResponse resp;
-        switch (parseReadResponse(rx, have, unitId, functionCode, out, count, resp)) {
-            case ParseResult::Ok:
-                // A reply that decodes cleanly but carries FEWER registers than were asked for
-                // is not success. The codec only checks the byte count against the caller's
-                // buffer capacity, so a short frame leaves the tail of `out` untouched -- while
-                // callers record the block as covering the full count they requested. Whatever
-                // that tail happens to hold is then decoded and published as genuine readings
-                // on a poll reporting Ok: uninitialised scratch in one driver, zeros in another
-                // (and a zero scale factor is legal, so zeros read as a real 0 W). Either way
-                // it defeats the never-fabricate-a-reading rule one layer below where that rule
-                // is enforced (review, 2026-07-25).
-                if (resp.registerCount != count) {
-                    outcome.status = ReadStatus::Protocol;
-                    return outcome;
-                }
-                outcome.status = ReadStatus::Ok;
-                return outcome;
-            case ParseResult::Exception:
-                outcome.status        = ReadStatus::Exception;
-                outcome.exceptionCode = resp.exceptionCode;
-                return outcome;
-            case ParseResult::Incomplete:
-                break;  // fall through and read more
-            case ParseResult::BadCrc:
-                // The one outcome that indicts the cable rather than the configuration. The
-                // codec has always kept it separate; fusing it here is what made a Modbus
-                // driver unable to ever report a checksum error.
-                outcome.status = ReadStatus::Crc;
-                return outcome;
-            default:
-                // WrongUnit / WrongFunction / Malformed.
-                outcome.status = ReadStatus::Protocol;
-                return outcome;
-        }
-
-        if (have >= sizeof(rx)) {
-            // A full ADU of bytes that still does not parse: the bus is not speaking Modbus at
-            // us. Reporting Protocol rather than reading forever.
-            outcome.status = ReadStatus::Protocol;
-            return outcome;
-        }
-        const size_t n = transport.read(rx + have, sizeof(rx) - have, timing.responseTimeoutMs);
-        if (n == 0) {
-            outcome.status = ReadStatus::Timeout;
-            return outcome;
-        }
-        have += n;
-    }
+    return runTransaction(
+        transport, req, reqLen, timing, [&](const uint8_t* rx, size_t have) {
+            ParseStep    step;
+            ReadResponse resp;
+            step.result        = parseReadResponse(rx, have, unitId, functionCode, out, count, resp);
+            step.exceptionCode = resp.exceptionCode;
+            // A reply that decodes cleanly but carries FEWER registers than were asked for is
+            // not success. The codec only checks the byte count against the caller's buffer
+            // capacity, so a short frame leaves the tail of `out` untouched -- while callers
+            // record the block as covering the full count they requested. Whatever that tail
+            // happens to hold is then decoded and published as genuine readings on a poll
+            // reporting Ok: uninitialised scratch in one driver, zeros in another (and a zero
+            // scale factor is legal, so zeros read as a real 0 W). Either way it defeats the
+            // never-fabricate-a-reading rule one layer below where that rule is enforced
+            // (review, 2026-07-25).
+            step.accepted = resp.registerCount == count;
+            return step;
+        });
 }
 
 TransactionOutcome writeSingleRegister(Transport& transport, uint8_t unitId, uint16_t address,
@@ -101,61 +142,20 @@ TransactionOutcome writeSingleRegister(Transport& transport, uint8_t unitId, uin
         return outcome;
     }
 
-    transport.flushInput();
-    if (transport.write(req, reqLen) != reqLen) {
-        outcome.status = TransactionStatus::TransportError;
-        return outcome;
-    }
-
-    uint8_t        rx[kMaxAdu];
-    size_t         have     = 0;
-    const uint64_t deadline = transport.nowMs() + timing.transactionDeadlineMs;
-    for (;;) {
-        if (transport.nowMs() >= deadline) {
-            outcome.status = TransactionStatus::Timeout;
-            return outcome;
-        }
-
-        WriteResponse resp;
-        switch (parseWriteResponse(rx, have, unitId, kWriteSingleRegister, resp)) {
-            case ParseResult::Ok:
-                // The echo is the confirmation. A device that answers with a different address
-                // or a different value has not done what was asked, however well-formed the
-                // frame is -- and treating that as success is how a setpoint silently does not
-                // arrive.
-                if (resp.address != address || resp.value != value) {
-                    outcome.status = TransactionStatus::Protocol;
-                    return outcome;
-                }
-                outcome.status = TransactionStatus::Ok;
-                return outcome;
-            case ParseResult::Exception:
-                // The ordinary answer to a control write that is refused: read-only register,
-                // out-of-range value, or a device that wants an unlock first.
-                outcome.status        = TransactionStatus::Exception;
-                outcome.exceptionCode = resp.exceptionCode;
-                return outcome;
-            case ParseResult::Incomplete:
-                break;  // fall through and read more
-            case ParseResult::BadCrc:
-                outcome.status = TransactionStatus::Crc;
-                return outcome;
-            default:
-                outcome.status = TransactionStatus::Protocol;
-                return outcome;
-        }
-
-        if (have >= sizeof(rx)) {
-            outcome.status = TransactionStatus::Protocol;
-            return outcome;
-        }
-        const size_t n = transport.read(rx + have, sizeof(rx) - have, timing.responseTimeoutMs);
-        if (n == 0) {
-            outcome.status = TransactionStatus::Timeout;
-            return outcome;
-        }
-        have += n;
-    }
+    return runTransaction(
+        transport, req, reqLen, timing, [&](const uint8_t* rx, size_t have) {
+            ParseStep     step;
+            WriteResponse resp;
+            step.result        = parseWriteResponse(rx, have, unitId, kWriteSingleRegister, resp);
+            // The ordinary answer to a control write that is refused: read-only register,
+            // out-of-range value, or a device that wants an unlock first.
+            step.exceptionCode = resp.exceptionCode;
+            // The echo is the confirmation. A device that answers with a different address or
+            // a different value has not done what was asked, however well-formed the frame is
+            // -- and treating that as success is how a setpoint silently does not arrive.
+            step.accepted = resp.address == address && resp.value == value;
+            return step;
+        });
 }
 
 }  // namespace heliograph::modbus

--- a/src/protocols/modbus/modbus_client.cpp
+++ b/src/protocols/modbus/modbus_client.cpp
@@ -114,7 +114,9 @@ ReadOutcome readRegisters(Transport& transport, uint8_t unitId, uint8_t function
         transport, req, reqLen, timing, [&](const uint8_t* rx, size_t have) {
             ParseStep    step;
             ReadResponse resp;
-            step.result        = parseReadResponse(rx, have, unitId, functionCode, out, count, resp);
+            step.result = parseReadResponse(rx, have, unitId, functionCode, out, count, resp);
+            // Read on every pass, acted on only when the result is Exception. Zero otherwise,
+            // because both response structs default-initialise every member.
             step.exceptionCode = resp.exceptionCode;
             // A reply that decodes cleanly but carries FEWER registers than were asked for is
             // not success. The codec only checks the byte count against the caller's buffer
@@ -146,9 +148,12 @@ TransactionOutcome writeSingleRegister(Transport& transport, uint8_t unitId, uin
         transport, req, reqLen, timing, [&](const uint8_t* rx, size_t have) {
             ParseStep     step;
             WriteResponse resp;
-            step.result        = parseWriteResponse(rx, have, unitId, kWriteSingleRegister, resp);
-            // The ordinary answer to a control write that is refused: read-only register,
-            // out-of-range value, or a device that wants an unlock first.
+            step.result = parseWriteResponse(rx, have, unitId, kWriteSingleRegister, resp);
+            // Carried out of the response whatever the verdict; the skeleton reads it only
+            // when the result IS Exception. That case is the ordinary answer to a refused
+            // control write -- a read-only register, an out-of-range value, or a device that
+            // wants an unlock first -- which is why it is a status of its own rather than a
+            // protocol error.
             step.exceptionCode = resp.exceptionCode;
             // The echo is the confirmation. A device that answers with a different address or
             // a different value has not done what was asked, however well-formed the frame is


### PR DESCRIPTION
Second of four steps from the codebase audit.

## What was wrong

`readRegisters` and `writeSingleRegister` carried the same thirty lines twice: flush and send, the deadline check, the incomplete-frame loop, the full-buffer bail-out, the timeout mapping.

Every one of those is a decision about a bus that answers slowly or not at all. Two copies meant a fix to one would leave the other exactly as wrong as before. I introduced the second copy myself, in #80.

## What it is now

One `runTransaction()`, with the caller supplying the part that genuinely differs: **how to parse**, and **what counts as an acceptable answer**.

Those are two questions, not one — a frame the codec decodes cleanly can still be the answer to a different question, which is precisely why the read path checks the register count and the write path checks the echo. `ParseStep` keeps them apart instead of collapsing them into a single bool.

A **template** rather than `std::function`: this runs per poll on a task with a fixed stack, and there is no reason to pay for an indirect call and a possible allocation to express "the caller decides how to parse".

## This is not a line-count win, and I am not selling it as one

94 lines in, 94 out. The comments carry reasoning worth more than the lines they cost, so they stayed.

What did change is measurable:

| | main | here |
|---|---|---|
| repeated 7-line blocks | 1 | 0 |
| code lines, comments excluded | 122 | 103 |

## No behaviour change, checked rather than assumed

The shared skeleton reads `resp` on **every** pass, including `Incomplete`, which the old code never did. Both `ReadResponse` and `WriteResponse` default-initialise every member (`= 0`), so those reads are defined and yield zeros nothing acts on — `accepted` is only consulted on `Ok`, `exceptionCode` only on `Exception`.

## Verification

- 811 native tests, including the full Modbus, SunSpec and Growatt suites
- `check_layering.sh` (8 rules)
- `waveshare-rs485-can` and `mock` build clean under `-Wall -Wextra`

## Risk

Low, but higher than [#95](https://github.com/Timdebruijn/heliograph/pull/95): this is the RS485 read path every Modbus inverter depends on. The behaviour is covered by existing tests that exercise Ok, Exception, BadCrc, Incomplete, timeout and short-frame cases through a fake transport — none of which needed changing, which is itself the evidence.