### PR TITLE
refactor(rest): one config write path, and the one route that must stay out of it

### DIFF
--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -34,6 +34,18 @@ ota::OtaManager   g_ota;
 
 constexpr const char* kJson = "application/json";
 
+/// The 400 a rejected configuration gets, whoever rejected it.
+///
+/// A ConfigError's field name is optional, so the message is either "field: reason" or the
+/// bare reason. That choice was spelled out at three sites -- two parsing a PATCH body and one
+/// validating a restored backup, which reaches a ConfigError by a different route entirely.
+/// Three places for one sentence is three ways for two endpoints to word the same refusal
+/// differently.
+ApiError invalidConfig(const ConfigError& error) {
+    return {400, "invalid_config",
+            error.field.empty() ? error.message : error.field + ": " + error.message};
+}
+
 void sendError(AsyncWebServerRequest* request, const ApiError& error) {
     std::string body;
     if (!buildErrorPayload(error, "", body)) {
@@ -136,9 +148,7 @@ bool RestApi::applyBodyTo(AsyncWebServerRequest* request, Configuration& updated
     // sending bad JSON in a loop.
     releaseBody();
     if (!parsed) {
-        sendError(request, {400, "invalid_config",
-                            error.field.empty() ? error.message
-                                                : error.field + ": " + error.message});
+        sendError(request, invalidConfig(error));
         return false;
     }
     return true;
@@ -736,9 +746,7 @@ bool RestApi::begin() {
             // both would be invisible to either check on its own.
             ConfigError error;
             if (!validate(merged, error)) {
-                sendError(request, {400, "invalid_config",
-                                    error.field.empty() ? error.message
-                                                        : error.field + ": " + error.message});
+                sendError(request, invalidConfig(error));
                 return;
             }
             // Never leave the bridge without an admin password. A redacted backup restored onto

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -127,6 +127,32 @@ void RestApi::releaseBody() {
     bodyBuffer_.shrink_to_fit();
 }
 
+bool RestApi::applyBodyTo(AsyncWebServerRequest* request, Configuration& updated,
+                          const DriverLookupFn& lookupDriver) {
+    ConfigError error;
+    const bool  parsed = applyConfigPatch(bodyBuffer_, updated, error, lookupDriver);
+    // Before the branch, not inside it: the buffer must go back whether the patch was accepted
+    // or refused, and an error path that forgets is a leak that only shows under a client
+    // sending bad JSON in a loop.
+    releaseBody();
+    if (!parsed) {
+        sendError(request, {400, "invalid_config",
+                            error.field.empty() ? error.message
+                                                : error.field + ": " + error.message});
+        return false;
+    }
+    return true;
+}
+
+bool RestApi::saveAndApply(AsyncWebServerRequest* request, const Configuration& updated) {
+    if (!context_.saveConfig(updated)) {
+        sendError(request, {500, "save_failed", "could not persist the configuration"});
+        return false;
+    }
+    context_.applyConfig(updated);  // lock-guarded publish; see RestContext
+    return true;
+}
+
 RestApi::~RestApi() { stop(); }
 
 void RestApi::notifyState(const DeviceState& state, uint64_t nowMs) {
@@ -277,13 +303,7 @@ bool RestApi::begin() {
             }
 
             Configuration updated = *context_.config;
-            ConfigError   error;
-            const bool    parsed = applyConfigPatch(bodyBuffer_, updated, error);
-            releaseBody();
-            if (!parsed) {
-                sendError(request, {400, "invalid_config",
-                                    error.field.empty() ? error.message
-                                                        : error.field + ": " + error.message});
+            if (!applyBodyTo(request, updated)) {
                 return;
             }
             // Refuse to finish setup without an admin password: everything after this
@@ -298,11 +318,9 @@ bool RestApi::begin() {
                 sendError(request, {400, "ssid_required", "a WiFi network is required"});
                 return;
             }
-            if (!context_.saveConfig(updated)) {
-                sendError(request, {500, "save_failed", "could not persist the configuration"});
+            if (!saveAndApply(request, updated)) {
                 return;
             }
-            context_.applyConfig(updated);  // lock-guarded publish; see RestContext
             // Echo the hostname: after the reboot this AP is gone and the user needs a
             // concrete address to go to. The setup page turns this into a clickable link.
             //
@@ -539,18 +557,12 @@ bool RestApi::begin() {
             // this, and applyConfig() below overwrites what context_.config points at.
             const Configuration before  = *context_.config;
             Configuration       updated = before;
-            ConfigError         error;
             // The lookup lets the config layer drop options orphaned by a previous driver
             // without itself knowing what a driver is; see applyConfigPatch's contract.
             const auto lookupDriver = [this](const std::string& id) -> const DriverDescriptor* {
                 return context_.registry != nullptr ? context_.registry->find(id) : nullptr;
             };
-            const bool parsed = applyConfigPatch(bodyBuffer_, updated, error, lookupDriver);
-            releaseBody();
-            if (!parsed) {
-                sendError(request, {400, "invalid_config",
-                                    error.field.empty() ? error.message
-                                                        : error.field + ": " + error.message});
+            if (!applyBodyTo(request, updated, lookupDriver)) {
                 return;
             }
 
@@ -623,11 +635,9 @@ bool RestApi::begin() {
                 }
             }
 
-            if (!context_.saveConfig(updated)) {
-                sendError(request, {500, "save_failed", "could not persist the configuration"});
+            if (!saveAndApply(request, updated)) {
                 return;
             }
-            context_.applyConfig(updated);  // lock-guarded publish; see RestContext
             const bool  rebootRequired = configChangeRequiresReboot(before, updated);
             std::string body;
             serializeConfig(updated, body, 4096, &rebootRequired);
@@ -776,11 +786,9 @@ bool RestApi::begin() {
             const bool rollbackStored =
                 context_.stashRollback != nullptr && context_.stashRollback();
 
-            if (!context_.saveConfig(merged)) {
-                sendError(request, {500, "save_failed", "could not persist the configuration"});
+            if (!saveAndApply(request, merged)) {
                 return;
             }
-            context_.applyConfig(merged);  // lock-guarded publish; see RestContext
 
             std::string body;
             if (!buildRestoreResultPayload(diff.size(), rebootRequired, rollbackStored, body)) {
@@ -1294,6 +1302,12 @@ void RestApi::releaseBody() {
     bodyRejected_ = nullptr;
     bodyBuffer_.clear();
 }
+// No routes on this build, so nothing reaches these. Stubbed for the same reason as their
+// neighbours: the header declares one class for both builds.
+bool RestApi::applyBodyTo(AsyncWebServerRequest*, Configuration&, const DriverLookupFn&) {
+    return false;
+}
+bool RestApi::saveAndApply(AsyncWebServerRequest*, const Configuration&) { return false; }
 
 }  // namespace heliograph::rest
 

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -153,6 +153,28 @@ private:
     bool bodyMissing(AsyncWebServerRequest* request, const char* expected);
     void releaseBody();
 
+    /// Merges the collected body into `updated`, or answers 400 and returns false.
+    ///
+    /// Releases the body either way, which is half of why this is one function: the release
+    /// belongs between the parse and the error, and writing that out three times is three
+    /// chances to leak the buffer down an error path. The other half is the message -- a
+    /// ConfigError carries an optional field name, and "field: message" versus bare "message"
+    /// was spelled out at every site, so a change to how a rejection reads would have had to
+    /// be made in all of them.
+    bool applyBodyTo(AsyncWebServerRequest* request, Configuration& updated,
+                     const DriverLookupFn& lookupDriver = {});
+
+    /// Persists `updated` and publishes it to the running system, or answers 500 and
+    /// returns false.
+    ///
+    /// The ORDER is the invariant: save first, publish second. Publishing a configuration that
+    /// failed to persist leaves the device running something it will not have after a reboot.
+    ///
+    /// Deliberately NOT used by the rollback route. rollbackConfig() has already swapped the
+    /// two stored blobs, so calling saveConfig() there would re-serialise the same
+    /// configuration over the copy just put in place -- it applies without saving, and says so.
+    bool saveAndApply(AsyncWebServerRequest* request, const Configuration& updated);
+
     RestContext context_;
     uint16_t    port_;
     bool        started_        = false;

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -155,12 +155,13 @@ private:
 
     /// Merges the collected body into `updated`, or answers 400 and returns false.
     ///
-    /// Releases the body either way, which is half of why this is one function: the release
-    /// belongs between the parse and the error, and writing that out three times is three
-    /// chances to leak the buffer down an error path. The other half is the message -- a
-    /// ConfigError carries an optional field name, and "field: message" versus bare "message"
-    /// was spelled out at every site, so a change to how a rejection reads would have had to
-    /// be made in all of them.
+    /// Releases the body either way, and that is the reason this is a function rather than a
+    /// pattern: the release belongs BETWEEN the parse and the error, so each of the two copies
+    /// was a chance to leak the buffer down an error path.
+    ///
+    /// The message itself is shaped by invalidConfig() in the .cpp, not here -- a third site
+    /// reaches the same 400 from validate() on a restored backup rather than from a patch, so
+    /// the wording has one owner and the parsing has another.
     bool applyBodyTo(AsyncWebServerRequest* request, Configuration& updated,
                      const DriverLookupFn& lookupDriver = {});
 


### PR DESCRIPTION
The remaining duplication from the audit. Two rules that were written out at every
config-mutating route.

## Parse — two copies

```cpp
const bool parsed = applyConfigPatch(bodyBuffer_, updated, error[, lookupDriver]);
releaseBody();
if (!parsed) {
    sendError(request, {400, "invalid_config",
                        error.field.empty() ? error.message
                                            : error.field + ": " + error.message});
    return;
}
```

The `releaseBody()` belongs **between** the parse and the error, so each copy was a chance to
leak the buffer down an error path. And the message shape — a `ConfigError`'s field name is
optional — was a chance for two routes to reject differently.

## Persist — three copies

```cpp
if (!context_.saveConfig(updated)) {
    sendError(request, {500, "save_failed", "could not persist the configuration"});
    return;
}
context_.applyConfig(updated);
```

The **order** is the invariant: publishing a configuration that failed to persist leaves the
device running something it will not have after a reboot.

`applyBodyTo()` and `saveAndApply()` now hold both. This follows `bodyMissing()`, which was
extracted from three copies for exactly this reason and says so in its own comment:

> Three copies of a rule that is only correct in one order is three chances to get it wrong,
> and a fourth route would have been a fourth.

## The route that deliberately stays out

`POST /api/v1/actions/undo-restore` applies **without** saving — `rollbackConfig()` has already
swapped the two stored blobs, so a `saveConfig()` there would re-serialise the same
configuration over the copy just put in place.

It is not in this diff, and `saveAndApply()`'s comment names it, so the next person tidying up
finds the reason before making the edit rather than after.

## What verifies this — honestly, not tests

The handlers live behind `#if defined(ESP32)`, so the host build compiles only the stubs.
`test_rest` never reaches `invalid_config` or `save_failed` and **cannot**. I checked before
claiming coverage I did not have.

What it rests on instead:

- The transformation is mechanical, and the diff shows every replacement as an exact
  substitution — no line changed except the ones removed.
- The restore route's `stashRollback` still runs **before** the save; I read the result back to
  confirm the ordering comment still describes the code under it.
- Flash went **down 444 bytes** (1 542 459 → 1 542 015). That is what removing duplicated code
  and nothing else looks like.
- 846 native tests, four board envs build, cppcheck clean, layering passes.

**This is itself an audit finding worth stating:** the REST error paths have no coverage and no
route to it while the handlers are ESP-only. That is the same structural problem 0.22.0 solved
for `setup()` by extracting `app::planDevices()` — a candidate for the same treatment, and a
bigger change than this one.

## No behaviour change

Same status codes, same messages, same order of operations, same route left out.
