### PR TITLE
refactor(registry): one answer to "is this the same driver?"

### DIFF
--- a/src/drivers/driver_registry.cpp
+++ b/src/drivers/driver_registry.cpp
@@ -98,13 +98,25 @@ bool validateDriverOptions(const DriverDescriptor& descriptor, const DriverOptio
     return true;
 }
 
+DriverRegistry::Entry* DriverRegistry::findEntry(const std::string& driverId) {
+    const auto it = std::find_if(entries_.begin(), entries_.end(), [&](const Entry& e) {
+        return e.descriptor.id == driverId;
+    });
+    return it == entries_.end() ? nullptr : &*it;
+}
+
+const DriverRegistry::Entry* DriverRegistry::findEntry(const std::string& driverId) const {
+    const auto it = std::find_if(entries_.begin(), entries_.end(), [&](const Entry& e) {
+        return e.descriptor.id == driverId;
+    });
+    return it == entries_.end() ? nullptr : &*it;
+}
+
 void DriverRegistry::registerDriver(const DriverDescriptor& descriptor, DriverFactory factory) {
-    for (auto& e : entries_) {
-        if (e.descriptor.id == descriptor.id) {
-            e.descriptor = descriptor;
-            e.factory    = std::move(factory);
-            return;
-        }
+    if (Entry* existing = findEntry(descriptor.id); existing != nullptr) {
+        existing->descriptor = descriptor;
+        existing->factory    = std::move(factory);
+        return;
     }
     entries_.push_back(Entry{descriptor, std::move(factory)});
 }
@@ -125,12 +137,8 @@ std::vector<DriverDescriptor> DriverRegistry::availableDrivers() const {
 }
 
 const DriverDescriptor* DriverRegistry::find(const std::string& driverId) const {
-    for (const auto& e : entries_) {
-        if (e.descriptor.id == driverId) {
-            return &e.descriptor;
-        }
-    }
-    return nullptr;
+    const Entry* entry = findEntry(driverId);
+    return entry == nullptr ? nullptr : &entry->descriptor;
 }
 
 bool DriverRegistry::contains(const std::string& driverId) const {

--- a/src/drivers/driver_registry.cpp
+++ b/src/drivers/driver_registry.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 
 #include <algorithm>
+#include <utility>
 
 #if ENABLE_DRIVER_EVERSOLAR
 #include "eversolar_legacy/eversolar_driver.h"
@@ -98,18 +99,21 @@ bool validateDriverOptions(const DriverDescriptor& descriptor, const DriverOptio
     return true;
 }
 
-DriverRegistry::Entry* DriverRegistry::findEntry(const std::string& driverId) {
+const DriverRegistry::Entry* DriverRegistry::findEntry(const std::string& driverId) const {
     const auto it = std::find_if(entries_.begin(), entries_.end(), [&](const Entry& e) {
         return e.descriptor.id == driverId;
     });
     return it == entries_.end() ? nullptr : &*it;
 }
 
-const DriverRegistry::Entry* DriverRegistry::findEntry(const std::string& driverId) const {
-    const auto it = std::find_if(entries_.begin(), entries_.end(), [&](const Entry& e) {
-        return e.descriptor.id == driverId;
-    });
-    return it == entries_.end() ? nullptr : &*it;
+// The non-const overload in terms of the const one, rather than a second copy of the search.
+// Writing the loop twice would have put a fresh duplicate in the change whose whole point is
+// removing one -- and the two could then disagree, which is exactly the failure being fixed.
+//
+// The const_cast is the safe direction of the standard idiom: *this is genuinely non-const
+// here, so casting away a constness this function itself added removes nothing real.
+DriverRegistry::Entry* DriverRegistry::findEntry(const std::string& driverId) {
+    return const_cast<Entry*>(std::as_const(*this).findEntry(driverId));
 }
 
 void DriverRegistry::registerDriver(const DriverDescriptor& descriptor, DriverFactory factory) {

--- a/src/drivers/driver_registry.h
+++ b/src/drivers/driver_registry.h
@@ -47,6 +47,16 @@ private:
         DriverDescriptor descriptor;
         DriverFactory    factory;
     };
+
+    /// The one place that knows how a driver id is matched, or nullptr.
+    ///
+    /// registerDriver() and find() each walked entries_ themselves, which meant two answers to
+    /// "is this the same driver?" that happened to agree. They must agree: registerDriver()
+    /// REPLACES on a match, so a lookup that disagreed with it would quietly register a second
+    /// entry the finder could never reach.
+    Entry*       findEntry(const std::string& driverId);
+    const Entry* findEntry(const std::string& driverId) const;
+
     std::vector<Entry> entries_;
 };
 


### PR DESCRIPTION
Fourth and last step from the codebase audit.

## What was wrong

`registerDriver()` and `find()` each walked `entries_` themselves — two implementations of "is this the same driver?" that happened to agree.

They **must** agree. `registerDriver()` *replaces* on a match, so a lookup that disagreed with it would quietly register a second entry that the finder could never reach.

## What it is now

One private `findEntry()`, const and non-const. The two callers become two lines each.

## On the other five `useStlAlgorithm` hits

cppcheck flags six raw loops. **I changed one.** The other five are `push_back` inside a range-for, and `std::transform` with a `back_inserter` and a lambda is *longer* and reads worse. Swapping clear code for an algorithm to satisfy a linter is not an improvement, and the brief asks for less code, not more.

One of the five is in `profiles_generated.cpp`, which is machine-written and never read for maintenance — that one would mean changing the generator to no benefit at all.

This one genuinely shrinks (six lines to two at the call site) and, more to the point, it is the only one where the loop was a *duplicated rule* rather than just a loop.

## Verification

- 811 native tests, including the full driver-registry suite
- `check_layering.sh` (8 rules)
- `waveshare-rs485-can` and `mock` build clean

## Risk

Very low. Pure extraction, no behaviour change, and the registry is covered by its own test suite.