### PR TITLE
Release 0.20.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,9 +141,18 @@ namespace {
 // label; above it the table stays, because four inverters are compared by scanning one column.
 // Nothing is hidden either way, which is what separates this from the column-hiding the web
 // asset has always refused. CI renders the strip and asserts both shapes.
+// 0.20.0 is the release where every output finally reports everything an inverter does. The
+// dashboard showed 6 of the 33 channels the model carries and Prometheus exported 8; MQTT, REST
+// and Home Assistant discovery were already complete. Both now follow the payload, and a
+// canonical id wired into neither fails the build rather than going quietly missing.
+//
+// MINOR, not patch: Prometheus gained a `phase` label on ac_voltage_volts and
+// ac_current_amperes. The names did not change, but a series with a new label is a new series,
+// so an existing Grafana panel keeps its history and stops receiving points. See
+// docs/prometheus.md.
 #define HELIOGRAPH_VERSION_MAJOR 0
-#define HELIOGRAPH_VERSION_MINOR 19
-#define HELIOGRAPH_VERSION_PATCH 1
+#define HELIOGRAPH_VERSION_MINOR 20
+#define HELIOGRAPH_VERSION_PATCH 0
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Version bump. Four changes since v0.19.1, all from one thread: *"ik wil alle info die beschikbaar is, maar geen lege tegels."*

## What is in it

| PR | What |
|---|---|
| [#103](https://github.com/Timdebruijn/heliograph/pull/103) | Dashboard shows every channel an inverter reports, and only those |
| [#104](https://github.com/Timdebruijn/heliograph/pull/104) | Prometheus exports all 33 channels instead of 8 |
| [#105](https://github.com/Timdebruijn/heliograph/pull/105) | Contributor guide: what a genuinely new measurement needs |
| [#106](https://github.com/Timdebruijn/heliograph/pull/106) | The fleet strip stops scrolling sideways on a laptop |

The measured story: a TL3000 reports **12** measurements and the dashboard showed **6**; the model carries **33** and Prometheus exported **8**. MQTT, REST and Home Assistant discovery were already complete — they iterate the payload. The two that lagged did so because they held hand-written lists nobody re-read, and nothing failed when a channel was missing from them.

Both follow the payload now, and a canonical id wired into neither **fails the build**.

## ⚠️ Why MINOR and not a patch

`heliograph_inverter_ac_voltage_volts` and `heliograph_inverter_ac_current_amperes` **gained a `phase` label**. The metric names are unchanged, but a series with a new label is a new series: an existing Grafana panel keeps its history and stops receiving points, with the new series starting empty beside it.

Selectors still match. Anything that assumed a single series wants `max by (device)` or `{phase="l1"}`. Written up under "Upgrading from 0.19.x or earlier" in `docs/prometheus.md`.

Everything else is additive.

## Verified on this exact tree

- **818 native tests**, including the seven-case `test_prometheus` suite that did not exist before #104
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py` (35 ids / 33 dashboard rows / 33 gauges), `check_dashboard_layout.py` at 390/700/780/1000/1200
- All four targets build; the binary reports `0.20.0`, read from the binary rather than the source
- `tools/check_version.sh v0.20.0` passes