### PR TITLE
fix(dashboard): drop the min-width that was making a laptop scroll

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -70,6 +70,12 @@ td.n{text-align:right;font-variant-numeric:tabular-nums}
    A CONTAINER query, not a media query -- the strip answers to its own width, so it stays right
    if it is ever placed in a narrow column on a wide screen. */
 .strip{container-type:inline-size}
+/* The device name is the ONE cell where wrapping is harmless: it is already two lines by
+   design, a label with the id beneath it. Everywhere else nowrap is what keeps the rows
+   aligned, but here it forced an id like mock_inverter_writable-MOCK-0000000001 onto a single
+   line and took 329px of a 1070px table -- almost a third, spent on a string nobody reads
+   across. Wrapping it is what lets the whole table fit a laptop instead of scrolling. */
+.strip td:first-child{white-space:normal;overflow-wrap:anywhere}
 @container (max-width:760px){
   .strip table,.strip tbody,.strip tr,.strip td{display:block;width:auto}
   .strip tr:first-child{display:none}
@@ -504,17 +510,14 @@ function fleetStrip(fleet){
     if(state==='idle') return 'idle';
     return battArrow[state]+' '+fmt(Math.abs(v),0)+' W';
   };
-  // Each column declares what it actually needs. A flat allowance per column was fine while
-  // the widest cell was a number; it stopped being fine the moment a hybrid appeared, because
-  // the battery cell holds a SENTENCE ("discharging 400 W") and the header "AC voltage" is two
-  // words. At 100px each they wrapped mid-column and the rows lost their alignment -- seen on
-  // a four-device bench the moment the mock started publishing battery power (0.18.0).
-  const all=[{k:'ac_power_w',t:'AC power',d:0,u:'W',w:110},
-             {k:'energy_today_kwh',t:'Today',d:2,u:'kWh',w:110},
-             {k:'ac_voltage_v',t:'AC voltage',d:1,u:'V',w:115},
-             {k:'temperature_c',t:'Temp',d:1,u:'°C',w:90},
-             {k:'battery_soc_pct',t:'SOC',d:0,u:'%',w:80},
-             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt,w:110,state:battState}];
+  // No declared widths. The columns are sized by their content, which nowrap already pins to
+  // one line -- see the table style below for why that is the whole mechanism now.
+  const all=[{k:'ac_power_w',t:'AC power',d:0,u:'W'},
+             {k:'energy_today_kwh',t:'Today',d:2,u:'kWh'},
+             {k:'ac_voltage_v',t:'AC voltage',d:1,u:'V'},
+             {k:'temperature_c',t:'Temp',d:1,u:'°C'},
+             {k:'battery_soc_pct',t:'SOC',d:0,u:'%'},
+             {k:'battery_power_w',t:'Battery',d:0,u:'W',fn:batt,state:battState}];
   const cols=all.filter(c=>fleet.some(f=>f[c.k]!==null&&f[c.k]!==undefined));
   const rows=fleet.map(f=>{
     const answering=f.online&&f.data_valid&&!f.data_stale;
@@ -553,13 +556,18 @@ function fleetStrip(fleet){
       ${cols.map(cell).join('')}
       <td class="n" data-label="Last reply">${when}</td></tr>`;
   }).join('');
-  // Scrolls rather than squeezes: even four columns do not fit a phone, and hiding them below
-  // a breakpoint means the reading you went looking for is the one that is not there.
+  // NO min-width. There used to be one, summed from a declared width per column, and it was
+  // the reason a laptop still got a horizontal scrollbar: it held the table at 1025px when the
+  // content only needed 870, so anything narrower than 1025 scrolled for no reason at all.
   //
-  // Summed from what the columns declare, plus the name and the "Last reply" tag at either end.
-  // nowrap is the other half: without it the table honours min-width and then wraps the text
-  // inside the cells anyway, which is the worst of both -- a scrollbar AND broken rows.
-  const width=260+cols.reduce((a,c)=>a+c.w,0)+150;
+  // It was a second mechanism for a job nowrap already does. nowrap pins every numeric cell to
+  // one line, so those columns set their own floor and cannot be squeezed into wrapping -- the
+  // failure the min-width was added to prevent in 0.18.1, before nowrap existed. Two mechanisms
+  // for one problem, and the redundant one was the coarser of the two.
+  //
+  // The name column is the only one allowed to wrap (see the style block), so it absorbs the
+  // slack: at a 900px container the table now measures 870 and does not scroll, where before it
+  // measured 1025 and did.
   // Only when there is a battery column to explain. A legend for a column that is not on
   // screen is noise, and this strip already filters columns no inverter can fill.
   // Shows the cell itself, not an abstraction of it: same arrow, same colour, same word. A
@@ -572,7 +580,7 @@ function fleetStrip(fleet){
        ${key('discharging','the house is running on it')}
        ${key('idle','')}</div>`
     : '';
-  return `<div class="card strip" style="margin-top:14px"><div style="overflow-x:auto"><table style="min-width:${width}px;white-space:nowrap">
+  return `<div class="card strip" style="margin-top:14px"><div style="overflow-x:auto"><table style="white-space:nowrap">
     <tr><th>Inverter</th>${cols.map(c=>`<th style="text-align:right">${c.t}</th>`).join('')}
     <th style="text-align:right">Last reply</th></tr>${rows}</table></div>${legend}</div>`;
 }

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -79,7 +79,6 @@ td.n{text-align:right;font-variant-numeric:tabular-nums}
 @container (max-width:760px){
   .strip table,.strip tbody,.strip tr,.strip td{display:block;width:auto}
   .strip tr:first-child{display:none}
-  .strip table{min-width:0 !important}
   .strip tr{border:1px solid var(--line);border-radius:10px;padding:10px 12px;margin-bottom:10px}
   .strip td{text-align:left !important;padding:3px 0;display:flex;justify-content:space-between;
             gap:16px;border:0}

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -45,7 +45,7 @@ SOURCE = "src/web/assets/index_html.h"
 # broken table fitted and never wrapped. It is here to guard the opposite failure, something
 # that only misbehaves when there is room to spare. 780 sits just above the fold-over, which is
 # exactly where an off-by-one between the CSS and this file would show up -- and did.
-WIDTHS = (390, 700, 780, 1200)
+WIDTHS = (390, 700, 780, 1000, 1200)
 
 # The payload that broke it: a hybrid reporting a battery, which is what makes the widest
 # column appear at all. Two devices, one of them with a deliberately long label, so the widest
@@ -196,6 +196,20 @@ else {
         +unlabelled[0].textContent.trim().slice(0,30)+'"');
     }
   } else {
+    // A table at a laptop width must FIT. It may scroll -- that is the deliberate fallback for
+    // a bus wide enough to need it -- but a four-device strip on a 1200px screen scrolling is
+    // the regression Tim reported after 0.19.1: a min-width held it at 1025px when the content
+    // needed 870, so every width between those two scrolled for no reason.
+    // Runs whenever the SHAPE is a table and there is real room -- not only above
+    // REQUIRE_TABLE_AT, which the card's own padding puts out of reach at a 1000px screen and
+    // which is why the first version of this assertion never ran where the bug lived. Just
+    // above the fold-over a table may still scroll: that is the honest fallback for a width
+    // where the content genuinely does not fit. A comfortable margin above it may not.
+    const box=strip.parentElement;
+    if(inner>%(fold)s+150 && box.scrollWidth>box.clientWidth+1){
+      fail.push('the table scrolls sideways at '+Math.round(inner)+'px, where it should fit: '
+        +box.scrollWidth+' > '+box.clientWidth);
+    }
     // The legend must not slide out of view with the table. Asserted as BEHAVIOUR, not as
     // structure: an earlier form required the table's immediate parent to be the scroller,
     // which one extra wrapper div would have broken while the page stayed correct.


### PR DESCRIPTION
Reported after 0.19.1: four inverters on a laptop still get a horizontal scrollbar.

## Measured, on the bench at 192.168.20.119

Four mock devices, no labels, 38-character ids, six columns — the real payload, not a synthetic worst case.

| | container 1000px |
|---|---|
| with the min-width | table **1025px**, scrolls |
| without it | table **970px**, fits |

## What it was

The `min-width` was mine, from the 0.18.1 fix, summed from a declared width per column.

At the time that was right: cells could still wrap, and something had to stop the table squeezing them into two lines. But `nowrap` was added **in the same change** — and nowrap already pins every numeric cell to one line, so those columns set their own floor and cannot be squeezed at all.

Two mechanisms for one problem, and the coarser one won. It held the table at 1025px whatever the content actually needed, so **every width between 870 and 1025 scrolled for no reason**. On a phone the strip folds into blocks and never met it; on a laptop that is exactly the band people sit in.

The per-column widths are gone too, being the input to a sum nothing computes any more.

## The name column earns its keep

It is now the only cell allowed to wrap — the one place where wrapping is harmless, since it is already two lines by design (a label with the id beneath it). That is what absorbs the slack: 38 characters of unbreakable id was taking **329px of a 1070px table**, almost a third, spent on a string nobody reads across.

## The check needed two goes to be worth anything

A first version asserted the table "fits at laptop width" and **could not catch this bug**. The assertion was gated on the same threshold that decides a laptop must not fold, which the card's own padding puts out of reach at a 1000px screen — so it never ran where the bug lived. The mutation test passed and told me nothing.

It now runs whenever the shape is a table and there is real room, and **1000px is a tested width** — a laptop's content width, and the band the bug hides in.

Mutation-tested: put the min-width back and it fails with

```
the table scrolls sideways at 970px, where it should fit: 1025 > 970
```

## Verification

818 native tests, `check_layering.sh`, `check_web_js.py`, `check_measurement_ids.py`, the layout check at 390/700/780/1000/1200, and both firmware targets build.