### PR TITLE
feat(diagnostics): report why a crash happened, not just that one did

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -154,14 +154,33 @@ A panic writes a full ELF core dump to the `coredump` partition (64 KB, present 
 partition tables; `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` is set in the prebuilt IDF config). It
 survives the reboot.
 
-The bridge now tells you it is there without a cable. The boot log carries a `coredump:` warn
-line naming the faulting task and PC, `GET /api/v1/diagnostics` reports
-`coredump_present` / `coredump_task` / `coredump_pc`, Prometheus exports
-`heliograph_coredump_present`, and Modbus register 828 carries the same flag. That is enough to
-know a crash happened, which task died, and roughly where — usually enough to decide whether it
-is worth going further.
+The bridge reads that dump at boot and reports it **without a cable**. `GET /api/v1/diagnostics`
+carries:
 
-To go further, pull the dump itself:
+| Field | What it says |
+|---|---|
+| `coredump_present` | a valid dump is stored |
+| `coredump_task` | the task that faulted |
+| `coredump_cause` / `coredump_cause_name` | the Xtensa EXCCAUSE, e.g. `28` / `LoadProhibited` |
+| `coredump_fault_address` | the address the faulting access reached for |
+| `coredump_backtrace` | up to 16 PCs, innermost first |
+| `coredump_backtrace_corrupted` | the IDF's own verdict on whether the stack walk stayed sane |
+| `coredump_pc` | one PC — see the warning below |
+
+**Start with the cause and the address.** `LoadProhibited` at `0x00000000` is a null dereference
+and needs no ELF, no cable and no symbol lookup to read. Most crashes are answered right there.
+
+**`coredump_pc` is not the fault.** It is where the panic handler was running, so decoding it
+tends to land somewhere in the IDF's own cache or panic code and explain nothing. It is reported
+because it is what the summary provides, not because it is the useful field — that is
+`coredump_backtrace[0]`.
+
+MQTT carries the cause and the faulting address on the diagnostics topic, but **not** the
+backtrace: sixteen addresses that never change, republished every interval, are payload weight
+for something nobody reads in Home Assistant. Prometheus exports `heliograph_coredump_present`
+as a 0/1 to alert on, and Modbus register 828 carries the same flag.
+
+To resolve the backtrace to file and line, or to pull the dump itself:
 
 ```bash
 python -m esp_coredump --chip esp32s3 --port /dev/tty.usbmodem* info_corefile .pio/build/waveshare-rs485-can/firmware.elf

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -88,6 +88,18 @@ struct BridgeInfo {
     bool        coredumpPresent = false;
     std::string coredumpTask;
     uint32_t    coredumpPc      = 0;
+    /// Why it faulted and what address it reached for. These answer the question without an
+    /// ELF: a LoadProhibited at 0 is a null dereference, and no symbol lookup says it better.
+    /// `coredumpCauseKnown` false means the dump carries no extra info, not that the cause was
+    /// zero -- and 0 is a real cause (IllegalInstruction).
+    uint32_t coredumpCause        = 0;
+    uint32_t coredumpFaultAddress = 0;
+    bool     coredumpCauseKnown   = false;
+    /// The call stack, innermost first, and whether the IDF thinks the walk stayed sane. Carried
+    /// as a vector rather than the fixed array it comes from: everything downstream iterates it,
+    /// and a size that cannot disagree with its contents is one fewer thing to get wrong.
+    std::vector<uint32_t> coredumpBacktrace;
+    bool                  coredumpBacktraceCorrupted = false;
 
     /// The board this firmware is running on. Reported to Home Assistant as the bridge
     /// device's model.

--- a/src/diagnostics/coredump.cpp
+++ b/src/diagnostics/coredump.cpp
@@ -2,6 +2,31 @@
 
 #include "coredump.h"
 
+namespace heliograph::diag {
+
+/// Xtensa EXCCAUSE values, from xtensa/corebits.h. Only the ones a firmware fault plausibly
+/// produces: the TLB and PIF causes exist on the architecture but not on this part in any way
+/// a driver bug reaches, and listing them would suggest a precision this table does not have.
+const char* exceptionCauseName(uint32_t cause) {
+    switch (cause) {
+        case 0:  return "IllegalInstruction";
+        case 1:  return "Syscall";
+        case 2:  return "InstructionFetchError";
+        case 3:  return "LoadStoreError";
+        case 5:  return "Alloca";
+        case 6:  return "DivideByZero";
+        case 7:  return "IllegalPC";
+        case 8:  return "PrivilegedInstruction";
+        case 9:  return "UnalignedLoadStore";
+        case 20: return "InstructionProhibited";
+        case 28: return "LoadProhibited";
+        case 29: return "StoreProhibited";
+        default: return nullptr;
+    }
+}
+
+}  // namespace heliograph::diag
+
 #if defined(ESP32)
 
 #include <esp_core_dump.h>
@@ -32,6 +57,25 @@ CoredumpSummary readCoredumpSummary() {
     // name uses all of it. strnlen bounds it; taking strlen would run into whatever follows.
     out.taskName.assign(summary.exc_task,
                         strnlen(summary.exc_task, sizeof(summary.exc_task)));
+
+    // The two fields that answer "why" without an ELF. exc_cause is an Xtensa EXCCAUSE and
+    // exc_vaddr is the address the faulting access reached for -- together they turn a reboot
+    // into "a null dereference on a load" before anything is decoded.
+    out.exceptionCause = summary.ex_info.exc_cause;
+    out.faultAddress   = summary.ex_info.exc_vaddr;
+    out.causeKnown     = true;
+
+    // The call stack, innermost first. Bounded by BOTH the reported depth and the array size:
+    // depth comes out of a dump that has already survived a crash, and trusting it alone would
+    // read past the end of a fixed 16-entry array if it were wrong.
+    const size_t depth = summary.exc_bt_info.depth < kMaxBacktrace
+                             ? summary.exc_bt_info.depth
+                             : kMaxBacktrace;
+    for (size_t i = 0; i < depth; ++i) {
+        out.backtrace[i] = summary.exc_bt_info.bt[i];
+    }
+    out.backtraceDepth      = depth;
+    out.backtraceCorrupted  = summary.exc_bt_info.corrupted;
     return out;
 }
 

--- a/src/diagnostics/coredump.cpp
+++ b/src/diagnostics/coredump.cpp
@@ -68,6 +68,13 @@ CoredumpSummary readCoredumpSummary() {
     // The call stack, innermost first. Bounded by BOTH the reported depth and the array size:
     // depth comes out of a dump that has already survived a crash, and trusting it alone would
     // read past the end of a fixed 16-entry array if it were wrong.
+    // The bound is only a bound if the two sizes agree. kMaxBacktrace is mirrored in the header
+    // so the host build needs no IDF include, and a mirror is exactly the kind of constant that
+    // drifts silently: were the IDF ever to shrink bt[], this loop would read past its end while
+    // still looking careful.
+    static_assert(sizeof(summary.exc_bt_info.bt) / sizeof(summary.exc_bt_info.bt[0]) ==
+                      kMaxBacktrace,
+                  "kMaxBacktrace no longer matches esp_core_dump_bt_info_t::bt");
     const size_t depth = summary.exc_bt_info.depth < kMaxBacktrace
                              ? summary.exc_bt_info.depth
                              : kMaxBacktrace;

--- a/src/diagnostics/coredump.h
+++ b/src/diagnostics/coredump.h
@@ -9,9 +9,13 @@
 // faulting task sat in flash where only a cable and espcoredump.py could reach it (audit,
 // 2026-07-26).
 //
-// This is the summary, not the dump. Retrieving the ELF itself still wants the host tool -- see
-// docs/hardware.md -- but knowing a dump EXISTS, and which task died, is what turns "something
-// happened" into a question worth taking the cable out for.
+// This is the summary, not the dump. Pulling the ELF still wants the host tool -- see
+// docs/hardware.md -- but the summary now carries the exception cause, the faulting address and
+// a sixteen-deep backtrace, which is usually the whole answer. "LoadProhibited at 0x00000000"
+// is a null dereference, and no cable makes that clearer.
+//
+// The cable is for turning backtrace ADDRESSES into file and line, and only when the cause and
+// the address were not enough.
 
 #pragma once
 

--- a/src/diagnostics/coredump.h
+++ b/src/diagnostics/coredump.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -25,12 +26,44 @@ namespace heliograph::diag {
 ///
 /// The other fields are only meaningful when `present` is true; outputs must report them as
 /// absent otherwise rather than as zero, since task "" at PC 0 is not a fact about anything.
+/// How deep a backtrace the IDF summary can hold. Fixed by esp_core_dump_bt_info_t, not chosen
+/// here -- mirrored as a constant so the host build and its tests do not need the IDF header.
+inline constexpr size_t kMaxBacktrace = 16;
+
 struct CoredumpSummary {
     bool        present = false;
     std::string taskName;         ///< task that caused the exception, "" if the dump omits it
     uint32_t    programCounter = 0;
     uint32_t    version        = 0;  ///< core dump format version, for reading the ELF later
+
+    /// Why it faulted, as an Xtensa EXCCAUSE, and the address it was reaching for.
+    ///
+    /// These two answer the question before a single symbol is looked up: "LoadProhibited at
+    /// 0x00000000" is a null dereference, and no ELF is needed to know that. Both were sitting
+    /// in the summary the firmware already read and were thrown away.
+    uint32_t exceptionCause = 0;
+    uint32_t faultAddress   = 0;
+    bool     causeKnown     = false;  ///< false when the dump carries no extra info at all
+
+    /// The call stack at the moment of the fault, innermost first.
+    ///
+    /// This is what `programCounter` alone could never give. That single PC is where the panic
+    /// handler was running, which is why decoding it landed in Cache_Freeze_ICache_Enable and
+    /// said nothing about the fault (2026-07-28).
+    uint32_t backtrace[kMaxBacktrace] = {};
+    size_t   backtraceDepth           = 0;
+    /// The IDF's own verdict on whether the stack walk stayed sane. A corrupted backtrace is
+    /// still worth showing -- it is often right for the first frame or two -- but it must be
+    /// shown as suspect rather than as fact.
+    bool backtraceCorrupted = false;
 };
+
+/// The EXCCAUSE as a name, or nullptr when the code is not one this table knows.
+///
+/// Returned rather than formatted so the caller decides how an unknown code reads. Values from
+/// xtensa/corebits.h, transcribed rather than included: this header is compiled on the host too,
+/// where that file does not exist.
+const char* exceptionCauseName(uint32_t cause);
 
 /// Reads the summary from flash. Call ONCE, at boot: it verifies a checksum over the whole
 /// stored image, which is far too much work to repeat per REST request.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,6 +369,12 @@ BridgeInfo bridgeInfo() {
     info.coredumpPresent  = g_coredump.present;
     info.coredumpTask     = g_coredump.taskName;
     info.coredumpPc       = g_coredump.programCounter;
+    info.coredumpCause        = g_coredump.exceptionCause;
+    info.coredumpFaultAddress = g_coredump.faultAddress;
+    info.coredumpCauseKnown   = g_coredump.causeKnown;
+    info.coredumpBacktrace.assign(g_coredump.backtrace,
+                                  g_coredump.backtrace + g_coredump.backtraceDepth);
+    info.coredumpBacktraceCorrupted = g_coredump.backtraceCorrupted;
     if (g_relays.count() > 0) {
         {
             std::lock_guard<std::mutex> lock(g_relayMutex);

--- a/src/outputs/json_util.h
+++ b/src/outputs/json_util.h
@@ -16,6 +16,7 @@
 #include "device/capability.h"
 #include "device/command.h"
 #include "device/device_state.h"
+#include "diagnostics/coredump.h"
 #include "diagnostics/diagnostics.h"
 #include "diagnostics/log_timestamp.h"
 
@@ -163,6 +164,30 @@ inline void writeDiagnostics(JsonObject doc, const DiagnosticsSnapshot& d,
         doc["coredump_pc"] = bridge.coredumpPc;
     } else {
         doc["coredump_pc"] = nullptr;
+    }
+    // Why it faulted, and what it was reaching for. Shared with MQTT on purpose: two short
+    // fields are enough for a Home Assistant notification to say "the bridge crashed on a null
+    // dereference" rather than "the bridge crashed". The BACKTRACE is deliberately not here --
+    // sixteen addresses republished every diagnostics interval, never changing, for something
+    // nobody reads in Home Assistant. It lives on the REST payload, which is fetched on purpose.
+    //
+    // Null, not 0, when the dump carries no extra info: 0 is a real cause (IllegalInstruction)
+    // and a real address, so neither can double as "unknown".
+    if (bridge.coredumpPresent && bridge.coredumpCauseKnown) {
+        const char* name       = diag::exceptionCauseName(bridge.coredumpCause);
+        doc["coredump_cause"]  = bridge.coredumpCause;
+        // The number stays alongside the name: a cause this table does not know is still worth
+        // reporting, and a reader with the Xtensa manual can look it up.
+        if (name != nullptr) {
+            doc["coredump_cause_name"] = name;
+        } else {
+            doc["coredump_cause_name"] = nullptr;
+        }
+        doc["coredump_fault_address"] = bridge.coredumpFaultAddress;
+    } else {
+        doc["coredump_cause"]         = nullptr;
+        doc["coredump_cause_name"]    = nullptr;
+        doc["coredump_fault_address"] = nullptr;
     }
     doc["wifi_connected"] = bridge.wifiConnected;
     // Only meaningful while associated; 0 dBm would look like an excellent signal.

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -373,6 +373,24 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     JsonDocument doc;
     json_util::writeDiagnostics(doc.to<JsonObject>(), d, bridge, bridge.boardName,
                                 bridge.mqttConnected);
+    // REST only. The backtrace is the one part of a crash dump worth sixteen numbers, and it is
+    // also the part nobody wants republished over MQTT every interval when it never changes.
+    // Someone fetching /api/v1/diagnostics is asking on purpose.
+    //
+    // Absent, not an empty array, when there is nothing to report: [] would read as "the stack
+    // walk found no frames", which is a different statement from "no dump is stored".
+    if (bridge.coredumpPresent && !bridge.coredumpBacktrace.empty()) {
+        JsonArray bt = doc["coredump_backtrace"].to<JsonArray>();
+        for (const uint32_t pc : bridge.coredumpBacktrace) {
+            bt.add(pc);
+        }
+        // The IDF's own verdict on the stack walk. A corrupted backtrace is still worth showing
+        // -- the innermost frame or two are usually right -- but it must be shown as suspect.
+        doc["coredump_backtrace_corrupted"] = bridge.coredumpBacktraceCorrupted;
+    } else {
+        doc["coredump_backtrace"]           = nullptr;
+        doc["coredump_backtrace_corrupted"] = nullptr;
+    }
     return finish(doc, out, maxBytes);
 }
 

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -332,6 +332,30 @@ static void test_the_mock_hybrid_payload_also_fits() {
 
 // --- diagnostics / identity / capabilities -----------------------------------------------
 
+/// The crash cause travels over MQTT; the backtrace deliberately does not.
+///
+/// Two short fields are what a Home Assistant notification needs to say "the bridge crashed on
+/// a null dereference" rather than "the bridge crashed". Sixteen addresses that never change,
+/// republished on every diagnostics interval, are payload weight for something nobody reads
+/// there -- so the backtrace lives on the REST payload, which is fetched on purpose.
+static void test_the_backtrace_stays_off_the_mqtt_payload() {
+    Rig  r;
+    auto bridge                 = makeBridge();
+    bridge.coredumpPresent      = true;
+    bridge.coredumpCause        = 29;  // EXCCAUSE_STORE_PROHIBITED
+    bridge.coredumpFaultAddress = 0x0000000C;
+    bridge.coredumpCauseKnown   = true;
+    bridge.coredumpBacktrace    = {0x42011AF0, 0x42010C34};
+
+    std::string json;
+    TEST_ASSERT_TRUE(buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+
+    TEST_ASSERT_EQUAL_STRING("StoreProhibited", doc["coredump_cause_name"].as<const char*>());
+    TEST_ASSERT_EQUAL_UINT32(0x0000000C, doc["coredump_fault_address"].as<uint32_t>());
+    TEST_ASSERT_TRUE(doc["coredump_backtrace"].isNull());
+}
+
 static void test_diagnostics_payload() {
     Rig r;
     r.poll();
@@ -1165,6 +1189,7 @@ int main(int, char**) {
     RUN_TEST(test_oversized_payload_is_refused_rather_than_truncated);
     RUN_TEST(test_state_payload_stays_well_within_the_bound);
     RUN_TEST(test_the_mock_hybrid_payload_also_fits);
+    RUN_TEST(test_the_backtrace_stays_off_the_mqtt_payload);
     RUN_TEST(test_diagnostics_payload);
     RUN_TEST(test_rssi_is_null_when_wifi_is_down);
     RUN_TEST(test_diagnostics_report_stack_marks_and_fragmentation);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1904,6 +1904,83 @@ static void test_coredump_details_are_null_when_none_is_stored() {
 
 // A dump whose summary could not be parsed still says present -- the ELF is retrievable with
 // the host tool even when the on-device summariser cannot read it.
+static void test_a_crash_reports_why_and_where_without_an_elf() {
+    Rig  r;
+    auto bridge               = makeBridge();
+    bridge.coredumpPresent    = true;
+    bridge.coredumpTask       = "loopTask";
+    bridge.coredumpPc         = 0x4037DAA9;
+    bridge.coredumpCause      = 28;  // EXCCAUSE_LOAD_PROHIBITED
+    bridge.coredumpFaultAddress = 0x00000000;
+    bridge.coredumpCauseKnown = true;
+    bridge.coredumpBacktrace  = {0x42011AF0, 0x42010C34, 0x4200FE18};
+
+    // These two are the whole point of the change: a null dereference on a load, said without
+    // decoding a single symbol. The single PC this dump also carries is where the PANIC HANDLER
+    // was running -- decoding it landed in the IDF's cache code and explained nothing.
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(28, doc["coredump_cause"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_STRING("LoadProhibited", doc["coredump_cause_name"].as<const char*>());
+    TEST_ASSERT_EQUAL_UINT32(0, doc["coredump_fault_address"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT32(3, doc["coredump_backtrace"].size());
+    TEST_ASSERT_EQUAL_UINT32(0x42011AF0, doc["coredump_backtrace"][0].as<uint32_t>());
+}
+
+static void test_cause_zero_is_a_cause_not_an_absence() {
+    Rig  r;
+    auto bridge                 = makeBridge();
+    bridge.coredumpPresent      = true;
+    bridge.coredumpCause        = 0;  // EXCCAUSE_ILLEGAL, a real fault
+    bridge.coredumpFaultAddress = 0;
+    bridge.coredumpCauseKnown   = true;
+
+    // 0 is a legitimate cause AND a legitimate faulting address, so neither may double as
+    // "unknown". causeKnown is what carries that, and this is the test that stops someone
+    // simplifying it away later.
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_FALSE(doc["coredump_cause"].isNull());
+    TEST_ASSERT_EQUAL_UINT32(0, doc["coredump_cause"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_STRING("IllegalInstruction", doc["coredump_cause_name"].as<const char*>());
+    TEST_ASSERT_FALSE(doc["coredump_fault_address"].isNull());
+}
+
+static void test_a_dump_without_extra_info_reports_null_not_zero() {
+    Rig  r;
+    auto bridge               = makeBridge();
+    bridge.coredumpPresent    = true;
+    bridge.coredumpTask       = "loopTask";
+    bridge.coredumpCauseKnown = false;  // the dump could not be summarised that far
+
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_TRUE(doc["coredump_present"].as<bool>());
+    TEST_ASSERT_TRUE(doc["coredump_cause"].isNull());
+    TEST_ASSERT_TRUE(doc["coredump_cause_name"].isNull());
+    TEST_ASSERT_TRUE(doc["coredump_fault_address"].isNull());
+    TEST_ASSERT_TRUE(doc["coredump_backtrace"].isNull());
+}
+
+static void test_an_unknown_cause_keeps_its_number() {
+    Rig  r;
+    auto bridge               = makeBridge();
+    bridge.coredumpPresent    = true;
+    bridge.coredumpCause      = 61;  // not in the table, and not going to be
+    bridge.coredumpCauseKnown = true;
+
+    // The name is null and the number survives: a cause this table does not know is still worth
+    // reporting to someone holding the Xtensa manual.
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(61, doc["coredump_cause"].as<uint32_t>());
+    TEST_ASSERT_TRUE(doc["coredump_cause_name"].isNull());
+}
+
 static void test_a_nameless_coredump_still_reports_present() {
     Rig  r;
     auto bridge            = makeBridge();
@@ -2503,6 +2580,10 @@ int main(int, char**) {
     RUN_TEST(test_prometheus_exports_the_publish_failure_counter);
     RUN_TEST(test_coredump_is_reported_when_one_is_stored);
     RUN_TEST(test_coredump_details_are_null_when_none_is_stored);
+    RUN_TEST(test_a_crash_reports_why_and_where_without_an_elf);
+    RUN_TEST(test_cause_zero_is_a_cause_not_an_absence);
+    RUN_TEST(test_a_dump_without_extra_info_reports_null_not_zero);
+    RUN_TEST(test_an_unknown_cause_keeps_its_number);
     RUN_TEST(test_a_nameless_coredump_still_reports_present);
     RUN_TEST(test_prometheus_always_reports_the_coredump_flag);
     RUN_TEST(test_stack_marks_are_null_before_the_first_sample);


### PR DESCRIPTION
The bridge read `esp_core_dump_get_summary()` and kept **three** fields out of it. The summary also carries the exception cause, the faulting address, and a sixteen-deep backtrace — read and thrown away.

## What that cost

Trying to diagnose the dump on the EverSolar bridge, its one PC decoded to:

```
0x4037daa9: Cache_Wait_Idle
 (inlined by) Cache_Freeze_ICache_Enable
```

That is the IDF's own cache code, on the panic path — where the *handler* was running, not where the fault was. The one field being reported was the one field that could not answer the question.

`exc_cause` and `exc_vaddr` need **no ELF at all**. "LoadProhibited at 0x00000000" is a null dereference, said in full, before a symbol is looked up. That is the difference between needing a cable and not.

**The dump lives in a flash partition and survives reboots**, so this reads the crash already stored on that bridge — not only the next one.

## Where each field goes, and why not everywhere

| Output | Gets |
|---|---|
| REST | everything, backtrace included |
| MQTT | cause + faulting address only |
| Prometheus | **nothing new** |
| Modbus | unchanged (the present flag) |

**MQTT** gets two short fields so a Home Assistant notification can say *"crashed on a null dereference"* instead of *"crashed"*. The backtrace does not travel: sixteen addresses that never change, republished every diagnostics interval, for something nobody reads there.

**Prometheus gets nothing.** `heliograph_coredump_present` already exists and is the right shape — a 0/1 to alert on. A backtrace is not a time series, and putting the cause in a label would change an existing series' identity for far less benefit than the `phase` label in #104 bought. Today's "every channel reaches every output" rule was about *measurements*; a crash dump is not one, and the reasoning does not transfer.

## Null, never zero

`0` is a real EXCCAUSE (`IllegalInstruction`) **and** a real faulting address, so neither can double as "unknown". `causeKnown` carries that, and `test_cause_zero_is_a_cause_not_an_absence` exists specifically to stop it being simplified away later.

The backtrace is bounded by the array size as well as the reported depth — that depth comes out of a structure that has already survived a crash, and trusting it alone would read past the end of a fixed sixteen-entry array if it were wrong.

## Verification

**823 native tests** (818 + 5 new), covering: cause and backtrace reported without an ELF, cause 0 treated as a cause, a dump without extra info reporting null rather than zero, an unknown cause keeping its number, and the backtrace staying off the MQTT payload.

`check_layering.sh`, `check_web_js.py`, `check_measurement_ids.py`, both firmware targets build clean.

## After merging

Flash the EverSolar bridge and fetch `/api/v1/diagnostics` — the crash from 2026-07-26 should finally say what it was. The backtrace addresses still want the ELF of whatever version crashed for symbol resolution, but the cause and faulting address do not.