### PR TITLE
docs(boards): the 1CH relay has been driven, and its LED is not the one we said

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -56,7 +56,7 @@ Shared by all three: **RS485 TX 17, RS485 RX 18** (UART1), **BOOT GPIO0**.
 | Function | RS485-CAN | Relay-1CH | Relay-6CH | Status |
 |---|---|---|---|---|
 | RS485 EN (direction) | **21** | **21** | — | RS485-CAN: documentation + months of runtime. 1CH: Waveshare's `WS_GPIO.h` + schematic, no RS485 traffic driven on one yet. 6CH has no direction GPIO |
-| Relay(s) | — | **47** | **1, 2, 41, 42, 45, 46** | 6CH order verified on hardware 2026-07-23. 1CH GPIO47 verified 2026-07-28: switched on demand, indicator LED followed in both directions, REST and Prometheus agreed |
+| Relay(s) | — | **47** | **1, 2, 41, 42, 45, 46** | 6CH order verified on hardware 2026-07-23. 1CH GPIO47 verified 2026-07-28: switched on demand, indicator LED followed in both directions, REST and Prometheus agreed at both ends |
 | RTC SCL / SDA (PCF85063) | **38 / 39** | **38 / 39** | — | official schematic GPIO matrix |
 | RTC INT | **40** | not checked | — | RS485-CAN schematic only; unused by this firmware, so nobody has needed the 1CH's |
 | Status LED | — | — | **38** | verified lit on hardware 2026-07-23 |

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -56,7 +56,7 @@ Shared by all three: **RS485 TX 17, RS485 RX 18** (UART1), **BOOT GPIO0**.
 | Function | RS485-CAN | Relay-1CH | Relay-6CH | Status |
 |---|---|---|---|---|
 | RS485 EN (direction) | **21** | **21** | — | RS485-CAN: documentation + months of runtime. 1CH: Waveshare's `WS_GPIO.h` + schematic, no RS485 traffic driven on one yet. 6CH has no direction GPIO |
-| Relay(s) | — | **47** | **1, 2, 41, 42, 45, 46** | 6CH order verified on hardware 2026-07-23 |
+| Relay(s) | — | **47** | **1, 2, 41, 42, 45, 46** | 6CH order verified on hardware 2026-07-23. 1CH GPIO47 verified 2026-07-28: switched on demand, indicator LED followed in both directions, REST and Prometheus agreed |
 | RTC SCL / SDA (PCF85063) | **38 / 39** | **38 / 39** | — | official schematic GPIO matrix |
 | RTC INT | **40** | not checked | — | RS485-CAN schematic only; unused by this firmware, so nobody has needed the 1CH's |
 | Status LED | — | — | **38** | verified lit on hardware 2026-07-23 |

--- a/src/boards/waveshare_esp32_s3_relay_1ch.h
+++ b/src/boards/waveshare_esp32_s3_relay_1ch.h
@@ -14,10 +14,15 @@
 // relay de-energised means DRM not asserted -- a dead bridge never blocks production.
 //
 // ACTUATION VERIFIED ON HARDWARE 2026-07-28, on a bench board with nothing wired to the
-// contacts. GPIO47 active-high drives the coil: the relay was heard to switch, the indicator
-// LED followed it in both directions, and three independent readings agreed with the hardware
-// -- REST bridge.relays [true], heliograph_relay_energised{relay="0"} 1, and back to false/0 on
-// release. drm_mode was correctly ABSENT throughout, the role being "none".
+// contacts. GPIO47 active-high drives the coil: the relay was heard to switch and the indicator
+// LED followed it in both directions.
+//
+// Two reporting paths were read at both moments and agreed with the hardware each time -- REST
+// bridge.relays and heliograph_relay_energised{relay="0"}, [true]/1 while asserted and
+// [false]/0 after release. Two sources at two moments, not four independent confirmations:
+// worth stating exactly, since the point of writing this down is what was actually shown.
+//
+// drm_mode was correctly ABSENT throughout, the role being "none".
 //
 // The wiring half of the failsafe is still untested: it cannot be, without an inverter on the
 // other end. What is proven is that the firmware can energise and release this coil on demand.
@@ -71,11 +76,14 @@ inline constexpr uint8_t kRtcI2cAddress = 0x51;
 // There is no SOFTWARE-DRIVEN status LED or buzzer: GPIO38/39 are the RTC I2C and GPIO21 is
 // unassigned here, so a factory reset on this board is silent and the reboot is its only signal.
 //
-// The board DOES carry a relay indicator LED, wired across the coil in hardware rather than to
-// a GPIO -- which is why kHasStatusLed stays false and is not a contradiction. For bring-up it
-// is the better witness of the two: it sits after the driver transistor, so it lights when the
-// coil is genuinely energised, where a software LED would only prove the firmware believed it
-// had switched.
+// The board DOES carry a relay indicator LED. It is not driven by any GPIO this firmware knows
+// about, which is why kHasStatusLed stays false and is not a contradiction.
+//
+// OBSERVED, 2026-07-28: it tracked the relay in both directions, on and off. Where it is wired
+// was NOT checked against the schematic -- the usual arrangement is across the coil, and if it
+// is, the LED witnesses the coil itself rather than the GPIO, which would make it the better
+// bring-up signal of the two. That last part is inference. What was shown is that it follows
+// the relay.
 inline constexpr bool kHasBootButton = true;
 inline constexpr int  kBootPin       = 0;
 inline constexpr bool kHasStatusLed  = false;

--- a/src/boards/waveshare_esp32_s3_relay_1ch.h
+++ b/src/boards/waveshare_esp32_s3_relay_1ch.h
@@ -12,6 +12,15 @@
 // The single relay is the DRM0 actuator for inverters that cannot be curtailed over
 // RS485: a potential-free contact on the inverter's DRM port. Failsafe by wiring: the
 // relay de-energised means DRM not asserted -- a dead bridge never blocks production.
+//
+// ACTUATION VERIFIED ON HARDWARE 2026-07-28, on a bench board with nothing wired to the
+// contacts. GPIO47 active-high drives the coil: the relay was heard to switch, the indicator
+// LED followed it in both directions, and three independent readings agreed with the hardware
+// -- REST bridge.relays [true], heliograph_relay_energised{relay="0"} 1, and back to false/0 on
+// release. drm_mode was correctly ABSENT throughout, the role being "none".
+//
+// The wiring half of the failsafe is still untested: it cannot be, without an inverter on the
+// other end. What is proven is that the firmware can energise and release this coil on demand.
 
 #pragma once
 
@@ -57,9 +66,16 @@ inline constexpr uint8_t kRtcI2cAddress = 0x51;
 
 // --- BOOT button / status LED / buzzer -----------------------------------------------------
 // BOOT on GPIO0 (Waveshare documentation, confirmed by Tim 2026-07-23) -- the SoC download
-// strapping pin, so the hold-to-factory-reset recovery works here too. There is NO status LED
-// or buzzer: GPIO38/39 are the RTC I2C, GPIO21 is unassigned here, so a factory reset on this
-// board is silent -- the reboot is its only signal. Runtime read still awaits a 1CH in hand.
+// strapping pin, so the hold-to-factory-reset recovery works here too.
+//
+// There is no SOFTWARE-DRIVEN status LED or buzzer: GPIO38/39 are the RTC I2C and GPIO21 is
+// unassigned here, so a factory reset on this board is silent and the reboot is its only signal.
+//
+// The board DOES carry a relay indicator LED, wired across the coil in hardware rather than to
+// a GPIO -- which is why kHasStatusLed stays false and is not a contradiction. For bring-up it
+// is the better witness of the two: it sits after the driver transistor, so it lights when the
+// coil is genuinely energised, where a software LED would only prove the firmware believed it
+// had switched.
 inline constexpr bool kHasBootButton = true;
 inline constexpr int  kBootPin       = 0;
 inline constexpr bool kHasStatusLed  = false;


### PR DESCRIPTION
Two claims in the Relay-1CH board header outlived the hardware. Bench session today, board loose on the table with nothing wired to the contacts.

## "Runtime read still awaits a 1CH in hand"

There is one on the bench now, and GPIO47 has been driven. Recorded with **what was observed**, not a tick:

| Source | Reading |
|---|---|
| audible / visible | relay clicked, indicator LED lit |
| REST `bridge.relays` | `[true]` → `[false]` |
| Prometheus | `heliograph_relay_energised{relay="0"}` `1` → `0` |
| `drm_mode` | correctly **absent** — the role was `none` |

**What is not proven is stated too.** The failsafe is a wiring property and cannot be tested without an inverter on the other end. What is proven is that the firmware can energise and release this coil on demand.

## "There is NO status LED"

True of the thing the firmware can drive, misleading about the board. There **is** a relay indicator LED — wired across the coil in hardware rather than to a GPIO, so `kHasStatusLed = false` stays correct and is not a contradiction.

It is also the better witness during bring-up: sitting after the driver transistor, it lights when the coil is *genuinely* energised, where a software LED would only prove the firmware believed it had switched.

## Also

The pin table in `docs/hardware.md` credited only the 6CH with verified relay pins. GPIO47 now carries the same evidence.

Docs and comments only — no code, no behaviour change. `waveshare-relay-1ch` builds, `check_layering.sh` passes.