### PR TITLE
feat(app): move the device plan out of setup(), where a test can reach it

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -76,6 +76,7 @@ build_src_filter =
     +<diagnostics/>
     +<drivers/driver_registry.cpp>
     +<drivers/discovery_engine.cpp>
+    +<app/device_plan.cpp>
     +<app/discovery_runner.cpp>
     +<app/capture_runner.cpp>
     +<drivers/eversolar_legacy/>

--- a/src/app/device_plan.cpp
+++ b/src/app/device_plan.cpp
@@ -43,9 +43,14 @@ std::vector<PlannedDevice> planDevices(const Configuration& config, const std::s
             continue;
         }
         for (size_t earlier = 0; earlier < i; ++earlier) {
-            // Only an earlier device that is itself starting can claim the bus. A refused one
-            // never calls begin(), so it cannot be the reason a third is refused -- without
-            // this, three copies would report two different refusals for the same conflict.
+            // Only an earlier device that is itself STARTING can claim the bus: a refused one
+            // never calls begin(), so it can never be the reason a later one is refused.
+            //
+            // Today this changes nothing -- the loop stops at the first match, which is always
+            // the one that started -- so it is a guard against a future second reason for
+            // refusing a device, not a fix for a bug that exists. Said plainly because a
+            // condition whose comment claims a failure it does not prevent is worse than no
+            // comment (review).
             if (planned[earlier].id == planned[i].id && planned[earlier].shouldStart()) {
                 planned[i].problem = describeRow(planned[i].row, planned[i].label) + " ('" +
                                      planned[i].id +

--- a/src/app/device_plan.cpp
+++ b/src/app/device_plan.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+
+#include "app/device_plan.h"
+
+namespace heliograph::app {
+
+std::string describeRow(size_t row, const std::string& label) {
+    const std::string base = "device " + std::to_string(row);
+    return label.empty() ? base : base + " (" + label + ")";
+}
+
+std::vector<PlannedDevice> planDevices(const Configuration& config, const std::string& driverId,
+                                       const DriverRegistry& registry) {
+    std::vector<PlannedDevice> planned;
+
+    // Device 1 comes from `driver`, the rest from `additional_devices`, in that order. One list
+    // so the poll loop has one thing to walk, and so a bring-up log reads in the same order the
+    // settings page shows.
+    //
+    // driverId is passed in rather than read from the config: it is the EFFECTIVE id, which may
+    // come from auto-detection or from what is compiled in, and resolving that needs the
+    // registry state at boot rather than the file on flash.
+    if (!driverId.empty()) {
+        planned.push_back({driverId, config.driver.label, &config.driver.options,
+                           planned.size() + 1, ""});
+    }
+    for (const auto& device : config.additionalDevices) {
+        planned.push_back(
+            {device.id, device.label, &device.options, planned.size() + 1, ""});
+    }
+
+    // Refused BEFORE anything is created or begun, because for a driver that cannot share a bus
+    // begin() is itself the harm.
+    //
+    // Asked of the REGISTRY, not of the configuration: whether a driver can share a bus is a
+    // property of the driver, and the config layer deliberately knows nothing about drivers.
+    //
+    // The FIRST occurrence wins and later ones are refused. That is what makes the order above
+    // load-bearing: it decides which of two identically-configured devices gets the bus.
+    for (size_t i = 0; i < planned.size(); ++i) {
+        const auto* descriptor = registry.find(planned[i].id);
+        if (descriptor == nullptr || descriptor->supportsMultipleDevices) {
+            continue;
+        }
+        for (size_t earlier = 0; earlier < i; ++earlier) {
+            // Only an earlier device that is itself starting can claim the bus. A refused one
+            // never calls begin(), so it cannot be the reason a third is refused -- without
+            // this, three copies would report two different refusals for the same conflict.
+            if (planned[earlier].id == planned[i].id && planned[earlier].shouldStart()) {
+                planned[i].problem = describeRow(planned[i].row, planned[i].label) + " ('" +
+                                     planned[i].id +
+                                     "') was not started: this driver supports only one device "
+                                     "per bridge";
+                break;
+            }
+        }
+    }
+    return planned;
+}
+
+}  // namespace heliograph::app

--- a/src/app/device_plan.h
+++ b/src/app/device_plan.h
@@ -26,6 +26,10 @@ namespace heliograph::app {
 struct PlannedDevice {
     std::string          id;
     std::string          label;
+    /// Points INTO the configuration that was planned. The plan does not own it, so the
+    /// configuration must outlive the plan -- which it does in setup(), where g_config is a
+    /// global. Worth stating: the first version of the tests passed a temporary and held
+    /// pointers into it, and passed only because nothing read them.
     const DriverOptions* options = nullptr;
     /// As the settings page numbers them: 1 is the `driver` section, 2..N are the additional
     /// devices. Carried because a bring-up failure has to say which ROW to go and look at.

--- a/src/app/device_plan.h
+++ b/src/app/device_plan.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+//
+// Which configured devices get started, and which are refused before they can do damage.
+//
+// This lived inside setup(), which is the one file the host build does not compile -- so the
+// rule it enforces had no test at all. That rule is not cosmetic: for a driver that cannot
+// share a bus, begin() IS the damage. The AA55 handshake opens with a bus-wide RE_REGISTER
+// broadcast, so a second instance starting up tells the first, already-polling inverter to
+// forget its address. A check that ran afterwards would report the refusal from the far side
+// of the harm (#63).
+//
+// Pure: a configuration and a registry in, a plan out. No transport, no clock, no hardware --
+// which is the whole point, because it means the rule can be tested rather than reasoned about.
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "config/configuration.h"
+#include "drivers/driver_registry.h"
+
+namespace heliograph::app {
+
+/// One configured device and what should happen to it.
+struct PlannedDevice {
+    std::string          id;
+    std::string          label;
+    const DriverOptions* options = nullptr;
+    /// As the settings page numbers them: 1 is the `driver` section, 2..N are the additional
+    /// devices. Carried because a bring-up failure has to say which ROW to go and look at.
+    size_t row = 0;
+    /// Empty means start it. Set means refused, in the words the diagnostics surface reports.
+    ///
+    /// Deliberately not a bool beside a string: two fields that must agree are two fields that
+    /// can disagree, and "start it, and here is why it was refused" is not a state worth being
+    /// able to represent.
+    std::string problem;
+
+    bool shouldStart() const { return problem.empty(); }
+};
+
+/// "device 2" or "device 2 (Schuur)".
+///
+/// The label goes in because "device 2 could not be started" sends someone to count rows on a
+/// settings page, and "device 2 (Schuur)" sends them to the shed. The number stays because an
+/// unlabelled bridge still has to be told which row.
+std::string describeRow(size_t row, const std::string& label);
+
+/// The devices to start, in the order they are configured, each carrying its verdict.
+///
+/// Order is load-bearing twice over: the poll loop walks this, and the refusal rule is
+/// "the FIRST one wins" -- so a plan that reordered would change which device gets the bus.
+std::vector<PlannedDevice> planDevices(const Configuration& config, const std::string& driverId,
+                                       const DriverRegistry& registry);
+
+}  // namespace heliograph::app

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "app/capture_runner.h"
+#include "app/device_plan.h"
 #include "app/discovery_runner.h"
 #include "boards/board.h"
 #include "config/configuration.h"
@@ -1233,14 +1234,12 @@ void setup() {
     // Device 1 comes from `driver`, the rest from `additional_devices`, in that order. One list
     // so the poll loop has one thing to walk, and so a bring-up log reads in the same order the
     // settings page shows.
-    struct Planned { std::string id; const DriverOptions* options; std::string label; };
-    std::vector<Planned> planned;
-    if (!driverId.empty()) {
-        planned.push_back({driverId, &g_config.driver.options, g_config.driver.label});
-    }
-    for (const auto& d : g_config.additionalDevices) {
-        planned.push_back({d.id, &d.options, d.label});
-    }
+    // The plan -- which devices to start and which to refuse -- is decided in app/device_plan,
+    // where the host build can reach it. It used to be decided here, in the one file no test
+    // compiles, and the rule it enforces is the one that keeps a second instance of a
+    // single-device driver from wiping the first one's address off the bus.
+    const std::vector<app::PlannedDevice> planned =
+        app::planDevices(g_config, driverId, g_registry);
     g_devicesConfigured = planned.size();
     // One slot per CONFIGURED device, filled in as each one starts. The Modbus unit ids are
     // keyed on this, not on the compacted g_deviceIds -- see the declaration.
@@ -1259,37 +1258,18 @@ void setup() {
         // to count rows on the settings page; "device 2 (Schuur) could not be started" sends
         // them to the shed. The row number stays, because that is what the settings page shows
         // and an unlabelled bridge still needs to be told which row.
-        const std::string row = p.label.empty()
-                                    ? "device " + std::to_string(plannedIndex + 1)
-                                    : "device " + std::to_string(plannedIndex + 1) + " (" +
-                                          p.label + ")";
+        const std::string row = app::describeRow(p.row, p.label);
 
-        // Refused BEFORE create() and begin(), because for a driver that cannot share a bus,
-        // begin() IS the damage. The AA55 handshake opens with a bus-wide RE_REGISTER
-        // broadcast, so a second instance starting up tells the first, already-polling inverter
-        // to forget its address -- and a check that ran afterwards would report the refusal
-        // from the far side of the harm (#63).
-        //
-        // Enforced here rather than in config validation because this is where the registry is:
-        // the answer is a property of the driver, not of the configuration file, and the config
-        // layer deliberately knows nothing about drivers.
-        const auto* descriptor = g_registry.find(p.id);
-        if (descriptor != nullptr && !descriptor->supportsMultipleDevices) {
-            bool alreadyPlanned = false;
-            for (size_t earlier = 0; earlier < plannedIndex; ++earlier) {
-                if (planned[earlier].id == p.id) {
-                    alreadyPlanned = true;
-                    break;
-                }
-            }
-            if (alreadyPlanned) {
-                log::warn("device '%s' skipped: this driver supports only one device per bridge",
-                          p.id.c_str());
-                g_deviceProblems.push_back(row + " ('" + p.id +
-                                           "') was not started: this driver supports only one "
-                                           "device per bridge");
-                continue;
-            }
+        // The refusal was decided in planDevices(), before anything was created, because for a
+        // driver that cannot share a bus begin() IS the damage: the AA55 handshake opens with a
+        // bus-wide RE_REGISTER, so a second instance tells the first, already-polling inverter
+        // to forget its address (#63). What is left here is REPORTING it -- the half that needs
+        // a serial port and a problems list, and the half that was never the interesting one.
+        if (!p.shouldStart()) {
+            log::warn("device '%s' skipped: this driver supports only one device per bridge",
+                      p.id.c_str());
+            g_deviceProblems.push_back(p.problem);
+            continue;
         }
 
         auto driver = g_registry.create(p.id, g_transport, *p.options);

--- a/test/test_device_plan/test_main.cpp
+++ b/test/test_device_plan/test_main.cpp
@@ -57,8 +57,8 @@ Configuration configWith(const std::string& first, const std::vector<std::string
 
 static void test_a_driver_that_shares_the_bus_may_appear_many_times() {
     const auto registry = makeRegistry();
-    const auto plan     = app::planDevices(
-        configWith("growatt_modbus", {"growatt_modbus", "growatt_modbus"}), "growatt_modbus",
+    const auto config   = configWith("growatt_modbus", {"growatt_modbus", "growatt_modbus"});
+    const auto plan     = app::planDevices(config, "growatt_modbus",
         registry);
 
     // Three MIC TL-X on one bus is the case this bridge was extended for. Refusing any of them
@@ -72,7 +72,8 @@ static void test_a_driver_that_shares_the_bus_may_appear_many_times() {
 
 static void test_a_second_exclusive_device_is_refused_before_it_can_speak() {
     const auto registry = makeRegistry();
-    const auto plan     = app::planDevices(configWith("eversolar_legacy", {"eversolar_legacy"}),
+    const auto config   = configWith("eversolar_legacy", {"eversolar_legacy"});
+    const auto plan     = app::planDevices(config,
                                            "eversolar_legacy", registry);
 
     TEST_ASSERT_EQUAL_UINT32(2, plan.size());
@@ -85,8 +86,8 @@ static void test_a_second_exclusive_device_is_refused_before_it_can_speak() {
 
 static void test_a_third_copy_is_refused_too_and_names_its_own_row() {
     const auto registry = makeRegistry();
-    const auto plan     = app::planDevices(
-        configWith("eversolar_legacy", {"eversolar_legacy", "eversolar_legacy"}),
+    const auto config   = configWith("eversolar_legacy", {"eversolar_legacy", "eversolar_legacy"});
+    const auto plan     = app::planDevices(config,
         "eversolar_legacy", registry);
 
     TEST_ASSERT_TRUE(plan[0].shouldStart());
@@ -101,8 +102,8 @@ static void test_a_third_copy_is_refused_too_and_names_its_own_row() {
 
 static void test_the_label_goes_in_the_refusal() {
     const auto registry = makeRegistry();
-    const auto plan     = app::planDevices(
-        configWith("eversolar_legacy", {"eversolar_legacy"}, {"Schuur"}), "eversolar_legacy",
+    const auto config   = configWith("eversolar_legacy", {"eversolar_legacy"}, {"Schuur"});
+    const auto plan     = app::planDevices(config, "eversolar_legacy",
         registry);
 
     // "device 2 could not be started" sends someone to count rows on a settings page.
@@ -112,7 +113,8 @@ static void test_the_label_goes_in_the_refusal() {
 
 static void test_an_unknown_driver_is_planned_and_left_to_fail_later() {
     const auto registry = makeRegistry();
-    const auto plan     = app::planDevices(configWith("not_a_driver", {"not_a_driver"}),
+    const auto config   = configWith("not_a_driver", {"not_a_driver"});
+    const auto plan     = app::planDevices(config,
                                            "not_a_driver", registry);
 
     // The registry has no opinion, so this rule has none either: both are planned, and both
@@ -125,7 +127,8 @@ static void test_an_unknown_driver_is_planned_and_left_to_fail_later() {
 
 static void test_two_different_exclusive_drivers_do_not_collide() {
     const auto registry = makeRegistry();
-    const auto plan     = app::planDevices(configWith("eversolar_legacy", {"growatt_modbus"}),
+    const auto config   = configWith("eversolar_legacy", {"growatt_modbus"});
+    const auto plan     = app::planDevices(config,
                                            "eversolar_legacy", registry);
 
     // The rule is per DRIVER, not per bus. Two different drivers each get their one instance.
@@ -135,7 +138,8 @@ static void test_two_different_exclusive_drivers_do_not_collide() {
 
 static void test_an_empty_driver_id_leaves_it_out_of_the_plan() {
     const auto registry = makeRegistry();
-    const auto plan     = app::planDevices(configWith("", {"growatt_modbus"}), "", registry);
+    const auto config   = configWith("", {"growatt_modbus"});
+    const auto plan     = app::planDevices(config, "", registry);
 
     // Nothing configured and nothing compiled in: the additional device is device 1, not
     // device 2 with a hole where the first should be.
@@ -146,13 +150,39 @@ static void test_an_empty_driver_id_leaves_it_out_of_the_plan() {
 
 static void test_rows_are_numbered_as_the_settings_page_shows_them() {
     const auto registry = makeRegistry();
-    const auto plan     = app::planDevices(
-        configWith("growatt_modbus", {"growatt_modbus", "growatt_modbus"}), "growatt_modbus",
+    const auto config   = configWith("growatt_modbus", {"growatt_modbus", "growatt_modbus"});
+    const auto plan     = app::planDevices(config, "growatt_modbus",
         registry);
 
     TEST_ASSERT_EQUAL_UINT32(1, plan[0].row);
     TEST_ASSERT_EQUAL_UINT32(2, plan[1].row);
     TEST_ASSERT_EQUAL_UINT32(3, plan[2].row);
+}
+
+// The plan points INTO the configuration rather than copying it, so the configuration has to
+// outlive the plan. This reads the options through that pointer, which is the only way the
+// contract gets exercised rather than merely written down -- the first version of these tests
+// passed a temporary configuration and held pointers into it, and passed because nothing ever
+// looked.
+static void test_the_options_pointer_reaches_the_configured_options() {
+    const auto registry = makeRegistry();
+    Configuration config;
+    config.driver.id                       = "growatt_modbus";
+    config.driver.options["unit_id"] = "7";
+    DriverSettings second;
+    second.id                       = "growatt_modbus";
+    second.options["unit_id"] = "9";
+    config.additionalDevices.push_back(second);
+
+    const auto plan = app::planDevices(config, "growatt_modbus", registry);
+
+    TEST_ASSERT_EQUAL_UINT32(2, plan.size());
+    TEST_ASSERT_NOT_NULL(plan[0].options);
+    TEST_ASSERT_NOT_NULL(plan[1].options);
+    // Each device's OWN options, not the first one's twice: a unit_id shared between two
+    // Modbus devices is a bus where both answer to the same address.
+    TEST_ASSERT_EQUAL_STRING("7", plan[0].options->at("unit_id").c_str());
+    TEST_ASSERT_EQUAL_STRING("9", plan[1].options->at("unit_id").c_str());
 }
 
 static void test_describe_row_names_the_label_when_there_is_one() {
@@ -170,6 +200,7 @@ int main() {
     RUN_TEST(test_two_different_exclusive_drivers_do_not_collide);
     RUN_TEST(test_an_empty_driver_id_leaves_it_out_of_the_plan);
     RUN_TEST(test_rows_are_numbered_as_the_settings_page_shows_them);
+    RUN_TEST(test_the_options_pointer_reaches_the_configured_options);
     RUN_TEST(test_describe_row_names_the_label_when_there_is_one);
     return UNITY_END();
 }

--- a/test/test_device_plan/test_main.cpp
+++ b/test/test_device_plan/test_main.cpp
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// Which configured devices get started, and which are refused before they can do damage.
+//
+// This logic lived in setup(), the one file the host build does not compile, so the rule it
+// enforces had no test at all -- and it is not a cosmetic rule. For a driver that cannot share
+// a bus, begin() IS the damage: the AA55 handshake opens with a bus-wide RE_REGISTER broadcast,
+// so a second instance starting up tells the first, already-polling inverter to forget its
+// address. Every case below describes a bus that would be corrupted if the answer were wrong.
+
+#include <unity.h>
+
+#include <string>
+
+#include "app/device_plan.h"
+#include "config/configuration.h"
+#include "drivers/driver_registry.h"
+
+using namespace heliograph;
+
+void setUp() {}
+void tearDown() {}
+
+namespace {
+
+/// A registry with two drivers: one that can share the bus and one that cannot.
+DriverRegistry makeRegistry() {
+    DriverRegistry registry;
+
+    DriverDescriptor shareable;
+    shareable.id                     = "growatt_modbus";
+    shareable.supportsMultipleDevices = true;
+    registry.registerDriver(shareable, [](Transport&, const DriverOptions&) { return nullptr; });
+
+    DriverDescriptor exclusive;
+    exclusive.id                      = "eversolar_legacy";
+    exclusive.supportsMultipleDevices = false;
+    registry.registerDriver(exclusive, [](Transport&, const DriverOptions&) { return nullptr; });
+
+    return registry;
+}
+
+/// A configuration with `driver` set and however many additional devices are named.
+Configuration configWith(const std::string& first, const std::vector<std::string>& extra,
+                         const std::vector<std::string>& labels = {}) {
+    Configuration config;
+    config.driver.id = first;
+    for (size_t i = 0; i < extra.size(); ++i) {
+        DriverSettings device;
+        device.id    = extra[i];
+        device.label = i < labels.size() ? labels[i] : "";
+        config.additionalDevices.push_back(device);
+    }
+    return config;
+}
+
+}  // namespace
+
+static void test_a_driver_that_shares_the_bus_may_appear_many_times() {
+    const auto registry = makeRegistry();
+    const auto plan     = app::planDevices(
+        configWith("growatt_modbus", {"growatt_modbus", "growatt_modbus"}), "growatt_modbus",
+        registry);
+
+    // Three MIC TL-X on one bus is the case this bridge was extended for. Refusing any of them
+    // would be the bug.
+    TEST_ASSERT_EQUAL_UINT32(3, plan.size());
+    for (const auto& device : plan) {
+        TEST_ASSERT_TRUE(device.shouldStart());
+        TEST_ASSERT_TRUE(device.problem.empty());
+    }
+}
+
+static void test_a_second_exclusive_device_is_refused_before_it_can_speak() {
+    const auto registry = makeRegistry();
+    const auto plan     = app::planDevices(configWith("eversolar_legacy", {"eversolar_legacy"}),
+                                           "eversolar_legacy", registry);
+
+    TEST_ASSERT_EQUAL_UINT32(2, plan.size());
+    // The FIRST one keeps the bus. Which one is refused is not arbitrary: it decides which
+    // inverter goes on reporting and which goes quiet.
+    TEST_ASSERT_TRUE(plan[0].shouldStart());
+    TEST_ASSERT_FALSE(plan[1].shouldStart());
+    TEST_ASSERT_TRUE(plan[1].problem.find("only one device per bridge") != std::string::npos);
+}
+
+static void test_a_third_copy_is_refused_too_and_names_its_own_row() {
+    const auto registry = makeRegistry();
+    const auto plan     = app::planDevices(
+        configWith("eversolar_legacy", {"eversolar_legacy", "eversolar_legacy"}),
+        "eversolar_legacy", registry);
+
+    TEST_ASSERT_TRUE(plan[0].shouldStart());
+    TEST_ASSERT_FALSE(plan[1].shouldStart());
+    TEST_ASSERT_FALSE(plan[2].shouldStart());
+    // Each refusal names its OWN row. Three inverters sharing a driver id produced three
+    // identical messages before rows were carried, which is useless on the very bus this
+    // exists for.
+    TEST_ASSERT_TRUE(plan[1].problem.find("device 2") != std::string::npos);
+    TEST_ASSERT_TRUE(plan[2].problem.find("device 3") != std::string::npos);
+}
+
+static void test_the_label_goes_in_the_refusal() {
+    const auto registry = makeRegistry();
+    const auto plan     = app::planDevices(
+        configWith("eversolar_legacy", {"eversolar_legacy"}, {"Schuur"}), "eversolar_legacy",
+        registry);
+
+    // "device 2 could not be started" sends someone to count rows on a settings page.
+    // "device 2 (Schuur)" sends them to the shed.
+    TEST_ASSERT_TRUE(plan[1].problem.find("device 2 (Schuur)") != std::string::npos);
+}
+
+static void test_an_unknown_driver_is_planned_and_left_to_fail_later() {
+    const auto registry = makeRegistry();
+    const auto plan     = app::planDevices(configWith("not_a_driver", {"not_a_driver"}),
+                                           "not_a_driver", registry);
+
+    // The registry has no opinion, so this rule has none either: both are planned, and both
+    // fail at create() with their own message. Refusing here would report the wrong reason --
+    // "only one per bridge" for a driver that does not exist.
+    TEST_ASSERT_EQUAL_UINT32(2, plan.size());
+    TEST_ASSERT_TRUE(plan[0].shouldStart());
+    TEST_ASSERT_TRUE(plan[1].shouldStart());
+}
+
+static void test_two_different_exclusive_drivers_do_not_collide() {
+    const auto registry = makeRegistry();
+    const auto plan     = app::planDevices(configWith("eversolar_legacy", {"growatt_modbus"}),
+                                           "eversolar_legacy", registry);
+
+    // The rule is per DRIVER, not per bus. Two different drivers each get their one instance.
+    TEST_ASSERT_TRUE(plan[0].shouldStart());
+    TEST_ASSERT_TRUE(plan[1].shouldStart());
+}
+
+static void test_an_empty_driver_id_leaves_it_out_of_the_plan() {
+    const auto registry = makeRegistry();
+    const auto plan     = app::planDevices(configWith("", {"growatt_modbus"}), "", registry);
+
+    // Nothing configured and nothing compiled in: the additional device is device 1, not
+    // device 2 with a hole where the first should be.
+    TEST_ASSERT_EQUAL_UINT32(1, plan.size());
+    TEST_ASSERT_EQUAL_STRING("growatt_modbus", plan[0].id.c_str());
+    TEST_ASSERT_EQUAL_UINT32(1, plan[0].row);
+}
+
+static void test_rows_are_numbered_as_the_settings_page_shows_them() {
+    const auto registry = makeRegistry();
+    const auto plan     = app::planDevices(
+        configWith("growatt_modbus", {"growatt_modbus", "growatt_modbus"}), "growatt_modbus",
+        registry);
+
+    TEST_ASSERT_EQUAL_UINT32(1, plan[0].row);
+    TEST_ASSERT_EQUAL_UINT32(2, plan[1].row);
+    TEST_ASSERT_EQUAL_UINT32(3, plan[2].row);
+}
+
+static void test_describe_row_names_the_label_when_there_is_one() {
+    TEST_ASSERT_EQUAL_STRING("device 1", app::describeRow(1, "").c_str());
+    TEST_ASSERT_EQUAL_STRING("device 2 (Schuur)", app::describeRow(2, "Schuur").c_str());
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_a_driver_that_shares_the_bus_may_appear_many_times);
+    RUN_TEST(test_a_second_exclusive_device_is_refused_before_it_can_speak);
+    RUN_TEST(test_a_third_copy_is_refused_too_and_names_its_own_row);
+    RUN_TEST(test_the_label_goes_in_the_refusal);
+    RUN_TEST(test_an_unknown_driver_is_planned_and_left_to_fail_later);
+    RUN_TEST(test_two_different_exclusive_drivers_do_not_collide);
+    RUN_TEST(test_an_empty_driver_id_leaves_it_out_of_the_plan);
+    RUN_TEST(test_rows_are_numbered_as_the_settings_page_shows_them);
+    RUN_TEST(test_describe_row_names_the_label_when_there_is_one);
+    return UNITY_END();
+}


### PR DESCRIPTION
The last structural test gap. `main.cpp` is not compiled by the host build, so nothing in `setup()` has ever had a test.

That was tolerable for the wiring. It was **not** tolerable for the rule living in the middle of it.

## The rule that had no test

A driver that cannot share a bus must be refused a **second** instance *before* anything starts it — because for such a driver `begin()` **is** the damage. The AA55 handshake opens with a bus-wide `RE_REGISTER`, so a second instance tells the first, already-polling inverter to forget its address ([#63](https://github.com/Timdebruijn/heliograph/pull/63)).

A safety property, on the exact bus this bridge exists for, with no test at all.

## What changed

The decision is now `app::planDevices()`: a configuration and a registry in, a plan out. No transport, no clock, no hardware.

`setup()` keeps the half that genuinely needs a serial port — creating drivers, logging, filling the problems list — and **reads** the verdict rather than computing it. `main.cpp` loses 20 lines; the module is 60 that a test can reach.

`PlannedDevice` carries `problem` and derives `shouldStart()` from it, rather than a bool beside a string. Two fields that must agree are two that can disagree, and *"start it, and here is why it was refused"* is not a state worth being able to represent.

## Nine cases, each describing a bus that breaks if the answer is wrong

- three shareable devices all starting — the MIC TL-X case this bridge was extended for
- a second exclusive device refused, and **the first keeping the bus**
- a third refused too, naming its own row
- the label reaching the message: `device 2 (Schuur)`, not `device 2`
- an unknown driver planned and left to fail later **with its own reason**, rather than being refused with the wrong one
- two different exclusive drivers not colliding — the rule is per driver, not per bus
- an empty driver id not leaving a hole at row 1
- rows numbered as the settings page shows them

## Mutation-tested twice

A test for a guard is worth what it fails on.

| mutation | result |
|---|---|
| delete the guard | 3 cases fail |
| make the **last** copy win instead of the first | 3 cases fail differently |

The second one matters most: it decides which inverter keeps reporting and which goes quiet, and it would never show up in a build.

## Verification

**834 native tests** (825 + 9), `check_layering.sh` — including rule 6, every test written is registered — and all four firmware targets build.