### PR TITLE
Release 0.21.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,8 +150,16 @@ namespace {
 // ac_current_amperes. The names did not change, but a series with a new label is a new series,
 // so an existing Grafana panel keeps its history and stops receiving points. See
 // docs/prometheus.md.
+// 0.21.0 makes a crash dump say WHY. The firmware read the IDF summary and kept three fields
+// out of it, discarding the exception cause, the faulting address and a sixteen-deep backtrace.
+// The one PC it did report is where the panic HANDLER was running, so it was the one field that
+// could not answer the question. The cause and the address need no ELF and no cable:
+// "LoadProhibited at 0x00000000" is a null dereference, said in full.
+//
+// The dump survives reboots in its own flash partition, so this reads crashes already stored,
+// not only the next one.
 #define HELIOGRAPH_VERSION_MAJOR 0
-#define HELIOGRAPH_VERSION_MINOR 20
+#define HELIOGRAPH_VERSION_MINOR 21
 #define HELIOGRAPH_VERSION_PATCH 0
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)


### PR DESCRIPTION
Version bump for [#108](https://github.com/Timdebruijn/heliograph/pull/108).

## What 0.21.0 adds

A crash dump now says **why**, not just that one happened.

The firmware read `esp_core_dump_get_summary()` and kept three fields, discarding the exception cause, the faulting address and a sixteen-deep backtrace. The one PC it did report is where the *panic handler* was running — which is why decoding the dump on the EverSolar bridge landed in `Cache_Freeze_ICache_Enable` and explained nothing.

`coredump_cause_name` and `coredump_fault_address` need **no ELF and no cable**: `LoadProhibited` at `0x00000000` is a null dereference, said in full.

The dump lives in its own flash partition and survives reboots, so this reads crashes **already stored** — not only the next one.

## New API fields

`GET /api/v1/diagnostics` gains `coredump_cause`, `coredump_cause_name`, `coredump_fault_address`, `coredump_backtrace` and `coredump_backtrace_corrupted`.

MQTT gets the cause and the address only; the backtrace stays off it. Prometheus and Modbus are unchanged — `heliograph_coredump_present` was already the right shape.

Additive: nothing renamed, nothing removed.

## Verified on this exact tree

- **823 native tests**, including five new ones covering cause 0 being a real cause rather than an absence, an unknown cause keeping its number, and the backtrace staying off the MQTT payload
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py`, `check_dashboard_layout.py`
- All four targets build; the binary reports `0.21.0`, read from the binary rather than the source
- `tools/check_version.sh v0.21.0` passes

## Next step on the bench

Flash `192.168.20.254` and fetch `/api/v1/diagnostics`. The crash stored there since 2026-07-26 should finally name itself.