### PR TITLE
Release 0.19.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,9 +128,16 @@ namespace {
 // one field that exists to hold a name in somebody's own language. The fix was written during
 // the 0.18.0 review and pushed to a branch whose pull request had already been merged, where it
 // sat, invisible, through two tags.
+// 0.19.0 changes nothing a bridge does. It is the cleanup pass: the diagnostics payload, the
+// Modbus transaction skeleton, the REST body guard and the driver lookup each existed twice and
+// now exist once, so a rule can no longer be fixed in one copy and left wrong in the other. The
+// audit that preceded it found no warnings, no deprecated dependencies and no dead code, which
+// is the more useful finding and is why this release is small. What it does add is a guard:
+// the release workflow now refuses a tag that disagrees with the version below, because three
+// releases in a row that agreed only because someone remembered is not a process.
 #define HELIOGRAPH_VERSION_MAJOR 0
-#define HELIOGRAPH_VERSION_MINOR 18
-#define HELIOGRAPH_VERSION_PATCH 2
+#define HELIOGRAPH_VERSION_MINOR 19
+#define HELIOGRAPH_VERSION_PATCH 0
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Version bump. **Nothing a bridge does changes** — this is the cleanup pass plus the release guard.

## What 0.19.0 contains

| PR | What |
|---|---|
| [#95](https://github.com/Timdebruijn/heliograph/pull/95) | One diagnostics payload instead of two copies |
| [#96](https://github.com/Timdebruijn/heliograph/pull/96) | One Modbus transaction skeleton instead of one per function code |
| [#97](https://github.com/Timdebruijn/heliograph/pull/97) | One REST body guard instead of three |
| [#98](https://github.com/Timdebruijn/heliograph/pull/98) | One driver-registry lookup instead of two |
| [#99](https://github.com/Timdebruijn/heliograph/pull/99) | The release workflow refuses a tag that disagrees with the firmware's version |

Four pieces of logic that existed twice now exist once, so a rule can no longer be fixed in one copy and left wrong in the other.

## The audit's real finding

Three of five categories were **empty**: no warnings under `-Wall -Wextra`, no outdated or deprecated dependencies (checked upstream, not from memory), and no dead code. cppcheck's 229 findings were almost all false positives — two that looked genuine turned out to be RAII and a range cppcheck cannot see, and "fixing" the first would have introduced a real bug where none existed.

That is why this release is small. Most of the work was establishing there was little to do.

## Note on the version number

Strictly this is a patch: no external behaviour changed and no API moved. Tagged 0.19.0 at Tim's instruction — recording the observation, not disputing the call.

## Verification on this exact tree

- 811 native tests
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py`
- All four targets build; the binary reports `0.19.0`, read from the binary rather than the source
- `tools/check_version.sh v0.19.0` passes — the guard's first use in anger

## What this release will prove

`release.yml` runs on tags only, so [#99](https://github.com/Timdebruijn/heliograph/pull/99)'s wiring has never executed. Tagging this is its first real run. If the step is wrong the release fails at its first job, before any binary is built or asset published.