### PR TITLE
Release 0.22.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,9 +168,14 @@ namespace {
 // It also ships the ELF as a release asset. A backtrace names addresses in the image that was
 // RUNNING, and rebuilding a tag afterwards does not reproduce the layout -- which is how the
 // dump on the production bridge became undecodable.
+// 0.22.0 closes the last structural test gap. The rule that refuses a second instance of a
+// driver which cannot share a bus lived inside setup(), the one file the host build does not
+// compile -- so a safety property, on the exact bus this bridge exists for, had no test. It is
+// app::planDevices() now: a configuration and a registry in, a plan out, and setup() reads the
+// verdict instead of computing it.
 #define HELIOGRAPH_VERSION_MAJOR 0
-#define HELIOGRAPH_VERSION_MINOR 21
-#define HELIOGRAPH_VERSION_PATCH 1
+#define HELIOGRAPH_VERSION_MINOR 22
+#define HELIOGRAPH_VERSION_PATCH 0
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Version bump for [#113](https://github.com/Timdebruijn/heliograph/pull/113) — the last structural test gap.

## What 0.22.0 changes

`main.cpp` is not compiled by the host build, so nothing in `setup()` ever had a test. Tolerable for wiring; **not** tolerable for the rule sitting in the middle of it.

A driver that cannot share a bus must be refused a second instance *before* anything starts it, because for such a driver `begin()` **is** the damage — the AA55 handshake opens with a bus-wide `RE_REGISTER`, so a second instance tells the first, already-polling inverter to forget its address.

A safety property, on the exact bus this bridge exists for, with no test at all.

It is `app::planDevices()` now: a configuration and a registry in, a plan out. No transport, no clock, no hardware. `setup()` keeps the half that needs a serial port and **reads** the verdict instead of computing it.

**No behaviour change.** The same devices start, the same ones are refused, with the same messages.

## Verified on this exact tree

- **835 native tests**, ten of them covering logic that was previously unreachable
- Mutation-tested twice: delete the guard, three fail; make the *last* copy win instead of the first, three fail differently — that second decides which inverter keeps reporting and which goes quiet
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py`, `check_dashboard_layout.py`
- All four targets build; the binary reports `0.22.0`, read from the binary
- `tools/check_version.sh v0.22.0` passes