### PR TITLE
Release 0.22.1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,9 +173,17 @@ namespace {
 // compile -- so a safety property, on the exact bus this bridge exists for, had no test. It is
 // app::planDevices() now: a configuration and a registry in, a plan out, and setup() reads the
 // verdict instead of computing it.
+// 0.22.1 changes nothing a bridge does. Three duplications collapsed to one definition each:
+// the Modbus exception frame, the OTA start-of-upload state, and a hand-written search that is
+// std::find_if. The audit behind it found no warnings, no deprecated dependencies and no dead
+// code, which is the more useful result and why this is a patch.
+//
+// The exception-frame work carried a real gap out with it: the write path had only the happy
+// case, so the check that stops a stale exception from another request being read as the answer
+// to this one had never been exercised on the control path.
 #define HELIOGRAPH_VERSION_MAJOR 0
 #define HELIOGRAPH_VERSION_MINOR 22
-#define HELIOGRAPH_VERSION_PATCH 0
+#define HELIOGRAPH_VERSION_PATCH 1
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Version bump. **Nothing a bridge does changes** — no API, no metric names, no behaviour.

## What is in it

| PR | What |
|---|---|
| [#115](https://github.com/Timdebruijn/heliograph/pull/115) | One Modbus exception-frame parser instead of two |
| [#116](https://github.com/Timdebruijn/heliograph/pull/116) | One place decides what an OTA upload starts from |
| [#117](https://github.com/Timdebruijn/heliograph/pull/117) | `findCause` is `std::find_if` |

## The audit behind it

Re-run against the tree as it stood after 0.22.0. **No warnings, no deprecated dependencies, no dead code** — that is the more useful finding and why this is a patch rather than anything larger. Repeated blocks went from 81 this morning to 69.

## The one thing that was more than tidying

#115 carried a real gap out with it. The **read** path had tests for a foreign function code, a foreign unit and a bad CRC on the exception branch; the **write** path had only the happy case.

So the check that stops a stale exception frame from a different request being accepted as the answer to this one had never been exercised on the *control* path — where being wrong means a setpoint silently not arriving. Three tests added, and mutation-testing now fails on both paths where it would previously have failed on one.

## Verified on this exact tree

- **838 native tests** (835 + 3)
- `check_layering.sh` (8 rules), `check_web_js.py`, `check_measurement_ids.py`, `check_dashboard_layout.py`
- All four targets build; the binary reports `0.22.1`, read from the binary rather than the source
- `tools/check_version.sh v0.22.1` passes