### PR TITLE
feat(web): the charge bar shows the level, the arrow shows the direction

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -294,6 +294,24 @@ function bar(pct,colour){
   return `<div class="bar"><svg width="100%" height="6" viewBox="0 0 100 6" preserveAspectRatio="none">
     <rect x="0" y="0" width="${Math.max(0,Math.min(100,pct)).toFixed(1)}" height="6" fill="${colour||'var(--acc)'}"></rect></svg></div>`;
 }
+/// Where a state of charge stops being comfortable. Named because they are a judgement, not a
+/// measurement, and a reader should find them stated once rather than inferred from two
+/// literals inside a ternary.
+const SOC_LOW=20, SOC_HALF=50;
+/// The charge bar's colour, which follows the LEVEL and nothing else.
+///
+/// It used to follow the DIRECTION: the same variable coloured the bar and the charging/
+/// discharging line, so a full battery that happened to be charging drew a red bar. The two
+/// answer different questions -- "how much is left" and "which way is it going" -- and one
+/// colour could only ever answer one of them.
+///
+/// Unknown is not empty. A device can report battery power without a state of charge, and the
+/// percentage beside this already renders as an em dash; painting the empty bar red would turn
+/// "we were not told" into "critically low", which is the one thing the reading must never do.
+function socColour(pct){
+  if(pct===null||pct===undefined)return 'var(--dim)';
+  return pct<SOC_LOW?'var(--bad)':pct<SOC_HALF?'var(--warn)':'var(--ok)';
+}
 
 // ---------------- canonical measurements ----------------
 // Label, group and decimals per id. Order here IS the order on screen. Units are NOT here --
@@ -461,8 +479,13 @@ function paintLive(){
   }
   // Battery, when any device reports one. Direction is carried by an ARROW as well as a colour,
   // so it survives a reader who cannot tell red from green, and the sign of the number never
-  // has to be decoded. Red for charging is the household reading: discharging means the house
-  // is running on its own stored sun instead of buying it.
+  // has to be decoded.
+  //
+  // EITHER channel brings the card up, not both. No shipped profile maps power without a state
+  // of charge -- checked, 2026-07-29 -- but profiles are added a TOML row at a time and a half
+  // mapped one is the ordinary intermediate state, not an exotic case. A contributor who maps
+  // the obvious power register before hunting down the SoC block then sees "— %" over a grey
+  // bar, which says what is missing; requiring both would have shown them nothing at all.
   const batts=multi?fleet.filter(f=>f.battery_soc_pct!=null||f.battery_power_w!=null)
                    :(shown(m,'battery.soc')||shown(m,'battery.power')?[{single:true}]:[]);
   for(const f of batts){
@@ -470,23 +493,31 @@ function paintLive(){
     const p=f.single?(m['battery.power']||{}).value:f.battery_power_w;
     const idle=p==null||Math.abs(Number(fmt(Math.abs(p),0)))===0;
     const state=idle?'idle':(p>0?'charging':'discharging');
-    const colour=state==='charging'?'var(--bad)':state==='discharging'?'var(--ok)':'var(--dim)';
-    const arrow=state==='charging'?'\u2193':state==='discharging'?'\u2191':'';
+    // Direction, not level -- the bar below answers the other question. Up and green is the
+    // battery gaining, down and red is it giving back, so every cue on this card points the
+    // same way: green and upward mean more energy available.
+    //
+    // The arrow shows the state of charge moving, NOT the direction of power flow. Those are
+    // opposites at the terminals -- current goes INTO a battery that is charging -- and the
+    // earlier version chose the flow reading. One of the two has to lose, and a reader looking
+    // at a percentage is asking which way that number is heading.
+    const dirColour=state==='charging'?'var(--ok)':state==='discharging'?'var(--bad)':'var(--dim)';
+    const arrow=state==='charging'?'\u2191':state==='discharging'?'\u2193':'';
     const rows=f.single
       ?MEAS.filter(([id,,g])=>g==='Battery'&&shown(m,id)).map(([id,label])=>
         `<div class="fact"><div class="k">${esc(label)}</div><div>${esc(reading(m,id))}</div></div>`).join('')
       :`<div class="fact"><div class="k">Power</div><div>${esc(fmt(Math.abs(p),0))} W ${state==='charging'?'in':'out'}</div></div>`;
     h+=`<div class="card" style="margin-top:20px">
       <div class="between"><div class="k">Battery${f.single?'':' · '+esc(f.label||f.id)}</div>
-        <div style="font-size:13px;color:${colour}" title="${esc(state)}">${arrow} ${esc(idle?'idle':state+' at '+fmt(Math.abs(p),0)+' W')}</div></div>
+        <div style="font-size:13px;color:${dirColour}" title="${esc(state)}">${arrow} ${esc(idle?'idle':state+' at '+fmt(Math.abs(p),0)+' W')}</div></div>
       <div class="soc">
         <div style="display:flex;align-items:baseline;gap:6px"><span class="pct">${esc(fmt(soc,0))}</span><span class="dim" style="font-size:16px">%</span></div>
         <div class="track"><div class="bar2"><svg width="100%" height="8" viewBox="0 0 100 8" preserveAspectRatio="none">
-          <rect x="0" y="0" width="${Math.max(0,Math.min(100,Number(soc)||0))}" height="8" fill="${colour}"></rect></svg></div>
+          <rect x="0" y="0" width="${Math.max(0,Math.min(100,Number(soc)||0))}" height="8" fill="${socColour(soc)}"></rect></svg></div>
           <div class="between hint" style="margin-top:4px"><span>empty</span><span>full</span></div></div>
       </div>
       <div class="cols" style="margin-top:14px">${rows}</div>
-      <div class="hint" style="margin-top:12px">Down and red is power going into the battery; up and green is the house running on stored sun. The arrow carries it as well as the colour, so the meaning survives losing either one.</div>
+      <div class="hint" style="margin-top:12px">Up and green means the battery is filling; down and red means the house is running on stored sun. The arrow says it as well as the colour, so the meaning survives losing either one. The bar is the level and not the direction — red below ${SOC_LOW}%, amber below ${SOC_HALF}%, green above — and stays grey when the inverter reports power but no state of charge.</div>
     </div>`;
   }
   if(multi){

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -305,9 +305,14 @@ const SOC_LOW=20, SOC_HALF=50;
 /// answer different questions -- "how much is left" and "which way is it going" -- and one
 /// colour could only ever answer one of them.
 ///
-/// Unknown is not empty. A device can report battery power without a state of charge, and the
-/// percentage beside this already renders as an em dash; painting the empty bar red would turn
-/// "we were not told" into "critically low", which is the one thing the reading must never do.
+/// Unknown is not empty, and the colour says so even though nobody can currently see it: an
+/// unknown state of charge draws a rect of zero width, so the fill is invisible either way --
+/// what actually separates "we were not told" from "critically low" on screen is the em dash
+/// the percentage renders instead of a 0. Measured, not assumed (review, 2026-07-29).
+///
+/// The branch stays because emitting var(--bad) for a value nobody supplied is wrong wherever
+/// it ends up, and because the day this bar grows a minimum-width sliver so an empty battery is
+/// still visible, that sliver would be red for a reading that does not exist.
 function socColour(pct){
   if(pct===null||pct===undefined)return 'var(--dim)';
   return pct<SOC_LOW?'var(--bad)':pct<SOC_HALF?'var(--warn)':'var(--ok)';
@@ -484,8 +489,9 @@ function paintLive(){
   // EITHER channel brings the card up, not both. No shipped profile maps power without a state
   // of charge -- checked, 2026-07-29 -- but profiles are added a TOML row at a time and a half
   // mapped one is the ordinary intermediate state, not an exotic case. A contributor who maps
-  // the obvious power register before hunting down the SoC block then sees "— %" over a grey
-  // bar, which says what is missing; requiring both would have shown them nothing at all.
+  // the obvious power register before hunting down the SoC block then sees the card with "— %"
+  // where the number goes, which says what is missing; requiring both would have shown them
+  // nothing at all and read as "batteries are not supported".
   const batts=multi?fleet.filter(f=>f.battery_soc_pct!=null||f.battery_power_w!=null)
                    :(shown(m,'battery.soc')||shown(m,'battery.power')?[{single:true}]:[]);
   for(const f of batts){

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -45,15 +45,32 @@ WIDTHS = (390, 700, 780, 1000, 1200)
 # Battery states, and what each must be able to say for itself. Rendered from the same page at
 # one width, because these are semantics and not layout.
 #
+# TWO questions, two answers, and the card must not confuse them. The DIRECTION line says which
+# way the charge is heading: up and green gaining, down and red giving back. The BAR says how
+# much is left, coloured by level alone. One variable used to drive both, so a full battery that
+# happened to be charging drew a red bar.
+#
 # Direction is carried by an ARROW as well as a colour, so it survives a reader who cannot tell
 # the red from the green, and the sign of the number never has to be decoded. Asserting only the
 # colour would let a future change drop the arrow and leave the meaning in a hue.
 BATTERY_CASES = [
     # (label, soc, power, must contain, must NOT contain)
-    ("discharging", 68, -1240, ["↑", "var(--ok)", 'title="discharging"'], ["-1240"]),
-    ("charging", 41, 1500, ["↓", "var(--bad)", 'title="charging"'], []),
+    # Discharging at a comfortable level: red on the line, green on the bar. Both appear, which
+    # is exactly what a single shared colour could not produce -- so this case alone would have
+    # failed before the split.
+    (
+        "discharging",
+        68,
+        -1240,
+        ["↓", "var(--bad)", 'title="discharging"', "var(--ok)"],
+        ["-1240"],
+    ),
+    # Charging while nearly empty: green on the line, red on the bar. The mirror image.
+    ("charging", 12, 1500, ["↑", "var(--ok)", 'title="charging"', "var(--bad)"], []),
     # A trickle that rounds away must not claim a direction next to a zero.
     ("idle", 55, 0.4, ["idle"], ["charging at 0 W", "discharging at 0 W"]),
+    # The middle band, so the amber threshold is not left to inspection.
+    ("half full", 35, -200, ["var(--warn)"], []),
 ]
 
 # Runs after the page has painted. Verdict goes in document.title, which --dump-dom gives back.
@@ -113,12 +130,19 @@ function check(){
     }
   }
 
-  // The legend became load-bearing the moment the word came out of the cell: it is the only
-  // place the arrows are explained. A battery on screen without it is undecodable.
+  // The legend became load-bearing the moment the word came out of the cell, and it now has
+  // TWO things to carry: what the arrow means, and that the bar answers a different question.
+  // Asserted separately, because dropping either half leaves a card that looks explained.
   const card=[...document.querySelectorAll('.card')].find(c=>c.querySelector('.soc'));
   if(!card) say('no battery card for a fleet that reports one');
-  else if(!card.textContent.includes('power going into the battery')){
-    say('the battery renders without the legend that explains its arrows');
+  else{
+    const legend=card.textContent;
+    if(!legend.includes('running on stored sun')){
+      say('the battery renders without the legend that explains its arrows');
+    }
+    if(!legend.includes('level and not the direction')){
+      say('the legend does not say the bar colour is the level rather than the direction');
+    }
   }
   return true;
 }

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -71,6 +71,21 @@ BATTERY_CASES = [
     ("idle", 55, 0.4, ["idle"], ["charging at 0 W", "discharging at 0 W"]),
     # The middle band, so the amber threshold is not left to inspection.
     ("half full", 35, -200, ["var(--warn)"], []),
+    # A device reporting power but no state of charge. Asserted on the BAR's own markup, not on
+    # the card's text: this one is discharging, so var(--bad) is legitimately present on the
+    # direction line and a whole-card search would have passed for the wrong reason.
+    #
+    # The fill is invisible here -- an unknown level draws a rect of zero width, same as a
+    # genuine 0% -- and what tells them apart on screen is the em dash where the number goes.
+    # Pinned anyway: emitting "critically low" for a value nobody supplied is wrong wherever it
+    # ends up, and it stops being invisible the day this bar grows a minimum-width sliver.
+    (
+        "state of charge unknown",
+        "null",
+        -1240,
+        ['height="8" fill="var(--dim)"'],
+        ['height="8" fill="var(--bad)"'],
+    ),
 ]
 
 # Runs after the page has painted. Verdict goes in document.title, which --dump-dom gives back.


### PR DESCRIPTION
The battery card answered two questions with one colour.

## What was wrong

`colour` drove both the direction line **and** the charge bar:

```js
const colour = state==='charging' ? 'var(--bad)' : state==='discharging' ? 'var(--ok)' : 'var(--dim)';
```

So a battery at 95% that happened to be charging drew a **red** bar, and one at 8% that happened
to be discharging drew a **green** one. How much is left and which way it is going are different
questions, and a single colour could only ever answer one of them.

## What it does now

| | |
|---|---|
| **The bar** | the level, and nothing else — red below 20%, amber below 50%, green above |
| **The line** | the direction — **↑ green** gaining, **↓ red** giving back |

Stepped rather than a continuous ramp: a straight red-to-green interpolation passes through an
olive that reads as neither, and it uses `--bad`/`--warn`/`--ok` from the existing palette
instead of inventing hues. The thresholds are named constants, not literals inside a ternary.

Everything on the card now points the same way — green and upward mean more energy available.

## What the arrow gave up, stated plainly

It used to show the direction of **power flow**, which at the terminals is the opposite of what
you might expect: current goes *into* a battery that is charging, so charging was `↓`. It now
shows the **state of charge** moving, so charging is `↑`.

One of the two readings had to lose. A reader looking at a percentage is asking which way that
number is heading, so the flow reading is the one that went.

## Unknown is not empty

A device can report battery power without a state of charge. **No shipped profile does** — I
checked: only `sph.toml` maps battery channels and it maps both; `mic_tl_x.toml` maps none.

The bar stays **grey** in that case rather than going red — though the review turned up that
**nobody can see that**. An unknown level draws a rect of zero width, exactly like a genuine 0%,
so the fill is invisible either way. Rendered and read back rather than reasoned about:

```
normal 68%     width=68  fill=var(--ok)   pct=68
SoC unknown    width=0   fill=var(--dim)  pct=—
genuinely 0%   width=0   fill=var(--bad)  pct=0
```

What actually separates "we were not told" from "critically low" on screen is the **em dash**
where the number goes. The branch stays anyway: emitting `var(--bad)` for a value nobody
supplied is wrong wherever it ends up, and it stops being invisible the day this bar grows a
minimum-width sliver so an empty battery is still something rather than nothing.

Either channel still brings the card up, which is a deliberate keep rather than an oversight:
profiles are added a TOML row at a time and a half-mapped one is the ordinary intermediate
state — the SPH was in exactly that condition until two days ago, missing eleven channels. A
contributor who maps the obvious power register before hunting down the SoC block sees the card
with `— %` where the number goes, which says what is missing. Requiring both would have shown
them nothing at all, and read as "batteries are not supported".

## The check gained the case that would have caught this

```python
("discharging", 68, -1240, ["↓", "var(--bad)", 'title="discharging"', "var(--ok)"], ["-1240"]),
```

Discharging at 68% must show `var(--bad)` on the line **and** `var(--ok)` on the bar in the same
render. A shared colour cannot produce both, so this case alone fails against the old code. Plus
a fourth case at 35% so the amber band is not left to inspection.

The legend assertion also split in two — the legend now has to explain the arrow *and* say the
bar is the level rather than the direction. Dropping either half leaves a card that looks
explained.

## Verification

846 native tests, five widths, four battery cases, layering and cppcheck clean, firmware builds
at 1 542 023 bytes.

Committed screenshots are unchanged and did not need regenerating — `docs/images/fixture.json`
is a single-inverter EverSolar with no battery, so the card does not appear in them. Checked
rather than assumed.

## Not in this PR

`src/main.cpp` still describes the old convention in the **0.18.0** release note. That is
history and 0.18.0 really did ship red-for-charging; rewriting it would make the log lie about
the past. The 0.24.0 note will record the reversal.



---

## Review pass

One finding, and it was a claim of mine rather than a defect in the behaviour: **the grey bar is
invisible** (see the corrected section above). The comment and the PR body both said a
contributor would see it. Corrected in both, and the case is now pinned in the layout check —
asserted on the *bar's own markup*, not the card's text, because that case is discharging so
`var(--bad)` is legitimately on the direction line and a whole-card search would have passed for
the wrong reason.

Mutation-tested: remove the guard from `socColour()` and the new case fails on both halves.

Also checked and found sound: the legend interpolates its thresholds correctly ("red below 20%,
amber below 50%, green above" — rendered, not assumed); `bar()` for the rated-power hero takes
an explicit colour and is unaffected; and the multi-device path reaches `socColour` through
`f.battery_soc_pct`, which is null for a device without one, so it behaves the same as the
single-device path.
