### PR TITLE
ci: refuse a tag that disagrees with the version the firmware reports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # FIRST, and before anything is installed: this needs only the checkout, fails in under a
+      # second, and its whole point is to stop a release that would ship a firmware reporting a
+      # different version than the one being published. Everything below is wasted work when
+      # the two disagree.
+      - name: Tag matches the version the firmware reports
+        run: bash tools/check_version.sh
+
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -159,3 +159,40 @@ Environments: one per board (`waveshare-rs485-can`, `waveshare-relay-1ch`, `wave
 
 The partition table gets **two app partitions** (`ota_0`/`ota_1`) plus `otadata`, which
 fits comfortably on 16 MB. A failed OTA thereby falls back to the previous partition.
+
+## Decision 4: the tag and the firmware must agree, and something must check it
+
+A release has **two** version numbers. The workflow takes its number from the tag name
+(`GITHUB_REF_NAME`); the firmware reports the `#define`s in `src/main.cpp`, and that is what
+reaches `/api/v1/status`, the Modbus identity block and the Home Assistant device.
+
+Nothing compared them. Tag without bumping and every bridge reports the old number while
+`latest.json` advertises the new one — and the dashboard's update check compares exactly those
+two, so it offers the same update forever, to everyone, until somebody notices by hand.
+
+This was a manual step through 0.18.0, 0.18.1 and 0.18.2, and went right three times only
+because someone remembered each time. That is not a property to rely on.
+
+`tools/check_version.sh` now runs as the **first** step of the release workflow, before
+anything is installed: it needs only the checkout and fails in under a second, because
+everything after it is wasted work when the two numbers disagree.
+
+It is also the pre-flight check to run by hand before creating a tag:
+
+```
+tools/check_version.sh            # what does the firmware declare?
+tools/check_version.sh v0.19.0    # would this tag be honest?
+```
+
+Two deliberate properties:
+
+- **A pre-release keeps the version of the release it leads to.** `v0.19.0-rc1` matches a
+  source declaring `0.19.0`; requiring the label in the source would mean a commit per
+  release candidate.
+- **Wired into the wrong workflow, it does nothing rather than breaking.** In ordinary CI
+  `GITHUB_REF_NAME` holds a branch name, and a check that read `main` as a version would fail
+  every pull request for a reason unrelated to the change. An explicit argument is always
+  checked; the environment variable only when it looks like a release tag.
+
+The release procedure is therefore: bump the defines, merge that, **then** tag the merge
+commit. Never move a tag onto a build that reports a different number.

--- a/tools/check_version.sh
+++ b/tools/check_version.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# Refuses a tag that disagrees with the version the firmware reports about itself.
+#
+# There are two versions in a release and nothing used to compare them. The workflow takes its
+# number from the TAG NAME; the firmware reports the #defines in src/main.cpp, and that is what
+# lands in /api/v1/status, the Modbus identity block and the Home Assistant device. Tag without
+# bumping and every bridge reports the old number while latest.json advertises the new one --
+# and the dashboard's update check compares exactly those two, so it offers the same update
+# forever, to everyone, until somebody notices.
+#
+# That is not hypothetical: the bump was a manual step through 0.18.0, 0.18.1 and 0.18.2, and
+# went right three times only because someone remembered.
+#
+# Usage:
+#   tools/check_version.sh            # print what the firmware declares
+#   tools/check_version.sh v0.19.0    # check a tag before creating it
+#   GITHUB_REF_NAME=v0.19.0 tools/check_version.sh
+set -euo pipefail
+
+source_file="src/main.cpp"
+
+read_define() {
+    # The define, not the rendered string: the string is assembled by the preprocessor and
+    # cannot be read out of the source without one.
+    local name="$1"
+    local value
+    value=$(grep -oE "^#define ${name} [0-9]+" "$source_file" | grep -oE '[0-9]+$' || true)
+    if [ -z "$value" ]; then
+        echo "check_version: cannot read ${name} from ${source_file}" >&2
+        exit 2
+    fi
+    printf '%s' "$value"
+}
+
+declared="$(read_define HELIOGRAPH_VERSION_MAJOR).$(read_define HELIOGRAPH_VERSION_MINOR).$(read_define HELIOGRAPH_VERSION_PATCH)"
+
+# An explicit argument is always checked. GITHUB_REF_NAME is only checked when it LOOKS like a
+# release tag -- in ordinary CI that variable holds a branch name, and a version check that
+# tried to read "main" as a version would fail every pull request for a reason that has nothing
+# to do with the change. Being wired into the wrong workflow should do nothing, not break it.
+tag="${1:-}"
+if [ -z "$tag" ]; then
+    case "${GITHUB_REF_NAME:-}" in
+        v[0-9]*) tag="$GITHUB_REF_NAME" ;;
+    esac
+fi
+if [ -z "$tag" ]; then
+    echo "$declared"
+    exit 0
+fi
+
+# A pre-release keeps the version of the release it leads to: v0.19.0-rc1 is 0.19.0 with a
+# label, and requiring the label in the source would mean a commit per release candidate.
+wanted="${tag#v}"
+wanted="${wanted%%-*}"
+
+if [ "$wanted" != "$declared" ]; then
+    cat >&2 <<EOF
+check_version: FAIL
+
+  tag says           ${tag}  (version ${wanted})
+  ${source_file} declares  ${declared}
+
+The firmware would report ${declared} while the release advertises ${wanted}. Every bridge
+would then be offered this update forever, because the dashboard compares those two numbers.
+
+Fix: set the defines in ${source_file} to ${wanted}, merge that, and tag the merge commit.
+Never move the tag onto a build that reports a different number.
+EOF
+    exit 1
+fi
+
+echo "check_version: OK (${tag} matches ${source_file})"


### PR DESCRIPTION
The thing I flagged three times today, now built.

## The problem

A release carries **two** version numbers:

- the workflow takes its number from the **tag name** (`GITHUB_REF_NAME`)
- the firmware reports the **`#define`s** in `src/main.cpp`, which is what reaches `/api/v1/status`, the Modbus identity block and the Home Assistant device

**Nothing compared them.** Tag without bumping and every bridge reports the old number while `latest.json` advertises the new one — and the dashboard's update check compares exactly those two, so it offers the same update *forever*, to *everyone*, until somebody notices by hand.

Three tags today — 0.18.0, 0.18.1, 0.18.2 — each needed that bump as a separate manual step. Each went right only because someone remembered. Remembering is not a property to build a release process on.

## What this adds

`tools/check_version.sh`, wired as the **first** step of the release workflow, before anything is installed: it needs only the checkout and fails in under a second, because everything after it is wasted work when the two numbers disagree.

It is also runnable by hand, which is where it is worth most — *before* the tag exists rather than after:

```bash
tools/check_version.sh v0.19.0
```

## Two deliberate properties, both about not being fragile

**A pre-release keeps the version of the release it leads to.** `v0.19.0-rc1` matches a source declaring `0.19.0`. Requiring the label in the source would mean a commit per release candidate.

**Wired into the wrong workflow it does nothing rather than breaking.** In ordinary CI `GITHUB_REF_NAME` holds a *branch* name, and a check that read `main` as a version would fail every pull request for a reason unrelated to the change. An explicit argument is always checked; the environment variable only when it looks like a release tag.

## Verification

All four paths exercised by hand:

| input | result |
|---|---|
| no argument | prints `0.18.2` |
| `v0.18.2` | OK |
| `v0.18.2-rc1` | OK |
| `v9.9.9` | fails, with the fix spelled out |
| `GITHUB_REF_NAME=main` | inert, exit 0 |

Workflow YAML parsed and the step confirmed to sit second, right after `checkout`. `check_layering.sh` passes. The procedure is written up in `docs/decisions.md`.

## Risk

None to the firmware — this touches no shipped code. The one risk is a false refusal blocking a legitimate release; that is why the pre-release and wrong-workflow cases are handled explicitly rather than left to a naive string compare.