### PR TITLE
feat(dashboard): show every channel an inverter reports, and only those

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -40,6 +40,19 @@ main{padding:20px;max-width:900px}
 .card .k{color:var(--dim);font-size:12px;text-transform:uppercase;letter-spacing:.04em}
 .card .v{font-size:22px;font-weight:600;margin-top:4px;font-variant-numeric:tabular-nums}
 .card .u{font-size:13px;color:var(--dim);font-weight:400}
+/* Detail rows under the headline tiles. Everything an inverter reports belongs on this page --
+   half of what a TL3000 sends was reaching the API and never the screen -- but not everything
+   deserves a 22px number. The few figures you read at a glance stay tiles; the rest are rows.
+   Grouped by where the reading comes from, because "MPPT 1 voltage" next to "AC voltage L1" is
+   two different questions sharing a word. */
+.detail{margin-top:14px;display:grid;gap:14px;align-items:start;
+        grid-template-columns:repeat(auto-fill,minmax(260px,1fr))}
+.detail section{background:var(--card);border:1px solid var(--line);border-radius:12px;
+                padding:13px 15px}
+.detail h4{margin:0 0 8px;font-size:12px;text-transform:uppercase;letter-spacing:.04em;
+           color:var(--dim);font-weight:500}
+.detail .row{display:flex;justify-content:space-between;gap:14px;padding:3px 0}
+.detail .row span:last-child{font-variant-numeric:tabular-nums}
 .dot{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px}
 .dot.ok{background:var(--ok)}.dot.bad{background:var(--bad)}.dot.warn{background:var(--warn)}
 table{width:100%;border-collapse:collapse;font-size:14px}
@@ -323,17 +336,102 @@ function bridgeTiles(b){
 }
 
 /// The single-inverter dashboard, unchanged. `g` reads the first device's measurements.
-function singleTiles(s,d,g){
-  return tile('AC Power',fmt(g('ac.power.total'),0),'W')+
-    tile('Today',fmt(g('energy.today'),2),'kWh')+
-    tile('Total',fmt(g('energy.total'),1),'kWh')+
-    tile('Temperature',fmt(g('inverter.temperature')),'°C')+
-    tile('AC Voltage',fmt(g('ac.phase_l1.voltage')),'V')+
-    tile('Frequency',fmt(g('ac.frequency'),2),'Hz')+
-    tile('Status',esc(s.status_text??'—'),'')+
-    // null means this protocol has no error code field at all -- not "no fault".
-    tile('Error code',s.error_code===null?'not reported':esc(s.error_code),'')+
-    tile('Last poll',d.last_successful_poll_seconds_ago??'—','s ago');
+/// Every canonical measurement: its label, which group it belongs to, and how many decimals it
+/// is worth. Order in this list IS the order on screen, so it is arranged the way someone reads
+/// an inverter rather than the way the ids happen to sort.
+///
+/// `H` puts a measurement on a headline tile; the rest name a group. Units are NOT here -- they
+/// arrive with each reading, so there is only one place that decides what a watt is called.
+///
+/// Decimals are per measurement and not per unit, deliberately: energy.today at 5.56 kWh wants
+/// two, energy.total at 35568.6 kWh wants one, and 35568.60 is noise pretending to be precision.
+///
+/// A new id in measurement.h without a row here is caught by tools/check_measurement_ids.py.
+/// Without that, adding a channel in C++ would show up on this page as a raw id.
+const MEAS=[
+  ['ac.power.total','AC power','H',0],
+  ['energy.today','Today','H',2],
+  ['energy.total','Total','H',1],
+  ['battery.soc','Battery','H',0],
+  ['ac.phase_l1.voltage','Voltage L1','AC',1],
+  ['ac.phase_l2.voltage','Voltage L2','AC',1],
+  ['ac.phase_l3.voltage','Voltage L3','AC',1],
+  ['ac.phase_l1.current','Current L1','AC',1],
+  ['ac.phase_l2.current','Current L2','AC',1],
+  ['ac.phase_l3.current','Current L3','AC',1],
+  ['ac.phase_l1.power','Power L1','AC',0],
+  ['ac.phase_l2.power','Power L2','AC',0],
+  ['ac.phase_l3.power','Power L3','AC',0],
+  ['ac.frequency','Frequency','AC',2],
+  ['dc.mppt_1.voltage','MPPT 1 voltage','DC / MPPT',1],
+  ['dc.mppt_1.current','MPPT 1 current','DC / MPPT',1],
+  ['dc.mppt_1.power','MPPT 1 power','DC / MPPT',0],
+  ['dc.mppt_2.voltage','MPPT 2 voltage','DC / MPPT',1],
+  ['dc.mppt_2.current','MPPT 2 current','DC / MPPT',1],
+  ['dc.mppt_2.power','MPPT 2 power','DC / MPPT',0],
+  ['dc.power.total','DC power total','DC / MPPT',0],
+  ['battery.power','Power','Battery',0],
+  ['battery.charge_power','Charging','Battery',0],
+  ['battery.discharge_power','Discharging','Battery',0],
+  ['battery.voltage','Voltage','Battery',1],
+  ['battery.current','Current','Battery',1],
+  ['battery.temperature','Temperature','Battery',1],
+  ['battery.energy_charged','Energy charged','Battery',2],
+  ['battery.energy_discharged','Energy discharged','Battery',2],
+  ['grid.import_power','Importing','Grid',0],
+  ['grid.export_power','Exporting','Grid',0],
+  ['inverter.temperature','Temperature','Device',1],
+  ['inverter.operating_hours','Operating hours','Device',0],
+];
+
+/// The dashboard for a single inverter: everything it reports, and nothing it does not.
+///
+/// A CHANNEL IS SHOWN WHEN THE PAYLOAD CARRIES ITS KEY, not when it carries a value. The API
+/// only emits measurements the driver declares as supported, so a present key means "this
+/// inverter has this"; a null value means "it has it, but not right now". Filtering on the
+/// value instead would make rows appear and vanish as readings go briefly stale, and a layout
+/// that reshuffles while you read it is worse than an em dash.
+///
+/// Before this, nine tiles were hard-coded. A TL3000 reports twelve measurements and six of
+/// them -- both MPPT strings, DC total, phase current, operating hours -- reached the REST API
+/// and never the screen. It also meant a single battery inverter showed no battery at all,
+/// while TWO of them did, because the fleet strip below picks its columns from the payload and
+/// these tiles did not.
+function singleTiles(s,d,g,m){
+  const has=id=>m!==undefined&&m[id]!==undefined;
+  const val=(id,dec)=>{const v=g(id);return v===null||v===undefined?'—':fmt(v,dec)};
+  const unit=id=>(m[id]&&m[id].unit)||'';
+
+  let out='';
+  for(const [id,label,group,dec] of MEAS){
+    if(group==='H'&&has(id)) out+=tile(label,val(id,dec),unit(id));
+  }
+  // Status and error code are not measurements and have their own rule: null means the protocol
+  // has no such field, so the tile is not shown at all. It used to read "not reported", which is
+  // a tile spending space to say nothing -- exactly the empty tile this page should not have.
+  if(s.status_text) out+=tile('Status',esc(s.status_text),'');
+  if(s.error_code!==null&&s.error_code!==undefined) out+=tile('Error code',esc(s.error_code),'');
+  out+=tile('Last poll',d.last_successful_poll_seconds_ago??'—','s ago');
+  return out;
+}
+
+/// The detail groups under the tiles. Empty groups are not rendered -- a heading over nothing
+/// is the same empty tile in a different shape.
+function detailGroups(m){
+  if(!m) return '';
+  const seen=new Set();
+  let html='';
+  for(const [,,group] of MEAS){
+    if(group==='H'||seen.has(group)) continue;
+    seen.add(group);
+    const rows=MEAS.filter(([id,,gr])=>gr===group&&m[id]!==undefined).map(([id,label,,dec])=>{
+      const v=m[id].value;
+      const shown=v===null||v===undefined?'—':fmt(v,dec)+' '+(m[id].unit||'');
+      return `<div class="row"><span class="dim">${esc(label)}</span><span>${esc(shown)}</span></div>`;
+    });
+    if(rows.length) html+=`<section><h4>${esc(group)}</h4>${rows.join('')}</section>`;
+  }
+  return html?`<div class="detail">${html}</div>`:'';
 }
 
 /// Totals across every polled inverter, each carrying how many it actually covers.
@@ -525,8 +623,12 @@ function render(s){
     // One inverter: exactly the dashboard this has always been. Several: the tiles that can
     // honestly be added become bridge totals, the ones that only mean something per device
     // move to the strip below, and nothing on this page presents one inverter as the bridge.
-    $('#tiles').innerHTML=(multi?fleetTiles(fleet,tot,expected):singleTiles(s,d,g))+bridgeTiles(b);
-    $('#fleet').innerHTML=multi?fleetStrip(fleet):'';
+    $('#tiles').innerHTML=(multi?fleetTiles(fleet,tot,expected):singleTiles(s,d,g,m))+bridgeTiles(b);
+    // The detail groups belong to ONE inverter. With several on the bus the measurements in
+    // s.measurements are the first device's, and presenting those as the bridge's would be the
+    // same lie the fleet totals were built to avoid -- so they are shown per device on the
+    // Device tab instead.
+    $('#fleet').innerHTML=multi?fleetStrip(fleet):detailGroups(m);
   }
   if(tab==='dev'){
     // Every configured device, not just the first. The bridge polls up to eight; this tab

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -335,7 +335,6 @@ function bridgeTiles(b){
     // No firmware tile: the version already sits in the header, permanently.
 }
 
-/// The single-inverter dashboard, unchanged. `g` reads the first device's measurements.
 /// Every canonical measurement: its label, which group it belongs to, and how many decimals it
 /// is worth. Order in this list IS the order on screen, so it is arranged the way someone reads
 /// an inverter rather than the way the ids happen to sort.
@@ -352,7 +351,7 @@ const MEAS=[
   ['ac.power.total','AC power','H',0],
   ['energy.today','Today','H',2],
   ['energy.total','Total','H',1],
-  ['battery.soc','Battery','H',0],
+  ['battery.soc','State of charge','H',0],
   ['ac.phase_l1.voltage','Voltage L1','AC',1],
   ['ac.phase_l2.voltage','Voltage L2','AC',1],
   ['ac.phase_l3.voltage','Voltage L3','AC',1],
@@ -397,14 +396,12 @@ const MEAS=[
 /// and never the screen. It also meant a single battery inverter showed no battery at all,
 /// while TWO of them did, because the fleet strip below picks its columns from the payload and
 /// these tiles did not.
-function singleTiles(s,d,g,m){
-  const has=id=>m!==undefined&&m[id]!==undefined;
-  const val=(id,dec)=>{const v=g(id);return v===null||v===undefined?'—':fmt(v,dec)};
-  const unit=id=>(m[id]&&m[id].unit)||'';
-
+function singleTiles(s,d,m){
   let out='';
   for(const [id,label,group,dec] of MEAS){
-    if(group==='H'&&has(id)) out+=tile(label,val(id,dec),unit(id));
+    // fmt() already renders null as an em dash, so there is no second opinion here about what
+    // "no reading" looks like.
+    if(group==='H'&&m[id]!==undefined) out+=tile(label,fmt(m[id].value,dec),m[id].unit||'');
   }
   // Status and error code are not measurements and have their own rule: null means the protocol
   // has no such field, so the tile is not shown at all. It used to read "not reported", which is
@@ -426,7 +423,10 @@ function detailGroups(m){
     seen.add(group);
     const rows=MEAS.filter(([id,,gr])=>gr===group&&m[id]!==undefined).map(([id,label,,dec])=>{
       const v=m[id].value;
-      const shown=v===null||v===undefined?'—':fmt(v,dec)+' '+(m[id].unit||'');
+      // The unit is appended only to a real reading: fmt() gives an em dash for null, and
+      // "— V" claims a missing volt rather than a missing measurement. trim() because a
+      // unitless channel would otherwise carry a trailing space into the DOM.
+      const shown=(v===null||v===undefined?fmt(v,dec):fmt(v,dec)+' '+(m[id].unit||'')).trim();
       return `<div class="row"><span class="dim">${esc(label)}</span><span>${esc(shown)}</span></div>`;
     });
     if(rows.length) html+=`<section><h4>${esc(group)}</h4>${rows.join('')}</section>`;
@@ -618,12 +618,11 @@ function render(s){
   // Boards without relays never send the field; the settings card keys off this.
   window.g_relayCount=(b.relays||[]).length;
   window.g_maxDevices=b.max_devices||window.g_maxDevices;
-  const g=id=>m[id]?m[id].value:null;
   if(tab==='dash'){
     // One inverter: exactly the dashboard this has always been. Several: the tiles that can
     // honestly be added become bridge totals, the ones that only mean something per device
     // move to the strip below, and nothing on this page presents one inverter as the bridge.
-    $('#tiles').innerHTML=(multi?fleetTiles(fleet,tot,expected):singleTiles(s,d,g,m))+bridgeTiles(b);
+    $('#tiles').innerHTML=(multi?fleetTiles(fleet,tot,expected):singleTiles(s,d,m))+bridgeTiles(b);
     // The detail groups belong to ONE inverter. With several on the bus the measurements in
     // s.measurements are the first device's, and presenting those as the bridge's would be the
     // same lie the fleet totals were built to avoid -- so they are shown per device on the

--- a/tools/check_measurement_ids.py
+++ b/tools/check_measurement_ids.py
@@ -74,7 +74,9 @@ def check_dashboard_labels(root: pathlib.Path, body: str) -> int:
     if missing:
         print("FAIL: no dashboard row for: " + ", ".join(missing))
     if unknown:
-        print("FAIL: dashboard row for an id that does not exist: " + ", ".join(unknown))
+        print(
+            "FAIL: dashboard row for an id that does not exist: " + ", ".join(unknown)
+        )
     if missing or unknown:
         return 1
     print(f"dashboard measurement rows: OK ({len(labelled)} ids)")

--- a/tools/check_measurement_ids.py
+++ b/tools/check_measurement_ids.py
@@ -46,6 +46,38 @@ def main() -> int:
     if missing or extra:
         return 1
     print(f"measurement_id::kAll: OK ({len(listed)} ids)")
+    return check_dashboard_labels(root, body)
+
+
+def check_dashboard_labels(root: pathlib.Path, body: str) -> int:
+    """Every canonical id must have a row in the dashboard's MEAS table.
+
+    The dashboard renders one row per measurement the payload carries, looking each id up in
+    that table for its label, its group and how many decimals it is worth. An id declared in
+    C++ and missing there does not fail anywhere -- it simply never appears on the page, which
+    is the bug this whole change was made to fix, arriving again through the back door.
+    """
+    ids = set(re.findall(r'=\s*"([a-z0-9_.]+)"', body))
+    # control.* are SETPOINTS, not readings. They are in kAll so a removed device's retained
+    # Home Assistant configs can be cleared, but no driver reports them as a measurement, so
+    # there is nothing for the dashboard to show and a row here would be a promise of a tile
+    # that can never appear.
+    ids = {i for i in ids if not i.startswith("control.")}
+    page = (root / "src/web/assets/index_html.h").read_text()
+    table = re.search(r"const MEAS=\[(.*?)\n\];", page, re.DOTALL)
+    if not table:
+        print("FAIL: the dashboard's MEAS table was not found")
+        return 1
+    labelled = set(re.findall(r"\['([a-z0-9_.]+)'", table.group(1)))
+    missing = sorted(ids - labelled)
+    unknown = sorted(labelled - ids)
+    if missing:
+        print("FAIL: no dashboard row for: " + ", ".join(missing))
+    if unknown:
+        print("FAIL: dashboard row for an id that does not exist: " + ", ".join(unknown))
+    if missing or unknown:
+        return 1
+    print(f"dashboard measurement rows: OK ({len(labelled)} ids)")
     return 0
 
 


### PR DESCRIPTION
Three symptoms, one cause.

## What was wrong

`singleTiles` was **nine hard-coded tiles**, while the fleet strip below it already picked its columns from the payload.

Measured on the TL3000 at 192.168.20.254: it reports **twelve** measurements and the dashboard showed **six**.

| reported by the inverter | on the dashboard |
|---|---|
| `ac.phase_l1.current` — 8.4 A | ✗ |
| `dc.mppt_1.voltage` — 322 V | ✗ |
| `dc.mppt_1.current` — 6.6 A | ✗ |
| `dc.mppt_1.power` — 2125.2 W | ✗ |
| `dc.power.total` — 2125.2 W | ✗ |
| `inverter.operating_hours` — 47547 h | ✗ |

Half of what the inverter sends, sitting in the REST payload, never on screen.

**The single-versus-several difference follows from the same thing.** The strip lists battery columns when a device fills them, so *two* hybrids showed a battery and *one* showed none.

**And the empty tiles** were the flip side: nine fixed tiles mean a driver without a frequency reading gets a tile saying `—`.

## What it is now

Tiles driven by the payload, like the strip. A headline tile for the few figures read at a glance; the rest as labelled rows grouped by where the reading comes from — AC, DC/MPPT, Battery, Grid, Device — because "MPPT 1 voltage" beside "AC voltage L1" is two different questions sharing a word.

Verified by rendering both a plain TL3000 (12 channels, no Battery or Grid group at all) and a hybrid (24 channels, both groups present).

## The rule that keeps it stable

**A channel is shown when the payload carries its key, not when it carries a value.** The API only emits measurements a driver declares as `supported`, so a present key means the inverter *has* the channel and a null value means it has no reading *right now*.

Filtering on the value instead would make rows appear and vanish as readings go briefly stale — a layout that reshuffles while it is being read is worse than an em dash.

Status and error code now follow the same rule rather than their old one: null means the protocol has no such field, so the tile is gone. It used to read "not reported", which is a tile spending space to say nothing.

## Guarded

An id in `measurement.h` without a row in the dashboard table is now a CI failure. Without it, the next channel added in C++ would be invisible here again — exactly as these six were.

`control.*` is excluded: those are setpoints, present in `kAll` so retained Home Assistant configs can be cleared, and no driver reports them as a reading.

## Verification

811 native tests, `check_layering.sh`, `check_web_js.py`, `check_measurement_ids.py` (now 33 rows), `check_dashboard_layout.py` at all four widths, and both firmware targets build.

## Related, not in this PR

Auditing the other outputs while here: **MQTT, REST and Home Assistant discovery all iterate every supported measurement and were already complete. Prometheus exports 8 of 33** — a fixed gauge table. That is a separate change because Prometheus metric names are an external contract and each one needs naming by hand, not generating.