### PR TITLE
build(web): strip the comments out of the page and gzip what ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,13 @@ jobs:
       - name: Embedded JS syntax
         run: python3 tools/check_web_js.py
 
+      # The firmware build runs this too, but that job does not run on every push. Here it is
+      # the only thing standing between a page and its stripped, gzipped copy: the script
+      # refuses to emit if a <script>/<style> tag went missing or the page lost more than 70%
+      # of its bytes, and those are the ways a line-based filter breaks a page quietly.
+      - name: Web assets strip + gzip
+        run: python3 tools/build_web.py
+
       # Renders the dashboard in the Chrome that ships with the runner image and asserts its
       # LAYOUT. 0.18.0 shipped a table that broke every row onto a second line and nothing
       # caught it -- the suite asserts what the page says, never how it comes out.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ compile_commands.json
 # in the tree is exactly the drift the codegen exists to prevent.
 profiles_generated.cpp
 
+# Generated at build time by tools/build_web.py from src/web/assets/*.h: the same page with
+# the comments removed and gzipped. Same rule -- the authored header is the source of truth.
+src/web/assets/generated/
+
 # --- Local configuration --------------------------------------------------------
 # PlatformIO's conventional per-user override file (upload ports, local flags).
 # Anything in it is machine-specific by definition.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,12 @@ pio test -e native                    # host test suite
 bash tools/check_layering.sh          # architecture invariants
 python3 tools/gen_profiles.py --check # profile schema (when touching profiles/)
 python3 tools/check_web_js.py         # embedded JS (when touching src/web/)
+python3 tools/build_web.py            # strip + gzip the pages (when touching src/web/)
 ```
+
+`src/web/assets/*.h` is what you edit; it is not what the device serves. Every build strips
+the comments out of it and gzips it into `src/web/assets/generated/`, which is not committed.
+Run `build_web.py` yourself to see the page rejected early if a `<script>` tag went missing.
 
 CI runs the same checks, plus both firmware builds.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,14 @@ test_dir = test
 ; Regenerates src/drivers/growatt_modbus/profiles_generated.cpp from profiles/*/*.toml
 ; before every build. A broken device profile fails the build with a validation message,
 ; never the running device. See docs/adding-a-device.md.
-extra_scripts = pre:tools/gen_profiles.py
+;
+; build_web.py does the same for the web UI: it strips the comments out of
+; src/web/assets/*.h and gzips each page into a PROGMEM array. Neither output is committed,
+; for the same reason -- the authored file is the source of truth, and a stale generated copy
+; in the tree is the drift the build step exists to prevent.
+extra_scripts =
+    pre:tools/gen_profiles.py
+    pre:tools/build_web.py
 build_flags =
     -std=gnu++17
     -Wall

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -200,15 +200,17 @@ bool RestApi::begin() {
         // dashboard would show a page full of dashes; serve the one page that can help.
         const bool portal = context_.portalActive && context_.portalActive();
         // Stream straight from flash. The plain beginResponse(code, type, const char*) form
-        // copies the whole literal into a heap String on every load -- ~46 KB for the
-        // dashboard, competing with the MQTT/JSON/RS485 buffers under memory pressure (review,
-        // 2026-07-21). The chunked filler serves it in place, no copy.
+        // copies the whole page into a heap String on every load, competing with the
+        // MQTT/JSON/RS485 buffers under memory pressure -- 46 KB of it when that was found
+        // (review, 2026-07-21). The chunked filler serves it in place, no copy. Gzip has since
+        // cut the page to 31 KB, which is still not a copy worth making on this heap.
         //
         // What ships is the gzipped page built by tools/build_web.py, not the authored header:
-        // 163 KB of dashboard leaves the device as 31 KB, and the same saving lands twice in
-        // flash because there are two OTA slots. No identity copy is kept as a fallback --
-        // every browser that can run this page accepts gzip, and keeping both spends the whole
-        // saving twice over.
+        // 163 KB of dashboard leaves the device as 31 KB, and that saving lands twice in flash
+        // because there are two OTA slots. No identity copy is kept as a fallback -- every
+        // browser that can run this page accepts gzip, and keeping both would spend the whole
+        // saving twice over. Note that this means the response is gzipped whether or not the
+        // client asked: `curl /` needs --compressed, where it did not before.
         const uint8_t* html    = portal ? web::kSetupHtmlGz : web::kIndexHtmlGz;
         const size_t   htmlLen = portal ? web::kSetupHtmlGzLen : web::kIndexHtmlGzLen;
         auto* response = request->beginResponse(
@@ -219,10 +221,10 @@ bool RestApi::begin() {
                 std::memcpy(buffer, html + index, n);
                 return n;
             });
+        response->addHeader("Content-Encoding", "gzip");
         // no-cache, or an OTA that changes the UI keeps showing the old page until the user
         // happens to hard-refresh (seen live: the freshly added update card stayed invisible).
         // The browser may still cache but must revalidate; the page is a few KB on a LAN.
-        response->addHeader("Content-Encoding", "gzip");
         response->addHeader("Cache-Control", "no-cache");
         request->send(response);
     });

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -19,8 +19,11 @@
 #include "outputs/rest/rest_payloads.h"
 #include "config/configuration_store.h"
 #include "ota/ota_manager.h"
-#include "web/assets/index_html.h"
-#include "web/assets/setup_html.h"
+// Generated at build time by tools/build_web.py from web/assets/*.h -- gitignored, never
+// committed. The authored headers are the source of truth and are no longer compiled in:
+// including them here would put both copies of every page in flash.
+#include "web/assets/generated/index_html_gz.h"
+#include "web/assets/generated/setup_html_gz.h"
 
 namespace heliograph::rest {
 namespace {
@@ -200,8 +203,14 @@ bool RestApi::begin() {
         // copies the whole literal into a heap String on every load -- ~46 KB for the
         // dashboard, competing with the MQTT/JSON/RS485 buffers under memory pressure (review,
         // 2026-07-21). The chunked filler serves it in place, no copy.
-        const char*  html    = portal ? web::kSetupHtml : web::kIndexHtml;
-        const size_t htmlLen = (portal ? sizeof(web::kSetupHtml) : sizeof(web::kIndexHtml)) - 1;
+        //
+        // What ships is the gzipped page built by tools/build_web.py, not the authored header:
+        // 163 KB of dashboard leaves the device as 31 KB, and the same saving lands twice in
+        // flash because there are two OTA slots. No identity copy is kept as a fallback --
+        // every browser that can run this page accepts gzip, and keeping both spends the whole
+        // saving twice over.
+        const uint8_t* html    = portal ? web::kSetupHtmlGz : web::kIndexHtmlGz;
+        const size_t   htmlLen = portal ? web::kSetupHtmlGzLen : web::kIndexHtmlGzLen;
         auto* response = request->beginResponse(
             "text/html", htmlLen,
             [html, htmlLen](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
@@ -213,6 +222,7 @@ bool RestApi::begin() {
         // no-cache, or an OTA that changes the UI keeps showing the old page until the user
         // happens to hard-refresh (seen live: the freshly added update card stayed invisible).
         // The browser may still cache but must revalidate; the page is a few KB on a LAN.
+        response->addHeader("Content-Encoding", "gzip");
         response->addHeader("Cache-Control", "no-cache");
         request->send(response);
     });

--- a/tools/build_web.py
+++ b/tools/build_web.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+#
+# Turns the commented, readable web assets in src/web/assets/*.h into what the device actually
+# serves: comments removed, gzip-compressed, emitted as a PROGMEM byte array.
+#
+# WHY THIS EXISTS
+#
+# The web UI is authored as one raw string literal per page, comments and all, and that is
+# deliberate -- those comments are the record of which failure each line prevents, and they
+# belong next to the line. But they ship, on every page load, out of a flash chip that holds
+# two OTA slots.
+#
+# WHAT IT DOES NOT DO
+#
+# No minifier, no renaming, no AST. Whole-line comments and blank lines only, plus the leading
+# indent. Anything cleverer would need to understand JS strings, regexes and template literals
+# to stay correct, and a web UI that silently breaks in one browser is a far worse trade than
+# the few kB it would win. gzip recovers most of what a minifier would anyway -- it is very
+# good at repeated `document.querySelector` -- so the clever half is not worth owning.
+#
+# The output is NOT committed. Same rule as tools/gen_profiles.py: the authored header is the
+# source of truth, and a stale generated copy in the tree is exactly the drift that a build
+# step exists to prevent. platformio.ini runs this before every build.
+#
+# USAGE
+#
+#     ./tools/build_web.py        # writes src/web/assets/generated/*.h and prints the sizes
+
+from __future__ import annotations
+
+import gzip
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path.cwd()
+
+# One header per page. The generated symbol keeps the `Gz` suffix so a route that still
+# references the plain literal fails to compile rather than silently serving the wrong bytes.
+PAGES = [
+    ("index_html.h", "kIndexHtmlGz"),
+    ("setup_html.h", "kSetupHtmlGz"),
+]
+
+RAW = re.compile(r'R"HTML\((.*?)\)HTML"', re.S)
+
+
+def set_root(root: pathlib.Path) -> None:
+    """Project root. Not simply `__file__`: under PlatformIO, SCons exec()s this script
+    without __file__, so the pre-script branch at the bottom sets it from the build
+    environment's PROJECT_DIR instead. Same shape as tools/gen_profiles.py."""
+    global ROOT
+    ROOT = root
+
+
+try:
+    set_root(pathlib.Path(__file__).resolve().parent.parent)
+except NameError:
+    pass  # provisional cwd; the PlatformIO branch below overrides it
+
+
+def assets() -> pathlib.Path:
+    return ROOT / "src" / "web" / "assets"
+
+
+def extract(path: pathlib.Path) -> str:
+    """The raw string literal's contents, i.e. exactly the bytes the device serves today."""
+    m = RAW.search(path.read_text(encoding="utf-8"))
+    if m is None:
+        raise SystemExit(f'{path.name}: no R"HTML(...)HTML" literal found')
+    return m.group(1)
+
+
+def strip_comments(src: str) -> str:
+    """Drop whole-line comments, blank lines and leading indent.
+
+    Only lines whose FIRST non-space character opens a comment are removed, so a trailing
+    comment after code is left alone -- finding the end of one needs to know whether the `//`
+    is inside a string, which is exactly the parsing this refuses to do.
+
+    Nothing is touched between an unbalanced backtick and its partner. The page is full of
+    multi-line template literals that emit HTML, and inside one a line beginning with `//` is
+    not a comment -- it is a protocol-relative URL, or a string, or the start of a regex, and
+    deleting it produces a page that is syntactically fine and visibly wrong. Their indent is
+    left alone too: it is part of the string's value.
+
+    Backtick parity is a crude tracker, and deliberately so. It is counted only over lines
+    that survive comment removal, so the backticks inside the comment prose above them never
+    reach it -- but a backtick inside a '...' or "..." string on a kept line would still fool
+    it. That failure mode is conservative in the right direction: it makes the stripper skip
+    lines it could have stripped, never strip lines it should have kept.
+
+    The two block-comment forms are tracked separately. Conflating them (one flag closed by
+    either `*/` or `-->`) lets an unterminated HTML comment swallow the rest of the file.
+    """
+    out: list[str] = []
+    block: str | None = None  # 'c' for /* */, 'h' for <!-- -->
+    in_literal = False
+    for line in src.split("\n"):
+        if in_literal:
+            # Verbatim, indent included: these bytes are string content, not source.
+            out.append(line)
+            if line.count("`") % 2 == 1:
+                in_literal = False
+            continue
+        t = line.strip()
+        if block == "c":
+            if "*/" in t:
+                block = None
+            continue
+        if block == "h":
+            if "-->" in t:
+                block = None
+            continue
+        if t.startswith("/*"):
+            if "*/" not in t:
+                block = "c"
+            continue
+        if t.startswith("<!--"):
+            if "-->" not in t:
+                block = "h"
+            continue
+        if t.startswith("//"):
+            continue
+        if not t:
+            continue
+        out.append(t)
+        if t.count("`") % 2 == 1:
+            in_literal = True
+    if block is not None:
+        raise SystemExit(
+            "unterminated block comment -- refusing to emit a truncated page"
+        )
+    if in_literal:
+        raise SystemExit(
+            "unterminated template literal -- refusing to emit a damaged page"
+        )
+    return "\n".join(out) + "\n"
+
+
+def sanity(original: str, stripped: str) -> None:
+    """Cheap invariants. A stripped page that is subtly broken is worse than a large one.
+
+    Not a substitute for tools/check_web_js.py, which runs the page's JS through node; this
+    only catches the structural damage a line-based filter can do.
+    """
+    for tag in ("<script>", "</script>", "</body>", "</html>", "<style>", "</style>"):
+        if original.count(tag) != stripped.count(tag):
+            raise SystemExit(f"structural change: {tag} count differs")
+    # A page that lost more than 70% of its bytes has lost code, not comments.
+    if len(stripped) < len(original) * 0.30:
+        raise SystemExit(
+            f"stripped page is {len(stripped)} of {len(original)} bytes -- that is not comments"
+        )
+
+
+def as_c_array(name: str, data: bytes) -> str:
+    rows = [
+        "    " + ", ".join(f"0x{b:02x}" for b in data[i : i + 16]) + ","
+        for i in range(0, len(data), 16)
+    ]
+    body = "\n".join(rows)
+    return (
+        f"inline const uint8_t {name}[] PROGMEM = {{\n{body}\n}};\n"
+        f"inline constexpr size_t {name}Len = {len(data)};\n"
+    )
+
+
+def build(page: str, gz_symbol: str) -> tuple[int, int, int, str]:
+    src = extract(assets() / page)
+    stripped = strip_comments(src)
+    sanity(src, stripped)
+    # mtime=0 so identical input gives identical output. The generated file is not committed,
+    # but a stable byte stream keeps an untouched page from dirtying the object it feeds.
+    blob = gzip.compress(stripped.encode("utf-8"), compresslevel=9, mtime=0)
+    header = f"""// SPDX-License-Identifier: MIT
+//
+// GENERATED by tools/build_web.py from {page} -- do not edit, do not commit.
+// {len(src)} bytes as authored, {len(stripped)} with comments removed, {len(blob)} gzipped.
+//
+// Served with `Content-Encoding: gzip`. The identity copy is deliberately NOT kept as a
+// fallback: every browser that can run this page accepts gzip, and keeping both spends the
+// whole saving twice -- in flash, in both OTA slots.
+
+#pragma once
+
+#include <pgmspace.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace heliograph::web {{
+
+{as_c_array(gz_symbol, blob)}
+}}  // namespace heliograph::web
+"""
+    return len(src), len(stripped), len(blob), header
+
+
+def self_test() -> None:
+    """The template-literal guard, stated as the cases it exists for.
+
+    It runs on every invocation because there is no Python test harness in this repo and a
+    guard nobody executes is a comment. It costs microseconds.
+    """
+    # A line that opens a template literal keeps everything up to the closing backtick --
+    # indent included, and `//` inside it is a URL, not a comment.
+    kept = strip_comments("  const a = `<a href=\n  //host/x\n  >`;\n")
+    assert "//host/x" in kept, kept
+    assert "  //host/x" in kept, "indent inside a literal is string content"
+    # A blank line inside a literal is content too.
+    assert strip_comments("x=`a\n\nb`;\n") == "x=`a\n\nb`;\n"
+    # Outside one, all three still go.
+    assert strip_comments("// gone\n\n  kept();\n") == "kept();\n"
+    # An unclosed literal means the tracker lost the thread; emitting would ship a page that
+    # is missing whatever came after it.
+    try:
+        strip_comments("x=`open\n")
+    except SystemExit:
+        pass
+    else:
+        raise AssertionError("unterminated literal was not caught")
+
+
+def run() -> int:
+    self_test()
+    out_dir = assets() / "generated"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    before = after = 0
+
+    for page, gz_symbol in PAGES:
+        raw, stripped, packed, header = build(page, gz_symbol)
+        before += raw
+        after += packed
+        pct = (1 - packed / raw) * 100
+        print(
+            f"build_web.py: {page:15} {raw:6} -> {stripped:6} -> {packed:5} gzipped (-{pct:.0f}%)"
+        )
+
+        # Write only on change, so an untouched page never dirties an mtime and triggers a
+        # needless rebuild of the REST layer.
+        target = out_dir / page.replace(".h", "_gz.h")
+        if not target.exists() or target.read_text(encoding="utf-8") != header:
+            target.write_text(header, encoding="utf-8")
+
+    print(
+        f"build_web.py: {before} bytes of page served as {after} ({before - after} saved)"
+    )
+    return 0
+
+
+# Under PlatformIO (extra_scripts) SCons provides Import(); standalone it does not.
+try:
+    Import("env")  # type: ignore[name-defined]  # noqa: F821
+    set_root(pathlib.Path(env["PROJECT_DIR"]))  # type: ignore[name-defined]  # noqa: F821
+    if run() != 0:
+        env.Exit(1)  # type: ignore[name-defined]  # noqa: F821
+except NameError:
+    if __name__ == "__main__":
+        sys.exit(run())


### PR DESCRIPTION
Groundwork for the UI redesign, landed on its own because it changes **how** the page is served
and not **what** it says. The redesign lands next; if it needs backing out, this stays.

## What changes

`tools/build_web.py` (new) runs before every build. It pulls the `R"HTML(...)HTML"` literal out
of each page, drops whole-line comments and blank lines, gzips the result and emits it as a
PROGMEM byte array. `GET /` serves that with `Content-Encoding: gzip`.

| | authored | comments stripped | gzipped |
|---|---|---|---|
| `index_html.h` | 162 680 | 100 412 | **30 852** (−81%) |
| `setup_html.h` | 16 974 | 10 733 | **4 227** (−75%) |
| total | 179 654 | | **35 079** |

Measured on the board, not inferred:

| | main | this branch |
|---|---|---|
| flash used (`waveshare-rs485-can`) | 1 684 895 | **1 540 043** |
| `firmware.bin` (what OTA pushes) | 1 685 296 | **1 540 448** |

**141 kB less flash, and it lands twice** — there are two OTA slots. The same 141 kB is off
every page load, on a board that is also driving the RS485 bus.

The page itself does not change. Same bytes, minus the comments.

## The generated headers are not committed

Same rule as `profiles_generated.cpp`, and for the same reason: `src/web/assets/*.h` is the
source of truth, and a stale generated copy in the tree is the exact drift a build step exists
to prevent. `platformio.ini` regenerates them pre-build, so there is no `--check` gate and
nothing to forget. CI runs the script directly too, because the `test` job does not build
firmware and the script is where a damaged page gets caught.

## One thing the sketch this came from got wrong

The stripper it proposed deletes any line whose first non-space character is `//`. This page is
full of multi-line template literals emitting HTML — `fleetStrip`, `deviceTable`, `tile`, nine
of them — and **inside a template literal a line starting with `//` is not a comment.** It is a
protocol-relative URL, or a string, or a regex. Deleting it gives you a page that parses fine
and is visibly wrong, which is the worst failure mode a build step can have.

Nothing between an unbalanced backtick and its partner is touched now, indent included: that
indent is part of the string. It costs 1 302 bytes gzipped out of 35 079. Backtick parity is a
crude tracker and the docstring says so — it is counted only over lines that survive comment
removal, so the backticks in the comment prose never reach it, and its failure mode is to skip
a line it could have stripped rather than strip one it should have kept.

`strip_comments()` carries a `self_test()` that runs on every invocation, because this repo has
no Python test harness and a guard nobody executes is a comment.

## Verification

- All four board envs build; `pio test -e native` 844/844.
- The gz array decompresses back to the stripped page byte for byte.
- Every `<script>` block of the stripped page passes `node --check`.
- Every line of the stripped output appears in the authored source, in order — nothing but
  comments and blank lines went missing.
- `check_web_js.py`, `check_measurement_ids.py`, `check_layering.sh` unchanged and passing; they
  read the authored header, which still exists.

## Known gap, deliberately left for the next PR

**No check renders the bytes that ship.** `check_dashboard_layout.py` and `make_screenshots.py`
both read the authored literal, so the stripped page is never put in front of a browser. This
PR is what makes "authored" and "served" two different things for the first time. The redesign
PR reworks both tools anyway — that is where they get pointed at the stripped page, rather than
doing it twice.

## Not verified on hardware

Not flashed yet. The one thing worth a real bridge: that the browser accepts the gzipped
response over the LAN. The header is added on the same `beginResponse` path that already
streamed the page from PROGMEM without a heap copy, which is unchanged.