### PR TITLE
fix(web): the add-by-hand button could not work, and a refresh shut every dropdown

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1413,6 +1413,10 @@ async function addExtra(){
   // picked here, by the same reading of the options that addressProblem() uses to complain.
   const primary=(cfg.driver||{}).id||'';
   if(!primary){alert('Choose a driver for the first inverter before adding a second.');return}
+  // The driver list is what says which option holds an address. Without it this would fall
+  // through to "no address option" and hand the new row the driver's default -- straight onto
+  // the primary. Refusing for a moment beats adding a row that cannot work.
+  if(!drivers){alert('Still reading the driver list. Try again in a moment.');return}
   const opt=addressOptionOf(primary);
   const options={};
   if(opt){
@@ -1420,7 +1424,10 @@ async function addExtra(){
       .map(d=>String((d.options||{})[opt.key]??'').trim()).filter(v=>v!==''));
     let next=Number(opt.default_value||1);
     const ceiling=Number(opt.max_value||247);
-    while(taken.has(String(next))&&next<ceiling)next++;
+    while(taken.has(String(next))&&next<=ceiling)next++;
+    // Running off the end must not fall back to a taken address -- that is the exact failure
+    // this block exists to prevent, and it would be silent.
+    if(next>ceiling){alert('Every bus address in this driver’s range is already in use.');return}
     options[opt.key]=String(next);
   }
   arr.push({driver_id:primary,label:'',options});
@@ -1989,7 +1996,15 @@ function tzOptions(ntp){
 function readerIsBusy(){
   const el=document.activeElement;
   if(!el||el===document.body)return false;
-  return el.tagName==='SELECT'||el.tagName==='INPUT'||el.tagName==='TEXTAREA';
+  const tag=el.tagName;
+  if(tag==='SELECT'||tag==='TEXTAREA')return true;
+  if(tag!=='INPUT')return false;
+  // Only the ones a repaint can actually rob. A checkbox commits the moment it is clicked and
+  // then KEEPS focus, so counting it here would freeze its tab for as long as the reader sits
+  // looking at the box they just ticked -- silently, which is the worse failure of the two.
+  // Buttons are excluded by the same test: a nav button holds focus after a tab switch, and
+  // treating that as "busy" would have stopped the Live tab updating the moment you opened it.
+  return !['checkbox','radio','button','submit','reset'].includes((el.type||'').toLowerCase());
 }
 function paint(){
   paintChrome();

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -586,7 +586,11 @@ async function loadInverters(force){
     }
   }catch(e){/* leave what is on screen: one failed request must not wipe a page being read */}
   finally{invBusy=false}
-  if(tab==='inv')paintInverters();
+  // `force` means a person just did something -- saved a device, removed one, added a row --
+  // and the result is the whole point of the repaint. Without it this is the five-second
+  // refresh arriving, which must not tear the page out from under someone using a control on
+  // it. Guarding paint() alone was not enough: this path repaints on its own (see readerIsBusy).
+  if(tab==='inv'&&(force||!readerIsBusy()))paintInverters();
 }
 function shapeOf(caps){
   if(!caps)return '—';
@@ -1387,16 +1391,44 @@ async function removeDevice(id){
   if(!r.ok){say('#dv_msg','err',esc(r.why));return}
   panel=null;invNextMs=0;loadInverters(true);
 }
+/// The option a driver uses to hold its bus address, or null when it addresses some other way
+/// (an AA55 device is found by serial number and declares none).
+function addressOptionOf(drvId){
+  const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
+  return ((drv&&drv.options)||[]).find(o=>o.key==='unit_id'||o.key==='address')||null;
+}
 async function addExtra(){
   const arr=((cfg.additional_devices)||[]).map(d=>({driver_id:d.driver_id,label:d.label||'',options:{...(d.options||{})}}));
   if(arr.length+1>=((S&&S.bridge&&S.bridge.max_devices)||8)){alert('This firmware polls at most '+((S&&S.bridge&&S.bridge.max_devices)||8)+' inverters.');return}
-  // Deliberately empty: an extra device that names no driver is refused, and an address
-  // defaulting to the primary's would collide and be skipped at boot with only a log line.
-  arr.push({driver_id:'',label:'',options:{}});
+
+  // The row has to arrive COMPLETE. It used to be pushed empty, with a comment explaining that
+  // an extra device naming no driver is refused -- which is exactly what the firmware then did,
+  // every time: "additional_devices[N].driver_id: must name a driver". The button could not
+  // work at all (reported from hardware, 2026-07-29).
+  //
+  // The primary's driver is the guess, because a second inverter on one bus is usually another
+  // of the same, and it is one dropdown away from being changed. What must NOT be guessed is
+  // the address: leaving it at the driver's default puts it on top of the primary, and two
+  // units answering to one address destroy each other's replies. So the first free one is
+  // picked here, by the same reading of the options that addressProblem() uses to complain.
+  const primary=(cfg.driver||{}).id||'';
+  if(!primary){alert('Choose a driver for the first inverter before adding a second.');return}
+  const opt=addressOptionOf(primary);
+  const options={};
+  if(opt){
+    const taken=new Set([cfg.driver,...arr]
+      .map(d=>String((d.options||{})[opt.key]??'').trim()).filter(v=>v!==''));
+    let next=Number(opt.default_value||1);
+    const ceiling=Number(opt.max_value||247);
+    while(taken.has(String(next))&&next<ceiling)next++;
+    options[opt.key]=String(next);
+  }
+  arr.push({driver_id:primary,label:'',options});
   const r=await patch({additional_devices:arr});
   if(!r.ok){alert('Could not add a row: '+r.why);return}
   invNextMs=0;await loadInverters(true);
-  alert('A row was added. Open “Name, driver and address” on the new inverter to fill it in, then restart.');
+  alert('A row was added'+(opt?' at address '+options[opt.key]:'')+
+        '. Open “Name, driver and address” on it to set the make and the name, then restart.');
 }
 async function saveUpdateCheck(on){
   const r=await patch({updates:{check_enabled:on}});
@@ -1942,8 +1974,28 @@ function tzOptions(ntp){
 }
 
 // ---------------- paint and refresh ----------------
+/// True while the reader is in the middle of using a control on the current tab.
+///
+/// Every paint replaces a tab's innerHTML wholesale, which destroys and rebuilds the elements
+/// inside it. Do that to an OPEN <select> and it shuts -- and since refresh() runs on every
+/// event the bridge emits, up to once a second, the driver list on the Inverters tab could not
+/// be read at all: it closed before you reached the bottom of it (reported from hardware,
+/// 2026-07-29). A half-typed address or label went the same way.
+///
+/// Asked of the focused element rather than of a flag, because the question is "is somebody
+/// using this right now", and a select holds focus for exactly as long as its popup is open.
+/// A repaint requested BY the page -- a wizard step, a driver change -- calls its paint
+/// function directly and is unaffected; only the timer-driven path defers.
+function readerIsBusy(){
+  const el=document.activeElement;
+  if(!el||el===document.body)return false;
+  return el.tagName==='SELECT'||el.tagName==='INPUT'||el.tagName==='TEXTAREA';
+}
 function paint(){
   paintChrome();
+  // The chrome above is a handful of text nodes and always safe to redraw. The tab below is
+  // not, so a reader mid-interaction keeps what is on screen until they are done with it.
+  if(readerIsBusy())return;
   if(tab==='live')paintLive();
   else if(tab==='inv')paintInverters();
   else if(tab==='int')paintInt();

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -239,6 +239,22 @@ const tick=setInterval(async()=>{
         say('the tab never repainted again after the control was left alone');
       }
     }
+
+    // 3. And it must not release too little. A BUTTON keeps focus after it is clicked, so
+    // counting one as "busy" would have frozen the Live tab the moment somebody opened it --
+    // a worse and quieter bug than the dropdown it was meant to fix.
+    goTab('live');
+    await new Promise(r=>setTimeout(r,200));
+    const nav=document.querySelector('nav button[data-t="live"]');
+    if(!nav) say('no nav button to test focus against');
+    else{
+      nav.focus();
+      const marker=document.createElement('span');
+      $('#live').appendChild(marker);
+      paint();
+      await new Promise(r=>setTimeout(r,50));
+      if(marker.isConnected) say('a focused nav button stopped the Live tab from updating');
+    }
   }catch(e){ say('the interaction assertions threw: '+e.message); }
   done();
 },25);

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -176,6 +176,76 @@ const tick=setInterval(()=>{
 """
 
 
+# The Inverters tab, which is where the page stops reporting and starts accepting input. Both
+# of these were reported from a real bridge on 2026-07-29 and neither is a layout question --
+# they are here because this is the only check that runs the actual page in a browser.
+INVERTERS_JS = r"""
+(function(){
+const fail=[];
+const say=m=>fail.push(m);
+const done=()=>{document.title=fail.length?'LAYOUT-FAIL '+fail.join(' || '):'LAYOUT-OK'};
+let tries=0;
+const tick=setInterval(async()=>{
+  if(!document.querySelector('.fleetrow') && ++tries<=80) return;
+  clearInterval(tick);
+  try{
+    goTab('inv');
+    await new Promise(r=>setTimeout(r,300));
+
+    // 1. "Add one by hand" must send a row the firmware will ACCEPT. It used to send
+    // {driver_id:''}, which validate() refuses with "must name a driver" -- so the button did
+    // nothing but raise an error, every time.
+    let sent=null;
+    const realPatch=window.patch;
+    window.patch=async b=>{sent=b;return{ok:true,body:{}}};
+    const realAlert=window.alert;
+    window.alert=()=>{};
+    await addExtra();
+    window.patch=realPatch; window.alert=realAlert;
+    if(!sent||!sent.additional_devices) say('adding a row by hand sent no device list');
+    else{
+      const row=sent.additional_devices[sent.additional_devices.length-1];
+      if(!row.driver_id) say('the new row names no driver, which the firmware refuses outright');
+      // And it must not land on an address something else already answers at: two units
+      // sharing one destroy each other's replies, and the row would be skipped at boot.
+      const addrOf=d=>String((d.options||{}).unit_id??(d.options||{}).address??'').trim();
+      const mine=addrOf(row);
+      if(mine!==''){
+        const others=[cfg.driver,...sent.additional_devices.slice(0,-1)].map(addrOf);
+        if(others.includes(mine)) say('the new row was given address '+mine+', already in use');
+      }
+    }
+
+    // 2. A control being used must survive the five-second refresh. Every paint replaces the
+    // tab's innerHTML, which shuts an open <select> -- so the driver list could not be read to
+    // the bottom before it closed itself.
+    togglePanel('wiz'); wizStep=4; paintInverters();
+    await new Promise(r=>setTimeout(r,100));
+    const sel=document.querySelector('#wizcard select');
+    if(!sel) say('the wizard offers no driver dropdown to choose from');
+    else{
+      sel.focus();
+      paint();
+      await new Promise(r=>setTimeout(r,50));
+      if(document.querySelector('#wizcard select')!==sel){
+        say('a refresh replaced the driver dropdown while it was being used');
+      }
+      // The other half: the guard must RELEASE. A tab that stops updating once anything was
+      // ever touched is a worse bug than the one being fixed.
+      sel.blur();
+      paint();
+      await new Promise(r=>setTimeout(r,50));
+      if(document.querySelector('#wizcard select')===sel){
+        say('the tab never repainted again after the control was left alone');
+      }
+    }
+  }catch(e){ say('the interaction assertions threw: '+e.message); }
+  done();
+},25);
+})();
+"""
+
+
 def find_chrome() -> str | None:
     for name in (
         "google-chrome",
@@ -276,6 +346,11 @@ def main() -> int:
             page = build_page(stripped, stub, f"{{soc:{soc},power:{power}}}", js)
             verdict, _ = render(chrome, page, 1000, scratch, label)
             status |= report(f"battery {label}", verdict)
+
+        # The tab that takes input rather than only showing it.
+        page = build_page(stripped, stub, "{soc:68,power:-1240}", INVERTERS_JS)
+        verdict, _ = render(chrome, page, 1000, scratch, "inverters")
+        status |= report("inverters tab interaction", verdict)
 
     return status
 

--- a/tools/demo_fleet.js
+++ b/tools/demo_fleet.js
@@ -113,7 +113,7 @@
     modbus:{enabled:true,port:502,unit_id:1,max_clients:8,idle_timeout_seconds:120},
     polling:{interval_seconds:10},
     serial:{override:false,baud_rate:9600,parity:'none',data_bits:8,stop_bits:1},
-    driver:{id:'eversolar_legacy',label:'Schuur',options:{}},
+    driver:{id:'eversolar_legacy',label:'Schuur',options:{layout:'auto',address:'16'}},
     additional_devices:[
       {driver_id:'growatt_modbus',label:'Garage',options:{profile:'sph_3_6kw',unit_id:'2'}},
       {driver_id:'growatt_modbus',label:'Dak achter',options:{profile:'mic_tl_x',unit_id:'3'}}],
@@ -127,7 +127,13 @@
   const driversDoc = {drivers:[
     {id:'eversolar_legacy',display_name:'EverSolar / Zeversolar legacy',support_level:'beta',
       description:'AA55 framing over RS485, for TL-series inverters abandoned by their portal.',
-      serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],options:[]},
+      serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
+      options:[
+        {key:'layout',display_name:'Payload layout',allowed_values:['auto','single','dual'],
+         default_value:'auto',description:'How to read the measurement payload; auto derives it from the frame length.'},
+        {key:'address',display_name:'Assigned bus address',default_value:'16',
+         min_value:16,max_value:254,
+         description:'Address this bridge hands its inverter at registration. Leave at 16 unless more than one shares the loop.'}]},
     {id:'growatt_modbus',display_name:'Growatt (Modbus)',support_level:'experimental',
       description:'Modbus RTU. The register map is a data file, so one driver serves several models.',
       serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],


### PR DESCRIPTION
Two bugs reported from a real bridge. Neither is cosmetic — one feature could not work at all.

## 1. "Add one by hand" always failed

```js
arr.push({driver_id:'',label:'',options:{}});
const r=await patch({additional_devices:arr});
```

`validate()` refuses an extra device that names no driver, so the button answered
**`additional_devices[N].driver_id: must name a driver`** every single time. The comment above
that line even said an empty driver is refused — it described the outcome and shipped it anyway.

### The row now arrives complete

The **primary's driver** is the guess: a second inverter on one bus is usually another of the
same make, and it is one dropdown away from being changed.

The **address is not guessed**. Leaving it at the driver's default puts the new unit on top of
the primary, and two units answering to one address destroy each other's replies — the row would
be accepted and then skipped at boot with only a log line. The first free address is picked,
read from the driver's own declared option the same way `addressProblem()` reads it to complain
about a collision.

Verified in a browser against the real page:

```
driver=eversolar_legacy  options={"address":"17"}
```

16 is the primary's, so it took 17.

## 2. Every refresh shut any open dropdown

Each paint replaces the tab's `innerHTML`, which destroys and rebuilds everything inside it —
and `refresh()` runs on every event the bridge emits, up to once a second. The driver list on
the Inverters tab closed before you could read to the bottom of it. A half-typed address or
label went the same way.

The page now defers a **timer-driven** repaint while the reader is using a control, asked of
`document.activeElement` rather than of a flag: a `<select>` holds focus for exactly as long as
its popup is open, which makes the question "is somebody using this right now" answerable
directly.

Guarding `paint()` alone was not enough — `loadInverters()` repaints on its own path and is
called from the timer. It defers too, unless `force` says a person just saved, removed or added
something and the result is the whole point of the repaint.

**The tab must also start again.** A guard that never releases is a worse bug than the one it
fixes, so that half is asserted too.

## The demo stub was lying, and it mattered here

`tools/demo_fleet.js` gave `eversolar_legacy` no options at all. The real descriptor declares
`layout` **and** `address` (default 16, range 16–254).

With no address option there would have been nothing for the new code to collide with, so the
fix would have looked correct against a fiction. The stub now matches the descriptor.

## Pinned, and mutation-tested both ways

`check_dashboard_layout.py` is the only check that runs the real page in a browser, so the
Inverters tab now gets a pass there too. Restore each bug and the right assertion fails:

| mutation | what the check says |
|---|---|
| push the empty row again | `the new row names no driver, which the firmware refuses outright` |
| remove the repaint guard | `a refresh replaced the driver dropdown while it was being used` |

It also asserts the new row does not land on an address something else already answers at, and
that the tab resumes repainting once the control is left alone.

## Verification

846 native tests, five widths, five battery cases, the new interaction pass, layering and the JS
checks green, firmware builds at 1 542 359 bytes.

## Not covered

The firmware's own refusal is not exercised — the demo stub accepts any PATCH, so the check
proves the row is *well formed*, not that this bridge accepts it. The shape is checked against
`validate()` by reading, and by the fact that the reported error names exactly the field that is
now filled in.
