### PR TITLE
Release 0.21.1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,9 +158,18 @@ namespace {
 //
 // The dump survives reboots in its own flash partition, so this reads crashes already stored,
 // not only the next one.
+// 0.21.1 stops 0.21.0 naming a fault the dump never recorded. A cause of 0 is EXCCAUSE_ILLEGAL
+// on the ISA, but an abort, a failed assert or a watchdog leaves the whole field zeroed -- and
+// that is the common case, so "IllegalInstruction at 0x00000000" was an invented fault on a
+// dump that was neither. A zero cause is now no cause, and a faulting address is reported only
+// for the causes that have one.
+//
+// It also ships the ELF as a release asset. A backtrace names addresses in the image that was
+// RUNNING, and rebuilding a tag afterwards does not reproduce the layout -- which is how the
+// dump on the production bridge became undecodable.
 #define HELIOGRAPH_VERSION_MAJOR 0
 #define HELIOGRAPH_VERSION_MINOR 21
-#define HELIOGRAPH_VERSION_PATCH 0
+#define HELIOGRAPH_VERSION_PATCH 1
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Fixes a bug in 0.21.0 found by pointing it at a real crash dump an hour after tagging it.

## What 0.21.1 fixes

**0.21.0 named a fault the dump never recorded.** A cause of `0` is `EXCCAUSE_ILLEGAL` on the ISA, so it was reported as `IllegalInstruction`. The dump on the production bridge showed why that is wrong: cause `0`, faulting address `0`, and a fault PC inside the chip's own ROM. An illegal instruction in Espressif's ROM does not happen — an abort, a failed assert or a watchdog does, and every one of those leaves the exception fields zeroed.

A zero cause is now **no** cause. A genuine illegal instruction goes unnamed as a result; inventing a fault is the worse mistake.

The faulting address is reported only for the causes that **have** one. `exc_vaddr` on a divide-by-zero is leftover, and a `0` there reads exactly like a null dereference without being one.

## And the ELF ships

A backtrace names addresses in the image that was **running**. Releases shipped only `.bin`, and rebuilding the tag afterwards does not reproduce the layout — tried against two candidate tags for the stored dump, both giving call chains that decoded cleanly and cannot exist.

Now published per board, gzipped: 32.3 MB → 11.7 MB.

## Verified on this exact tree

- **825 native tests**, including a new one covering the cause table directly — it was previously unreachable, sitting inside the ESP32-only block
- `check_layering.sh`, `check_web_js.py`, `check_measurement_ids.py`, `check_dashboard_layout.py`
- All four targets build; the binary reports `0.21.1`, read from the binary rather than the source
- `tools/check_version.sh v0.21.1` passes
- The release YAML's gzip step was parsed to confirm it folds into one command with its redirect — that failure would only surface at tag time

## Note

The dump currently on the bridge predates ELF publishing and stays unresolvable. Clear it after flashing so the next one is distinguishable.