### PR TITLE
refactor(ota): one place decides what an upload starts from

### DIFF
--- a/src/ota/ota_manager.cpp
+++ b/src/ota/ota_manager.cpp
@@ -58,6 +58,19 @@ bool shouldConfirmHealthyBoot(bool wifiConnected, uint64_t uptimeMs, bool alread
     return pollingHealthy && uptimeMs >= kOfflineConfirmThresholdMs;
 }
 
+/// Shared by both builds on purpose -- see the declaration for why an #if between two copies of
+/// this is the dangerous kind of duplication.
+void OtaManager::startTracking(size_t expectedSize, const std::string& expectedSha256) {
+    running_      = true;
+    magicChecked_ = false;
+    written_      = 0;
+    expected_     = expectedSize;
+    expectedSha_  = expectedSha256;
+    writtenSha256_.clear();
+    hasher_.reset();
+    lastError_.clear();
+}
+
 #if defined(ESP32)
 
 // Overrides the WEAK hook in the Arduino core (esp32-hal-misc.c). Without this override,
@@ -100,14 +113,7 @@ OtaResult OtaManager::begin(size_t expectedSize, const std::string& expectedSha2
         return Update.getError() == UPDATE_ERROR_SPACE ? OtaResult::TooLarge
                                                        : OtaResult::NoPartition;
     }
-    running_      = true;
-    magicChecked_ = false;
-    written_      = 0;
-    expected_     = expectedSize;
-    expectedSha_  = expectedSha256;
-    writtenSha256_.clear();
-    hasher_.reset();
-    lastError_.clear();
+    startTracking(expectedSize, expectedSha256);
     return OtaResult::Ok;
 }
 
@@ -192,14 +198,7 @@ OtaResult OtaManager::begin(size_t expectedSize, const std::string& expectedSha2
     if (running_) {
         return OtaResult::AlreadyRunning;
     }
-    running_      = true;
-    magicChecked_ = false;
-    written_      = 0;
-    expected_     = expectedSize;
-    expectedSha_  = expectedSha256;
-    writtenSha256_.clear();
-    hasher_.reset();
-    lastError_.clear();
+    startTracking(expectedSize, expectedSha256);
     return OtaResult::Ok;
 }
 

--- a/src/ota/ota_manager.h
+++ b/src/ota/ota_manager.h
@@ -129,6 +129,15 @@ private:
     // call site lives on the single AsyncTCP task, so this is belt-and-braces -- but that
     // single-task property is an implicit library detail, not something this class enforces,
     // and running() is exactly the kind of flag a future caller polls from another task.
+    /// The state an upload starts from, set in ONE place for both builds.
+    ///
+    /// These eight fields were assigned identically in the ESP32 begin() and the host begin(),
+    /// which is a worse duplication than most: the two live on opposite sides of an #if, so a
+    /// field added to one and forgotten in the other would leave the host tests setting up a
+    /// different starting state than the device. The tests would pass and the bridge would
+    /// carry a stale value into a firmware update.
+    void startTracking(size_t expectedSize, const std::string& expectedSha256);
+
     std::atomic<bool> running_{false};
     bool        magicChecked_ = false;
     size_t      written_    = 0;


### PR DESCRIPTION
Second of three from the codebase audit.

## The duplication, and why this one is worse than most

The eight fields an OTA begins from — `running_`, `magicChecked_`, `written_`, `expected_`, `expectedSha_`, `writtenSha256_`, `hasher_`, `lastError_` — were assigned in the ESP32 `begin()` and again in the host `begin()`, identically.

The two copies sit on **opposite sides of an `#if`**. A field added to one and forgotten in the other would leave the host tests setting up a different starting state than the device runs with: **the tests would pass, and a bridge would carry a stale value into a firmware update.**

That is not a shape of bug a build catches.

`startTracking()` now — defined once above the `#if`, called by both.

## No new tests, and that was checked rather than assumed

`test_a_second_upload_starts_from_a_clean_hash` already covers it:

| mutation | result |
|---|---|
| drop `written_ = 0` | fails, `Expected 0 Was 3` |
| drop `hasher_.reset()` | fails, `Expected 0 Was 7` |

## Verification

835 native tests, `check_layering.sh`, `waveshare-rs485-can` builds.

## Risk

Low. Pure extraction of an assignment block, no behaviour change, and the coverage was verified by mutation before deciding not to add tests.