### PR TITLE
feat(prometheus): export every channel, not the eight that were written down

### DIFF
--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -66,6 +66,21 @@ heliograph_inverter_ac_power_watts{device="growatt_modbus-3"} 1105.000
 counters, the relay and DRM series. They are not per device: the counters live in one place for
 the whole bus, so labelling them would invent a distinction the firmware does not make.
 
+### Upgrading from 0.19.x or earlier
+
+`heliograph_inverter_ac_voltage_volts` and `heliograph_inverter_ac_current_amperes` **gained a
+`phase` label**. The metric names did not change, but a series with a new label is a new series:
+an existing panel keeps its history and stops receiving points, and the new series starts empty
+beside it.
+
+Selectors keep working — `heliograph_inverter_ac_voltage_volts{device="x"}` still matches, now
+returning one series per phase. What needs a look is anything that assumed a single series, such
+as a panel with no legend format or an alert on the bare metric. `max by (device)` or
+`{phase="l1"}` restores the old meaning.
+
+Nothing else was renamed. Everything else in this release is new metrics that were simply not
+exported before.
+
 ### If you already have a dashboard
 
 **The first device is labelled too.** That is a breaking change and it was chosen deliberately:
@@ -117,16 +132,64 @@ All gauges, all carrying `device`, and all **omitted entirely when the value is 
 inverter reports temperature and another does not gives one series, not two with a fabricated
 one. A metric no inverter reports is absent entirely, header included.
 
+Two of these carry a second label besides `device`. A phase and an MPPT string are dimensions of
+the same quantity, not different quantities, so they are labels rather than three metric names —
+`sum by (device) (heliograph_inverter_ac_power_watts)` works, and would not if L1, L2 and L3 were
+`..._l1_volts` and friends.
+
+**Whole inverter**
+
 | Metric | Unit |
 |---|---|
 | `heliograph_inverter_ac_power_watts` | W |
-| `heliograph_inverter_dc_power_watts` | W (derived) |
-| `heliograph_inverter_ac_voltage_volts` | V (L1) |
-| `heliograph_inverter_ac_current_amperes` | A (L1) |
+| `heliograph_inverter_dc_power_watts` | W (whole array, derived) |
 | `heliograph_inverter_grid_frequency_hertz` | Hz |
 | `heliograph_inverter_energy_today_kwh` | kWh |
 | `heliograph_inverter_energy_total_kwh` | kWh, lifetime |
+| `heliograph_inverter_operating_hours` | h, lifetime |
 | `heliograph_inverter_temperature_celsius` | °C |
+
+**Per phase** — extra label `phase="l1"`, `"l2"`, `"l3"`
+
+| Metric | Unit |
+|---|---|
+| `heliograph_inverter_ac_voltage_volts` | V |
+| `heliograph_inverter_ac_current_amperes` | A |
+| `heliograph_inverter_ac_phase_power_watts` | W |
+
+`ac_phase_power_watts` is a separate family from `ac_power_watts` on purpose. Parts and their
+sum in one family is how a `sum()` silently double-counts.
+
+**Per MPPT string** — extra label `string="1"`, `"2"`
+
+| Metric | Unit |
+|---|---|
+| `heliograph_inverter_mppt_voltage_volts` | V |
+| `heliograph_inverter_mppt_current_amperes` | A |
+| `heliograph_inverter_mppt_power_watts` | W |
+
+**Battery** — a separate prefix, because a battery is its own thing that happens to be reported
+through the inverter. A query for the inverter's temperature should not have to exclude the
+battery's.
+
+| Metric | Unit |
+|---|---|
+| `heliograph_battery_state_of_charge_percent` | % |
+| `heliograph_battery_power_watts` | W, positive charging |
+| `heliograph_battery_charge_power_watts` | W |
+| `heliograph_battery_discharge_power_watts` | W |
+| `heliograph_battery_voltage_volts` | V |
+| `heliograph_battery_current_amperes` | A |
+| `heliograph_battery_temperature_celsius` | °C |
+| `heliograph_battery_energy_charged_kwh` | kWh, lifetime |
+| `heliograph_battery_energy_discharged_kwh` | kWh, lifetime |
+
+**Grid meter**
+
+| Metric | Unit |
+|---|---|
+| `heliograph_grid_import_power_watts` | W |
+| `heliograph_grid_export_power_watts` | W |
 
 Which of these appear depends on the inverter: a driver only reports what its device actually
 provides, so a single-phase inverter has no three-phase series and an inverter without a

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -71,11 +71,12 @@ void appendDeviceValue(std::string& out, const char* name, const std::string& de
     out += name;
     out += "{device=\"" + escapeLabel(deviceId) + "\"";
     if (labelName != nullptr) {
+        // Escaped like the device id beside it. Every value in the table today is a literal
+        // that needs no escaping, which is exactly why the asymmetry would have survived: the
+        // day a label carries anything derived, it would be the one field that does not.
         out += ",";
         out += labelName;
-        out += "=\"";
-        out += labelValue;
-        out += "\"";
+        out += "=\"" + escapeLabel(labelValue) + "\"";
     }
     out += "}";
     out += buf;
@@ -195,7 +196,11 @@ constexpr GaugeSpec kInverterGauges[] = {
 std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const BridgeInfo& bridge,
                          const DiagnosticsSnapshot& d) {
     std::string out;
-    out.reserve(2048 + devices.size() * 512);
+    // Sized against the gauge table rather than a number typed once and left behind. 512 bytes
+    // per device was written when eight gauges existed; at thirty-odd a device emits closer to
+    // 2.5 KB, so an eight-device bus reserved 6 KB for 20 KB of output and grew the string
+    // repeatedly -- on a heap this page is served from, and which fragments.
+    out.reserve(2048 + devices.size() * (std::size(kInverterGauges) * 80));
 
     // One build_info series per device: the firmware and board are the bridge's, the driver is
     // the device's, and on a mixed bus those differ.
@@ -249,7 +254,12 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
             continue;  // already emitted with the first row carrying this name
         }
 
-        bool headerWritten = false;
+        // From the family's FIRST row, never from whichever row happened to have a reading.
+        // Every row of a family carries the same help text today, but nothing enforces that, and
+        // taking it from the data would make the documentation a scraper sees depend on which
+        // inverter answered first.
+        const char* help         = kInverterGauges[i].help;
+        bool        headerWritten = false;
         for (const auto& gauge : kInverterGauges) {
             if (std::strcmp(gauge.name, name) != 0) {
                 continue;
@@ -260,7 +270,7 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
                     continue;  // omit, do not zero
                 }
                 if (!headerWritten) {
-                    appendHelp(out, name, gauge.help, "gauge");
+                    appendHelp(out, name, help, "gauge");
                     headerWritten = true;
                 }
                 appendDeviceValue(out, name, dev.id, m->value, gauge.labelName,

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -3,6 +3,8 @@
 #include "prometheus_metrics.h"
 
 #include <cstdio>
+#include <cstring>   // std::strcmp, grouping the gauge table by name
+#include <iterator>  // std::size
 #include <vector>
 
 #include "relays/drm.h"
@@ -55,12 +57,27 @@ std::string escapeLabel(const std::string& value) {
 }
 
 /// `<name>{device="<id>"} <value>`.
+/// One sample, labelled by device and optionally by one more dimension.
+///
+/// The extra label is how a phase or an MPPT string is expressed, rather than by baking the
+/// number into the metric NAME. Three names for the same quantity cannot be summed, averaged or
+/// graphed together without listing all three, and adding a fourth phase would mean a fourth
+/// name; a label costs one series and answers all of that with sum() and by().
 void appendDeviceValue(std::string& out, const char* name, const std::string& deviceId,
-                       double value) {
+                       double value, const char* labelName = nullptr,
+                       const char* labelValue = nullptr) {
     char buf[64];
     std::snprintf(buf, sizeof(buf), " %.3f\n", value);
     out += name;
-    out += "{device=\"" + escapeLabel(deviceId) + "\"}";
+    out += "{device=\"" + escapeLabel(deviceId) + "\"";
+    if (labelName != nullptr) {
+        out += ",";
+        out += labelName;
+        out += "=\"";
+        out += labelValue;
+        out += "\"";
+    }
+    out += "}";
     out += buf;
 }
 
@@ -70,27 +87,107 @@ void appendDeviceFlag(std::string& out, const char* name, const std::string& dev
     out += set ? "1\n" : "0\n";
 }
 
-/// One measurement, as one metric family across every device.
+/// One measurement, as one series within a metric family.
+///
+/// Several rows may share a `name`: that is how per-phase and per-string channels become one
+/// family distinguished by a label. HELP and TYPE are written once per NAME, not once per row --
+/// a repeated HELP line is a parse error in strict parsers, and grouping is why the emit loop
+/// below walks names on the outside and rows on the inside.
 struct GaugeSpec {
     const char* measurementId;
     const char* name;
     const char* help;
+    const char* labelName  = nullptr;
+    const char* labelValue = nullptr;
 };
 
 constexpr GaugeSpec kInverterGauges[] = {
+    // --- AC, whole inverter -------------------------------------------------------------
     {measurement_id::kAcPowerTotal, "heliograph_inverter_ac_power_watts",
-     "Current AC output power"},
-    {measurement_id::kDcPowerTotal, "heliograph_inverter_dc_power_watts",
-     "Current DC input power (derived)"},
-    {measurement_id::kAcL1Voltage, "heliograph_inverter_ac_voltage_volts", "AC voltage on L1"},
-    {measurement_id::kAcL1Current, "heliograph_inverter_ac_current_amperes", "AC current on L1"},
+     "Current AC output power, whole inverter"},
     {measurement_id::kAcFrequency, "heliograph_inverter_grid_frequency_hertz", "Grid frequency"},
+
+    // --- AC, per phase ------------------------------------------------------------------
+    // The phase is a LABEL, not part of the name. Three names for one quantity cannot be
+    // summed or graphed together without naming all three.
+    //
+    // Per-phase power is a separate family from the total above, deliberately. Putting parts
+    // and their sum in one family is how a sum() silently double-counts.
+    {measurement_id::kAcL1Voltage, "heliograph_inverter_ac_voltage_volts", "AC voltage",
+     "phase", "l1"},
+    {measurement_id::kAcL2Voltage, "heliograph_inverter_ac_voltage_volts", "AC voltage",
+     "phase", "l2"},
+    {measurement_id::kAcL3Voltage, "heliograph_inverter_ac_voltage_volts", "AC voltage",
+     "phase", "l3"},
+    {measurement_id::kAcL1Current, "heliograph_inverter_ac_current_amperes", "AC current",
+     "phase", "l1"},
+    {measurement_id::kAcL2Current, "heliograph_inverter_ac_current_amperes", "AC current",
+     "phase", "l2"},
+    {measurement_id::kAcL3Current, "heliograph_inverter_ac_current_amperes", "AC current",
+     "phase", "l3"},
+    {measurement_id::kAcL1Power, "heliograph_inverter_ac_phase_power_watts",
+     "AC output power of one phase", "phase", "l1"},
+    {measurement_id::kAcL2Power, "heliograph_inverter_ac_phase_power_watts",
+     "AC output power of one phase", "phase", "l2"},
+    {measurement_id::kAcL3Power, "heliograph_inverter_ac_phase_power_watts",
+     "AC output power of one phase", "phase", "l3"},
+
+    // --- DC ------------------------------------------------------------------------------
+    // Same split as AC: the array total is its own family, the strings carry a label.
+    {measurement_id::kDcPowerTotal, "heliograph_inverter_dc_power_watts",
+     "Current DC input power, whole array"},
+    {measurement_id::kDcMppt1Voltage, "heliograph_inverter_mppt_voltage_volts",
+     "DC voltage of one MPPT string", "string", "1"},
+    {measurement_id::kDcMppt2Voltage, "heliograph_inverter_mppt_voltage_volts",
+     "DC voltage of one MPPT string", "string", "2"},
+    {measurement_id::kDcMppt1Current, "heliograph_inverter_mppt_current_amperes",
+     "DC current of one MPPT string", "string", "1"},
+    {measurement_id::kDcMppt2Current, "heliograph_inverter_mppt_current_amperes",
+     "DC current of one MPPT string", "string", "2"},
+    {measurement_id::kDcMppt1Power, "heliograph_inverter_mppt_power_watts",
+     "DC input power of one MPPT string", "string", "1"},
+    {measurement_id::kDcMppt2Power, "heliograph_inverter_mppt_power_watts",
+     "DC input power of one MPPT string", "string", "2"},
+
+    // --- Energy and runtime ---------------------------------------------------------------
+    // kWh rather than the joules Prometheus would prefer: these two names shipped in 0.5.0 and
+    // renaming them would break every dashboard and alert rule already pointed at them, for a
+    // unit nobody reads solar production in.
     {measurement_id::kEnergyToday, "heliograph_inverter_energy_today_kwh",
      "Energy produced today"},
     {measurement_id::kEnergyTotal, "heliograph_inverter_energy_total_kwh",
      "Lifetime energy produced"},
+    {measurement_id::kOperatingHours, "heliograph_inverter_operating_hours",
+     "Lifetime hours the inverter reports having run"},
     {measurement_id::kTemperature, "heliograph_inverter_temperature_celsius",
      "Inverter temperature"},
+
+    // --- Battery ---------------------------------------------------------------------------
+    // Its own metric prefix, not heliograph_inverter_: a battery is a separate thing that
+    // happens to be reported through the inverter, and a query for inverter temperature should
+    // not have to exclude the battery's.
+    {measurement_id::kBatterySoc, "heliograph_battery_state_of_charge_percent",
+     "Battery state of charge"},
+    {measurement_id::kBatteryPower, "heliograph_battery_power_watts",
+     "Battery power, positive charging and negative discharging"},
+    {measurement_id::kBatteryChargePower, "heliograph_battery_charge_power_watts",
+     "Power flowing into the battery"},
+    {measurement_id::kBatteryDischargePower, "heliograph_battery_discharge_power_watts",
+     "Power flowing out of the battery"},
+    {measurement_id::kBatteryVoltage, "heliograph_battery_voltage_volts", "Battery voltage"},
+    {measurement_id::kBatteryCurrent, "heliograph_battery_current_amperes", "Battery current"},
+    {measurement_id::kBatteryTemperature, "heliograph_battery_temperature_celsius",
+     "Battery temperature"},
+    {measurement_id::kBatteryEnergyCharged, "heliograph_battery_energy_charged_kwh",
+     "Lifetime energy stored in the battery"},
+    {measurement_id::kBatteryEnergyDischarged, "heliograph_battery_energy_discharged_kwh",
+     "Lifetime energy taken from the battery"},
+
+    // --- Grid meter --------------------------------------------------------------------------
+    {measurement_id::kGridImportPower, "heliograph_grid_import_power_watts",
+     "Power drawn from the grid"},
+    {measurement_id::kGridExportPower, "heliograph_grid_export_power_watts",
+     "Power delivered to the grid"},
 };
 
 }  // namespace
@@ -131,18 +228,44 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
     // header is written lazily so a family no device reports is absent entirely rather than
     // present as a bare header -- which is a parse error in strict parsers, and is why the
     // whole family loops here instead of each device rendering its own block.
-    for (const auto& gauge : kInverterGauges) {
+    // Names on the outside, rows within a name on the inside, devices innermost. Rows sharing a
+    // name are one family -- the three phases of a voltage, the strings of an array -- and a
+    // family gets exactly one HELP and one TYPE however many series it holds. Emitting them per
+    // row would repeat those lines, which strict parsers reject outright.
+    //
+    // The pass that finds a name's first row is what makes this O(rows^2) in the table size.
+    // With thirty-odd rows that is nothing, and it keeps the table a plain list that reads in
+    // declaration order rather than something pre-grouped that has to be maintained as groups.
+    for (size_t i = 0; i < std::size(kInverterGauges); ++i) {
+        const char* name = kInverterGauges[i].name;
+        bool        first = true;
+        for (size_t j = 0; j < i; ++j) {
+            if (std::strcmp(kInverterGauges[j].name, name) == 0) {
+                first = false;
+                break;
+            }
+        }
+        if (!first) {
+            continue;  // already emitted with the first row carrying this name
+        }
+
         bool headerWritten = false;
-        for (const auto& dev : devices) {
-            const auto* m = dev.state->measurements.find(gauge.measurementId);
-            if (m == nullptr || !m->supported || !m->valid || m->stale) {
-                continue;  // omit, do not zero
+        for (const auto& gauge : kInverterGauges) {
+            if (std::strcmp(gauge.name, name) != 0) {
+                continue;
             }
-            if (!headerWritten) {
-                appendHelp(out, gauge.name, gauge.help, "gauge");
-                headerWritten = true;
+            for (const auto& dev : devices) {
+                const auto* m = dev.state->measurements.find(gauge.measurementId);
+                if (m == nullptr || !m->supported || !m->valid || m->stale) {
+                    continue;  // omit, do not zero
+                }
+                if (!headerWritten) {
+                    appendHelp(out, name, gauge.help, "gauge");
+                    headerWritten = true;
+                }
+                appendDeviceValue(out, name, dev.id, m->value, gauge.labelName,
+                                  gauge.labelValue);
             }
-            appendDeviceValue(out, gauge.name, dev.id, m->value);
         }
     }
 

--- a/test/test_prometheus/test_main.cpp
+++ b/test/test_prometheus/test_main.cpp
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// The Prometheus exposition: which channels reach a scraper, and in what shape.
+//
+// This output had no suite of its own. It was exercised sideways from test_rest, which is how
+// it went unnoticed that it exported 8 of the 33 channels the model carries -- both MPPT
+// strings, every battery reading, the second and third phase and the operating hours reached
+// the REST API and MQTT and stopped here.
+//
+// The shape matters as much as the coverage. A metric name is an external contract: once it is
+// in somebody's dashboard and alert rules, it is not a name any more, it is an interface.
+
+#include <unity.h>
+
+#include <string>
+
+#include "device/bridge_info.h"
+#include "device/device_state.h"
+#include "device/measurement.h"
+#include "diagnostics/diagnostics.h"
+#include "outputs/prometheus/prometheus_metrics.h"
+
+using namespace heliograph;
+
+void setUp() {}
+void tearDown() {}
+
+namespace {
+
+BridgeInfo makeBridge() {
+    BridgeInfo b;
+    b.firmwareVersion = "0.19.1";
+    b.boardName       = "rs485-can";
+    return b;
+}
+
+/// Declares a channel and gives it a reading in one step, because a declared channel with no
+/// value is not what a scraper sees.
+void report(DeviceState& s, const char* id, MeasurementType type, Unit unit, const char* name,
+            double value) {
+    s.measurements.declare(id, type, unit, name);
+    s.measurements.set(id, value, 1000);
+}
+
+/// A single-phase inverter with one string: the shape of Tim's TL3000.
+DeviceState singlePhase() {
+    DeviceState s;
+    s.identity.driverId = "eversolar_legacy";
+    report(s, measurement_id::kAcPowerTotal, MeasurementType::Power, Unit::Watt, "AC Power", 2070);
+    report(s, measurement_id::kAcL1Voltage, MeasurementType::Voltage, Unit::Volt, "V L1", 240.5);
+    report(s, measurement_id::kAcL1Current, MeasurementType::Current, Unit::Ampere, "A L1", 8.4);
+    report(s, measurement_id::kDcMppt1Voltage, MeasurementType::Voltage, Unit::Volt, "MPPT1 V",
+           322.0);
+    report(s, measurement_id::kDcMppt1Power, MeasurementType::Power, Unit::Watt, "MPPT1 W",
+           2125.2);
+    report(s, measurement_id::kOperatingHours, MeasurementType::Duration, Unit::Hour, "Hours",
+           47547);
+    s.dataValid = true;
+    return s;
+}
+
+/// Three phases and a battery: everything the single-phase case does not have.
+DeviceState hybrid() {
+    DeviceState s = singlePhase();
+    s.identity.driverId = "growatt_modbus";
+    report(s, measurement_id::kAcL2Voltage, MeasurementType::Voltage, Unit::Volt, "V L2", 238.1);
+    report(s, measurement_id::kAcL3Voltage, MeasurementType::Voltage, Unit::Volt, "V L3", 239.9);
+    report(s, measurement_id::kBatterySoc, MeasurementType::Ratio, Unit::Percent, "SOC", 64);
+    report(s, measurement_id::kBatteryPower, MeasurementType::Power, Unit::Watt, "Batt W", -1180);
+    report(s, measurement_id::kBatteryTemperature, MeasurementType::Temperature, Unit::Celsius,
+           "Batt °C", 28.4);
+    return s;
+}
+
+std::string metricsOf(const DeviceState& s, const char* id = "inv-1") {
+    DiagnosticsSnapshot d;
+    return prometheus::buildMetrics({{id, &s}}, makeBridge(), d);
+}
+
+size_t occurrences(const std::string& hay, const std::string& needle) {
+    size_t n = 0;
+    for (size_t at = hay.find(needle); at != std::string::npos;
+         at = hay.find(needle, at + needle.size())) {
+        ++n;
+    }
+    return n;
+}
+
+}  // namespace
+
+static void test_the_channels_that_used_to_be_dropped_are_exported() {
+    const std::string text = metricsOf(singlePhase());
+    // Each of these reached the REST API and MQTT and never Prometheus.
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_mppt_voltage_volts{device=\"inv-1\","
+                               "string=\"1\"} 322.000") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_mppt_power_watts{device=\"inv-1\","
+                               "string=\"1\"} 2125.200") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_operating_hours{device=\"inv-1\"} 47547.000")
+                     != std::string::npos);
+}
+
+static void test_a_phase_is_a_label_not_a_name() {
+    const std::string text = metricsOf(hybrid());
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_voltage_volts{device=\"inv-1\","
+                               "phase=\"l1\"} 240.500") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_voltage_volts{device=\"inv-1\","
+                               "phase=\"l3\"} 239.900") != std::string::npos);
+    // The number must not have leaked into the metric name, which would make the three phases
+    // three families that cannot be summed without naming all three.
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_voltage_l2_volts") == std::string::npos);
+}
+
+static void test_one_help_and_one_type_however_many_phases() {
+    const std::string text = metricsOf(hybrid());
+    // Three series share this family. Repeating HELP or TYPE is a parse error in strict
+    // parsers, and grouping the table by name is the only thing preventing it.
+    TEST_ASSERT_EQUAL_UINT32(1, occurrences(text, "# HELP heliograph_inverter_ac_voltage_volts"));
+    TEST_ASSERT_EQUAL_UINT32(1, occurrences(text, "# TYPE heliograph_inverter_ac_voltage_volts"));
+    TEST_ASSERT_EQUAL_UINT32(3, occurrences(text, "heliograph_inverter_ac_voltage_volts{device="));
+}
+
+static void test_a_battery_is_its_own_metric_prefix() {
+    const std::string text = metricsOf(hybrid());
+    TEST_ASSERT_TRUE(text.find("heliograph_battery_state_of_charge_percent{device=\"inv-1\"} "
+                               "64.000") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_battery_power_watts{device=\"inv-1\"} -1180.000")
+                     != std::string::npos);
+    // A query for the inverter's temperature must not have to exclude the battery's.
+    TEST_ASSERT_TRUE(text.find("heliograph_battery_temperature_celsius") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_temperature_celsius") == std::string::npos);
+}
+
+static void test_a_channel_the_inverter_lacks_produces_nothing_at_all() {
+    const std::string text = metricsOf(singlePhase());
+    // Not a zero, and not a bare HELP/TYPE with no samples under it -- which is the shape the
+    // lazy header exists to prevent and the reason the loop walks families rather than devices.
+    TEST_ASSERT_TRUE(text.find("heliograph_battery_state_of_charge_percent") == std::string::npos);
+    TEST_ASSERT_TRUE(text.find("# HELP heliograph_battery_power_watts") == std::string::npos);
+    TEST_ASSERT_TRUE(text.find("phase=\"l2\"") == std::string::npos);
+    TEST_ASSERT_TRUE(text.find("string=\"2\"") == std::string::npos);
+}
+
+static void test_the_array_total_is_not_in_the_same_family_as_its_strings() {
+    const std::string text = metricsOf(singlePhase());
+    // Parts and their sum in one family is how a sum() silently double-counts.
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_mppt_power_watts{device=\"inv-1\","
+                               "string=\"1\"}") != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_power_watts{device=\"inv-1\"} 2070.000")
+                     != std::string::npos);
+    // The whole-inverter AC total carries no phase label, so it can never be mistaken for one.
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_ac_power_watts{device=\"inv-1\",phase=")
+                     == std::string::npos);
+}
+
+static void test_an_invalidated_reading_is_omitted_rather_than_reported() {
+    DeviceState s = singlePhase();
+    s.measurements.invalidate(measurement_id::kDcMppt1Power);
+    const std::string text = metricsOf(s);
+    // Omitted, never zeroed: a 0 W string reads as a dead panel, which is a different fault
+    // from a reading the bridge does not currently have.
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_mppt_power_watts") == std::string::npos);
+    // The rest of the array survives: validity is per channel, not per metric family.
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_mppt_voltage_volts") != std::string::npos);
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_the_channels_that_used_to_be_dropped_are_exported);
+    RUN_TEST(test_a_phase_is_a_label_not_a_name);
+    RUN_TEST(test_one_help_and_one_type_however_many_phases);
+    RUN_TEST(test_a_battery_is_its_own_metric_prefix);
+    RUN_TEST(test_a_channel_the_inverter_lacks_produces_nothing_at_all);
+    RUN_TEST(test_the_array_total_is_not_in_the_same_family_as_its_strings);
+    RUN_TEST(test_an_invalidated_reading_is_omitted_rather_than_reported);
+    return UNITY_END();
+}

--- a/test/test_prometheus/test_main.cpp
+++ b/test/test_prometheus/test_main.cpp
@@ -119,14 +119,25 @@ static void test_one_help_and_one_type_however_many_phases() {
 }
 
 static void test_a_battery_is_its_own_metric_prefix() {
-    const std::string text = metricsOf(hybrid());
+    DeviceState s = hybrid();
+    // BOTH temperatures, on purpose. The first version of this test asserted that the inverter
+    // one was absent -- which it was, because the fixture never reported it. It passed without
+    // saying anything about the prefixes, which is the failure mode a test like this exists to
+    // avoid rather than demonstrate.
+    report(s, measurement_id::kTemperature, MeasurementType::Temperature, Unit::Celsius,
+           "Inverter °C", 47.1);
+    const std::string text = metricsOf(s);
+
     TEST_ASSERT_TRUE(text.find("heliograph_battery_state_of_charge_percent{device=\"inv-1\"} "
                                "64.000") != std::string::npos);
     TEST_ASSERT_TRUE(text.find("heliograph_battery_power_watts{device=\"inv-1\"} -1180.000")
                      != std::string::npos);
-    // A query for the inverter's temperature must not have to exclude the battery's.
-    TEST_ASSERT_TRUE(text.find("heliograph_battery_temperature_celsius") != std::string::npos);
-    TEST_ASSERT_TRUE(text.find("heliograph_inverter_temperature_celsius") == std::string::npos);
+    // Two temperatures, two families, two different numbers: a query for the inverter's must
+    // not have to exclude the battery's, and must not accidentally return it.
+    TEST_ASSERT_TRUE(text.find("heliograph_battery_temperature_celsius{device=\"inv-1\"} 28.400")
+                     != std::string::npos);
+    TEST_ASSERT_TRUE(text.find("heliograph_inverter_temperature_celsius{device=\"inv-1\"} 47.100")
+                     != std::string::npos);
 }
 
 static void test_a_channel_the_inverter_lacks_produces_nothing_at_all() {

--- a/tools/check_measurement_ids.py
+++ b/tools/check_measurement_ids.py
@@ -46,7 +46,8 @@ def main() -> int:
     if missing or extra:
         return 1
     print(f"measurement_id::kAll: OK ({len(listed)} ids)")
-    return check_dashboard_labels(root, body)
+    status = check_dashboard_labels(root, body)
+    return status | check_prometheus_gauges(root, declared)
 
 
 def check_dashboard_labels(root: pathlib.Path, body: str) -> int:
@@ -80,6 +81,33 @@ def check_dashboard_labels(root: pathlib.Path, body: str) -> int:
     if missing or unknown:
         return 1
     print(f"dashboard measurement rows: OK ({len(labelled)} ids)")
+    return 0
+
+
+def check_prometheus_gauges(root: pathlib.Path, declared: set[str]) -> int:
+    """Every canonical measurement must have a gauge in the Prometheus table.
+
+    Prometheus shipped 8 of the 33 channels the model carries for several releases: both MPPT
+    strings, every battery reading, the second and third phase and the operating hours reached
+    REST and MQTT and stopped at a hand-written table nobody re-read. Nothing failed, because a
+    missing gauge is simply a metric that never appears -- and a metric that never appears is
+    indistinguishable from an inverter that does not report it.
+
+    control.* is exempt: those are setpoints, present in kAll so retained Home Assistant configs
+    can be cleared, and no driver reports them as a reading.
+    """
+    wanted = {c for c in declared if not c.startswith("kActivePowerLimit")}
+    metrics = (root / "src/outputs/prometheus/prometheus_metrics.cpp").read_text()
+    table = re.search(r"kInverterGauges\[\] = \{(.*?)\n\};", metrics, re.DOTALL)
+    if not table:
+        print("FAIL: the Prometheus gauge table was not found")
+        return 1
+    exported = set(re.findall(r"measurement_id::(k\w+)", table.group(1)))
+    missing = sorted(wanted - exported)
+    if missing:
+        print("FAIL: no Prometheus gauge for: " + ", ".join(missing))
+        return 1
+    print(f"prometheus gauges: OK ({len(exported)} ids)")
     return 0
 
 


### PR DESCRIPTION
Follow-up to [#103](https://github.com/Timdebruijn/heliograph/pull/103). That one fixed the dashboard; this is the other output the audit found dropping data.

## What was missing

Prometheus exported **8 of the 33** channels the measurement model carries. MQTT, REST and Home Assistant discovery all iterate every supported measurement and were already complete — Prometheus had a hand-written gauge table that nobody re-read.

| | TL3000 | hybrid |
|---|---|---|
| channels reported | 12 | ~24 |
| channels exported before | 8 | 8 |
| missing | 4 | 16 |

On a hybrid that is the entire battery, both MPPT strings, two phases and the operating hours.

**Nothing failed**, which is the point. A missing gauge is a metric that never appears, and a metric that never appears looks exactly like an inverter that does not report it.

## A phase and an MPPT string are labels, not names

They are dimensions of one quantity, so:

```promql
sum by (device) (heliograph_inverter_ac_voltage_volts)
```

works — which it could not if L1, L2 and L3 were `..._l1_volts`, `..._l2_volts`, `..._l3_volts`. And a fourth phase would have meant a fourth metric name.

**Parts are kept out of their totals.** `ac_phase_power_watts` is a separate family from `ac_power_watts`, and `mppt_power_watts` from `dc_power_watts` — parts and their sum in one family is how a `sum()` silently double-counts.

**The battery gets its own prefix.** It is a separate thing that happens to be reported through the inverter; a query for the inverter's temperature should not have to exclude the battery's.

**kWh stays kWh** though Prometheus would prefer joules. Those two names shipped in 0.5.0 and renaming them breaks every dashboard already pointed at them, for a unit nobody reads solar production in.

## ⚠️ One breaking change

`heliograph_inverter_ac_voltage_volts` and `heliograph_inverter_ac_current_amperes` **gained a `phase` label**. The names are unchanged, but a series with a new label is a new series: an existing panel keeps its history and stops receiving points.

Selectors still match. What needs a look is anything assuming a single series — `max by (device)` or `{phase="l1"}` restores the old meaning. Written up under "Upgrading from 0.19.x or earlier" in `docs/prometheus.md`.

Everything else here is purely additive.

## This output had no test suite

It was exercised sideways from `test_rest`, which is how the gap survived several releases. `test_prometheus` adds seven cases: the channels that were dropped, the label shape, one HELP per family however many phases, the battery prefix, an absent channel producing nothing at all (not a zero, not a bare header), totals kept out of part families, and an invalidated reading omitted rather than zeroed.

## Verified

- **818 native tests** (811 + 7 new)
- A canonical id with no gauge is now a CI failure — the same rule the dashboard got in #103
- `check_layering.sh`, `check_web_js.py`, `check_dashboard_layout.py`
- Both firmware targets build clean
- The exposition output was **read, not just asserted**: one HELP/TYPE per family with three phase series under it, MPPT strings labelled, battery under its own prefix, no bare headers