### PR TITLE
chore(test): build a configured device by name, not by position

### DIFF
--- a/test/support/configured_device.h
+++ b/test/support/configured_device.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+//
+// Builds a DriverSettings by NAME rather than by position. Header-only, like the rest of
+// test/support, so every suite can include it.
+//
+// The aggregate form the tests used --
+//
+//     DriverSettings{"growatt_modbus", false, {{"unit_id", "2"}}}
+//
+// warns about the field it leaves off (-Wmissing-field-initializers on `label`), which is the
+// harmless half. The other half is that it is positional: `label` was added to the end of the
+// struct and every one of these silently kept compiling, now meaning "no label" where before
+// there was no such concept. The next field added to DriverSettings does the same again, and
+// the compiler cannot tell the difference between a field a test declined to set and one it
+// never heard of.
+//
+// C++20 designated initialisers would say this in the language. This project is gnu++17, so it
+// is a function instead -- which has the advantage that a new field with a sensible default
+// needs no change here at all.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "config/configuration.h"
+
+namespace heliograph::test {
+
+/// An additional device as an operator would configure one: a driver, its options, and
+/// optionally what they call it.
+///
+/// autoDetect is deliberately not a parameter. It defaults to false in the struct and no test
+/// here sets it; a parameter nobody passes is one more thing to keep true.
+inline DriverSettings configuredDevice(std::string driverId, DriverOptions options = {},
+                                       std::string label = "") {
+    DriverSettings device;
+    device.id      = std::move(driverId);
+    device.options = std::move(options);
+    device.label   = std::move(label);
+    return device;
+}
+
+}  // namespace heliograph::test

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -13,6 +13,7 @@
 #include "network/provisioning_policy.h"
 #include "ota/ota_manager.h"
 #include "ota/sha256.h"
+#include "support/configured_device.h"
 
 using namespace heliograph;
 using heliograph::ota::looksLikeFirmware;
@@ -1058,8 +1059,8 @@ static void test_extra_devices_survive_a_restart() {
     MemoryBackend      backend;
     ConfigurationStore store(backend);
     auto               c = provisionedConfig();
-    c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {{"unit_id", "2"}}});
-    c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {{"unit_id", "3"}}});
+    c.additionalDevices.push_back(test::configuredDevice("growatt_modbus", {{"unit_id", "2"}}));
+    c.additionalDevices.push_back(test::configuredDevice("growatt_modbus", {{"unit_id", "3"}}));
     TEST_ASSERT_TRUE(store.save(c));
 
     Configuration loaded;

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -24,6 +24,7 @@
 #include "support/fake_eversolar_device.h"
 #include "fixtures/eversolar_frames.h"
 #include "support/mock_transport.h"
+#include "support/configured_device.h"
 
 using namespace heliograph;
 using test::FakeEversolarDevice;
@@ -331,11 +332,11 @@ static void test_the_device_count_is_bounded() {
     Configuration c;
     ConfigError   e;
     for (size_t i = 0; i < kMaxDevices - 1; ++i) {
-        c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {}});
+        c.additionalDevices.push_back(test::configuredDevice("growatt_modbus"));
     }
     TEST_ASSERT_TRUE(validate(c, e));  // driver + kMaxDevices-1 == the cap
 
-    c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {}});
+    c.additionalDevices.push_back(test::configuredDevice("growatt_modbus"));
     TEST_ASSERT_FALSE(validate(c, e));
     TEST_ASSERT_EQUAL_STRING("additional_devices", e.field.c_str());
 }
@@ -346,7 +347,7 @@ static void test_the_device_count_is_bounded() {
 static void test_adding_a_device_requires_a_reboot() {
     const Configuration base;
     auto                more = base;
-    more.additionalDevices.push_back(DriverSettings{"sunspec", false, {}});
+    more.additionalDevices.push_back(test::configuredDevice("sunspec"));
     TEST_ASSERT_TRUE(configChangeRequiresReboot(base, more));
 
     auto retuned = more;
@@ -784,7 +785,7 @@ static void test_an_asserted_out_of_range_option_is_left_for_the_caller() {
 static void test_a_stored_out_of_range_extra_device_option_is_healed() {
     Configuration c;
     c.driver.id = "growatt_modbus";
-    c.additionalDevices.push_back(DriverSettings{"growatt_modbus", false, {{"unit_id", "300"}}});
+    c.additionalDevices.push_back(test::configuredDevice("growatt_modbus", {{"unit_id", "300"}}));
     ConfigError e;
     const auto  lookup = [](const std::string& id) -> const DriverDescriptor* {
         return id == "growatt_modbus" ? &boundedUnitIdDescriptor() : nullptr;
@@ -1033,7 +1034,7 @@ static void test_renaming_a_device_needs_a_restart() {
     TEST_ASSERT_TRUE(configChangeRequiresReboot(a, b));
 
     Configuration c = a;
-    c.additionalDevices.push_back(DriverSettings{"mock_inverter", false, {}, "Balkon"});
+    c.additionalDevices.push_back(test::configuredDevice("mock_inverter", {}, "Balkon"));
     Configuration d = c;
     d.additionalDevices[0].label = "Garage";
     TEST_ASSERT_TRUE(configChangeRequiresReboot(c, d));


### PR DESCRIPTION
Second of four from the cleanup audit. Clears the remaining six
`-Wmissing-field-initializers` in the native build.

## What the warning was actually about

Seven sites built a device positionally:

```cpp
DriverSettings{"growatt_modbus", false, {{"unit_id", "2"}}}
```

The warning names the missing `label`, and on its own that is harmless — the field is
value-initialised either way.

The part the warning does *not* say is the reason to fix it. These are positional. `label` was
added to the end of `DriverSettings` and all seven of these kept compiling, now meaning "no
label" where previously there was no such concept. A compiler cannot distinguish a field a test
declined to set from one it never heard of, so the next field added to that struct does the
same thing again — quietly, to every test that constructs one.

`DriverSettings` is not a stable shape. It gained `label` in 0.18.x, and
`configChangeRequiresReboot` already carries a comment explaining that it compares that struct
*field by field, not via `operator==`*, precisely so a new field cannot silently join a
behavioural rule. This is the same hazard on the test side.

## The change

`test::configuredDevice(driverId, options, label)` in `test/support/`, header-only like the
rest of that directory. One place, named arguments, and a new field with a sensible default
needs no change here at all.

`autoDetect` is deliberately not a parameter: it defaults to `false`, no test sets it, and a
parameter nobody passes is one more thing to keep true.

C++20 designated initialisers would express this in the language. The project is `gnu++17`, so
it is a function.

## Verification

- 844/844 native tests.
- The six `-Wmissing-field-initializers` are gone from a **cold** `pio test -e native`.
- Layering invariants pass.
- Test-only. No firmware source touched, so no behaviour change and no flash impact.

## Note on the remaining warning

A cold build on this branch still shows the `-Wdangling-gsl` in `test_growatt_driver`. That is
[#125](https://github.com/Timdebruijn/heliograph/pull/125), which branches from the same commit
rather than stacking. Once it lands, a cold native build is warning-free.
