### PR TITLE
feat(growatt): connect the write chain, still gated shut

### DIFF
--- a/src/drivers/growatt_modbus/growatt_driver.cpp
+++ b/src/drivers/growatt_modbus/growatt_driver.cpp
@@ -285,16 +285,103 @@ DeviceIdentity GrowattDriver::identity() const {
     return id;
 }
 
+/// The write row for a command, or nullptr when this profile has none it can actually serve.
+///
+/// Three separate reasons to say no, and they are checked here so that capabilities() and
+/// execute() can never disagree about which commands exist -- a driver that ADVERTISES a
+/// setpoint and then refuses it is worse than one that never offered.
+const WriteMapping* GrowattDriver::writeFor(InverterCommandType type) const {
+    for (size_t i = 0; i < options_.profile->writeCount; ++i) {
+        const WriteMapping& w = options_.profile->writes[i];
+        if (w.command != type) {
+            continue;
+        }
+        // Unverified rows are documented research, not a control surface. A row goes live only
+        // when somebody has written the register on real hardware, read it back, and confirmed
+        // against the inverter's own reported output that it took effect.
+        if (!w.verified) {
+            return nullptr;
+        }
+        // The Modbus client speaks FC06 only. A row needing FC16 -- more than one register, or
+        // a firmware that demands write-multiple for a single one -- cannot be served, and
+        // pretending otherwise would send a frame the device never asked for.
+        if (w.words != 1 || w.useWriteMultiple) {
+            return nullptr;
+        }
+        return &w;
+    }
+    return nullptr;
+}
+
 InverterCapabilities GrowattDriver::capabilities() const {
     InverterCapabilities caps;
     caps.phaseCount = options_.profile->phaseCount;
     caps.mpptCount  = options_.profile->mpptCount;
     caps.hasBattery = options_.profile->hasBattery;
+
+    // Advertised from the same lookup execute() uses, so the two cannot drift apart. A profile
+    // with only unverified rows reports exactly what it did before this existed: read-only.
+    for (size_t i = 0; i < options_.profile->writeCount; ++i) {
+        const WriteMapping* w = writeFor(options_.profile->writes[i].command);
+        if (w == nullptr) {
+            continue;
+        }
+        caps.addWrite(requiredCapability(w->command));
+        NumericCapability& n = caps.numeric[static_cast<size_t>(w->command)];
+        n.supported          = true;
+        n.writable           = true;
+        n.minimum            = w->minimum;
+        n.maximum            = w->maximum;
+        n.step               = w->step;
+        n.unit               = w->unit;
+    }
     return caps;
 }
 
-CommandResult GrowattDriver::execute(const InverterCommand&) {
-    return CommandResult::Unsupported;  // read-only until the map is confirmed on hardware
+CommandResult GrowattDriver::execute(const InverterCommand& command) {
+    if (transport_ == nullptr) {
+        return CommandResult::Unsupported;
+    }
+    const WriteMapping* w = writeFor(command.type);
+    if (w == nullptr) {
+        return CommandResult::Unsupported;
+    }
+    if (!command.numericValue.has_value()) {
+        return CommandResult::Rejected;
+    }
+    // Bounds are checked HERE as well as in the dispatcher. The dispatcher enforces what
+    // capabilities() advertised; this enforces what the register actually accepts, and the two
+    // are the same number today only because both read it from the same row.
+    const double value = *command.numericValue;
+    if (value < w->minimum || value > w->maximum) {
+        return CommandResult::OutOfRange;
+    }
+    const double raw = value / w->scale;
+    if (raw < 0.0 || raw > 65535.0) {
+        return CommandResult::OutOfRange;
+    }
+
+    const modbus::TransactionOutcome outcome = modbus::writeSingleRegister(
+        *transport_, options_.unitId, w->address, static_cast<uint16_t>(raw + 0.5),
+        modbus::ReadTiming{kTransactionDeadlineMs, kResponseTimeoutMs});
+    switch (outcome.status) {
+        case modbus::TransactionStatus::Ok:
+            return CommandResult::Ok;
+        case modbus::TransactionStatus::Exception:
+            // The device understood and refused: a read-only register, a value it will not take,
+            // or a mode that has to be unlocked first. Rejected, not a transport failure -- the
+            // bus worked perfectly.
+            return CommandResult::Rejected;
+        case modbus::TransactionStatus::Timeout:
+            // Its own result, not folded into DriverError: silence on the bus points at wiring
+            // or a unit id, and a driver fault points at this code. Two different call-outs.
+            return CommandResult::Timeout;
+        default:
+            // Crc, Protocol, TransportError. The write may or may not have landed -- a CRC
+            // failure on the ECHO means the device answered and we could not read it. Reported
+            // as an error rather than guessed either way.
+            return CommandResult::DriverError;
+    }
 }
 
 }  // namespace heliograph::growatt

--- a/src/drivers/growatt_modbus/growatt_driver.h
+++ b/src/drivers/growatt_modbus/growatt_driver.h
@@ -52,6 +52,13 @@ public:
     BusErrorCounts busErrors() const override { return busErrors_; }
 
 private:
+    /// The write row that can actually serve this command, or nullptr.
+    ///
+    /// Used by BOTH capabilities() and execute() so the two can never disagree about which
+    /// setpoints exist. A driver that advertises a command and then refuses it is worse than
+    /// one that never offered it.
+    const WriteMapping* writeFor(InverterCommandType type) const;
+
     /// Crc is separate from Protocol for the same reason it is in the codec: it is the only one
     /// that means the wire is bad, and it is what the checksum-error metric and its alert key on.
     enum class ReadResult { Ok, Timeout, Exception, Crc, Protocol, TransportError };

--- a/test/test_growatt_driver/test_main.cpp
+++ b/test/test_growatt_driver/test_main.cpp
@@ -668,6 +668,188 @@ static void test_the_mic_profile_converts_half_seconds_to_hours() {
     TEST_ASSERT_DOUBLE_WITHIN(0.01, 12345.0, hours->value);
 }
 
+// --- write path -------------------------------------------------------------------------
+//
+// The chain runs profile row -> capabilities() -> execute() -> FC06. Every case below turns on
+// one link of it, because a driver that ADVERTISES a setpoint and then refuses it is worse than
+// one that never offered.
+
+namespace {
+
+/// A profile carrying one VERIFIED write row, which no shipped profile has.
+///
+/// Built here rather than by flipping a real profile's flag: `verified = true` means somebody
+/// wrote the register on hardware and confirmed the effect, and a test must not be able to
+/// claim that on a device's behalf.
+const WriteMapping kTestWrites[] = {
+    {InverterCommandType::SetActivePowerLimitPercent, "Active Power Limit", RegSpace::Holding, 3,
+     1, false, 1.0, 0.0, 100.0, 1.0, Unit::Percent, true},
+};
+
+/// The same row, needing FC16 -- which the Modbus client cannot send.
+const WriteMapping kMultiWordWrites[] = {
+    {InverterCommandType::SetActivePowerLimitPercent, "Active Power Limit", RegSpace::Holding, 3,
+     2, false, 1.0, 0.0, 100.0, 1.0, Unit::Percent, true},
+};
+
+GrowattProfile profileWith(const WriteMapping* writes, size_t count) {
+    GrowattProfile p = *findProfile("mic_tl_x");
+    p.writes         = writes;
+    p.writeCount     = count;
+    return p;
+}
+
+/// Echoes a well-formed FC06 confirmation, which is what a device that accepted the write sends.
+void echoWrites(MockTransport& t) {
+    t.setResponder([](const std::vector<uint8_t>& req, std::vector<uint8_t>& reply) {
+        if (req.size() < 6 || req[1] != 0x06) {
+            return false;
+        }
+        reply.assign(req.begin(), req.begin() + 6);
+        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
+        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
+        reply.push_back(static_cast<uint8_t>(crc >> 8));
+        return true;
+    });
+}
+
+/// The same row with verified = false, which is how every shipped profile carries it.
+const WriteMapping kUnverifiedWrites[] = {
+    {InverterCommandType::SetActivePowerLimitPercent, "Active Power Limit", RegSpace::Holding, 3,
+     1, false, 1.0, 0.0, 100.0, 1.0, Unit::Percent, false},
+};
+
+}  // namespace
+
+// THE GATE THAT MATTERS MOST, and the one nothing was checking.
+//
+// A test existed asserting that the shipped row carries verified = false -- but that is a fact
+// about the DATA. Nothing asserted the driver acts on it, so deleting the check in writeFor()
+// left every test green while unverified research became a live control surface on somebody's
+// inverter. Found by mutation-testing this change, not by reading it.
+static void test_an_unverified_row_is_neither_advertised_nor_executed() {
+    MockTransport transport;
+    echoWrites(transport);
+    GrowattProfile profile = profileWith(kUnverifiedWrites, 1);
+    GrowattOptions options;
+    options.profile = &profile;
+    GrowattDriver driver(transport, options);
+
+    TEST_ASSERT_FALSE(driver.capabilities().canWrite(InverterCapability::SetActivePowerLimit));
+    const auto& n = driver.capabilities().numeric[static_cast<size_t>(
+        InverterCommandType::SetActivePowerLimitPercent)];
+    TEST_ASSERT_FALSE(n.writable);
+
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 60.0;
+    TEST_ASSERT_EQUAL(CommandResult::Unsupported, driver.execute(cmd));
+    // Nothing on the bus. `verified` means a person confirmed the register on hardware, and
+    // until then the row is documentation.
+    TEST_ASSERT_EQUAL_UINT32(0, transport.writes.size());
+}
+
+static void test_a_verified_row_becomes_an_advertised_setpoint() {
+    MockTransport  transport;
+    GrowattProfile profile = profileWith(kTestWrites, 1);
+    GrowattOptions options;
+    options.profile = &profile;
+    GrowattDriver driver(transport, options);
+
+    const auto caps = driver.capabilities();
+    TEST_ASSERT_TRUE(caps.canWrite(InverterCapability::SetActivePowerLimit));
+    const auto& n = caps.numeric[static_cast<size_t>(
+        InverterCommandType::SetActivePowerLimitPercent)];
+    TEST_ASSERT_TRUE(n.writable);
+    // The bounds come from the row, so the dispatcher enforces what the register accepts rather
+    // than a number typed twice.
+    TEST_ASSERT_EQUAL_DOUBLE(0.0, n.minimum);
+    TEST_ASSERT_EQUAL_DOUBLE(100.0, n.maximum);
+}
+
+static void test_a_verified_row_writes_the_register_it_names() {
+    MockTransport transport;
+    echoWrites(transport);
+    GrowattProfile profile = profileWith(kTestWrites, 1);
+    GrowattOptions options;
+    options.unitId  = 2;
+    options.profile = &profile;
+    GrowattDriver driver(transport, options);
+
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 60.0;
+    TEST_ASSERT_EQUAL(CommandResult::Ok, driver.execute(cmd));
+
+    // unit 2, FC06, register 3, value 60 -- the frame the profile row describes, not a frame
+    // that happens to be accepted.
+    TEST_ASSERT_EQUAL_UINT32(1, transport.writes.size());
+    const auto& f = transport.writes.back();
+    TEST_ASSERT_EQUAL_UINT8(0x02, f[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x06, f[1]);
+    TEST_ASSERT_EQUAL_UINT16(3, (f[2] << 8) | f[3]);
+    TEST_ASSERT_EQUAL_UINT16(60, (f[4] << 8) | f[5]);
+}
+
+static void test_a_value_outside_the_row_bounds_never_reaches_the_bus() {
+    MockTransport transport;
+    echoWrites(transport);
+    GrowattProfile profile = profileWith(kTestWrites, 1);
+    GrowattOptions options;
+    options.profile = &profile;
+    GrowattDriver driver(transport, options);
+
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 150.0;
+    TEST_ASSERT_EQUAL(CommandResult::OutOfRange, driver.execute(cmd));
+    // Refused before the frame is built. An inverter asked for 150% is an inverter asked
+    // something meaningless, and finding out from its exception reply is finding out too late.
+    TEST_ASSERT_EQUAL_UINT32(0, transport.writes.size());
+}
+
+static void test_a_row_needing_write_multiple_is_refused_not_faked() {
+    MockTransport  transport;
+    GrowattProfile profile = profileWith(kMultiWordWrites, 1);
+    GrowattOptions options;
+    options.profile = &profile;
+    GrowattDriver driver(transport, options);
+
+    // The client speaks FC06 only. Sending a single-register write for a two-register row would
+    // put half a value in the device, which is worse than declining.
+    TEST_ASSERT_FALSE(driver.capabilities().canWrite(InverterCapability::SetActivePowerLimit));
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 60.0;
+    TEST_ASSERT_EQUAL(CommandResult::Unsupported, driver.execute(cmd));
+    TEST_ASSERT_EQUAL_UINT32(0, transport.writes.size());
+}
+
+static void test_a_device_that_refuses_is_rejected_not_reported_as_a_fault() {
+    MockTransport transport;
+    transport.setResponder([](const std::vector<uint8_t>& req, std::vector<uint8_t>& reply) {
+        if (req.size() < 2) {
+            return false;
+        }
+        reply = {req[0], static_cast<uint8_t>(req[1] | 0x80), 0x02};  // illegal data address
+        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
+        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
+        reply.push_back(static_cast<uint8_t>(crc >> 8));
+        return true;
+    });
+    GrowattProfile profile = profileWith(kTestWrites, 1);
+    GrowattOptions options;
+    options.profile = &profile;
+    GrowattDriver driver(transport, options);
+
+    InverterCommand cmd;
+    cmd.type         = InverterCommandType::SetActivePowerLimitPercent;
+    cmd.numericValue = 60.0;
+    // The bus worked perfectly and the device said no. Reporting that as a driver fault sends
+    // somebody to look at wiring.
+    TEST_ASSERT_EQUAL(CommandResult::Rejected, driver.execute(cmd));
+}
+
 // The active-power-limit row is research, not a control surface: it stays dormant until a
 // bench session sets verified = true AND the driver grows a write path (execute() still
 // returns Unsupported). Both gates are asserted here so neither can be dropped unnoticed.
@@ -720,6 +902,12 @@ int main(int, char**) {
     RUN_TEST(test_the_mic_profile_probes_3000_but_publishes_nothing_from_it);
     RUN_TEST(test_the_mic_profile_decodes_a_realistic_frame);
     RUN_TEST(test_the_mic_profile_converts_half_seconds_to_hours);
+    RUN_TEST(test_an_unverified_row_is_neither_advertised_nor_executed);
+    RUN_TEST(test_a_verified_row_becomes_an_advertised_setpoint);
+    RUN_TEST(test_a_verified_row_writes_the_register_it_names);
+    RUN_TEST(test_a_value_outside_the_row_bounds_never_reaches_the_bus);
+    RUN_TEST(test_a_row_needing_write_multiple_is_refused_not_faked);
+    RUN_TEST(test_a_device_that_refuses_is_rejected_not_reported_as_a_fault);
     RUN_TEST(test_the_mic_power_limit_write_row_is_declared_but_dormant);
     return UNITY_END();
 }


### PR DESCRIPTION
The chain ran `profile row → generator → kMicTlXWrites[] → attached to the profile → nothing`. The array was compiled into the firmware and **no code read it**. `capabilities()` reported phases, MPPTs and a battery flag; `execute()` returned `Unsupported` unconditionally.

## What connects

Both ends now read the **same** lookup, `writeFor()`, so they cannot drift — a driver that advertises a setpoint and then refuses it is worse than one that never offered.

Three reasons to decline live in that one function:

- no row for this command
- **the row is unverified**
- the row needs FC16, which this Modbus client cannot send

That last one matters more than it looks. Sending a single-register write for a two-register row puts *half a value* in the device. Declining is the only honest answer until the client grows FC16.

## Nothing is enabled by this

Every shipped profile carries `verified = false`, so the MIC TL-X power-limit row stays exactly as dormant as it was. What changes is that setting the flag, after a bench session, is now **sufficient**.

## The gate that matters most had no test, and I nearly shipped it that way

A test existed asserting the shipped row carries `verified = false` — a fact about the **data**. Nothing asserted the driver *acts* on it.

Deleting the check in `writeFor()` left all 34 cases green while unverified research became a live control surface on somebody's inverter. Found by mutation-testing after writing the tests, not by reading them.

## Six cases

- an unverified row neither advertised nor executed
- a verified one advertised with the row's own bounds
- the exact FC06 frame the row describes — unit, register, value
- a value outside those bounds never reaching the bus at all
- an FC16 row refused rather than faked
- a device exception reported as `Rejected`, not a driver fault — the bus worked, the inverter said no, and sending somebody to check wiring for that is a wasted afternoon

**All three gates are mutation-tested.** Remove any one and a case fails.

## Verification

844 native tests (838 + 6), `check_layering.sh`, both targets build.

## Risk

None to current behaviour: no shipped profile has a verified row, so every Growatt remains read-only. The risk this introduces is future — a `verified = true` set without a bench session — which is why the flag's meaning is written into the profile, the header and the test that guards it.