### PR TITLE
dashboard: the fleet strip folds when it cannot fit, and CI now asserts both shapes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       # No browser is installed here on purpose: the check fails loudly when it cannot find one,
       # so a runner image that stops shipping Chrome shows up as a red check rather than as a
       # layout check that quietly stopped rendering anything.
-      - name: Dashboard layout
+      - name: Fleet strip layout
         run: python3 tools/check_dashboard_layout.py
 
       - name: Canonical measurement ids are enumerable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,16 @@ jobs:
       - name: Embedded JS syntax
         run: python3 tools/check_web_js.py
 
+      # Renders the dashboard in the Chrome that ships with the runner image and asserts its
+      # LAYOUT. 0.18.0 shipped a table that broke every row onto a second line and nothing
+      # caught it -- the suite asserts what the page says, never how it comes out.
+      #
+      # No browser is installed here on purpose: the check fails loudly when it cannot find one,
+      # so a runner image that stops shipping Chrome shows up as a red check rather than as a
+      # layout check that quietly stopped rendering anything.
+      - name: Dashboard layout
+        run: python3 tools/check_dashboard_layout.py
+
       - name: Canonical measurement ids are enumerable
         run: python3 tools/check_measurement_ids.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,16 @@ jobs:
       - name: Embedded JS syntax
         run: python3 tools/check_web_js.py
 
+      # Renders the dashboard in the Chrome that ships with the runner image and asserts its
+      # LAYOUT. 0.18.0 shipped a table that broke every row onto a second line and nothing
+      # caught it -- the suite asserts what the page says, never how it comes out.
+      #
+      # No browser is installed here on purpose: the check fails loudly when it cannot find one,
+      # so a runner image that stops shipping Chrome shows up as a red check rather than as a
+      # layout check that quietly stopped rendering anything.
+      - name: Dashboard layout
+        run: python3 tools/check_dashboard_layout.py
+
       - name: Native test suite
         run: pio test -e native
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       # No browser is installed here on purpose: the check fails loudly when it cannot find one,
       # so a runner image that stops shipping Chrome shows up as a red check rather than as a
       # layout check that quietly stopped rendering anything.
-      - name: Dashboard layout
+      - name: Fleet strip layout
         run: python3 tools/check_dashboard_layout.py
 
       - name: Native test suite

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -46,6 +46,28 @@ table{width:100%;border-collapse:collapse;font-size:14px}
 td,th{text-align:left;padding:7px 8px;border-bottom:1px solid var(--line)}
 th{color:var(--dim);font-weight:500;font-size:12px;text-transform:uppercase}
 td.n{text-align:right;font-variant-numeric:tabular-nums}
+/* The fleet strip has two shapes. Above 760px it stays a table, on its own merits: four
+   inverters are compared by scanning one column, which a stack of blocks cannot do. Below it,
+   the same table folds into one block per inverter.
+   Reported from hardware: at 390px the table showed the device NAMES and nothing else -- every
+   reading sat behind a horizontal scrollbar, which is not a reading.
+   NOTHING is hidden by the fold. Every value keeps its own label, which is the whole difference
+   between reshaping and the column-hiding this file has always refused: a column dropped below
+   a breakpoint is the reading you went looking for, gone.
+   A CONTAINER query, not a media query -- the strip answers to its own width, so it stays right
+   if it is ever placed in a narrow column on a wide screen. */
+.strip{container-type:inline-size}
+@container (max-width:760px){
+  .strip table,.strip tbody,.strip tr,.strip td{display:block;width:auto}
+  .strip tr:first-child{display:none}
+  .strip table{min-width:0 !important}
+  .strip tr{border:1px solid var(--line);border-radius:10px;padding:10px 12px;margin-bottom:10px}
+  .strip td{text-align:left !important;padding:3px 0;display:flex;justify-content:space-between;
+            gap:16px;border:0}
+  .strip td:first-child{display:block;font-weight:600;margin-bottom:7px}
+  .strip td[data-label]::before{content:attr(data-label);color:var(--dim);font-size:12px;
+                                font-weight:400}
+}
 .dim{color:var(--dim)}.hide{display:none}
 .tag{font-size:11px;padding:2px 7px;border-radius:99px;border:1px solid var(--line);color:var(--dim)}
 a.tag{text-decoration:none;border-color:#2f81f7;color:#2f81f7}
@@ -422,14 +444,16 @@ function fleetStrip(fleet){
     const cell=c=>{
       const v=f[c.k];
       const has=v!==null&&v!==undefined;
-      if(!c.state||!has) return `<td class="n">${esc(num(v,c))}</td>`;
+      // data-label carries the column heading INTO the cell. Stacked, the header row is gone,
+      // so without this a block would be a column of unlabelled numbers.
+      if(!c.state||!has) return `<td class="n" data-label="${esc(c.t)}">${esc(num(v,c))}</td>`;
       const state=c.state(v);
-      return `<td class="n" title="${esc(state)}" style="color:${battColour[state]}">${
-        esc(num(v,c))}</td>`;
+      return `<td class="n" data-label="${esc(c.t)}" title="${esc(state)}" style="color:${
+        battColour[state]}">${esc(num(v,c))}</td>`;
     };
     return `<tr><td><span class="dot ${answering?'ok':'bad'}"></span>${named}</td>
       ${cols.map(cell).join('')}
-      <td class="n">${when}</td></tr>`;
+      <td class="n" data-label="Last reply">${when}</td></tr>`;
   }).join('');
   // Scrolls rather than squeezes: even four columns do not fit a phone, and hiding them below
   // a breakpoint means the reading you went looking for is the one that is not there.
@@ -450,7 +474,7 @@ function fleetStrip(fleet){
        ${key('discharging','the house is running on it')}
        ${key('idle','')}</div>`
     : '';
-  return `<div class="card" style="margin-top:14px"><div style="overflow-x:auto"><table style="min-width:${width}px;white-space:nowrap">
+  return `<div class="card strip" style="margin-top:14px"><div style="overflow-x:auto"><table style="min-width:${width}px;white-space:nowrap">
     <tr><th>Inverter</th>${cols.map(c=>`<th style="text-align:right">${c.t}</th>`).join('')}
     <th style="text-align:right">Last reply</th></tr>${rows}</table></div>${legend}</div>`;
 }

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -119,7 +119,12 @@ document.title = fail.length ? 'LAYOUT-FAIL ' + fail.join(' || ') : 'LAYOUT-OK';
 
 
 def find_chrome() -> str | None:
-    for name in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser"):
+    for name in (
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+    ):
         found = shutil.which(name)
         if found:
             return found
@@ -142,7 +147,7 @@ def main() -> int:
         print("dashboard layout: FAIL (fleetStrip not found)")
         return 1
     end = joined.find("\nfunction ", start + 10)
-    fleet_strip = joined[start:end if end > 0 else len(joined)]
+    fleet_strip = joined[start : end if end > 0 else len(joined)]
 
     chrome = find_chrome()
     if chrome is None:
@@ -156,21 +161,35 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="heliograph-layout-") as scratch:
         for width in WIDTHS:
             page = pathlib.Path(scratch) / f"dashboard-{width}.html"
-            page.write_text(PAGE % {
-                "style": style.group(1), "script": fleet_strip,
-                "fleet": FLEET, "width": width,
-            })
+            page.write_text(
+                PAGE
+                % {
+                    "style": style.group(1),
+                    "script": fleet_strip,
+                    "fleet": FLEET,
+                    "width": width,
+                }
+            )
             result = subprocess.run(
                 [
-                    chrome, "--headless", "--disable-gpu", "--no-sandbox",
-                    f"--window-size={width},700", "--virtual-time-budget=2000",
-                    "--dump-dom", page.as_uri(),
+                    chrome,
+                    "--headless",
+                    "--disable-gpu",
+                    "--no-sandbox",
+                    f"--window-size={width},700",
+                    "--virtual-time-budget=2000",
+                    "--dump-dom",
+                    page.as_uri(),
                 ],
-                capture_output=True, text=True, timeout=120,
+                capture_output=True,
+                text=True,
+                timeout=120,
             )
             verdict = re.search(r"<title>(LAYOUT-[^<]*)</title>", result.stdout)
             if verdict is None:
-                print(f"dashboard layout @{width}px: FAIL (no verdict; the page did not run)")
+                print(
+                    f"dashboard layout @{width}px: FAIL (no verdict; the page did not run)"
+                )
                 print(result.stderr[-600:])
                 status = 1
                 continue

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 #
-# Renders the dashboard in a real browser and asserts its LAYOUT, not its pixels.
+# Renders part of the dashboard in a real browser and asserts its LAYOUT, not its pixels.
+#
+# SCOPE, stated plainly because a green tick here is easy to over-read: this covers the
+# per-inverter fleet strip and nothing else. The status cards, the settings tab, the logs tab
+# and the setup portal are NOT rendered by it. It is named for the file it may grow into, not
+# for the ground it currently covers -- and the CI step is named for the strip, so a passing
+# check does not quietly claim the page is fine.
+#
+# The invariant it asserts is per CELL, not per row: a numeric cell or a column header must
+# occupy one line. Rows are deliberately NOT compared, because the device-name cell is two
+# lines by design when a device has a label, with the id underneath in small type.
 #
 # 0.18.0 shipped a table that scrolled sideways and broke every cell onto a second line, and
 # nothing caught it: the tests assert what the page SAYS, never how it comes out. It was found
@@ -10,7 +20,7 @@
 # Deliberately not a screenshot comparison. A committed baseline image would have to survive a
 # different font stack on a CI runner than on the machine that generated it, and a check that
 # cries wolf gets switched off -- which is worse than not having it. What broke in 0.18.0 was a
-# layout INVARIANT ("a row is one line tall"), and an invariant can be asserted directly:
+# layout INVARIANT ("a cell is one line tall"), and an invariant can be asserted directly:
 # relative geometry, no reference image, no font dependency.
 #
 # The page asserts itself. A script appended to the document runs the checks against real
@@ -29,12 +39,15 @@ import tempfile
 SOURCE = "src/web/assets/index_html.h"
 
 # Phone, small tablet, laptop. The first two are where a six-column strip cannot fit and the
-# layout has to hold up by scrolling rather than by folding.
+# layout has to hold up by scrolling rather than by folding -- and they are the ones that catch
+# the 0.18.0 regression. 1200 does NOT catch it and is not expected to: at that width the
+# broken table fitted and never wrapped. It is here to guard the opposite failure, something
+# that only misbehaves when there is room to spare.
 WIDTHS = (390, 700, 1200)
 
 # The payload that broke it: a hybrid reporting a battery, which is what makes the widest
-# column appear at all. Two devices so a mismatch in row height is visible as a difference and
-# not only as an absolute.
+# column appear at all. Two devices, one of them with a deliberately long label, so the widest
+# realistic name is exercised rather than the neatest one.
 #
 # WIDTHS matter more than anything else here, and this is the thing the first version of this
 # file got wrong. Rendered at 900px the broken 0.18.0 table PASSED -- its min-width was 860, so
@@ -107,11 +120,25 @@ else {
     fail.push('the document scrolls horizontally: '
       +document.documentElement.scrollWidth+' > '+document.documentElement.clientWidth);
   }
-  // The scroll must live on the wrapper, not on the card, or the legend below it slides out of
-  // view with the table.
-  const scroller=strip.parentElement;
-  if(getComputedStyle(scroller).overflowX!=='auto'){
-    fail.push('the table is not inside a horizontally scrollable wrapper');
+  // The legend must not slide out of view with the table. Asserted as BEHAVIOUR, not as
+  // structure: an earlier form required the table's immediate parent to be the scroller, which
+  // one extra wrapper div would have broken while the page stayed perfectly correct. What
+  // matters is not which element scrolls, it is what ends up inside it.
+  let scroller=strip.parentElement;
+  while(scroller && scroller.id!=='host' && getComputedStyle(scroller).overflowX!=='auto'){
+    scroller=scroller.parentElement;
+  }
+  if(!scroller || scroller.id==='host'){
+    fail.push('the table has no horizontally scrollable ancestor: it cannot scroll, so it will'
+      +' squeeze instead');
+  } else {
+    const legend=[...strip.closest('.card').querySelectorAll('div')]
+      .find(d=>d.textContent.includes('power going into the battery'));
+    if(!legend){
+      fail.push('the battery column renders without the legend that explains its arrows');
+    } else if(scroller.contains(legend)){
+      fail.push('the legend sits inside the scrolling area and slides away with the table');
+    }
   }
 }
 document.title = fail.length ? 'LAYOUT-FAIL ' + fail.join(' || ') : 'LAYOUT-OK';

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+#
+# Renders the dashboard in a real browser and asserts its LAYOUT, not its pixels.
+#
+# 0.18.0 shipped a table that scrolled sideways and broke every cell onto a second line, and
+# nothing caught it: the tests assert what the page SAYS, never how it comes out. It was found
+# by eye, on hardware, minutes after the tag.
+#
+# Deliberately not a screenshot comparison. A committed baseline image would have to survive a
+# different font stack on a CI runner than on the machine that generated it, and a check that
+# cries wolf gets switched off -- which is worse than not having it. What broke in 0.18.0 was a
+# layout INVARIANT ("a row is one line tall"), and an invariant can be asserted directly:
+# relative geometry, no reference image, no font dependency.
+#
+# The page asserts itself. A script appended to the document runs the checks against real
+# computed geometry and writes the verdict into the DOM; Chrome is asked for the rendered DOM
+# and this reads the verdict out. That avoids a DevTools-protocol client or a headless-browser
+# library -- a dependency this project does not otherwise need, for a job that one <script>
+# already does.
+
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+SOURCE = "src/web/assets/index_html.h"
+
+# Phone, small tablet, laptop. The first two are where a six-column strip cannot fit and the
+# layout has to hold up by scrolling rather than by folding.
+WIDTHS = (390, 700, 1200)
+
+# The payload that broke it: a hybrid reporting a battery, which is what makes the widest
+# column appear at all. Two devices so a mismatch in row height is visible as a difference and
+# not only as an absolute.
+#
+# WIDTHS matter more than anything else here, and this is the thing the first version of this
+# file got wrong. Rendered at 900px the broken 0.18.0 table PASSED -- its min-width was 860, so
+# it fitted and never had to wrap. The bug only bites where the table is asked to fit into less
+# room than its content needs, which is the phone and tablet case it was reported on. Checking
+# one comfortable width proves nothing; the narrow ones are the whole point.
+FLEET = """[
+  {"id":"inverter-A","label":"Dak huis","online":true,"data_valid":true,"data_stale":false,
+   "last_successful_poll_seconds_ago":2,"ac_power_w":2310,"energy_today_kwh":12.5,
+   "ac_voltage_v":230.4,"temperature_c":41.2,"battery_soc_pct":64,"battery_power_w":2450},
+  {"id":"inverter-B","label":"Schuur achter met een lange naam","online":true,
+   "data_valid":true,"data_stale":false,"last_successful_poll_seconds_ago":12,
+   "ac_power_w":880,"energy_today_kwh":4.25,"ac_voltage_v":229.1,"temperature_c":38.0,
+   "battery_soc_pct":40,"battery_power_w":-1180}
+]"""
+
+PAGE = """<!doctype html><html><head><meta charset="utf-8"><style>%(style)s</style></head>
+<body><div id="host" style="width:%(width)spx"></div>
+<script>
+const fmt=(v,d)=>Number(v).toFixed(d);
+const esc=s=>String(s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+%(script)s
+document.getElementById('host').innerHTML=fleetStrip(%(fleet)s);
+
+const fail=[];
+const strip=document.querySelector('#host table');
+if(!strip){ fail.push('no table rendered'); }
+else {
+  // How many LINES does each cell's text occupy? A Range over the cell's contents returns one
+  // client rect per line box, so this counts wrapping directly -- no height ratio, no pixel
+  // tolerance, nothing that depends on the runner's font metrics.
+  //
+  // The first version of this file compared cell HEIGHTS against the shortest cell and allowed
+  // 1.6x. That silently passed the real 0.18.0 regression: padding does not double when the
+  // text does, so a wrapped cell measured 74px against 57px -- 1.3x, comfortably inside the
+  // tolerance. A check that lets the bug it was written for through is worse than no check,
+  // which is why this one is mutation-tested against the broken revision.
+  //
+  // Rects are MERGED BY VERTICAL OVERLAP, not bucketed by position. A cell holding the
+  // "Last reply" pill yields two rects on one line -- the span's padded box at top 79 height
+  // 19, and its text at top 82 height 13 -- which overlap and are plainly the same line. An
+  // earlier version rounded tops into buckets and split those two into "2 lines", failing a
+  // page that was correct. Overlap is what "same line" means; rounding is a guess at it.
+  const lineCount=el=>{
+    const r=document.createRange();
+    r.selectNodeContents(el);
+    const rects=[...r.getClientRects()]
+      .filter(x=>x.width>0 && x.height>0)
+      .sort((a,b)=>a.top-b.top);
+    let lines=0, bottom=-Infinity;
+    for(const x of rects){
+      if(x.top>=bottom){ lines++; bottom=x.bottom; }
+      else { bottom=Math.max(bottom,x.bottom); }
+    }
+    return Math.max(lines,1);
+  };
+  // Numbers and headers. Not the device-name cell: it is DELIBERATELY two lines when a device
+  // has a label, with the id underneath in small type.
+  const cells=[...strip.querySelectorAll('td.n'), ...strip.querySelectorAll('th')];
+  if(cells.length===0){ fail.push('no cells found to measure'); }
+  for(const c of cells){
+    const lines=lineCount(c);
+    if(lines>1){
+      fail.push('wraps onto '+lines+' lines: "'+c.textContent.trim().slice(0,40)+'"');
+    }
+  }
+  // The strip is allowed to scroll sideways -- that is a deliberate decision. The PAGE is not:
+  // a document that scrolls horizontally means something escaped its container.
+  if(document.documentElement.scrollWidth > document.documentElement.clientWidth){
+    fail.push('the document scrolls horizontally: '
+      +document.documentElement.scrollWidth+' > '+document.documentElement.clientWidth);
+  }
+  // The scroll must live on the wrapper, not on the card, or the legend below it slides out of
+  // view with the table.
+  const scroller=strip.parentElement;
+  if(getComputedStyle(scroller).overflowX!=='auto'){
+    fail.push('the table is not inside a horizontally scrollable wrapper');
+  }
+}
+document.title = fail.length ? 'LAYOUT-FAIL ' + fail.join(' || ') : 'LAYOUT-OK';
+</script></body></html>"""
+
+
+def find_chrome() -> str | None:
+    for name in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser"):
+        found = shutil.which(name)
+        if found:
+            return found
+    mac = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    return mac if pathlib.Path(mac).exists() else None
+
+
+def main() -> int:
+    root = pathlib.Path(__file__).resolve().parent.parent
+    source = (root / SOURCE).read_text()
+
+    style = re.search(r"<style>(.*?)</style>", source, re.S)
+    scripts = re.findall(r"<script>(.*?)</script>", source, re.S)
+    if not style or not scripts:
+        print("dashboard layout: FAIL (no <style> or <script> found)")
+        return 1
+    joined = "\n".join(scripts)
+    start = joined.find("function fleetStrip(fleet){")
+    if start < 0:
+        print("dashboard layout: FAIL (fleetStrip not found)")
+        return 1
+    end = joined.find("\nfunction ", start + 10)
+    fleet_strip = joined[start:end if end > 0 else len(joined)]
+
+    chrome = find_chrome()
+    if chrome is None:
+        # Loud, not skipped. A layout check that quietly does nothing when the browser is
+        # missing reports a clean tree it never rendered -- which is the failure this whole
+        # file exists to stop happening again.
+        print("dashboard layout: FAIL (no Chrome/Chromium on PATH to render with)")
+        return 1
+
+    status = 0
+    with tempfile.TemporaryDirectory(prefix="heliograph-layout-") as scratch:
+        for width in WIDTHS:
+            page = pathlib.Path(scratch) / f"dashboard-{width}.html"
+            page.write_text(PAGE % {
+                "style": style.group(1), "script": fleet_strip,
+                "fleet": FLEET, "width": width,
+            })
+            result = subprocess.run(
+                [
+                    chrome, "--headless", "--disable-gpu", "--no-sandbox",
+                    f"--window-size={width},700", "--virtual-time-budget=2000",
+                    "--dump-dom", page.as_uri(),
+                ],
+                capture_output=True, text=True, timeout=120,
+            )
+            verdict = re.search(r"<title>(LAYOUT-[^<]*)</title>", result.stdout)
+            if verdict is None:
+                print(f"dashboard layout @{width}px: FAIL (no verdict; the page did not run)")
+                print(result.stderr[-600:])
+                status = 1
+                continue
+            text = verdict.group(1)
+            if text.startswith("LAYOUT-OK"):
+                print(f"dashboard layout @{width}px: OK")
+                continue
+            status = 1
+            print(f"dashboard layout @{width}px: FAIL")
+            for problem in text.removeprefix("LAYOUT-FAIL ").split(" || "):
+                print("  " + problem)
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -9,9 +9,10 @@
 # for the ground it currently covers -- and the CI step is named for the strip, so a passing
 # check does not quietly claim the page is fine.
 #
-# The invariant it asserts is per CELL, not per row: a numeric cell or a column header must
-# occupy one line. Rows are deliberately NOT compared, because the device-name cell is two
-# lines by design when a device has a label, with the id underneath in small type.
+# Two invariants. Per CELL, not per row: a numeric cell or a column header must occupy one
+# line -- rows are deliberately NOT compared, because the device-name cell is two lines by
+# design when a device has a label. And per WIDTH: the strip must be a table where one fits and
+# a stack of labelled blocks where it does not, with nothing hidden either way.
 #
 # 0.18.0 shipped a table that scrolled sideways and broke every cell onto a second line, and
 # nothing caught it: the tests assert what the page SAYS, never how it comes out. It was found
@@ -65,7 +66,7 @@ FLEET = """[
 ]"""
 
 PAGE = """<!doctype html><html><head><meta charset="utf-8"><style>%(style)s</style></head>
-<body><div id="host" style="width:%(width)spx"></div>
+<body><div id="host" class="strip" style="width:%(width)spx"></div>
 <script>
 const fmt=(v,d)=>Number(v).toFixed(d);
 const esc=s=>String(s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
@@ -120,24 +121,59 @@ else {
     fail.push('the document scrolls horizontally: '
       +document.documentElement.scrollWidth+' > '+document.documentElement.clientWidth);
   }
-  // The legend must not slide out of view with the table. Asserted as BEHAVIOUR, not as
-  // structure: an earlier form required the table's immediate parent to be the scroller, which
-  // one extra wrapper div would have broken while the page stayed perfectly correct. What
-  // matters is not which element scrolls, it is what ends up inside it.
-  let scroller=strip.parentElement;
-  while(scroller && scroller.id!=='host' && getComputedStyle(scroller).overflowX!=='auto'){
-    scroller=scroller.parentElement;
+  // TWO SHAPES, and which one is correct depends on the width. Below the fold-over the strip
+  // must stack into one block per inverter and NOT scroll sideways -- that shape exists because
+  // at 390px the table showed the device names and nothing else, every reading behind a
+  // scrollbar. Above it the table must stay a table, because comparing four inverters by
+  // scanning one column is the thing the stack cannot do.
+  const stacked=getComputedStyle(strip).display==='block';
+  // Measured on the HOST, not the window: the container query keys off the strip's own
+  // width, so anything else would be asserting against a different number than the CSS
+  // reads. The window is deliberately wider than the host so a scrollbar never counts
+  // as the page overflowing.
+  const wide=document.getElementById('host').clientWidth>800;
+  if(wide && stacked){
+    fail.push('folded into blocks at a width where the table fits and reads better');
   }
-  if(!scroller || scroller.id==='host'){
-    fail.push('the table has no horizontally scrollable ancestor: it cannot scroll, so it will'
-      +' squeeze instead');
+  if(!wide && !stacked){
+    fail.push('still a table at a width where it cannot fit: the readings end up off-screen');
+  }
+
+  if(stacked){
+    // Nothing may scroll sideways here. The fold exists precisely to remove that scroll, so a
+    // stacked strip that still overflows has not actually solved anything.
+    for(const el of [strip, strip.parentElement]){
+      if(el.scrollWidth > el.clientWidth + 1){
+        fail.push('the stacked strip still scrolls sideways: '
+          +el.scrollWidth+' > '+el.clientWidth);
+        break;
+      }
+    }
+    // Every value must carry its own label once the header row is gone, or a block is a column
+    // of unlabelled numbers. This is what separates folding from hiding.
+    const unlabelled=[...strip.querySelectorAll('td.n')].filter(c=>!c.dataset.label);
+    if(unlabelled.length){
+      fail.push(unlabelled.length+' stacked cells have no label: "'
+        +unlabelled[0].textContent.trim().slice(0,30)+'"');
+    }
   } else {
-    const legend=[...strip.closest('.card').querySelectorAll('div')]
-      .find(d=>d.textContent.includes('power going into the battery'));
-    if(!legend){
-      fail.push('the battery column renders without the legend that explains its arrows');
-    } else if(scroller.contains(legend)){
-      fail.push('the legend sits inside the scrolling area and slides away with the table');
+    // The legend must not slide out of view with the table. Asserted as BEHAVIOUR, not as
+    // structure: an earlier form required the table's immediate parent to be the scroller,
+    // which one extra wrapper div would have broken while the page stayed correct.
+    let scroller=strip.parentElement;
+    while(scroller && scroller.id!=='host' && getComputedStyle(scroller).overflowX!=='auto'){
+      scroller=scroller.parentElement;
+    }
+    if(!scroller || scroller.id==='host'){
+      fail.push('the table has no horizontally scrollable ancestor: it will squeeze instead');
+    } else {
+      const legend=[...strip.closest('.card').querySelectorAll('div')]
+        .find(d=>d.textContent.includes('power going into the battery'));
+      if(!legend){
+        fail.push('the battery column renders without the legend that explains its arrows');
+      } else if(scroller.contains(legend)){
+        fail.push('the legend sits inside the scrolling area and slides away with the table');
+      }
     }
   }
 }
@@ -203,7 +239,7 @@ def main() -> int:
                     "--headless",
                     "--disable-gpu",
                     "--no-sandbox",
-                    f"--window-size={width},700",
+                    f"--window-size={width + 60},760",
                     "--virtual-time-budget=2000",
                     "--dump-dom",
                     page.as_uri(),

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -43,8 +43,9 @@ SOURCE = "src/web/assets/index_html.h"
 # layout has to hold up by scrolling rather than by folding -- and they are the ones that catch
 # the 0.18.0 regression. 1200 does NOT catch it and is not expected to: at that width the
 # broken table fitted and never wrapped. It is here to guard the opposite failure, something
-# that only misbehaves when there is room to spare.
-WIDTHS = (390, 700, 1200)
+# that only misbehaves when there is room to spare. 780 sits just above the fold-over, which is
+# exactly where an off-by-one between the CSS and this file would show up -- and did.
+WIDTHS = (390, 700, 780, 1200)
 
 # The payload that broke it: a hybrid reporting a battery, which is what makes the widest
 # column appear at all. Two devices, one of them with a deliberately long label, so the widest
@@ -66,7 +67,7 @@ FLEET = """[
 ]"""
 
 PAGE = """<!doctype html><html><head><meta charset="utf-8"><style>%(style)s</style></head>
-<body><div id="host" class="strip" style="width:%(width)spx"></div>
+<body><div id="host" style="width:%(width)spx"></div>
 <script>
 const fmt=(v,d)=>Number(v).toFixed(d);
 const esc=s=>String(s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
@@ -127,16 +128,54 @@ else {
   // scrollbar. Above it the table must stay a table, because comparing four inverters by
   // scanning one column is the thing the stack cannot do.
   const stacked=getComputedStyle(strip).display==='block';
-  // Measured on the HOST, not the window: the container query keys off the strip's own
-  // width, so anything else would be asserting against a different number than the CSS
-  // reads. The window is deliberately wider than the host so a scrollbar never counts
-  // as the page overflowing.
-  const wide=document.getElementById('host').clientWidth>800;
-  if(wide && stacked){
-    fail.push('folded into blocks at a width where the table fits and reads better');
-  }
-  if(!wide && !stacked){
-    fail.push('still a table at a width where it cannot fit: the readings end up off-screen');
+  // Measured on the HOST, not the window: the container query keys off the strip's own width,
+  // so anything else would be asserting against a different number than the CSS reads. The
+  // window is deliberately wider than the host so a scrollbar never counts as the page
+  // overflowing.
+  //
+  // The threshold is READ OUT OF THE STYLESHEET, never written here. It was hard-coded as 800
+  // while the CSS folded at 760, which left a 40px band where this check demanded blocks and
+  // the CSS produced a table -- a spurious failure that only stayed hidden because the three
+  // tested widths happened to miss it. Two numbers that have to mean the same thing are one
+  // number too many.
+  // Measured on the element that IS the container -- the card fleetStrip emits with class
+  // "strip" -- and not on the host around it. The container query reads that box's INNER width,
+  // so the card's own padding is part of the sum. An earlier form measured the host and put
+  // class="strip" on it as well, which made the harness disagree with the product in two ways
+  // at once: a second nested container, and a width the CSS was never looking at. It showed up
+  // as a fold at 780px that the stylesheet did not ask for.
+  const container=strip.closest('.strip');
+  if(container===null){ fail.push('the strip is not inside a query container'); }
+  // The CONTENT box, which is the box a container query evaluates against -- not clientWidth,
+  // which includes the card's padding. Off by exactly that padding, this expected a table at
+  // 780px while the stylesheet had already folded, because the card's inner width was 752.
+  const cs=container?getComputedStyle(container):null;
+  const inner=container
+    ? container.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight)
+    : 0;
+  //
+  // WHICH SHAPE IS REQUIRED is this file's own judgement at the extremes, and only a reading of
+  // the stylesheet in between. Deriving it entirely from the CSS made the check validate the
+  // stylesheet against itself: set the fold-over to 1px and it read that same 1, expected a
+  // table everywhere, got one, and passed a build where the fold never happened -- the very
+  // regression it exists to catch. Found by mutation-testing it, not by reading it.
+  //
+  // So: a phone must stack whatever the CSS says, a laptop must not, and between those two the
+  // stylesheet's own threshold decides.
+  const REQUIRE_STACKED_AT=440;   // no phone may be shown the table
+  const REQUIRE_TABLE_AT=1000;    // no laptop may be shown fragments
+  const wide=inner > %(fold)s;
+  if(inner<=REQUIRE_STACKED_AT && !stacked){
+    fail.push('still a table at '+Math.round(inner)+'px: a phone cannot show it, and every'
+      +' reading ends up behind a scrollbar');
+  } else if(inner>=REQUIRE_TABLE_AT && stacked){
+    fail.push('folded into blocks at '+Math.round(inner)+'px, where the table fits and lets'
+      +' four inverters be compared down one column');
+  } else if(inner>REQUIRE_STACKED_AT && inner<REQUIRE_TABLE_AT){
+    // In between, either shape is defensible and the stylesheet decides -- but it must decide
+    // CONSISTENTLY with the threshold it declares.
+    if(wide && stacked){ fail.push('folded above its own declared fold-over width'); }
+    if(!wide && !stacked){ fail.push('still a table below its own declared fold-over width'); }
   }
 
   if(stacked){
@@ -199,6 +238,13 @@ def main() -> int:
     root = pathlib.Path(__file__).resolve().parent.parent
     source = (root / SOURCE).read_text()
 
+    fold = re.search(r"@container \(max-width:\s*(\d+)px\)", source)
+    if fold is None:
+        print(
+            "fleet strip layout: FAIL (no @container fold-over threshold found in the CSS)"
+        )
+        return 1
+
     style = re.search(r"<style>(.*?)</style>", source, re.S)
     scripts = re.findall(r"<script>(.*?)</script>", source, re.S)
     if not style or not scripts:
@@ -231,6 +277,7 @@ def main() -> int:
                     "script": fleet_strip,
                     "fleet": FLEET,
                     "width": width,
+                    "fold": fold.group(1),
                 }
             )
             result = subprocess.run(


### PR DESCRIPTION
Two things that have to land together: the fleet strip gets a second shape, and the layout check learns to assert both.

## The problem, measured

Reported from hardware with four inverters on the bus: *"niet te lezen, de helft valt eraf en ik moet naar rechts scrollen."*

Measured, it is worse than reported. At 390px the table showed the device **names and nothing else** — every single reading sat behind a horizontal scrollbar. A reading you have to scroll to find is not a reading.

The table put its wide axis on the *metrics*: seven fixed columns, while the thing there are few of is *devices*. On a phone that argument is lost before it starts.

## Why the table stays anyway

The opposite was measured too, before building anything. **Above ~800px the table is the better shape by a distance**: four inverters are compared by scanning a single column, which a stack of blocks cannot do, and a grid of panels wastes the space it is given.

Replacing the table would have fixed the phone and spoiled the desk. So it **folds** rather than being replaced.

## Nothing is hidden

Below 760px the same table becomes one bordered block per inverter, every value beside its own label.

That distinction is the whole point. The comment in this file has always refused to hide columns below a breakpoint, and **that refusal still stands** — a dropped column is exactly the reading someone went looking for, gone. Folding drops nothing: the header row's labels move into the cells as `data-label` and reappear beside every value.

## Two implementation choices

**One renderer.** The same `fleetStrip` emits the same markup either way; CSS reshapes it. No second rendering path to keep in step.

**A container query, not a media query.** The strip answers to its own width, so it stays right if it is ever placed in a narrow column on a wide screen. The window is not what decides whether a table fits — the space the table is given is.

## The check now asserts both shapes

A check that only knew the table would have passed a build where the fold never happened — the same class of regression it exists to prevent, one level up.

Per width it asserts: a table where one fits, a stack of labelled blocks where one does not, no sideways scroll once stacked, and **every stacked cell carrying its own label**. That last one is what makes folding different from hiding, so it is checked rather than trusted.

### Mutation-tested three ways

Each against a real defect, not an invented one:

| mutation | caught as |
|---|---|
| the original `v0.18.0` revision | `wraps onto 2 lines: "12.50 kWh"` |
| fold-over removed | `still a table at a width where it cannot fit` |
| `data-label` removed | `12 stacked cells have no label: "2310 W"` |

The tree as it stands passes at 390, 700 and 1200.

### Two harness bugs found by running it

- The document-overflow assertion failed at 700px on the runner's **own scrollbar** — the host was set to exactly the window width, leaving no room for it.
- Which shape to expect was read off `window.innerWidth`. The container query keys off the *strip's* width, so the check was asserting against a different number than the CSS reads.

## Scope, stated because a green tick is easy to over-read

This covers the fleet strip. The status cards, settings tab, logs tab and setup portal are **not** rendered by it — which is why the CI step is named "Fleet strip layout" rather than for the page.

## Verification

811 native tests, `check_layering.sh`, `check_web_js.py`, and the layout check at all three widths. The runner has Chrome — proven by the earlier run on this branch, not assumed.