### PR TITLE
Release 0.19.1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,9 +135,15 @@ namespace {
 // is the more useful finding and is why this release is small. What it does add is a guard:
 // the release workflow now refuses a tag that disagrees with the version below, because three
 // releases in a row that agreed only because someone remembered is not a process.
+// 0.19.1 makes the per-inverter strip readable on a phone. With four inverters on the bus it
+// showed the device names and nothing else -- every reading sat behind a horizontal scrollbar.
+// Below 760px the same table now folds into one block per inverter, every value beside its own
+// label; above it the table stays, because four inverters are compared by scanning one column.
+// Nothing is hidden either way, which is what separates this from the column-hiding the web
+// asset has always refused. CI renders the strip and asserts both shapes.
 #define HELIOGRAPH_VERSION_MAJOR 0
 #define HELIOGRAPH_VERSION_MINOR 19
-#define HELIOGRAPH_VERSION_PATCH 0
+#define HELIOGRAPH_VERSION_PATCH 1
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Version bump. The user-visible change is [#101](https://github.com/Timdebruijn/heliograph/pull/101).

## What 0.19.1 fixes

Reported from hardware with four inverters on the bus: the strip was unreadable and half of it sat off to the right. Measured, it was worse — **at 390px the table showed the device names and nothing else.** Every reading was behind a horizontal scrollbar.

Below 760px the same table now folds into one block per inverter, every value beside its own label. Above it the table stays, because four inverters are compared by scanning a single column — that was measured too, before anything was built, and it is why the table was not simply replaced.

**Nothing is hidden either way.** That is the distinction from the column-hiding the web asset has always refused, and that refusal still stands.

CI now renders the strip and asserts both shapes, at 390, 700, 780 and 1200px.

## Verified on this exact tree

- 811 native tests
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_dashboard_layout.py` at all four widths
- All four targets build; the binary reports `0.19.1`, read from the binary rather than the source
- `tools/check_version.sh v0.19.1` passes

## First bump that is guarded rather than remembered

0.18.0 through 0.18.2 each needed this as a manual step that went right only because someone thought of it. Since [#99](https://github.com/Timdebruijn/heliograph/pull/99) the workflow refuses a tag that disagrees with the defines, as its first job, before anything is built.