### PR TITLE
fix(diagnostics): stop naming a fault the dump did not record, and ship the ELF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,19 @@ jobs:
       #
       # if-no-files-found: error rather than the default warning. A silently empty artifact would
       # surface three steps later as a cp that cannot find its source, in the job that publishes.
+      # The ELF is what turns a crash dump's backtrace into file and line, and it is thrown away
+      # everywhere else. A dump names addresses in the image that was RUNNING, so the ELF has to
+      # be the one that shipped -- rebuilding the tag afterwards does not reproduce the layout
+      # closely enough, which is exactly how a real dump on the EverSolar bridge became
+      # undecodable (2026-07-28).
+      #
+      # Compressed because it is ~33 MB of mostly debug information and gzips to a fraction of
+      # that. Three boards uncompressed would be 100 MB of release storage per tag, for a file
+      # most releases never need.
+      - name: Compress the ELF for the release
+        run: gzip -9 -c .pio/build/waveshare-${{ matrix.board }}/firmware.elf
+             > .pio/build/waveshare-${{ matrix.board }}/firmware.elf.gz
+
       - name: Upload images
         uses: actions/upload-artifact@v7
         with:
@@ -155,6 +168,7 @@ jobs:
           path: |
             .pio/build/waveshare-${{ matrix.board }}/firmware.bin
             .pio/build/waveshare-${{ matrix.board }}/firmware.factory.bin
+            .pio/build/waveshare-${{ matrix.board }}/firmware.elf.gz
           if-no-files-found: error
           retention-days: 1
 
@@ -200,6 +214,9 @@ jobs:
             cp "fw/fw-${board}/firmware.bin" "dist/heliograph-${VERSION}-${board}.bin"
             cp "fw/fw-${board}/firmware.factory.bin" \
                "dist/heliograph-${VERSION}-${board}-factory.bin"
+            # Debug symbols for this exact image. Only useful with a crash dump, which is why it
+            # is not on the flasher site -- it is a release asset you fetch when you need it.
+            cp "fw/fw-${board}/firmware.elf.gz" "dist/heliograph-${VERSION}-${board}.elf.gz"
           done
           ls -l dist
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -170,6 +170,12 @@ carries:
 **Start with the cause and the address.** `LoadProhibited` at `0x00000000` is a null dereference
 and needs no ELF, no cable and no symbol lookup to read. Most crashes are answered right there.
 
+**A null `coredump_cause` does not mean the dump is useless.** It means the panic was not a CPU
+exception — an abort, a failed assert, a watchdog — and those leave the IDF's exception fields
+zeroed. The backtrace is still there and is still the answer. Cause `0` is reported as *no*
+cause deliberately: `0` is `IllegalInstruction` on the ISA, but an abort looks identical in this
+struct, and naming one after the other would invent a fault that did not happen.
+
 **`coredump_pc` is not the fault.** It is where the panic handler was running, so decoding it
 tends to land somewhere in the IDF's own cache or panic code and explain nothing. It is reported
 because it is what the summary provides, not because it is the useful field — that is
@@ -180,7 +186,27 @@ backtrace: sixteen addresses that never change, republished every interval, are 
 for something nobody reads in Home Assistant. Prometheus exports `heliograph_coredump_present`
 as a 0/1 to alert on, and Modbus register 828 carries the same flag.
 
-To resolve the backtrace to file and line, or to pull the dump itself:
+### Resolving the backtrace
+
+The addresses are offsets into the image that was **running**, so you need that image's ELF.
+Every release publishes one per board:
+
+```bash
+gh release download v0.21.1 --pattern 'heliograph-*-rs485-can.elf.gz'
+gunzip heliograph-0.21.1-rs485-can.elf.gz
+xtensa-esp32s3-elf-addr2line -pfiaC -e heliograph-0.21.1-rs485-can.elf 0x420529B7 0x420506CD
+```
+
+The toolchain lives at
+`~/.platformio/packages/toolchain-xtensa-esp-elf/bin/xtensa-esp32s3-elf-addr2line`.
+
+**Rebuilding the tag is not a substitute.** It produces a different layout, and the addresses
+then land in unrelated functions that decode perfectly and mean nothing — tried on a real dump
+from this bridge, against two candidate tags, and both gave call chains that could not exist.
+If the release predates ELF publishing (before 0.21.1), the dump cannot be resolved. Clear it
+and wait for one that can.
+
+To pull the dump itself, with a cable:
 
 ```bash
 python -m esp_coredump --chip esp32s3 --port /dev/tty.usbmodem* info_corefile .pio/build/waveshare-rs485-can/firmware.elf

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -192,9 +192,12 @@ The addresses are offsets into the image that was **running**, so you need that 
 Every release publishes one per board:
 
 ```bash
-gh release download v0.21.1 --pattern 'heliograph-*-rs485-can.elf.gz'
-gunzip heliograph-0.21.1-rs485-can.elf.gz
-xtensa-esp32s3-elf-addr2line -pfiaC -e heliograph-0.21.1-rs485-can.elf 0x420529B7 0x420506CD
+# The release the bridge was RUNNING when it crashed -- not the newest one.
+VERSION=0.21.1
+gh release download "v${VERSION}" --pattern "heliograph-*-rs485-can.elf.gz"
+gunzip "heliograph-${VERSION}-rs485-can.elf.gz"
+xtensa-esp32s3-elf-addr2line -pfiaC \
+  -e "heliograph-${VERSION}-rs485-can.elf" 0x420529B7 0x420506CD
 ```
 
 The toolchain lives at

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -95,6 +95,9 @@ struct BridgeInfo {
     uint32_t coredumpCause        = 0;
     uint32_t coredumpFaultAddress = 0;
     bool     coredumpCauseKnown   = false;
+    /// Whether the faulting address means anything for this cause. Only a load or a store has
+    /// one; elsewhere the field is leftover, and 0 there looks exactly like a null dereference.
+    bool coredumpFaultAddressKnown = false;
     /// The call stack, innermost first, and whether the IDF thinks the walk stayed sane. Carried
     /// as a vector rather than the fixed array it comes from: everything downstream iterates it,
     /// and a size that cannot disagree with its contents is one fewer thing to get wrong.

--- a/src/diagnostics/coredump.cpp
+++ b/src/diagnostics/coredump.cpp
@@ -7,22 +7,56 @@ namespace heliograph::diag {
 /// Xtensa EXCCAUSE values, from xtensa/corebits.h. Only the ones a firmware fault plausibly
 /// produces: the TLB and PIF causes exist on the architecture but not on this part in any way
 /// a driver bug reaches, and listing them would suggest a precision this table does not have.
-const char* exceptionCauseName(uint32_t cause) {
-    switch (cause) {
-        case 0:  return "IllegalInstruction";
-        case 1:  return "Syscall";
-        case 2:  return "InstructionFetchError";
-        case 3:  return "LoadStoreError";
-        case 5:  return "Alloca";
-        case 6:  return "DivideByZero";
-        case 7:  return "IllegalPC";
-        case 8:  return "PrivilegedInstruction";
-        case 9:  return "UnalignedLoadStore";
-        case 20: return "InstructionProhibited";
-        case 28: return "LoadProhibited";
-        case 29: return "StoreProhibited";
-        default: return nullptr;
+namespace {
+
+/// One row per cause: what it is called, and whether a faulting ADDRESS means anything for it.
+///
+/// Both questions live here because they were two switch statements that had already drifted --
+/// one knew about LoadStoreRing and the other did not, with no stated reason. A cause is one
+/// thing; asking two questions of it should not need two lists that can disagree.
+struct CauseSpec {
+    uint32_t    code;
+    const char* name;
+    /// exc_vaddr is the address a load or a store reached for. On any other cause the field is
+    /// leftover, and a 0 there reads exactly like a null-pointer dereference without being one.
+    bool hasFaultAddress;
+};
+
+constexpr CauseSpec kCauses[] = {
+    {0, "IllegalInstruction", false},
+    {1, "Syscall", false},
+    {2, "InstructionFetchError", false},
+    {3, "LoadStoreError", true},
+    {5, "Alloca", false},
+    {6, "DivideByZero", false},
+    {7, "IllegalPC", false},
+    {8, "PrivilegedInstruction", false},
+    {9, "UnalignedLoadStore", true},
+    {20, "InstructionProhibited", false},
+    {26, "LoadStorePrivilege", true},
+    {28, "LoadProhibited", true},
+    {29, "StoreProhibited", true},
+};
+
+const CauseSpec* findCause(uint32_t cause) {
+    for (const auto& spec : kCauses) {
+        if (spec.code == cause) {
+            return &spec;
+        }
     }
+    return nullptr;
+}
+
+}  // namespace
+
+const char* exceptionCauseName(uint32_t cause) {
+    const CauseSpec* spec = findCause(cause);
+    return spec != nullptr ? spec->name : nullptr;
+}
+
+bool causeHasFaultAddress(uint32_t cause) {
+    const CauseSpec* spec = findCause(cause);
+    return spec != nullptr && spec->hasFaultAddress;
 }
 
 }  // namespace heliograph::diag
@@ -81,18 +115,7 @@ CoredumpSummary readCoredumpSummary() {
     // address a load or a store reached for; on a divide-by-zero or an illegal instruction it
     // is whatever happened to be in the field, and 0 there is noise wearing the shape of a
     // null-pointer dereference.
-    switch (summary.ex_info.exc_cause) {
-        case 3:   // LoadStoreError
-        case 9:   // UnalignedLoadStore
-        case 26:  // LoadStoreRing
-        case 28:  // LoadProhibited
-        case 29:  // StoreProhibited
-            out.faultAddressKnown = true;
-            break;
-        default:
-            out.faultAddressKnown = false;
-            break;
-    }
+    out.faultAddressKnown = causeHasFaultAddress(summary.ex_info.exc_cause);
 
     // The call stack, innermost first. Bounded by BOTH the reported depth and the array size:
     // depth comes out of a dump that has already survived a crash, and trusting it alone would

--- a/src/diagnostics/coredump.cpp
+++ b/src/diagnostics/coredump.cpp
@@ -63,7 +63,36 @@ CoredumpSummary readCoredumpSummary() {
     // into "a null dereference on a load" before anything is decoded.
     out.exceptionCause = summary.ex_info.exc_cause;
     out.faultAddress   = summary.ex_info.exc_vaddr;
-    out.causeKnown     = true;
+
+    // A CAUSE OF 0 IS TREATED AS NO CAUSE, and that is a deliberate trade.
+    //
+    // 0 is EXCCAUSE_ILLEGAL on the ISA, so this gives up the ability to name a genuine illegal
+    // instruction. It is still right: a panic that is not a CPU exception at all -- an abort, a
+    // failed assert, a watchdog -- leaves the whole ex_info zeroed, and that is far and away
+    // the common case. Reporting a zeroed field as "IllegalInstruction at 0x00000000" invents
+    // a fault, which is the one thing this project does not do with a reading.
+    //
+    // Found on a real dump from a production bridge: cause 0, vaddr 0, and a fault PC inside
+    // the chip's own ROM. An illegal instruction in Espressif's ROM is not a thing that
+    // happens; an abort walking out through the panic handler is (2026-07-28).
+    out.causeKnown = summary.ex_info.exc_cause != 0;
+
+    // The faulting address only means something for a fault that HAS one. exc_vaddr is the
+    // address a load or a store reached for; on a divide-by-zero or an illegal instruction it
+    // is whatever happened to be in the field, and 0 there is noise wearing the shape of a
+    // null-pointer dereference.
+    switch (summary.ex_info.exc_cause) {
+        case 3:   // LoadStoreError
+        case 9:   // UnalignedLoadStore
+        case 26:  // LoadStoreRing
+        case 28:  // LoadProhibited
+        case 29:  // StoreProhibited
+            out.faultAddressKnown = true;
+            break;
+        default:
+            out.faultAddressKnown = false;
+            break;
+    }
 
     // The call stack, innermost first. Bounded by BOTH the reported depth and the array size:
     // depth comes out of a dump that has already survived a crash, and trusting it alone would

--- a/src/diagnostics/coredump.h
+++ b/src/diagnostics/coredump.h
@@ -47,7 +47,14 @@ struct CoredumpSummary {
     /// in the summary the firmware already read and were thrown away.
     uint32_t exceptionCause = 0;
     uint32_t faultAddress   = 0;
-    bool     causeKnown     = false;  ///< false when the dump carries no extra info at all
+    /// False when the dump records no usable cause. A cause of 0 counts as none: 0 is
+    /// EXCCAUSE_ILLEGAL on the ISA, but an abort, a failed assert or a watchdog leaves the
+    /// whole field zeroed, and naming that "IllegalInstruction" invents a fault.
+    bool causeKnown = false;
+    /// False when the cause is not one that HAS a faulting address. exc_vaddr is what a load or
+    /// a store reached for; on any other cause it is leftover, and a 0 there reads exactly like
+    /// a null-pointer dereference without being one.
+    bool faultAddressKnown = false;
 
     /// The call stack at the moment of the fault, innermost first.
     ///

--- a/src/diagnostics/coredump.h
+++ b/src/diagnostics/coredump.h
@@ -76,6 +76,13 @@ struct CoredumpSummary {
 /// where that file does not exist.
 const char* exceptionCauseName(uint32_t cause);
 
+/// Whether a faulting ADDRESS means anything for this cause.
+///
+/// Only a load or a store has one. Asked separately from the name because they are separate
+/// questions, and answered from the same table because two lists about the same causes had
+/// already drifted apart once.
+bool causeHasFaultAddress(uint32_t cause);
+
 /// Reads the summary from flash. Call ONCE, at boot: it verifies a checksum over the whole
 /// stored image, which is far too much work to repeat per REST request.
 ///

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -379,7 +379,8 @@ BridgeInfo bridgeInfo() {
     info.coredumpPc       = g_coredump.programCounter;
     info.coredumpCause        = g_coredump.exceptionCause;
     info.coredumpFaultAddress = g_coredump.faultAddress;
-    info.coredumpCauseKnown   = g_coredump.causeKnown;
+    info.coredumpCauseKnown        = g_coredump.causeKnown;
+    info.coredumpFaultAddressKnown = g_coredump.faultAddressKnown;
     info.coredumpBacktrace.assign(g_coredump.backtrace,
                                   g_coredump.backtrace + g_coredump.backtraceDepth);
     info.coredumpBacktraceCorrupted = g_coredump.backtraceCorrupted;

--- a/src/outputs/json_util.h
+++ b/src/outputs/json_util.h
@@ -173,20 +173,26 @@ inline void writeDiagnostics(JsonObject doc, const DiagnosticsSnapshot& d,
     //
     // Null, not 0, when the dump carries no extra info: 0 is a real cause (IllegalInstruction)
     // and a real address, so neither can double as "unknown".
+    // Two separate questions, and conflating them is what put "IllegalInstruction at 0x00000000"
+    // on a dump that was an abort. Whether a CAUSE was recorded, and whether that cause is one
+    // that HAS a faulting address, are not the same thing.
     if (bridge.coredumpPresent && bridge.coredumpCauseKnown) {
-        const char* name       = diag::exceptionCauseName(bridge.coredumpCause);
-        doc["coredump_cause"]  = bridge.coredumpCause;
+        doc["coredump_cause"] = bridge.coredumpCause;
         // The number stays alongside the name: a cause this table does not know is still worth
         // reporting, and a reader with the Xtensa manual can look it up.
+        const char* name = diag::exceptionCauseName(bridge.coredumpCause);
         if (name != nullptr) {
             doc["coredump_cause_name"] = name;
         } else {
             doc["coredump_cause_name"] = nullptr;
         }
+    } else {
+        doc["coredump_cause"]      = nullptr;
+        doc["coredump_cause_name"] = nullptr;
+    }
+    if (bridge.coredumpPresent && bridge.coredumpFaultAddressKnown) {
         doc["coredump_fault_address"] = bridge.coredumpFaultAddress;
     } else {
-        doc["coredump_cause"]         = nullptr;
-        doc["coredump_cause_name"]    = nullptr;
         doc["coredump_fault_address"] = nullptr;
     }
     doc["wifi_connected"] = bridge.wifiConnected;

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -344,8 +344,9 @@ static void test_the_backtrace_stays_off_the_mqtt_payload() {
     bridge.coredumpPresent      = true;
     bridge.coredumpCause        = 29;  // EXCCAUSE_STORE_PROHIBITED
     bridge.coredumpFaultAddress = 0x0000000C;
-    bridge.coredumpCauseKnown   = true;
-    bridge.coredumpBacktrace    = {0x42011AF0, 0x42010C34};
+    bridge.coredumpCauseKnown        = true;
+    bridge.coredumpFaultAddressKnown = true;  // StoreProhibited genuinely has one
+    bridge.coredumpBacktrace         = {0x42011AF0, 0x42010C34};
 
     std::string json;
     TEST_ASSERT_TRUE(buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "config/configuration.h"
+#include "diagnostics/coredump.h"
 #include "diagnostics/logger.h"
 #include "outputs/modbus_tcp/modbus_tcp_server.h"
 #include "device/device_context.h"
@@ -1939,6 +1940,30 @@ static void test_a_crash_reports_why_and_where_without_an_elf() {
 // So a zero cause is reported as no cause. The trade is real and worth stating: a genuine
 // illegal instruction now goes unnamed. Naming an abort after a fault it did not have is worse,
 // and inventing a reading is the one thing this project does not do.
+// The cause table itself, which nothing reached before: the switch deciding whether a cause has
+// a faulting address lived inside the ESP32-only block, so no host test could see it. Two lists
+// about the same causes had already drifted -- one knew LoadStorePrivilege and the other did
+// not -- and neither was testable.
+static void test_the_cause_table_answers_both_questions_consistently() {
+    // Named and carrying an address: the load and store faults.
+    TEST_ASSERT_EQUAL_STRING("LoadProhibited", diag::exceptionCauseName(28));
+    TEST_ASSERT_TRUE(diag::causeHasFaultAddress(28));
+    TEST_ASSERT_EQUAL_STRING("StoreProhibited", diag::exceptionCauseName(29));
+    TEST_ASSERT_TRUE(diag::causeHasFaultAddress(29));
+    TEST_ASSERT_EQUAL_STRING("UnalignedLoadStore", diag::exceptionCauseName(9));
+    TEST_ASSERT_TRUE(diag::causeHasFaultAddress(9));
+
+    // Named, but no address is involved: nothing was being addressed.
+    TEST_ASSERT_EQUAL_STRING("DivideByZero", diag::exceptionCauseName(6));
+    TEST_ASSERT_FALSE(diag::causeHasFaultAddress(6));
+    TEST_ASSERT_EQUAL_STRING("IllegalInstruction", diag::exceptionCauseName(0));
+    TEST_ASSERT_FALSE(diag::causeHasFaultAddress(0));
+
+    // Unknown to the table: no name, and certainly no address to claim.
+    TEST_ASSERT_NULL(diag::exceptionCauseName(61));
+    TEST_ASSERT_FALSE(diag::causeHasFaultAddress(61));
+}
+
 static void test_a_zero_cause_is_reported_as_no_cause() {
     Rig  r;
     auto bridge                 = makeBridge();
@@ -2622,6 +2647,7 @@ int main(int, char**) {
     RUN_TEST(test_coredump_is_reported_when_one_is_stored);
     RUN_TEST(test_coredump_details_are_null_when_none_is_stored);
     RUN_TEST(test_a_crash_reports_why_and_where_without_an_elf);
+    RUN_TEST(test_the_cause_table_answers_both_questions_consistently);
     RUN_TEST(test_a_zero_cause_is_reported_as_no_cause);
     RUN_TEST(test_a_fault_address_is_only_reported_where_it_means_something);
     RUN_TEST(test_a_dump_without_extra_info_reports_null_not_zero);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1928,24 +1928,65 @@ static void test_a_crash_reports_why_and_where_without_an_elf() {
     TEST_ASSERT_EQUAL_UINT32(0x42011AF0, doc["coredump_backtrace"][0].as<uint32_t>());
 }
 
-static void test_cause_zero_is_a_cause_not_an_absence() {
+// This test used to assert the OPPOSITE, and was right on the ISA and wrong in practice.
+//
+// 0 is EXCCAUSE_ILLEGAL, so yesterday it was reported as "IllegalInstruction". Then a real dump
+// arrived: the EverSolar bridge had cause 0, vaddr 0, and a fault PC of 0x4037DAA9 -- inside
+// the chip's ROM. An illegal instruction in Espressif's own ROM does not happen; an abort, a
+// failed assert or a watchdog walking out through the panic handler does, and every one of
+// those leaves the whole ex_info zeroed.
+//
+// So a zero cause is reported as no cause. The trade is real and worth stating: a genuine
+// illegal instruction now goes unnamed. Naming an abort after a fault it did not have is worse,
+// and inventing a reading is the one thing this project does not do.
+static void test_a_zero_cause_is_reported_as_no_cause() {
     Rig  r;
     auto bridge                 = makeBridge();
     bridge.coredumpPresent      = true;
-    bridge.coredumpCause        = 0;  // EXCCAUSE_ILLEGAL, a real fault
+    bridge.coredumpTask         = "loopTask";
+    bridge.coredumpCause        = 0;
     bridge.coredumpFaultAddress = 0;
-    bridge.coredumpCauseKnown   = true;
+    bridge.coredumpCauseKnown   = false;  // what the reader now decides for a zero cause
 
-    // 0 is a legitimate cause AND a legitimate faulting address, so neither may double as
-    // "unknown". causeKnown is what carries that, and this is the test that stops someone
-    // simplifying it away later.
     std::string json;
     TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), bridge, json));
     auto doc = parse(json);
-    TEST_ASSERT_FALSE(doc["coredump_cause"].isNull());
-    TEST_ASSERT_EQUAL_UINT32(0, doc["coredump_cause"].as<uint32_t>());
-    TEST_ASSERT_EQUAL_STRING("IllegalInstruction", doc["coredump_cause_name"].as<const char*>());
-    TEST_ASSERT_FALSE(doc["coredump_fault_address"].isNull());
+    TEST_ASSERT_TRUE(doc["coredump_present"].as<bool>());
+    TEST_ASSERT_TRUE(doc["coredump_cause"].isNull());
+    TEST_ASSERT_TRUE(doc["coredump_cause_name"].isNull());
+    TEST_ASSERT_TRUE(doc["coredump_fault_address"].isNull());
+}
+
+// A faulting address belongs to a fault that HAS one. exc_vaddr is what a load or a store
+// reached for; on a divide-by-zero it is leftover, and a 0 there reads exactly like a null
+// dereference without being one.
+static void test_a_fault_address_is_only_reported_where_it_means_something() {
+    Rig  r;
+    auto withAddress                 = makeBridge();
+    withAddress.coredumpPresent      = true;
+    withAddress.coredumpCause        = 28;  // LoadProhibited: vaddr is the address it read
+    withAddress.coredumpFaultAddress = 0x0000002C;
+    withAddress.coredumpCauseKnown   = true;
+    withAddress.coredumpFaultAddressKnown = true;
+
+    std::string json;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), withAddress, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(0x2C, doc["coredump_fault_address"].as<uint32_t>());
+
+    auto without                 = makeBridge();
+    without.coredumpPresent      = true;
+    without.coredumpCause        = 6;  // DivideByZero: no address is involved
+    without.coredumpFaultAddress = 0;
+    without.coredumpCauseKnown   = true;
+    without.coredumpFaultAddressKnown = false;
+
+    std::string json2;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(r.diagnostics.snapshot(), without, json2));
+    auto doc2 = parse(json2);
+    // The cause survives; only the address that does not apply is withheld.
+    TEST_ASSERT_EQUAL_STRING("DivideByZero", doc2["coredump_cause_name"].as<const char*>());
+    TEST_ASSERT_TRUE(doc2["coredump_fault_address"].isNull());
 }
 
 static void test_a_dump_without_extra_info_reports_null_not_zero() {
@@ -2581,7 +2622,8 @@ int main(int, char**) {
     RUN_TEST(test_coredump_is_reported_when_one_is_stored);
     RUN_TEST(test_coredump_details_are_null_when_none_is_stored);
     RUN_TEST(test_a_crash_reports_why_and_where_without_an_elf);
-    RUN_TEST(test_cause_zero_is_a_cause_not_an_absence);
+    RUN_TEST(test_a_zero_cause_is_reported_as_no_cause);
+    RUN_TEST(test_a_fault_address_is_only_reported_where_it_means_something);
     RUN_TEST(test_a_dump_without_extra_info_reports_null_not_zero);
     RUN_TEST(test_an_unknown_cause_keeps_its_number);
     RUN_TEST(test_a_nameless_coredump_still_reports_present);


### PR DESCRIPTION
Two things, both found by taking 0.21.0 to a real crash dump an hour after tagging it.

## 1. A zero cause was reported as `IllegalInstruction`

`0` is `EXCCAUSE_ILLEGAL` on the ISA, so yesterday that looked correct. The dump on the production bridge says otherwise:

```
coredump_cause          0  → "IllegalInstruction"
coredump_fault_address  0x00000000
coredump_pc             0x4037DAA9      ← inside the chip's ROM
```

An illegal instruction in Espressif's own ROM does not happen. An **abort** does — a failed assert, a watchdog — and every one of those leaves the whole `ex_info` zeroed. That is far and away the common case.

So the payload reported a fault that never occurred, at an address nothing touched. That is precisely what this project refuses to do with a reading, and I shipped it an hour ago.

**A zero cause is now no cause.** The trade is real and written down: a genuine illegal instruction goes unnamed. That is the cheaper mistake.

**The faulting address is now reported only for the causes that have one** — the load and store faults. `exc_vaddr` on a divide-by-zero is leftover, and a `0` there reads exactly like a null dereference without being one. Two questions, two flags; conflating them is what produced "IllegalInstruction at 0x00000000" on a dump that was neither.

## 2. The ELF is now a release asset

A backtrace names addresses in the image that was **running**, and releases shipped only `.bin`.

Rebuilding the tag afterwards does not reproduce the layout. Tried against two candidate tags for the stored dump; both produced call chains that decoded perfectly and cannot exist — REST payload building calling a `DeviceState` constructor calling a red-black tree copy. Confident nonsense, exactly as `docs/hardware.md` warned it would be.

Gzipped in the build job: **32.3 MB → 11.7 MB**. Three boards is 35 MB a tag, for a file most releases never need and one release badly does.

## The tests that pinned the old behaviour

`test_cause_zero_is_a_cause_not_an_absence` asserted exactly what is now wrong. It is **replaced, not deleted**, by a test that states why the answer inverted — otherwise the next reader restores the ISA-correct version and the bug with it.

A second new test covers the faulting address being withheld where it means nothing while the cause survives.

## Verification

- **824 native tests**
- `check_layering.sh` — which caught a brand name in one of my own comments outside `src/drivers/`, rule 1 doing its job
- `check_web_js.py`, `check_measurement_ids.py`, both firmware targets build
- Workflow YAML parsed; the compress step sits between build and upload

## Note

The dump currently on the bridge predates ELF publishing, so it stays unresolvable. `docs/hardware.md` now says that plainly: clear it and wait for one that can be resolved.