### PR TITLE
Release 0.23.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,9 +181,43 @@ namespace {
 // The exception-frame work carried a real gap out with it: the write path had only the happy
 // case, so the check that stops a stale exception from another request being read as the answer
 // to this one had never been exercised on the control path.
+// 0.23.0 replaces the local web UI. Eight tabs become five -- Live, Inverters, Integrations,
+// Health, Bridge -- grouped by what you are doing rather than by which endpoint the numbers came
+// from. Live leads with one answer instead of nine equal tiles, and a fleet total always carries
+// how many inverters it covers, so "2 037 W" can no longer quietly mean "two of the three
+// answered". No endpoint, field or payload changed to do it.
+//
+// The screen that earns the release is the one for an inverter that has never replied. It used
+// to say "check your wiring". It now names the three causes in the order they actually happen --
+// two units on one address, A and B swapped, termination in the wrong place -- each with the
+// test that settles it beside it, and an honest "no test, check the jumpers" for the one that
+// has none.
+//
+// The session chart is a ring buffer in the browser, filled from the status payload that already
+// arrives. The bridge stores no time series and gained no endpoint for it, which is why the
+// chart says "held in this browser" on screen.
+//
+// TWO CHANGES A BRIDGE OWNER WILL NOTICE:
+//
+// The page is served gzipped and no identity copy is kept, so `curl http://<bridge>/` needs
+// --compressed where it did not before. The /api/v1 endpoints are untouched. It buys 139 kB of
+// flash -- twice, because there are two OTA slots -- and sends 33 kB instead of 163 kB per load.
+//
+// One hybrid register map had ac.power.total pointing at an APPARENT power register, so those
+// bridges have been publishing volt-amperes as watts -- wrong by the power factor, to MQTT,
+// Prometheus, Modbus and Home Assistant alike. It points at real power now, and existing history
+// for that series is not comparable across this upgrade. Eleven channels the map ignored came
+// with it; four energy registers stay unmapped, because the sources disagree and a plausible
+// wrong number is worse than a missing one. Which map, and which registers, is in the release
+// notes and in the profile -- naming it here is the drivers layer's business, not this file's.
+//
+// Also: a driver write path is connected end to end and still gated shut -- no register row is
+// marked verified, so nothing can move an inverter yet. And renaming the admin account stopped
+// double-encoding a non-ASCII password, which had been signing those users out at the next
+// admin action ever since the account could be renamed.
 #define HELIOGRAPH_VERSION_MAJOR 0
-#define HELIOGRAPH_VERSION_MINOR 22
-#define HELIOGRAPH_VERSION_PATCH 1
+#define HELIOGRAPH_VERSION_MINOR 23
+#define HELIOGRAPH_VERSION_PATCH 0
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Bumps the firmware version to **0.23.0** and records what it contains. `src/main.cpp` only.

## What is in it

| PR | |
|---|---|
| [#119](https://github.com/Timdebruijn/heliograph/pull/119) | the SPH read apparent power and called it output, and ignored eleven channels |
| [#120](https://github.com/Timdebruijn/heliograph/pull/120) | the Growatt write chain, connected and still gated shut |
| [#121](https://github.com/Timdebruijn/heliograph/pull/121) | the screenshot pipeline, committed instead of remembered |
| [#122](https://github.com/Timdebruijn/heliograph/pull/122) | strip the comments out of the page and gzip what ships |
| [#123](https://github.com/Timdebruijn/heliograph/pull/123) | five screens instead of eight, and inline diagnosis for a silent inverter |

## Why MINOR and not patch

**A Growatt SPH published apparent power as its output.** `ac.power.total` read register 40 —
Pac1, in VA — so every SPH has been reporting volt-amperes as watts to MQTT, Prometheus, Modbus
and Home Assistant, wrong by the power factor whenever the inverter is not at unity. It reads 35
now. The series keeps its name and changes its meaning, which is the one thing a running Grafana
panel or an HA sensor cannot absorb quietly.

## Two behaviour changes worth stating plainly

- **`curl http://<bridge>/` needs `--compressed`.** The page is served gzipped with no identity
  copy kept. `/api/v1/*` is untouched, so scrapers and integrations are unaffected.
- **Everyone with the web UI open is signed out once.** The sessionStorage key changed with the
  rebuild. Per tab, so it costs one password prompt.

## Not changed

No endpoint, no field, no payload. The whole new UI is drawn from what `/api/v1/status` already
returned. `setup_html.h` is untouched.

## Verification

`tools/check_version.sh v0.23.0` agrees with `src/main.cpp` — and still rejects `v0.24.0`, so
the guard is doing something. All four board envs build, 844/844 native tests, every check green.

Flash on `waveshare-rs485-can`: **1 542 455** bytes, against 1 684 895 at v0.22.1.

## Not verified on hardware

This firmware has not been flashed. The new UI has never run against a real bridge — worth a
look at the discovery wizard first, as the most stateful thing carried over.