### PR TITLE
refactor(rest): the body guard is one rule, written once

### DIFF
--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -106,6 +106,17 @@ bool RestApi::bodyAlreadyAnswered(AsyncWebServerRequest* request) {
     return true;
 }
 
+bool RestApi::bodyMissing(AsyncWebServerRequest* request, const char* expected) {
+    if (bodyAlreadyAnswered(request)) {
+        return true;
+    }
+    if (bodyOwner_ != request) {
+        sendError(request, {400, "empty_body", expected});
+        return true;
+    }
+    return false;
+}
+
 void RestApi::releaseBody() {
     bodyOwner_    = nullptr;
     bodyRejected_ = nullptr;
@@ -229,14 +240,7 @@ bool RestApi::begin() {
         [this, authorised](AsyncWebServerRequest* request) {
             // The request handler forms the response; the body handler only collects. If the
             // body never completed, nothing was queued and this is a genuinely empty POST.
-            // collectBody may already have answered (413 too large, 409 busy). send()
-            // replaces the stored response, so falling through to the generic error below
-            // would overwrite the real reason with "a JSON body is required".
-            if (bodyAlreadyAnswered(request)) {
-                return;
-            }
-            if (bodyOwner_ != request) {
-                sendError(request, {400, "empty_body", "a JSON body is required"});
+            if (bodyMissing(request, "a JSON body is required")) {
                 return;
             }
             if (!context_.portalActive || !context_.portalActive()) {
@@ -515,14 +519,7 @@ bool RestApi::begin() {
                 releaseBody();
                 return;
             }
-            // collectBody may already have answered (413 too large, 409 busy). send()
-            // replaces the stored response, so falling through to the generic error below
-            // would overwrite the real reason with "a JSON body is required".
-            if (bodyAlreadyAnswered(request)) {
-                return;
-            }
-            if (bodyOwner_ != request) {
-                sendError(request, {400, "empty_body", "a JSON body is required"});
+            if (bodyMissing(request, "a JSON body is required")) {
                 return;
             }
 
@@ -692,14 +689,7 @@ bool RestApi::begin() {
                 releaseBody();
                 return;  // authorised() stored the 401
             }
-            // collectBody may already have answered (413 too large, 409 busy). send()
-            // replaces the stored response, so falling through to the generic error below
-            // would overwrite the real reason with "a backup file is required".
-            if (bodyAlreadyAnswered(request)) {
-                return;
-            }
-            if (bodyOwner_ != request) {
-                sendError(request, {400, "empty_body", "a backup file is required"});
+            if (bodyMissing(request, "a backup file is required")) {
                 return;
             }
             BackupContents contents;
@@ -1283,6 +1273,9 @@ bool RestApi::collectBody(AsyncWebServerRequest*, const uint8_t*, size_t, size_t
     return false;
 }
 bool RestApi::bodyAlreadyAnswered(AsyncWebServerRequest*) { return false; }
+// No server, so no body ever arrives -- and nothing on this build calls it. Stubbed for the
+// same reason as its neighbours: the header declares one class for both builds.
+bool RestApi::bodyMissing(AsyncWebServerRequest*, const char*) { return true; }
 
 void RestApi::releaseBody() {
     bodyOwner_    = nullptr;

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -139,6 +139,18 @@ private:
     /// Same lesson the OTA route learned with its _tempObject marker, arrived at from the
     /// other direction: there it was the specific error being replaced by a generic one.
     bool bodyAlreadyAnswered(AsyncWebServerRequest* request);
+
+    /// True when the handler must stop: either the body handler already answered, or no body
+    /// arrived at all. `expected` names what was wanted, because "a JSON body" and "a backup
+    /// file" are different things to whoever is reading the error.
+    ///
+    /// One function because the ORDER of those two checks is the whole point and it was
+    /// written out three times. Ask "was this already answered?" first: collectBody may have
+    /// stored a 413 or a 409, and send() replaces the stored response, so testing for a
+    /// missing body first would overwrite the real reason with a generic one. Three copies of
+    /// a rule that is only correct in one order is three chances to get it wrong, and a fourth
+    /// route would have been a fourth.
+    bool bodyMissing(AsyncWebServerRequest* request, const char* expected);
     void releaseBody();
 
     RestContext context_;


### PR DESCRIPTION
Third of four steps from the codebase audit.

## What was wrong

Three route handlers (`POST /provision`, `PATCH /config`, `POST /config/restore`) opened with the same seven lines and the same three-line comment.

**The order of the two checks is the whole point.** `collectBody` may have stored a 413 (too large) or a 409 (busy), and `send()` replaces the stored response — so asking "is the body missing?" first overwrites the real reason with a generic one. Upload a file one byte over the limit and the API says the body was missing.

That is a bug this codebase has already had and fixed. It was then written out three times, which is three chances to get it wrong, and would have been four at the next route.

## What it is now

One `bodyMissing(request, expected)`. The message stays a parameter, because "a JSON body is required" and "a backup file is required" are different things to whoever reads the error.

Stubbed in the host section as well, next to `bodyAlreadyAnswered`, following the convention this file already uses: one class declared for both builds, two definitions.

## Verification

- 811 native tests
- `check_layering.sh` (8 rules)
- `waveshare-rs485-can` and `mock` build clean

## Risk

Low. No behaviour change: the same two checks in the same order, returning the same errors. The consolidation is mechanical — the regex that performed it required an exact match of all seven lines plus the comment, so a site that differed would not have been touched silently.