### PR TITLE
tools: the screenshot pipeline, committed instead of remembered

### DIFF
--- a/docs/images/fixture.json
+++ b/docs/images/fixture.json
@@ -1,0 +1,516 @@
+{
+  "status": {
+    "bridge": {
+      "id": "heliograph-a1b2c3",
+      "name": "Heliograph",
+      "firmware_version": "0.22.1 (Jul 28 2026 16:05:01)",
+      "board_id": "rs485-can",
+      "ip_address": "192.168.1.50",
+      "ip_mode": "dhcp",
+      "max_devices": 8,
+      "devices_configured": 1,
+      "devices_started": 1,
+      "device_problems": [],
+      "uptime_seconds": 10899,
+      "wifi_connected": true,
+      "wifi_rssi_dbm": -58,
+      "mqtt_connected": true,
+      "modbus_listening": true,
+      "modbus_clients": 0,
+      "time_synced": true,
+      "time": "2026-07-28 21:51:04",
+      "ntp_last_sync": "2026-07-28 21:49:30",
+      "ntp_server": "pool.ntp.org",
+      "ntp_server_source": "dhcp",
+      "free_heap_bytes": 149760,
+      "boot_button_pressed": false
+    },
+    "device": {
+      "id": "eversolar_legacy-16",
+      "label": "Dak huis",
+      "driver_id": "eversolar_legacy",
+      "support_level": "beta",
+      "manufacturer": "Ever-Solar",
+      "model": "TL3000-20",
+      "serial_number": "SN0000000000",
+      "online": true,
+      "data_valid": true,
+      "data_stale": false,
+      "consecutive_poll_failures": 0,
+      "last_successful_poll_seconds_ago": 9
+    },
+    "measurements": {
+      "ac.power.total": {
+        "value": 0,
+        "unit": "W",
+        "valid": true,
+        "stale": false
+      },
+      "ac.phase_l1.voltage": {
+        "value": 230.6,
+        "unit": "V",
+        "valid": true,
+        "stale": false
+      },
+      "ac.phase_l1.current": {
+        "value": 0.3,
+        "unit": "A",
+        "valid": true,
+        "stale": false
+      },
+      "ac.frequency": {
+        "value": 50,
+        "unit": "Hz",
+        "valid": true,
+        "stale": false
+      },
+      "dc.mppt_1.voltage": {
+        "value": 219,
+        "unit": "V",
+        "valid": true,
+        "stale": false
+      },
+      "dc.mppt_1.current": {
+        "value": 0,
+        "unit": "A",
+        "valid": true,
+        "stale": false
+      },
+      "dc.mppt_1.power": {
+        "value": 0,
+        "unit": "W",
+        "valid": true,
+        "stale": false,
+        "derived": true
+      },
+      "dc.power.total": {
+        "value": 0,
+        "unit": "W",
+        "valid": true,
+        "stale": false,
+        "derived": true
+      },
+      "energy.today": {
+        "value": 16.13,
+        "unit": "kWh",
+        "valid": true,
+        "stale": false
+      },
+      "energy.total": {
+        "value": 35579.1,
+        "unit": "kWh",
+        "valid": true,
+        "stale": false
+      },
+      "inverter.temperature": {
+        "value": 31.5,
+        "unit": "\u00b0C",
+        "valid": true,
+        "stale": false
+      },
+      "inverter.operating_hours": {
+        "value": 47556,
+        "unit": "h",
+        "valid": true,
+        "stale": false
+      }
+    },
+    "status_code": 1,
+    "status_text": "Grid-connected (normal)",
+    "error_code": null,
+    "devices": [
+      {
+        "id": "eversolar_legacy-16",
+        "label": "Dak huis",
+        "online": true,
+        "data_valid": true,
+        "data_stale": false,
+        "modbus_unit_id": 1,
+        "last_successful_poll_seconds_ago": 9,
+        "energy_today_kwh": 16.13,
+        "ac_voltage_v": 230.6,
+        "temperature_c": 31.5,
+        "battery_soc_pct": null,
+        "battery_power_w": null,
+        "ac_power_w": 0
+      }
+    ],
+    "totals": {
+      "devices_answering": 1,
+      "devices_polled": 1,
+      "ac_power_w": 0,
+      "ac_power_devices": 1,
+      "energy_today_kwh": 16.13,
+      "energy_today_devices": 1,
+      "energy_total_kwh": 35579.1,
+      "energy_total_devices": 1
+    },
+    "poll_success_total": 1069,
+    "poll_failure_total": 1
+  },
+  "config": {
+    "version": 1,
+    "bridge_name": "Heliograph",
+    "wifi": {
+      "ssid": "HomeNetwork",
+      "hostname": "heliograph-a1b2c3",
+      "ip": "",
+      "gateway": "",
+      "subnet": "",
+      "dns1": "",
+      "dns2": "",
+      "password_set": true
+    },
+    "mqtt": {
+      "enabled": true,
+      "host": "192.168.1.50",
+      "port": 1883,
+      "base_topic": "solarbridge",
+      "discovery_prefix": "homeassistant",
+      "discovery_enabled": true,
+      "qos": 0,
+      "username_set": true,
+      "password_set": true
+    },
+    "modbus": {
+      "enabled": true,
+      "port": 502,
+      "unit_id": 1,
+      "diagnostics_unit_id": 250,
+      "max_clients": 4,
+      "idle_timeout_seconds": 20,
+      "write_enabled": false
+    },
+    "polling": {
+      "interval_seconds": 10
+    },
+    "relays": {
+      "enabled": false,
+      "roles": []
+    },
+    "driver": {
+      "id": "eversolar_legacy",
+      "auto_detect": false,
+      "label": "Dak huis",
+      "options": {}
+    },
+    "additional_devices": [],
+    "ntp": {
+      "enabled": true,
+      "use_dhcp": true,
+      "server": "pool.ntp.org",
+      "timezone": "CET-1CEST,M3.5.0,M10.5.0/3",
+      "timezone_name": "Europe/Amsterdam"
+    },
+    "serial": {
+      "override": false,
+      "baud_rate": 9600,
+      "parity": "none",
+      "data_bits": 8,
+      "stop_bits": 1
+    },
+    "updates": {
+      "check_enabled": true
+    },
+    "logging": {
+      "level": "info"
+    },
+    "security": {
+      "password_set": true,
+      "read_only_mode": true
+    }
+  },
+  "diagnostics": {
+    "uptime_seconds": 10899,
+    "firmware_version": "0.22.1 (Jul 28 2026 16:05:01)",
+    "board": "Waveshare ESP32-S3-RS485-CAN",
+    "free_heap_bytes": 149504,
+    "minimum_free_heap_bytes": 107196,
+    "max_alloc_heap_bytes": 98292,
+    "psram_size_bytes": 8388608,
+    "psram_free_bytes": 8378140,
+    "reset_reason": 3,
+    "ota_image_state": "valid",
+    "coredump_present": false,
+    "coredump_task": null,
+    "coredump_pc": null,
+    "coredump_cause": null,
+    "coredump_cause_name": null,
+    "coredump_fault_address": null,
+    "wifi_connected": true,
+    "wifi_rssi_dbm": -58,
+    "mqtt_connected": true,
+    "time_synced": true,
+    "time": "2026-07-28 21:51:04",
+    "ntp_last_sync": "2026-07-28 21:49:30",
+    "ntp_server": "pool.ntp.org",
+    "ntp_server_source": "dhcp",
+    "poll_success_total": 1069,
+    "poll_failure_total": 1,
+    "consecutive_poll_failures": 0,
+    "checksum_error_total": 0,
+    "rs485_timeout_total": 1,
+    "invalid_frame_total": 0,
+    "wifi_reconnect_total": 0,
+    "mqtt_reconnect_total": 0,
+    "modbus_client_connections_total": 0,
+    "rest_requests_total": 57,
+    "mqtt_publish_failure_total": 0,
+    "last_successful_poll_ms": 10889626,
+    "rs485_stack_free_bytes": 3532,
+    "loop_stack_free_bytes": 3784,
+    "last_error": "poll failed: timeout",
+    "coredump_backtrace": null,
+    "coredump_backtrace_corrupted": null
+  },
+  "drivers": {
+    "drivers": [
+      {
+        "id": "sunspec",
+        "display_name": "SunSpec Modbus (generic)",
+        "manufacturer": "SunSpec",
+        "protocol": "SunSpec Modbus RTU",
+        "support_level": "experimental",
+        "supports_read": true,
+        "supports_write": true,
+        "auto_detection": true,
+        "serial_profiles": [
+          {
+            "baud_rate": 9600,
+            "parity": "none",
+            "data_bits": 8,
+            "stop_bits": 1
+          },
+          {
+            "baud_rate": 19200,
+            "parity": "none",
+            "data_bits": 8,
+            "stop_bits": 1
+          }
+        ],
+        "options": [
+          {
+            "key": "unit_id",
+            "display_name": "Modbus unit id",
+            "description": "Slave address of the inverter on the RS485 bus. Range 1-247.",
+            "default_value": "1",
+            "min_value": 1,
+            "max_value": 247,
+            "allowed_values": []
+          },
+          {
+            "key": "base_address",
+            "display_name": "SunSpec base register",
+            "description": "Where the 'SunS' marker lives. 40000 covers most devices; 50000 is the other common choice, and some vendors sit elsewhere. Each extra guess would cost a discovery round trip, so this is set rather than searched.",
+            "default_value": "40000",
+            "min_value": 0,
+            "max_value": 65534,
+            "allowed_values": []
+          }
+        ]
+      },
+      {
+        "id": "eversolar_legacy",
+        "display_name": "Ever-Solar / Zeversolar (legacy PMU)",
+        "manufacturer": "Ever-Solar",
+        "protocol": "EverSolar PMU RS485",
+        "support_level": "beta",
+        "supports_read": true,
+        "supports_write": false,
+        "auto_detection": true,
+        "serial_profiles": [
+          {
+            "baud_rate": 9600,
+            "parity": "none",
+            "data_bits": 8,
+            "stop_bits": 1
+          }
+        ],
+        "options": [
+          {
+            "key": "layout",
+            "display_name": "Payload layout",
+            "description": "How to interpret the measurement payload. 'auto' derives it from the frame length (28 bytes = 1 string, 32 = 2). Force one only if a device contradicts that.",
+            "default_value": "auto",
+            "allowed_values": [
+              "auto",
+              "single",
+              "dual"
+            ]
+          },
+          {
+            "key": "address",
+            "display_name": "Assigned bus address",
+            "description": "Address this bridge hands to its inverter at registration. Leave at 16 unless you have more than one inverter on the same RS485 loop; then give each its own, counting up (16, 17, 18...). The inverter does not store it -- it is handed out at registration and forgotten on power loss. Range 16-254.",
+            "default_value": "16",
+            "min_value": 16,
+            "max_value": 254,
+            "allowed_values": []
+          }
+        ]
+      },
+      {
+        "id": "solax_x1",
+        "display_name": "SolaX X1 series (RS485)",
+        "manufacturer": "SolaX",
+        "protocol": "SolaX X1 RS485 (PMU)",
+        "support_level": "experimental",
+        "supports_read": true,
+        "supports_write": false,
+        "auto_detection": true,
+        "serial_profiles": [
+          {
+            "baud_rate": 9600,
+            "parity": "none",
+            "data_bits": 8,
+            "stop_bits": 1
+          }
+        ],
+        "options": [
+          {
+            "key": "address",
+            "display_name": "Assigned bus address",
+            "description": "Address handed to the inverter at registration (reference default 10 = 0x0A). Range 1-254.",
+            "default_value": "10",
+            "min_value": 1,
+            "max_value": 254,
+            "allowed_values": []
+          }
+        ]
+      },
+      {
+        "id": "growatt_modbus",
+        "display_name": "Growatt (Modbus RTU)",
+        "manufacturer": "Growatt",
+        "protocol": "Modbus RTU",
+        "support_level": "experimental",
+        "supports_read": true,
+        "supports_write": false,
+        "auto_detection": true,
+        "serial_profiles": [
+          {
+            "baud_rate": 9600,
+            "parity": "none",
+            "data_bits": 8,
+            "stop_bits": 1
+          },
+          {
+            "baud_rate": 115200,
+            "parity": "none",
+            "data_bits": 8,
+            "stop_bits": 1
+          }
+        ],
+        "options": [
+          {
+            "key": "unit_id",
+            "display_name": "Modbus unit id",
+            "description": "The inverter's Modbus slave address (Growatt default is 1). Range 1-247.",
+            "default_value": "1",
+            "min_value": 1,
+            "max_value": 247,
+            "allowed_values": []
+          },
+          {
+            "key": "profile",
+            "display_name": "Register-map profile",
+            "description": "Which Growatt register map to use (profiles/growatt/). Empty = the default profile.",
+            "default_value": "",
+            "allowed_values": [
+              "",
+              "mic_tl_x",
+              "sph"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "mock_0000000001",
+        "display_name": "Mock Inverter",
+        "manufacturer": "Heliograph open-source project",
+        "protocol": "none (simulated)",
+        "support_level": "stable",
+        "supports_read": true,
+        "supports_write": false,
+        "auto_detection": false,
+        "serial_profiles": [],
+        "options": [
+          {
+            "key": "day_length_minutes",
+            "display_name": "Simulated day length",
+            "description": "How long one simulated sunrise-to-sunset cycle takes. Short by default so a full curve is visible within minutes of booting.",
+            "default_value": "10",
+            "min_value": 1,
+            "max_value": 1440,
+            "allowed_values": []
+          },
+          {
+            "key": "unit_id",
+            "display_name": "Simulated unit",
+            "description": "Which simulated inverter this is. Give each mock under Extra devices its own number: it is what keeps them apart, and it staggers their solar curves so they do not all report the same value at the same moment.",
+            "default_value": "1",
+            "min_value": 1,
+            "max_value": 8,
+            "allowed_values": []
+          }
+        ]
+      },
+      {
+        "id": "mock_inverter_0000000001",
+        "display_name": "Mock Inverter (writable)",
+        "manufacturer": "Heliograph open-source project",
+        "protocol": "none (simulated)",
+        "support_level": "stable",
+        "supports_read": true,
+        "supports_write": true,
+        "auto_detection": false,
+        "serial_profiles": [],
+        "options": [
+          {
+            "key": "day_length_minutes",
+            "display_name": "Simulated day length",
+            "description": "How long one simulated sunrise-to-sunset cycle takes. Short by default so a full curve is visible within minutes of booting.",
+            "default_value": "10",
+            "min_value": 1,
+            "max_value": 1440,
+            "allowed_values": []
+          },
+          {
+            "key": "unit_id",
+            "display_name": "Simulated unit",
+            "description": "Which simulated inverter this is. Give each mock under Extra devices its own number: it is what keeps them apart, and it staggers their solar curves so they do not all report the same value at the same moment.",
+            "default_value": "1",
+            "min_value": 1,
+            "max_value": 8,
+            "allowed_values": []
+          }
+        ]
+      }
+    ]
+  },
+  "discovery": {
+    "status": "idle",
+    "mode": "quick",
+    "busy": false
+  },
+  "capture": {
+    "status": "idle",
+    "line": {
+      "baud_rate": 9600,
+      "parity": "none",
+      "data_bits": 8,
+      "stop_bits": 1,
+      "idle_gap_ms": 0
+    },
+    "requested_seconds": 30,
+    "max_frames": 64,
+    "summary": {
+      "frames": 0,
+      "bytes": 0,
+      "modbus_crc_ok": 0,
+      "aa55_frames_ok": 0,
+      "truncated": false
+    },
+    "frames": []
+  }
+}

--- a/tools/make_screenshots.py
+++ b/tools/make_screenshots.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Regenerates the dashboard screenshots in docs/images/.
+
+The page ships as a C++ string literal and fetches its data over REST, so a screenshot needs
+three things standing at once: the HTML out of the header, a server answering the API calls,
+and a browser that can click a tab. This does all three.
+
+It was done by hand for PR #56 and the recipe lived nowhere, so the next round meant working it
+out again from the results. Committed for that reason rather than because it runs often.
+
+    # capture fresh data from a running bridge, sanitise it, and shoot every tab
+    python3 tools/make_screenshots.py --bridge 192.168.20.254
+
+    # re-shoot from the captured fixture, no bridge needed
+    python3 tools/make_screenshots.py
+
+DATA IS SANITISED ON CAPTURE, not on render: serial numbers, the MAC-derived hostname, the WiFi
+SSID and the NTP server are replaced before anything is written to disk. The fixture is
+committed and a screenshot is published, so a real serial reaching either is a real leak, and
+the only safe place to stop it is the moment the payload arrives.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import json
+import pathlib
+import re
+import shutil
+import socketserver
+import subprocess
+import sys
+import threading
+import urllib.error
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+ASSET = ROOT / "src/web/assets/index_html.h"
+FIXTURE = ROOT / "docs/images/fixture.json"
+
+# Endpoint -> filename stem. The page GETs exactly these; anything else it asks for gets a 404,
+# which is what a bridge with the feature switched off would answer anyway.
+ENDPOINTS = ["status", "config", "diagnostics", "drivers", "discovery", "capture"]
+
+# data-t value -> output file. Tabs are switched by CLICK, not by URL, so each shot navigates to
+# the same page and clicks its way there.
+TABS = {
+    "dash": "dashboard.png",
+    "dev": "device.png",
+    "diag": "diagnostics.png",
+    "cfg": "settings.png",
+    "logs": "logs.png",
+}
+
+
+def sanitise(payload):
+    """Replaces anything identifying with a plausible stand-in, in place.
+
+    Plausible rather than blanked: a screenshot showing `----` teaches a reader nothing about
+    what the field looks like in use, which is the entire point of the screenshot.
+    """
+    if isinstance(payload, dict):
+        return {k: _field(k, v) for k, v in payload.items()}
+    if isinstance(payload, list):
+        return [sanitise(v) for v in payload]
+    return payload
+
+
+def _field(key: str, value):
+    if isinstance(value, (dict, list)):
+        return sanitise(value)
+    if not isinstance(value, str):
+        return value
+    if key in ("serial_number", "serial"):
+        return "SN0000000000"
+    if key == "hostname":
+        return "heliograph-a1b2c3"
+    if key == "ssid":
+        return "HomeNetwork"
+    if key in ("ntp_server",):
+        return "pool.ntp.org"
+    if key in ("id", "instance_key", "device"):
+        # Two different shapes wear the same key. The BRIDGE id is heliograph-<mac tail>, in
+        # lowercase hex; a DEVICE id is driver-<serial>, usually uppercase. The first version
+        # only substituted uppercase runs and let heliograph-56a11c straight through into a
+        # committed fixture.
+        #
+        # The bridge id gets the same stand-in as the hostname, because on a real device both
+        # come from the same MAC and a reader who sees them disagree learns something false.
+        if value.startswith("heliograph-"):
+            return "heliograph-a1b2c3"
+        # Shape kept -- driver-SERIAL -- because the id is what MQTT topics and the Modbus unit
+        # mapping are keyed on, and a reader needs to recognise the form.
+        return re.sub(r"[A-Za-z0-9]{8,}$", "0000000001", value)
+    if re.fullmatch(r"(\d{1,3}\.){3}\d{1,3}", value):
+        return "192.168.1.50"
+    return value
+
+
+# Shapes that must never survive sanitisation. Checked after the fact rather than trusted,
+# because the fixture is committed and the screenshots are published: a rule that silently stops
+# matching is a leak nobody notices, and the first version of the id rule did exactly that.
+LEAK_PATTERNS = {
+    "MAC-derived name": re.compile(r"heliograph-[0-9a-f]{6}"),
+    "serial-shaped run": re.compile(r"\b[A-Z]{2,}[0-9]{6,}\b"),
+    "private IPv4": re.compile(
+        r"\b(?:192\.168\.\d{1,3}|10\.\d{1,3}\.\d{1,3}"
+        r"|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3})\.\d{1,3}\b"
+    ),
+}
+
+# The values sanitise() puts in. Matched by the patterns above by design -- they are the same
+# SHAPE, which is the point of a plausible stand-in -- and subtracted afterwards.
+#
+# Deliberately not folded into the patterns as negative lookaheads. The first version tried
+# that, put the lookahead one group too late, and flagged its own replacement: a clever regex
+# that stops matching what it was supposed to is the failure this check exists to prevent.
+STAND_INS = {"heliograph-a1b2c3", "SN0000000000", "192.168.1.50"}
+
+
+def audit(payload: dict) -> list[str]:
+    """Anything identifying that survived, as a list of complaints."""
+    blob = json.dumps(payload)
+    found = []
+    for name, pattern in LEAK_PATTERNS.items():
+        hits = sorted(set(pattern.findall(blob)) - STAND_INS)
+        if hits:
+            found.append(f"{name}: {hits[:5]}")
+    return found
+
+
+def capture(host: str) -> dict:
+    out = {}
+    for name in ENDPOINTS:
+        url = f"http://{host}/api/v1/{name}"
+        try:
+            with urllib.request.urlopen(url, timeout=10) as response:
+                out[name] = sanitise(json.load(response))
+        except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as exc:
+            # Recorded as absent rather than fatal: a bridge with no capture stored, or discovery
+            # never run, legitimately has nothing to say and the page renders that state fine.
+            print(f"  {name}: not captured ({exc})")
+            out[name] = None
+    return out
+
+
+def extract_page() -> str:
+    """The HTML out of the PROGMEM literal, with the C++ escaping undone."""
+    source = ASSET.read_text()
+    # Any raw-string delimiter, not a hard-coded one: the asset uses R"HTML( today and the
+    # delimiter is the author's free choice, so pinning it would break on a rename that changes
+    # nothing about the page.
+    match = re.search(r'R"([A-Za-z_]*)\((.*)\)\1"', source, re.S)
+    if not match:
+        raise SystemExit("could not find a raw string literal in " + str(ASSET))
+    return match.group(2)
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    page = ""
+    data: dict = {}
+
+    def log_message(self, *args):  # noqa: D102 - quiet
+        pass
+
+    def do_GET(self):  # noqa: N802 - http.server's spelling
+        path = self.path.split("?")[0]
+        if path.startswith("/api/v1/"):
+            name = path[len("/api/v1/") :].strip("/")
+            payload = self.data.get(name)
+            if payload is None:
+                self.send_error(404)
+                return
+            body = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/api/v1/events":
+            # The page opens an EventSource. Answering 404 lets it fail fast and render from the
+            # REST payloads; leaving the request hanging would keep the browser busy past the
+            # virtual-time budget and the screenshot would catch a half-drawn page.
+            self.send_error(404)
+            return
+
+        tab = ""
+        if "?" in self.path:
+            tab = dict(
+                p.split("=", 1)
+                for p in self.path.split("?", 1)[1].split("&")
+                if "=" in p
+            ).get("tab", "")
+        body = self.page
+        if tab:
+            # Clicking rather than setting a variable: the tab button is what loads that tab's
+            # data, and a screenshot of a tab whose fetch never ran is a screenshot of nothing.
+            body += (
+                "<script>addEventListener('load',()=>{"
+                f"const b=document.querySelector('[data-t=\"{tab}\"]');b&&b.click();"
+                "});</script>"
+            )
+        encoded = body.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def find_chrome() -> str:
+    for name in (
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+    ):
+        found = shutil.which(name)
+        if found:
+            return found
+    mac = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    if pathlib.Path(mac).exists():
+        return mac
+    raise SystemExit("no Chrome or Chromium on PATH to render with")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--bridge", help="host to capture fresh data from, e.g. 192.168.20.254"
+    )
+    parser.add_argument("--out", default="docs/images", help="where the PNGs go")
+    parser.add_argument("--width", type=int, default=1100)
+    parser.add_argument("--height", type=int, default=900)
+    args = parser.parse_args()
+
+    out_dir = ROOT / args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.bridge:
+        print(f"capturing from {args.bridge}")
+        data = capture(args.bridge)
+        # Refused BEFORE writing. A leak caught after the file is on disk is a leak that may
+        # already be in a commit.
+        leaks = audit(data)
+        if leaks:
+            print("REFUSED: identifying data survived sanitisation", file=sys.stderr)
+            for leak in leaks:
+                print(f"  {leak}", file=sys.stderr)
+            print(
+                "  add a rule to _field() for the field that carries it",
+                file=sys.stderr,
+            )
+            return 1
+        FIXTURE.write_text(json.dumps(data, indent=2) + "\n")
+        print(f"  sanitised fixture written to {FIXTURE.relative_to(ROOT)}")
+    else:
+        if not FIXTURE.exists():
+            raise SystemExit(f"no fixture at {FIXTURE}; run once with --bridge <host>")
+        data = json.loads(FIXTURE.read_text())
+
+    Handler.page = extract_page()
+    Handler.data = data
+    chrome = find_chrome()
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        for tab, filename in TABS.items():
+            target = out_dir / filename
+            subprocess.run(
+                [
+                    chrome,
+                    "--headless",
+                    "--disable-gpu",
+                    "--no-sandbox",
+                    "--hide-scrollbars",
+                    f"--window-size={args.width},{args.height}",
+                    "--virtual-time-budget=4000",
+                    f"--screenshot={target}",
+                    f"http://127.0.0.1:{port}/?tab={tab}",
+                ],
+                capture_output=True,
+                timeout=120,
+            )
+            size = target.stat().st_size if target.exists() else 0
+            print(f"  {filename:18s} {size // 1024:4d} KB")
+            if size == 0:
+                print("    (empty -- the page did not render)")
+                return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/make_screenshots.py
+++ b/tools/make_screenshots.py
@@ -171,6 +171,11 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             name = path[len("/api/v1/") :].strip("/")
             payload = self.data.get(name)
             if payload is None:
+                # 404 covers two cases and wants to for both: an endpoint that was not captured
+                # (a bridge with no stored capture answers the same), and /api/v1/events, which
+                # the page opens as an EventSource. Failing that one FAST matters -- left
+                # hanging, the browser stays busy past the virtual-time budget and the
+                # screenshot catches a half-drawn page.
                 self.send_error(404)
                 return
             body = json.dumps(payload).encode()
@@ -180,13 +185,6 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(body)
             return
-        if path == "/api/v1/events":
-            # The page opens an EventSource. Answering 404 lets it fail fast and render from the
-            # REST payloads; leaving the request hanging would keep the browser busy past the
-            # virtual-time budget and the screenshot would catch a half-drawn page.
-            self.send_error(404)
-            return
-
         tab = ""
         if "?" in self.path:
             tab = dict(
@@ -233,6 +231,11 @@ def main() -> int:
         "--bridge", help="host to capture fresh data from, e.g. 192.168.20.254"
     )
     parser.add_argument("--out", default="docs/images", help="where the PNGs go")
+    parser.add_argument(
+        "--fixture",
+        default=str(FIXTURE),
+        help="captured data to render from; --bridge OVERWRITES this file",
+    )
     parser.add_argument("--width", type=int, default=1100)
     parser.add_argument("--height", type=int, default=900)
     args = parser.parse_args()
@@ -240,6 +243,11 @@ def main() -> int:
     out_dir = ROOT / args.out
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    # Explicit rather than derived from --out. Capturing writes the fixture, and the first
+    # version wrote the COMMITTED one whatever --out said -- so a run aimed at a scratch
+    # directory quietly rewrote a repository file. Noticed only because a mid-test restore from
+    # a backup was needed and the reason was not obvious.
+    fixture = pathlib.Path(args.fixture)
     if args.bridge:
         print(f"capturing from {args.bridge}")
         data = capture(args.bridge)
@@ -255,12 +263,13 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
-        FIXTURE.write_text(json.dumps(data, indent=2) + "\n")
-        print(f"  sanitised fixture written to {FIXTURE.relative_to(ROOT)}")
+        fixture.parent.mkdir(parents=True, exist_ok=True)
+        fixture.write_text(json.dumps(data, indent=2) + "\n")
+        print(f"  sanitised fixture written to {fixture}")
     else:
-        if not FIXTURE.exists():
-            raise SystemExit(f"no fixture at {FIXTURE}; run once with --bridge <host>")
-        data = json.loads(FIXTURE.read_text())
+        if not fixture.exists():
+            raise SystemExit(f"no fixture at {fixture}; run once with --bridge <host>")
+        data = json.loads(fixture.read_text())
 
     Handler.page = extract_page()
     Handler.data = data


### PR DESCRIPTION
`docs/images/` was regenerated by hand for [#56](https://github.com/Timdebruijn/heliograph/pull/56) and the recipe lived nowhere. Only the results were committed, so the next round meant working the method out again from its own output.

Written now, ahead of the frontend work, so it is ready when the screenshots need redoing.

## What it takes

Three things have to stand at once for one shot: the HTML out of the PROGMEM literal, a server answering the REST calls the page makes, and a browser that can **click** a tab — tabs are switched by a `data-t` handler, not by a URL, so navigating cannot reach them.

The script serves the page from a throwaway port, injects one line that clicks the requested tab, and shoots each one.

```bash
python3 tools/make_screenshots.py --bridge 192.168.20.254   # capture, sanitise, shoot
python3 tools/make_screenshots.py                            # re-shoot from the fixture
```

Capturing writes a **sanitised fixture**, which is committed, so a later run needs no bridge and produces the same pictures.

## Sanitisation is checked, not trusted

The fixture goes into the repository and the screenshots go on the README, so a serial reaching either is a real leak — and **the first version of the rules had one**.

The `id` rule substituted uppercase runs, which is the shape of a *device* serial, and let `heliograph-56a11c` through: the **bridge** id wears the same key and is lowercase MAC hex. I found it by grepping the output, which is not a method that survives me.

So a leak audit now runs **before the file is written** and refuses to write at all, exit 1, naming what survived:

```
REFUSED: identifying data survived sanitisation
  MAC-derived name: ['heliograph-56a11c']
  add a rule to _field() for the field that carries it
```

Mutation-tested: drop the bridge-id rule and it catches the MAC name; drop the serial rule and it catches the serial.

The stand-ins are subtracted from the audit **explicitly** rather than excluded by lookahead. The first attempt put the lookahead one group too late and flagged its own replacement — a clever regex that stops matching what it was written for is precisely the failure this check exists to prevent.

## Verified

Run end to end against a live bridge: five tabs, all non-empty, fixture clean on a fresh grep for the real serial, hostname and SSID. `ruff` passes.

## Note

The committed fixture reflects the dashboard as it stands **today**. After the frontend work it wants recapturing — which is now one command.