### PR TITLE
refactor(modbus): one exception frame parser, and the write path finally tests it

### DIFF
--- a/src/protocols/modbus/modbus_rtu.cpp
+++ b/src/protocols/modbus/modbus_rtu.cpp
@@ -99,6 +99,42 @@ size_t expectedReadResponseLength(uint16_t quantity) {
     return 5 + static_cast<size_t>(quantity) * 2;  // unit + fn + bytecount + data + crc
 }
 
+namespace {
+
+/// The exception reply, which is the same frame whatever was asked.
+///
+/// unit + (function | 0x80) + code + CRC, five bytes, and every check on it is identical for a
+/// read and for a write. It was written out twice, and the two copies had NOT drifted -- but
+/// this is the path a device uses to say "I refuse", and a fix applied to one of two copies
+/// leaves the other quietly wrong. The function-code check below is exactly such a fix (#67).
+///
+/// A template because ReadResponse and WriteResponse are separate types that happen to carry
+/// the same three fields; giving them a shared base to avoid one template would be the larger
+/// change. The caller tests the exception flag first -- it has to, to know to come here at all
+/// -- and has already established len >= 5.
+template <typename Response>
+ParseResult parseExceptionFrame(const uint8_t* buf, uint8_t expectedUnit,
+                                uint8_t expectedFunction, Response& out) {
+    if (!crcOk(buf, 5)) {
+        return ParseResult::BadCrc;
+    }
+    if (buf[0] != expectedUnit) {
+        return ParseResult::WrongUnit;
+    }
+    // The echoed function (exception flag stripped) must match what we asked. Without this a
+    // stale or misrouted exception frame -- right unit, valid CRC, but for a different request
+    // -- would be accepted as the answer to this one on a shared multidrop bus.
+    if ((buf[1] & ~kExceptionFlag) != expectedFunction) {
+        return ParseResult::WrongFunction;
+    }
+    out.unitId        = buf[0];
+    out.functionCode  = buf[1];
+    out.exceptionCode = buf[2];
+    return ParseResult::Exception;
+}
+
+}  // namespace
+
 ParseResult parseReadResponse(const uint8_t* buf, size_t len, uint8_t expectedUnit,
                               uint8_t expectedFunction, uint16_t* regsOut, size_t regsCapacity,
                               ReadResponse& out) {
@@ -109,22 +145,7 @@ ParseResult parseReadResponse(const uint8_t* buf, size_t len, uint8_t expectedUn
     // Exception first: it is 5 bytes, so demanding the full data-frame length would stall on a
     // device that is trying to tell us the request was illegal.
     if ((buf[1] & kExceptionFlag) != 0) {
-        if (!crcOk(buf, 5)) {
-            return ParseResult::BadCrc;
-        }
-        if (buf[0] != expectedUnit) {
-            return ParseResult::WrongUnit;
-        }
-        // The echoed function (exception flag stripped) must match what we asked. Without this
-        // a stale or misrouted exception frame -- right unit, valid CRC, but for a different
-        // request -- would be accepted as the answer to this one on a shared multidrop bus.
-        if ((buf[1] & ~kExceptionFlag) != expectedFunction) {
-            return ParseResult::WrongFunction;
-        }
-        out.unitId        = buf[0];
-        out.functionCode  = buf[1];
-        out.exceptionCode = buf[2];
-        return ParseResult::Exception;
+        return parseExceptionFrame(buf, expectedUnit, expectedFunction, out);
     }
 
     const uint8_t byteCount = buf[2];
@@ -169,22 +190,7 @@ ParseResult parseWriteResponse(const uint8_t* buf, size_t len, uint8_t expectedU
         return ParseResult::Incomplete;
     }
     if ((buf[1] & kExceptionFlag) != 0) {
-        if (!crcOk(buf, 5)) {
-            return ParseResult::BadCrc;
-        }
-        if (buf[0] != expectedUnit) {
-            return ParseResult::WrongUnit;
-        }
-        // The echoed function (exception flag stripped) must match what we asked. Without this
-        // a stale or misrouted exception frame -- right unit, valid CRC, but for a different
-        // request -- would be accepted as the answer to this one on a shared multidrop bus.
-        if ((buf[1] & ~kExceptionFlag) != expectedFunction) {
-            return ParseResult::WrongFunction;
-        }
-        out.unitId        = buf[0];
-        out.functionCode  = buf[1];
-        out.exceptionCode = buf[2];
-        return ParseResult::Exception;
+        return parseExceptionFrame(buf, expectedUnit, expectedFunction, out);
     }
     if (len < 8) {
         return ParseResult::Incomplete;

--- a/src/protocols/modbus/modbus_rtu.cpp
+++ b/src/protocols/modbus/modbus_rtu.cpp
@@ -23,6 +23,38 @@ bool crcOk(const uint8_t* buf, size_t len) {
     return crc16(buf, len - 2) == bytes::le16(buf, len - 2);
 }
 
+/// The exception reply, which is the same frame whatever was asked.
+///
+/// unit + (function | 0x80) + code + CRC, five bytes, and every check on it is identical for a
+/// read and for a write. It was written out twice, and the two copies had NOT drifted -- but
+/// this is the path a device uses to say "I refuse", and a fix applied to one of two copies
+/// leaves the other quietly wrong. The function-code check below is exactly such a fix (#67).
+///
+/// A template because ReadResponse and WriteResponse are separate types that happen to carry
+/// the same three fields; giving them a shared base to avoid one template would be the larger
+/// change. The caller tests the exception flag first -- it has to, to know to come here at all
+/// -- and has already established len >= 5.
+template <typename Response>
+ParseResult parseExceptionFrame(const uint8_t* buf, uint8_t expectedUnit,
+                                uint8_t expectedFunction, Response& out) {
+    if (!crcOk(buf, 5)) {
+        return ParseResult::BadCrc;
+    }
+    if (buf[0] != expectedUnit) {
+        return ParseResult::WrongUnit;
+    }
+    // The echoed function (exception flag stripped) must match what we asked. Without this a
+    // stale or misrouted exception frame -- right unit, valid CRC, but for a different request
+    // -- would be accepted as the answer to this one on a shared multidrop bus.
+    if ((buf[1] & ~kExceptionFlag) != expectedFunction) {
+        return ParseResult::WrongFunction;
+    }
+    out.unitId        = buf[0];
+    out.functionCode  = buf[1];
+    out.exceptionCode = buf[2];
+    return ParseResult::Exception;
+}
+
 }  // namespace
 
 uint16_t crc16(const uint8_t* data, size_t len) {
@@ -99,41 +131,6 @@ size_t expectedReadResponseLength(uint16_t quantity) {
     return 5 + static_cast<size_t>(quantity) * 2;  // unit + fn + bytecount + data + crc
 }
 
-namespace {
-
-/// The exception reply, which is the same frame whatever was asked.
-///
-/// unit + (function | 0x80) + code + CRC, five bytes, and every check on it is identical for a
-/// read and for a write. It was written out twice, and the two copies had NOT drifted -- but
-/// this is the path a device uses to say "I refuse", and a fix applied to one of two copies
-/// leaves the other quietly wrong. The function-code check below is exactly such a fix (#67).
-///
-/// A template because ReadResponse and WriteResponse are separate types that happen to carry
-/// the same three fields; giving them a shared base to avoid one template would be the larger
-/// change. The caller tests the exception flag first -- it has to, to know to come here at all
-/// -- and has already established len >= 5.
-template <typename Response>
-ParseResult parseExceptionFrame(const uint8_t* buf, uint8_t expectedUnit,
-                                uint8_t expectedFunction, Response& out) {
-    if (!crcOk(buf, 5)) {
-        return ParseResult::BadCrc;
-    }
-    if (buf[0] != expectedUnit) {
-        return ParseResult::WrongUnit;
-    }
-    // The echoed function (exception flag stripped) must match what we asked. Without this a
-    // stale or misrouted exception frame -- right unit, valid CRC, but for a different request
-    // -- would be accepted as the answer to this one on a shared multidrop bus.
-    if ((buf[1] & ~kExceptionFlag) != expectedFunction) {
-        return ParseResult::WrongFunction;
-    }
-    out.unitId        = buf[0];
-    out.functionCode  = buf[1];
-    out.exceptionCode = buf[2];
-    return ParseResult::Exception;
-}
-
-}  // namespace
 
 ParseResult parseReadResponse(const uint8_t* buf, size_t len, uint8_t expectedUnit,
                               uint8_t expectedFunction, uint16_t* regsOut, size_t regsCapacity,

--- a/test/test_modbus/rtu.cpp
+++ b/test/test_modbus/rtu.cpp
@@ -240,6 +240,56 @@ static void test_write_exception_is_reported() {
     TEST_ASSERT_EQUAL_HEX8(0x04, resp.exceptionCode);
 }
 
+// The exception frame is now parsed by ONE helper shared by both parsers, so both call sites
+// have to be shown to get its checks. The read path already had these; the write path had only
+// the happy case, which meant the function-code check -- added because a stale exception frame
+// from a different request would otherwise be accepted as the answer to this one -- was never
+// exercised on the write side at all.
+static void test_write_exception_with_a_foreign_function_is_refused() {
+    uint8_t frame[8];
+    frame[0]           = 0x01;
+    frame[1]           = kReadHoldingRegisters | kExceptionFlag;  // 0x83, not our 0x06
+    frame[2]           = 0x02;
+    const uint16_t crc = crc16(frame, 3);
+    frame[3]           = static_cast<uint8_t>(crc & 0xFF);
+    frame[4]           = static_cast<uint8_t>((crc >> 8) & 0xFF);
+
+    // Right unit, valid CRC, genuine exception -- and the answer to a question we did not ask.
+    // On a multidrop bus that is a frame meant for somebody else.
+    WriteResponse resp;
+    TEST_ASSERT_EQUAL(ParseResult::WrongFunction,
+                      parseWriteResponse(frame, 5, 0x01, kWriteSingleRegister, resp));
+}
+
+static void test_write_exception_from_another_unit_is_refused() {
+    uint8_t frame[8];
+    frame[0]           = 0x02;  // not the unit we addressed
+    frame[1]           = kWriteSingleRegister | kExceptionFlag;
+    frame[2]           = 0x02;
+    const uint16_t crc = crc16(frame, 3);
+    frame[3]           = static_cast<uint8_t>(crc & 0xFF);
+    frame[4]           = static_cast<uint8_t>((crc >> 8) & 0xFF);
+
+    WriteResponse resp;
+    TEST_ASSERT_EQUAL(ParseResult::WrongUnit,
+                      parseWriteResponse(frame, 5, 0x01, kWriteSingleRegister, resp));
+}
+
+static void test_write_exception_with_a_bad_crc_indicts_the_cable() {
+    uint8_t frame[8];
+    frame[0] = 0x01;
+    frame[1] = kWriteSingleRegister | kExceptionFlag;
+    frame[2] = 0x02;
+    frame[3] = 0x00;  // deliberately not the CRC
+    frame[4] = 0x00;
+
+    // Crc, not Protocol: this is the one outcome that blames the wiring rather than the
+    // configuration, and a driver that cannot report it can never report a checksum error.
+    WriteResponse resp;
+    TEST_ASSERT_EQUAL(ParseResult::BadCrc,
+                      parseWriteResponse(frame, 5, 0x01, kWriteSingleRegister, resp));
+}
+
 void run_modbus_rtu() {
     RUN_TEST(test_crc_matches_the_canonical_vector);
     RUN_TEST(test_crc_second_vector);
@@ -259,4 +309,7 @@ void run_modbus_rtu() {
     RUN_TEST(test_registers_overflowing_the_caller_buffer_are_refused);
     RUN_TEST(test_write_single_echo_is_validated);
     RUN_TEST(test_write_exception_is_reported);
+    RUN_TEST(test_write_exception_with_a_foreign_function_is_refused);
+    RUN_TEST(test_write_exception_from_another_unit_is_refused);
+    RUN_TEST(test_write_exception_with_a_bad_crc_indicts_the_cable);
 }


### PR DESCRIPTION
First of three from the codebase audit.

## The duplication

`parseReadResponse` and `parseWriteResponse` each carried the same eighteen lines: CRC over five bytes, unit check, echoed-function check, the three fields lifted out.

Measured before touching anything: **eighteen of nineteen lines identical**, diverging exactly where the exception ends and the data frame begins. They had *not* drifted.

They are one helper now anyway. This is the path a device uses to say *"I refuse"*, and the function-code check in it is itself a fix that was applied once ([#67](https://github.com/Timdebruijn/heliograph/pull/67)). A fix applied to one of two copies leaves the other quietly wrong, and nothing would say so.

## The audit found something better than the duplication

The **read** path had tests for a foreign function code, a foreign unit and a bad CRC on the exception branch.

**The write path had only the happy case.**

So the check that stops a stale exception frame from a different request being accepted as the answer to this one had never been exercised on the write side — on the *control* path, where being wrong means a setpoint silently not arriving.

Three cases added there: foreign function, foreign unit, bad CRC.

## Mutation-tested

| mutation | before this PR | now |
|---|---|---|
| remove the function-code check | read path only | **both paths fail** |
| remove the CRC check | read path only | write path catches it |

That first row is the whole point of the consolidation, demonstrated rather than asserted.

## Verification

838 native tests (835 + 3), `check_layering.sh`, both firmware targets build.

## Risk

This is the RS485 protocol codec. Low but not zero — which is why the branch was measured for drift before merging, and why the mutation tests are on the checks rather than on the shape. No behaviour change: the same eighteen checks, in one place, reached from both callers.