### PR TITLE
refactor(diagnostics): findCause is std::find_if

### DIFF
--- a/src/diagnostics/coredump.cpp
+++ b/src/diagnostics/coredump.cpp
@@ -2,6 +2,9 @@
 
 #include "coredump.h"
 
+#include <algorithm>
+#include <iterator>
+
 namespace heliograph::diag {
 
 /// Xtensa EXCCAUSE values, from xtensa/corebits.h. Only the ones a firmware fault plausibly
@@ -39,12 +42,9 @@ constexpr CauseSpec kCauses[] = {
 };
 
 const CauseSpec* findCause(uint32_t cause) {
-    for (const auto& spec : kCauses) {
-        if (spec.code == cause) {
-            return &spec;
-        }
-    }
-    return nullptr;
+    const auto* found = std::find_if(std::begin(kCauses), std::end(kCauses),
+                                     [cause](const CauseSpec& spec) { return spec.code == cause; });
+    return found == std::end(kCauses) ? nullptr : found;
 }
 
 }  // namespace


### PR DESCRIPTION
Third and last from the codebase audit.

## What changed

`findCause` walked `kCauses` by hand to return a pointer or `nullptr` — which is exactly what `std::find_if` is for. The loop said nothing the algorithm's name does not.

## What deliberately did not

cppcheck flags **five** raw loops. This is the only one changed.

Three are `push_back` inside a range-for (`device_plan`, `state_store`, `driver_registry`), where `std::transform` with a `back_inserter` and a lambda is *longer* and reads worse. One is in `profiles_generated.cpp`, which is machine-written and never maintained by hand.

Swapping clear code for an algorithm to satisfy a linter is not an improvement, and the brief asks for less code, not more.

## Verification

`test_the_cause_table_answers_both_questions_consistently` covers the three paths through this function — a known cause, a cause with no faulting address, and an unknown code. 835 native tests, `check_layering.sh`, both targets build.

## Risk

Negligible. Same search, same return contract, one call site.