### PR TITLE
fix(test): an assertion that read freed stack

### DIFF
--- a/test/test_growatt_driver/test_main.cpp
+++ b/test/test_growatt_driver/test_main.cpp
@@ -735,10 +735,16 @@ static void test_an_unverified_row_is_neither_advertised_nor_executed() {
     options.profile = &profile;
     GrowattDriver driver(transport, options);
 
-    TEST_ASSERT_FALSE(driver.capabilities().canWrite(InverterCapability::SetActivePowerLimit));
-    const auto& n = driver.capabilities().numeric[static_cast<size_t>(
-        InverterCommandType::SetActivePowerLimitPercent)];
-    TEST_ASSERT_FALSE(n.writable);
+    // Held by VALUE. capabilities() returns by value, so binding a reference into the result
+    // leaves it dangling the moment the full expression ends -- the assertion below then read
+    // freed stack, which happens to still hold the right answer often enough to pass. Caught by
+    // -Wdangling-gsl in the native build, where a second incremental `pio test` had been hiding
+    // it (audit, 2026-07-29).
+    const InverterCapabilities caps = driver.capabilities();
+    TEST_ASSERT_FALSE(caps.canWrite(InverterCapability::SetActivePowerLimit));
+    TEST_ASSERT_FALSE(
+        caps.numeric[static_cast<size_t>(InverterCommandType::SetActivePowerLimitPercent)]
+            .writable);
 
     InverterCommand cmd;
     cmd.type         = InverterCommandType::SetActivePowerLimitPercent;


### PR DESCRIPTION
First of four from the cleanup audit. One test file, ten lines.

## The defect

```cpp
const auto& n = driver.capabilities().numeric[static_cast<size_t>(
    InverterCommandType::SetActivePowerLimitPercent)];
TEST_ASSERT_FALSE(n.writable);
```

`capabilities()` returns **by value**. The temporary dies at the end of the full expression, so
`n` dangles and the assertion reads the stack slot it used to occupy. It passed — freed stack
usually still holds what was written there.

That matters more than a flaky test normally would. This is the gate that stops an unverified
register row becoming a live control surface on a real inverter, and the test's own comment
records that the gate was added *because* nothing was checking it. The assertion guarding it
was resting on luck.

## The fix, and the proof it is one

Held by value. Then mutation-tested rather than eyeballed — flip the fixture row to
`verified = true`:

```
test_an_unverified_row_is_neither_advertised_nor_executed: Expected FALSE Was TRUE  [FAILED]
36 test cases: 1 failed, 34 succeeded
```

The repaired assertion is the one that catches it, so it tests the property rather than the
memory.

## Why nobody saw the warning

`-Wdangling-gsl` fires on the native build, but a second `pio test` is incremental and
recompiles nothing — so it prints no warnings at all. My own first pass at this audit read that
as "zero warnings" and said so. It only appears after `rm -rf .pio/build/native`.

CI runs on a cold cache, so it *has* been emitting this warning on every single run. Nothing
reads it: the build is not `-Werror` and the log is only opened when something fails.

## Verification

844/844 native tests. Test-only — no firmware source changed, so no behaviour change and no
flash impact.

## Still open from the audit

- Six `-Wmissing-field-initializers` in `test_rest` and `test_provisioning` — PR 2.
- 17 byte-identical lines of capability declaration across two drivers — PR 3.
- The web tooling repeating `strip_comments(extract(...))` in three places — PR 4.
- **New, found while writing this PR:** `pio test` without `-e native` tries to build the test
  suite for the three hardware envs, where it fails at link (`undefined reference to setup`)
  after about two minutes. CI is unaffected because it always passes `-e native`. Worth a
  `test_ignore` or an explicit default so the obvious command does the obvious thing.
