### PR TITLE
refactor(drivers): one PMU PV capability list, and a test that watches it

### DIFF
--- a/src/drivers/eversolar_legacy/eversolar_driver.cpp
+++ b/src/drivers/eversolar_legacy/eversolar_driver.cpp
@@ -2,6 +2,7 @@
 // See eversolar_driver.h for provenance.
 
 #include "eversolar_driver.h"
+#include "drivers/pmu_pv_capabilities.h"
 
 #include <cstring>
 
@@ -65,24 +66,13 @@ bool EversolarDriver::begin(Transport& transport) {
         return false;
     }
 
-    capabilities_ = InverterCapabilities{};
-    capabilities_.addRead(InverterCapability::ReadAcPower);
-    capabilities_.addRead(InverterCapability::ReadAcVoltage);
-    capabilities_.addRead(InverterCapability::ReadAcCurrent);
-    capabilities_.addRead(InverterCapability::ReadGridFrequency);
-    capabilities_.addRead(InverterCapability::ReadDcVoltage);
-    capabilities_.addRead(InverterCapability::ReadDcCurrent);
-    capabilities_.addRead(InverterCapability::ReadDcPower);
-    capabilities_.addRead(InverterCapability::ReadEnergyToday);
-    capabilities_.addRead(InverterCapability::ReadEnergyTotal);
-    capabilities_.addRead(InverterCapability::ReadTemperature);
-    capabilities_.addRead(InverterCapability::ReadOperatingHours);
-    capabilities_.addRead(InverterCapability::ReadStatus);
-    // Deliberately absent: ReadErrors (the protocol carries no error code field) and
-    // everything battery/multi-phase. write stays empty.
-    capabilities_.phaseCount = 1;
-    capabilities_.mpptCount  = 1;  // revised upward if a dual-string payload arrives
-    capabilities_.hasBattery = false;
+    // Shared with the other PMU-family driver; see pmu_pv_capabilities.h. mpptCount starts at 1
+    // and is revised upward if a dual-string payload arrives.
+    //
+    // Deliberately NOT added here: ReadErrors. This variant of the protocol carries no error
+    // code field, so declaring it would advertise a channel that can never produce a value.
+    // Battery and multi-phase are absent for the same reason, and write stays empty.
+    capabilities_ = pmuPvCapabilities();
 
     identity_               = DeviceIdentity{};
     identity_.manufacturer  = "Ever-Solar";

--- a/src/drivers/pmu_pv_capabilities.h
+++ b/src/drivers/pmu_pv_capabilities.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+//
+// The read channels a single-phase PV inverter on the PMU protocol family reports.
+//
+// Two drivers declared this list independently, line for line identical, twelve calls each.
+// That is not a coincidence worth preserving by hand: both speak the same framing and their
+// parsers emit the SAME fifteen measurement ids, because the channels come from the payload
+// layout rather than from the manufacturer. Adding a channel to one and forgetting the other
+// would have been silent -- the capability list is what /api/v1/devices/<id>/capabilities
+// publishes and what the dashboard uses to decide which rows exist, so a driver that stops
+// declaring a channel it still delivers simply stops showing it.
+//
+// It lives in the drivers layer, not in src/protocols/pmu/. That directory is a pure codec
+// which includes <cstddef> and <cstdint> and nothing else; teaching it about the canonical
+// device model would be the more expensive kind of tidying.
+//
+// WHAT THIS DELIBERATELY DOES NOT COVER: anything a specific device adds or lacks. The two
+// payload variants are not identical -- one carries a fault bitmask and the other has no error
+// field at all -- so each driver states its own difference next to the call, where the reason
+// for it can be read. A helper that tried to cover both would need a flag per difference, and
+// a list of flags is the same duplication with more indirection.
+
+#pragma once
+
+#include "device/capability.h"
+
+namespace heliograph {
+
+/// Every read channel the PMU-family PV payload carries, with the single-phase, single-string
+/// shape both devices boot with.
+///
+/// mpptCount is the value at boot, not a verdict: both drivers revise it upward when a second
+/// string turns out to report real voltage, which is why it is set here rather than derived.
+inline InverterCapabilities pmuPvCapabilities() {
+    InverterCapabilities caps;
+    caps.addRead(InverterCapability::ReadAcPower);
+    caps.addRead(InverterCapability::ReadAcVoltage);
+    caps.addRead(InverterCapability::ReadAcCurrent);
+    caps.addRead(InverterCapability::ReadGridFrequency);
+    caps.addRead(InverterCapability::ReadDcVoltage);
+    caps.addRead(InverterCapability::ReadDcCurrent);
+    caps.addRead(InverterCapability::ReadDcPower);
+    caps.addRead(InverterCapability::ReadEnergyToday);
+    caps.addRead(InverterCapability::ReadEnergyTotal);
+    caps.addRead(InverterCapability::ReadTemperature);
+    caps.addRead(InverterCapability::ReadOperatingHours);
+    caps.addRead(InverterCapability::ReadStatus);
+    caps.phaseCount = 1;
+    caps.mpptCount  = 1;
+    caps.hasBattery = false;
+    return caps;
+}
+
+}  // namespace heliograph

--- a/src/drivers/solax_x1/solax_driver.cpp
+++ b/src/drivers/solax_x1/solax_driver.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "diagnostics/logger.h"
+#include "drivers/pmu_pv_capabilities.h"
 
 namespace heliograph::solax {
 namespace {
@@ -48,23 +49,11 @@ bool SolaxDriver::begin(Transport& transport) {
         return false;
     }
 
-    capabilities_ = InverterCapabilities{};
-    capabilities_.addRead(InverterCapability::ReadAcPower);
-    capabilities_.addRead(InverterCapability::ReadAcVoltage);
-    capabilities_.addRead(InverterCapability::ReadAcCurrent);
-    capabilities_.addRead(InverterCapability::ReadGridFrequency);
-    capabilities_.addRead(InverterCapability::ReadDcVoltage);
-    capabilities_.addRead(InverterCapability::ReadDcCurrent);
-    capabilities_.addRead(InverterCapability::ReadDcPower);
-    capabilities_.addRead(InverterCapability::ReadEnergyToday);
-    capabilities_.addRead(InverterCapability::ReadEnergyTotal);
-    capabilities_.addRead(InverterCapability::ReadTemperature);
-    capabilities_.addRead(InverterCapability::ReadOperatingHours);
-    capabilities_.addRead(InverterCapability::ReadStatus);
-    capabilities_.addRead(InverterCapability::ReadErrors);  // 32-bit fault bitmask
-    capabilities_.phaseCount = 1;
-    capabilities_.mpptCount  = 1;  // datasheet; revised upward if PV2 shows real voltage
-    capabilities_.hasBattery = false;
+    // Shared with the other PMU-family driver; see pmu_pv_capabilities.h. mpptCount starts at
+    // 1 per the datasheet and is revised upward if PV2 turns out to show real voltage.
+    capabilities_ = pmuPvCapabilities();
+    // This variant's own addition: the payload carries a 32-bit fault bitmask.
+    capabilities_.addRead(InverterCapability::ReadErrors);
 
     identity_              = DeviceIdentity{};
     identity_.manufacturer = "SolaX";

--- a/test/test_eversolar/driver.cpp
+++ b/test/test_eversolar/driver.cpp
@@ -3,6 +3,7 @@
 
 #include <unity.h>
 
+#include <bitset>
 #include <vector>
 
 #include "device/device_context.h"
@@ -48,6 +49,44 @@ static void test_begin_configures_the_only_known_profile() {
     TEST_ASSERT_EQUAL(SerialParity::None, r.transport.profile().parity);
     TEST_ASSERT_EQUAL_UINT8(8, r.transport.profile().dataBits);
     TEST_ASSERT_EQUAL_UINT8(1, r.transport.profile().stopBits);
+}
+
+// What this driver DECLARES it can read, pinned channel by channel.
+//
+// Nothing asserted this before, which mattered the moment the twelve addRead() calls became a
+// shared pmuPvCapabilities(): a refactor of a list nobody checks is a refactor nobody can
+// verify. The list is not cosmetic -- it is what /api/v1/devices/<id>/capabilities publishes
+// and what the dashboard uses to decide which rows exist, so a channel silently dropped here
+// disappears from every screen while the data keeps arriving.
+//
+// ReadErrors is the one to watch. This protocol variant carries no error field, and the other
+// driver sharing that helper does have one; if the shared list ever grows it, this inverter
+// starts advertising a channel that can never produce a value.
+static void test_the_declared_read_channels_are_exactly_the_pmu_pv_set() {
+    Rig r;
+    TEST_ASSERT_TRUE(r.begin());
+    const InverterCapabilities caps = r.driver.capabilities();
+
+    // EXACTLY, as a set comparison rather than a dozen has() calls. Spot-checking the twelve
+    // that should be there proves nothing about a thirteenth that should not, and ReadErrors
+    // arriving by accident is the specific failure this guards.
+    std::bitset<kCapabilityCount> expected;
+    for (const auto capability :
+         {InverterCapability::ReadAcPower, InverterCapability::ReadAcVoltage,
+          InverterCapability::ReadAcCurrent, InverterCapability::ReadGridFrequency,
+          InverterCapability::ReadDcVoltage, InverterCapability::ReadDcCurrent,
+          InverterCapability::ReadDcPower, InverterCapability::ReadEnergyToday,
+          InverterCapability::ReadEnergyTotal, InverterCapability::ReadTemperature,
+          InverterCapability::ReadOperatingHours, InverterCapability::ReadStatus}) {
+        expected.set(static_cast<size_t>(capability));
+    }
+    TEST_ASSERT_TRUE_MESSAGE(caps.read == expected,
+                             "declared read channels are not exactly the PMU PV set");
+    TEST_ASSERT_TRUE(caps.write.none());
+
+    TEST_ASSERT_EQUAL_UINT8(1, caps.phaseCount);
+    TEST_ASSERT_EQUAL_UINT8(1, caps.mpptCount);  // revised upward by a dual-string payload
+    TEST_ASSERT_FALSE(caps.hasBattery);
 }
 
 // The exact shape a bridge has after an OTA update from a firmware that predates the "address"
@@ -819,6 +858,7 @@ static void test_snapshots_are_immutable_and_independent() {
 
 void run_eversolar_driver() {
     RUN_TEST(test_begin_configures_the_only_known_profile);
+    RUN_TEST(test_the_declared_read_channels_are_exactly_the_pmu_pv_set);
     RUN_TEST(test_a_config_without_the_address_option_still_gets_the_first_address);
     RUN_TEST(test_an_out_of_range_stored_address_falls_back_rather_than_to_zero);
     RUN_TEST(test_begin_broadcasts_re_register);

--- a/test/test_solax_driver/test_main.cpp
+++ b/test/test_solax_driver/test_main.cpp
@@ -7,6 +7,7 @@
 
 #include <unity.h>
 
+#include <bitset>
 #include <cstring>
 #include <vector>
 
@@ -274,6 +275,38 @@ static void test_noise_before_the_reply_does_not_cost_the_reply() {
     TEST_ASSERT_EQUAL(static_cast<int>(PollResult::Ok), static_cast<int>(driver.poll(state)));
 }
 
+// The same pin as the other PMU-family driver has, and for the same reason -- this one needed
+// it more, not less. Sharing pmuPvCapabilities() between two drivers means an edit there moves
+// BOTH, and this is the driver with something to lose: ReadErrors is its own addition, declared
+// next to the shared call rather than inside it. Nothing was asserting that line existed.
+static void test_the_declared_read_channels_are_the_pmu_pv_set_plus_errors() {
+    MockTransport transport;
+    SolaxDriver   driver(transport);
+    TEST_ASSERT_TRUE(driver.begin(transport));
+    const InverterCapabilities caps = driver.capabilities();
+
+    std::bitset<kCapabilityCount> expected;
+    for (const auto capability :
+         {InverterCapability::ReadAcPower, InverterCapability::ReadAcVoltage,
+          InverterCapability::ReadAcCurrent, InverterCapability::ReadGridFrequency,
+          InverterCapability::ReadDcVoltage, InverterCapability::ReadDcCurrent,
+          InverterCapability::ReadDcPower, InverterCapability::ReadEnergyToday,
+          InverterCapability::ReadEnergyTotal, InverterCapability::ReadTemperature,
+          InverterCapability::ReadOperatingHours, InverterCapability::ReadStatus,
+          // This variant's own: the payload carries a 32-bit fault bitmask. Drop the addRead
+          // beside the shared call and this is the only thing that notices.
+          InverterCapability::ReadErrors}) {
+        expected.set(static_cast<size_t>(capability));
+    }
+    TEST_ASSERT_TRUE_MESSAGE(caps.read == expected,
+                             "declared read channels are not the PMU PV set plus ReadErrors");
+    TEST_ASSERT_TRUE(caps.write.none());
+
+    TEST_ASSERT_EQUAL_UINT8(1, caps.phaseCount);
+    TEST_ASSERT_EQUAL_UINT8(1, caps.mpptCount);  // at boot; PV2 revises it, see below
+    TEST_ASSERT_FALSE(caps.hasBattery);
+}
+
 static void test_pv2_channels_appear_only_when_pv2_shows_real_voltage() {
     MockTransport   transport;
     FakeSolaxDevice device;
@@ -314,6 +347,7 @@ int main(int, char**) {
     RUN_TEST(test_silence_from_an_empty_bus_is_not_registered);
     RUN_TEST(test_probe_reports_serial_and_identity_evidence);
     RUN_TEST(test_noise_before_the_reply_does_not_cost_the_reply);
+    RUN_TEST(test_the_declared_read_channels_are_the_pmu_pv_set_plus_errors);
     RUN_TEST(test_pv2_channels_appear_only_when_pv2_shows_real_voltage);
     return UNITY_END();
 }


### PR DESCRIPTION
Third of four from the cleanup audit. The first one that touches firmware.

## What was duplicated, and what was not

The audit said "17 byte-identical lines". Reading them properly, it is **twelve** — and the
difference is the interesting part:

```
< capabilities_.addRead(InverterCapability::ReadErrors);  // 32-bit fault bitmask
---
> // Deliberately absent: ReadErrors (the protocol carries no error code field)
```

So a naive extraction of all seventeen would have been wrong in one of two ways: either it adds
a fault channel to an inverter whose protocol has no error field, or it drops one from an
inverter that does have it.

## Why sharing the twelve *is* grounded

I checked before extracting, because two drivers implementing one interface looking alike is
not by itself duplication. Both parsers emit the **same fifteen measurement ids**:

```
kAcFrequency kAcL1Current kAcL1Voltage kAcPowerTotal kDcMppt1Current kDcMppt1Power
kDcMppt1Voltage kDcMppt2Current kDcMppt2Power kDcMppt2Voltage kDcPowerTotal kEnergyToday
kEnergyTotal kOperatingHours kTemperature
```

Identical, because the channels come from the shared payload layout rather than from the
manufacturer. That is a fact worth one definition.

## Where it lives

`src/drivers/pmu_pv_capabilities.h`, **not** `src/protocols/pmu/`. That directory is a pure
codec that includes `<cstddef>` and `<cstdint>` and nothing else; teaching it about the
canonical device model would be the expensive kind of tidying. There is precedent for a shared,
brand-free header at the drivers level: `modbus_bus_tally.h`.

Each driver still states its own difference next to the call, with the reason. A helper with a
flag per difference would be the same duplication with more indirection.

## The part that made this riskier than it looked

**Nothing asserted either capability list.** One of the two driver suites had no capability
test at all. A refactor of a list nobody checks is a refactor nobody can verify — and this list
is not cosmetic: it is what `/api/v1/devices/<id>/capabilities` publishes and what the dashboard
reads to decide which rows exist. A channel dropped here disappears from every screen while the
data keeps arriving.

So the list is now pinned, as a **set comparison** rather than a dozen `has()` calls — checking
the twelve that belong proves nothing about a thirteenth that does not, and a stray `ReadErrors`
is the specific accident this guards.

Mutation-tested, which is the only reason I trust it:

```
# add ReadErrors to the shared helper
test_the_declared_read_channels_are_exactly_the_pmu_pv_set:
    declared read channels are not exactly the PMU PV set   [FAILED]
```

## Verification

- 845 native tests (844 + the new one), all passing.
- Layering invariants pass — the helper is brand-free.
- `waveshare-rs485-can` and `mock` build. Flash 1 542 459 bytes, four bytes off the v0.23.0
  build; the inline helper compiles to what the open-coded calls did.

## No behaviour change

Same twelve channels on both drivers, same `ReadErrors` on the one that had it, same
phase/MPPT/battery shape. `/api/v1/devices/<id>/capabilities` returns exactly what it returned
before.
