### PR TITLE
feat(web): a bridge nobody has configured is invited, not accused

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -398,6 +398,10 @@ function paintChrome(){
   // learn to ignore. With one device this is the header it has always been, stale tag included.
   const inv=multi
     ?chip(answering===expected?'ok':'bad',`Inverters ${esc(answering)}/${esc(expected)} answering`)
+    // Amber, not red, and no stale/no-data tags: a bridge nobody has configured is not failing
+    // at anything. It wants attention, which is what amber says, and the wiring alarm belongs
+    // to a bus somebody has actually connected.
+    :neverConfigured()?chip('warn','No inverter set up yet')
     :chip(d.online?'ok':'bad','Inverter'+(d.data_stale?' <span class="tag">stale</span>':'')+
        (d.data_valid?'':' <span class="tag">no data</span>'));
   $('#chips').innerHTML=inv+
@@ -433,8 +437,44 @@ function isFleet(s){
   const expected=(s.bridge||{}).devices_configured??polled;
   return expected>1||polled>1;
 }
+/// True when nobody has ever told this bridge what it is connected to.
+///
+/// The setup portal saves a network and an admin password and nothing else, so `driver.id`
+/// stays empty on a bridge that has just been provisioned. The firmware then starts its
+/// highest-priority driver anyway -- something has to be polled -- and that device never
+/// answers, because no inverter has been chosen, let alone wired.
+///
+/// Without this the first screen after setup accused the owner of a wiring fault: three named
+/// causes, A/B swapped at the top, for a bus they had not touched yet. The diagnosis is right
+/// for a bridge someone has connected something to and wrong for one still in its box, and the
+/// two look identical from the poll results alone -- the difference is only in the config.
+///
+/// Undefined while cfg is still loading, and that is deliberate: "we have not asked yet" must
+/// not flash a first-run panel at somebody with four working inverters.
+function neverConfigured(){
+  return !!cfg && !((cfg.driver||{}).id||'') && !((cfg.additional_devices||[]).length);
+}
+/// The one thing to do next, said once and shown wherever the reader happens to be.
+/// `here` is true when the Inverters tab is drawing it. That tab already carries the heading
+/// and is already where the second button would send you, so it gets neither -- a card that
+/// repeats the title above it and offers to take you where you are reads like a bug.
+function firstRunCard(here){
+  return `<div class="card" style="margin-top:20px">
+    ${here?'':'<div style="font-size:17px;font-weight:600">No inverter set up yet</div>'}
+    <div class="hint" style="margin-top:6px">The bridge is on your network and reachable — that
+      part is done. What it does not know yet is what is on the other end of the RS485 pair.</div>
+    <div class="hint" style="margin-top:8px">Wire A, B and ground to the inverter first, then let
+      the bridge look for it. Discovery listens at each driver's own line speed and reports what
+      answered; nothing is written to the inverter and nothing is changed until you confirm.</div>
+    <div class="acts"><button onclick="${here?"togglePanel('wiz')":"goTab('inv');togglePanel('wiz')"}">Find my inverter</button>
+      ${here?'':'<button class="alt" onclick="goTab(\'inv\')">Open the Inverters tab</button>'}</div>
+  </div>`;
+}
 function paintLive(){
   if(!S)return;
+  // Before anything else: a bridge nobody has configured has no production to lead with, and a
+  // headline dash over an empty page is not an answer to "what now".
+  if(neverConfigured()){$('#live').innerHTML=firstRunCard(false);return}
   const b=S.bridge, d=S.device, m=S.measurements||{}, fleet=S.devices||[], tot=S.totals||{};
   const expected=b.devices_configured??(tot.devices_polled??fleet.length);
   const multi=isFleet(S);
@@ -601,8 +641,9 @@ function paintInverters(){
   const b=S.bridge, problems=b.device_problems||[];
   const configured=b.devices_configured??invIds.length;
   let h=`<div class="between">
-    <div><div style="font-size:17px;font-weight:600">${esc(invIds.length)} inverter${invIds.length===1?'':'s'} polled${
-      configured!==invIds.length?` of ${esc(configured)} configured`:''}</div>
+    <div><div style="font-size:17px;font-weight:600">${neverConfigured()?'No inverter set up yet'
+      :`${esc(invIds.length)} inverter${invIds.length===1?'':'s'} polled${
+        configured!==invIds.length?` of ${esc(configured)} configured`:''}`}</div>
       <div class="hint">All on the onboard RS485 bus, polled in turn. Up to ${esc(b.max_devices||8)}.</div></div>
     <div class="acts" style="margin:0">
       <button onclick="togglePanel('wiz')">${panel==='wiz'?'Close':'Find inverters'}</button>
@@ -614,7 +655,12 @@ function paintInverters(){
   // is where the wizard's old advice ran out at "check your wiring" -- these are the three
   // causes in the order they actually happen, each with the test that settles it.
   const silent=invIds.filter(id=>(devCache[id]||{}).last_successful_poll_seconds_ago==null);
-  if(problems.length||configured!==invIds.length||silent.length){
+  // A bridge nobody has configured yet is silent for a reason that has nothing to do with its
+  // wiring, so it gets the invitation rather than the diagnosis. Everything below is written
+  // for someone who HAS connected an inverter and is not getting a reply from it.
+  if(neverConfigured()){
+    h+=firstRunCard(true);
+  }else if(problems.length||configured!==invIds.length||silent.length){
     const who=silent.map(id=>esc((devCache[id]||{}).label||id)).join(', ');
     h+=`<div class="card bad" style="margin-top:14px">
       <b>${silent.length?who+(silent.length===1?' has':' have')+' never replied':'Not every configured inverter started'}</b>
@@ -641,8 +687,11 @@ function paintInverters(){
       </div></div>`;
   }
 
+  // Nothing configured means nothing to list. The firmware still started its default driver --
+  // something has to be polled -- but showing that placeholder in red as "never answered"
+  // contradicts the invitation directly above it, and the reader never asked for it.
   h+='<div class="stack" style="margin-top:14px">';
-  for(const id of invIds){
+  for(const id of (neverConfigured()?[]:invIds)){
     const dev=devCache[id]||{}, m=measCache[id]||{}, caps=capsCache[id];
     const ident=dev.identity||{}, drv=dev.driver||{};
     const ago=dev.last_successful_poll_seconds_ago;
@@ -685,7 +734,7 @@ function paintInverters(){
   // decide what happens on the wire, and both need a restart.
   const c=cfg||{};
   h+=`<div class="card" style="margin-top:12px">
-    <div class="between"><div><b>Bus &amp; polling</b> <span class="tag warn">needs restart</span></div>
+    <div class="between"><div><b>Bus &amp; polling</b> <span class="tag warn">changes here need a restart</span></div>
       <button class="alt sm" onclick="togglePanel('bus')">${panel==='bus'?'Close':'Change'}</button></div>
     <div class="hint">${c.serial?`${esc(c.serial.baud_rate)} ${esc(c.serial.data_bits)}${esc(String(c.serial.parity||'n')[0].toUpperCase())}${esc(c.serial.stop_bits)}, ${c.serial.override?'<b>overridden here</b>':'set by the driver'}`:'—'} · polling every ${esc((c.polling||{}).interval_seconds??10)} s. Only override the line when discovery found a device at a profile the driver does not lead with — otherwise the driver decides, and that is right for almost every install.</div>
     ${panel==='bus'?busForm(c):''}

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -452,7 +452,15 @@ function isFleet(s){
 /// Undefined while cfg is still loading, and that is deliberate: "we have not asked yet" must
 /// not flash a first-run panel at somebody with four working inverters.
 function neverConfigured(){
-  return !!cfg && !((cfg.driver||{}).id||'') && !((cfg.additional_devices||[]).length);
+  if(!cfg||!S)return false;
+  if(((cfg.driver||{}).id||'')||((cfg.additional_devices||[]).length))return false;
+  // AND nothing is answering. An empty driver.id is a legitimate, documented setting -- "let
+  // the firmware pick the highest-priority driver" -- so a bridge wired to the inverter that
+  // driver happens to serve works perfectly with this field never filled in. Reading the config
+  // alone hid a fleet producing 1850 W behind "no inverter set up yet", which is a worse lie
+  // than the wiring accusation it replaced (review, 2026-07-29: found by rendering it).
+  if((S.totals||{}).devices_answering)return false;
+  return (S.device||{}).last_successful_poll_seconds_ago==null;
 }
 /// The one thing to do next, said once and shown wherever the reader happens to be.
 /// `here` is true when the Inverters tab is drawing it. That tab already carries the heading

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -108,6 +108,13 @@ button.alt{background:none;border:1px solid var(--line);color:var(--fg)}
 <div class="card">
   <p class="sub" style="margin:0">After saving, the bridge restarts and joins your network.
   This setup network disappears. Find it again by its hostname, or via your router.</p>
+  <!-- This page asks for a network and a password and nothing about the inverter, so it used to
+       end reading like the end of the job. It is not: the bridge arrives on the LAN knowing
+       nothing about what is on the RS485 pair, and the owner who thinks they are finished meets
+       a dashboard with no production on it. One sentence, here, where the expectation is set. -->
+  <p class="sub" style="margin:8px 0 0">One thing is left after that: telling it which inverter
+  it is wired to. Open <b>Inverters</b> on the dashboard and let it search — the RS485 pair (A, B
+  and ground) needs to be connected first.</p>
 </div>
 </div>
 <script>

--- a/tools/autopick_bridge.js
+++ b/tools/autopick_bridge.js
@@ -1,0 +1,96 @@
+// A bridge running on the AUTO-PICKED driver, and working. driver.id is empty -- which is a
+// documented, legitimate setting meaning "let the firmware choose the highest-priority driver"
+// -- and the inverter it happens to serve is answering, producing 1850 W.
+//
+// This is the case that makes "is the config empty?" the wrong question on its own. Reading
+// only the config hid a producing fleet behind "no inverter set up yet".
+(function(){
+  const status = {
+    device:{online:true,data_valid:true,data_stale:false,last_successful_poll_seconds_ago:4},
+    bridge:{firmware_version:'0.23.0',board_id:'waveshare-rs485-can',
+      board_name:'Waveshare ESP32-S3-RS485-CAN',hostname:'heliograph-a1b2c3',
+      uptime_seconds:41,wifi_connected:true,wifi_rssi_dbm:-61,mqtt_connected:false,
+      modbus_listening:true,modbus_clients:0,time_synced:true,time:'2026-07-29 09:12:03',
+      devices_configured:1,devices_started:1,devices_polled:1,max_devices:8,
+      device_problems:[],relays:[]},
+    status_text:'',error_code:null,
+    measurements:{'ac.power.total':{value:1850,unit:'W'},'energy.today':{value:9.2,unit:'kWh'},'energy.total':{value:12034.5,unit:'kWh'}},
+    devices:[{id:'eversolar_legacy-unknown',label:'',online:false,data_valid:false,
+      data_stale:true,last_successful_poll_seconds_ago:4,ac_power_w:1850,
+      energy_today_kwh:null,ac_voltage_v:null,temperature_c:null,
+      battery_soc_pct:null,battery_power_w:null}],
+    totals:{ac_power_w:0,ac_power_devices:0,energy_today_kwh:0,energy_today_devices:0,
+      energy_total_kwh:0,energy_total_devices:0,devices_polled:1,devices_answering:1},
+    poll_success_total:0,poll_failure_total:37
+  };
+  const config = {
+    bridge_name:'Heliograph',
+    wifi:{ssid:'Zonnehuis',hostname:'heliograph-a1b2c3',password_set:true,ip:'',gateway:'',
+      subnet:'',dns1:'',dns2:''},
+    mqtt:{enabled:false,host:'',port:1883,username_set:false,password_set:false,
+      base_topic:'heliograph',discovery_enabled:true},
+    modbus:{enabled:true,port:502,unit_id:1,max_clients:8,idle_timeout_seconds:120},
+    polling:{interval_seconds:10},
+    serial:{override:false,baud_rate:9600,parity:'none',data_bits:8,stop_bits:1},
+    // What provisioning leaves behind: no driver named at all.
+    driver:{id:'',label:'',options:{}},
+    additional_devices:[],
+    ntp:{enabled:true,use_dhcp:true,server:'pool.ntp.org',
+      timezone:'CET-1CEST,M3.5.0,M10.5.0/3',timezone_name:'Europe/Amsterdam'},
+    security:{password_set:true,read_only_mode:true},
+    logging:{level:'info'}, updates:{check_enabled:true}, relays:{enabled:false,roles:[]}
+  };
+  const driversDoc = {drivers:[
+    {id:'eversolar_legacy',display_name:'EverSolar / Zeversolar legacy',support_level:'beta',
+      description:'AA55 framing over RS485, for TL-series inverters abandoned by their portal.',
+      serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
+      options:[{key:'layout',display_name:'Payload layout',allowed_values:['auto','single','dual'],
+                default_value:'auto',description:'auto derives it from the frame length.'},
+               {key:'address',display_name:'Assigned bus address',default_value:'16',
+                min_value:16,max_value:254,description:'Handed to the inverter at registration.'}]},
+    {id:'growatt_modbus',display_name:'Growatt (Modbus)',support_level:'experimental',
+      description:'Modbus RTU. The register map is a data file.',
+      serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
+      options:[{key:'profile',display_name:'Register map',allowed_values:['','sph_3_6kw','mic_tl_x'],
+                default_value:'',description:'Which model this unit is.'},
+               {key:'unit_id',display_name:'Bus address',default_value:'1',min_value:1,max_value:247,
+                description:'Must match the address in the inverter’s menu.'}]},
+  ]};
+  const diagnostics = {uptime_seconds:41,firmware_version:'0.23.0',
+    board:'Waveshare ESP32-S3-RS485-CAN',free_heap_bytes:201000,minimum_free_heap_bytes:198000,
+    max_alloc_heap_bytes:120000,reset_reason:'power-on',ota_image_state:'valid',
+    coredump_present:false,wifi_connected:true,wifi_rssi_dbm:-61,mqtt_connected:false,
+    time_synced:true,time:'2026-07-29 09:12:03',poll_success_total:0,poll_failure_total:37,
+    consecutive_poll_failures:37,checksum_error_total:0,rs485_timeout_total:37,
+    invalid_frame_total:0,last_error:'no reply from the inverter'};
+
+  const json=(b,s)=>Promise.resolve(new Response(JSON.stringify(b),
+    {status:s||200,headers:{'Content-Type':'application/json'}}));
+  window.__discoveryReport = {status:'done',busy:false,candidates:[]};  // the empty-handed case
+  window.fetch=(url,opts)=>{
+    const u=String(url);
+    const m=u.match(/^\/api\/v1\/devices\/([^/?]+)(\/[a-z]+)?/);
+    if(m){
+      if(m[2]==='/measurements')return json({measurements:{}});
+      if(m[2]==='/capabilities')return json(null,404);
+      return json({id:decodeURIComponent(m[1]),label:'',
+        identity:{driver_id:'eversolar_legacy'},
+        driver:{id:'eversolar_legacy',display_name:'EverSolar / Zeversolar legacy',
+                support_level:'beta',supports_write:false},
+        online:true,data_valid:true,data_stale:false,
+        last_successful_poll_seconds_ago:4,consecutive_poll_failures:0});
+    }
+    if(u.startsWith('/api/v1/status'))return json(status);
+    if(u.startsWith('/api/v1/devices'))return json({devices:status.devices.map(d=>d.id)});
+    if(u.startsWith('/api/v1/config/backup'))return json(config);
+    if(u.startsWith('/api/v1/config'))return json(config);
+    if(u.startsWith('/api/v1/drivers'))return json(driversDoc);
+    if(u.startsWith('/api/v1/diagnostics'))return json(diagnostics);
+    if(u.startsWith('/api/v1/logs'))return json({level:'info',total:0,returned:0,lines:[]});
+    if(u.startsWith('/api/v1/discovery'))return json(window.__discoveryReport);
+    if(u.startsWith('/api/v1/capture'))return json({status:'idle'});
+    if(u.startsWith('/api/v1/'))return json({ok:true},202);
+    return Promise.reject(new Error('fresh bridge stub: no network'));
+  };
+  window.EventSource=function(){this.close=()=>{}};
+})();

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -306,6 +306,32 @@ const tick=setInterval(async()=>{
 """
 
 
+# A working bridge whose driver.id was never filled in. "Empty" means the firmware picks the
+# highest-priority driver, so somebody who wires up the inverter that driver serves and never
+# opens the wizard has exactly this configuration -- and 1850 W on screen.
+AUTOPICK_JS = r"""
+(function(){
+const fail=[];
+let tries=0;
+const tick=setInterval(async()=>{
+  if(!cfg && ++tries<=80) return;
+  clearInterval(tick);
+  try{
+    if(neverConfigured()) fail.push('a producing bridge was called unconfigured');
+    goTab('live');
+    await new Promise(r=>setTimeout(r,250));
+    const live=document.getElementById('live').textContent;
+    if(live.includes('No inverter set up yet')) fail.push('Live hides a producing inverter');
+    // sp() separates thousands with a THIN SPACE (U+2009), not an ordinary one. Matching on
+    // the plain-space form silently found nothing and reported the production as missing.
+    if(!live.includes('1\u2009850')) fail.push('Live does not show the production');
+  }catch(e){ fail.push('the auto-pick assertions threw: '+e.message); }
+  document.title=fail.length?'LAYOUT-FAIL '+fail.join(' || '):'LAYOUT-OK';
+},25);
+})();
+"""
+
+
 def find_chrome() -> str | None:
     for name in (
         "google-chrome",
@@ -419,6 +445,14 @@ def main() -> int:
         page = page.replace("</body>", f"<script>{FRESH_BRIDGE_JS}</script></body>", 1)
         verdict, _ = render(chrome, page, 1000, scratch, "fresh")
         status |= report("first run, nothing configured", verdict)
+
+        # The mirror image, and the reason the config alone is not the question: driver.id is
+        # equally empty here, but the inverter it auto-picked is answering.
+        auto = (ROOT / "tools" / "autopick_bridge.js").read_text(encoding="utf-8")
+        page = build_web.inject_before_script(stripped, auto)
+        page = page.replace("</body>", f"<script>{AUTOPICK_JS}</script></body>", 1)
+        verdict, _ = render(chrome, page, 1000, scratch, "autopick")
+        status |= report("auto-picked driver, answering", verdict)
 
     return status
 

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -262,6 +262,50 @@ const tick=setInterval(async()=>{
 """
 
 
+# A bridge that has just been provisioned: on the network, admin password set, and nothing ever
+# said about the RS485 side. The firmware still starts its highest-priority driver, which never
+# answers -- so from the poll results alone this is indistinguishable from a miswired bus.
+#
+# It used to be shown as one: three named wiring causes, A/B swapped at the top, on the very
+# first screen after setup. Everything here exists so that the page reads the CONFIG instead and
+# invites rather than accuses.
+FRESH_BRIDGE_JS = r"""
+(function(){
+const fail=[];
+const say=m=>fail.push(m);
+let tries=0;
+const tick=setInterval(async()=>{
+  if(!cfg && ++tries<=80) return;
+  clearInterval(tick);
+  try{
+    if(!neverConfigured()) say('the fresh-bridge stub was not recognised as unconfigured');
+    for(const tab of ['live','inv']){
+      goTab(tab);
+      await new Promise(r=>setTimeout(r,250));
+      const body=document.getElementById(tab).textContent;
+      if(!body.includes('No inverter set up yet')){
+        say(tab+' does not say an inverter still has to be set up');
+      }
+      // The wiring diagnosis is for a bus somebody has connected. Naming a fault on one that
+      // was never wired is the accusation this whole branch exists to stop.
+      for(const accusation of ['A and B swapped','Termination in the wrong place','never replied']){
+        if(body.includes(accusation)) say(tab+' blames the wiring: "'+accusation+'"');
+      }
+    }
+    // Live must offer a way in rather than a dead headline.
+    goTab('live');
+    await new Promise(r=>setTimeout(r,250));
+    if(!document.querySelector('#live button')) say('Live offers nothing to do next');
+    // And the header must not raise an alarm about a bus nobody has connected.
+    const chips=document.getElementById('chips');
+    if(chips.querySelector('.dot.bad')) say('the header shows a fault on an unconfigured bridge');
+  }catch(e){ say('the fresh-bridge assertions threw: '+e.message); }
+  document.title=fail.length?'LAYOUT-FAIL '+fail.join(' || '):'LAYOUT-OK';
+},25);
+})();
+"""
+
+
 def find_chrome() -> str | None:
     for name in (
         "google-chrome",
@@ -367,6 +411,14 @@ def main() -> int:
         page = build_page(stripped, stub, "{soc:68,power:-1240}", INVERTERS_JS)
         verdict, _ = render(chrome, page, 1000, scratch, "inverters")
         status |= report("inverters tab interaction", verdict)
+
+        # And the state every owner passes through exactly once, on a different stub: a bridge
+        # that has just been provisioned and has never been told what it is wired to.
+        fresh = (ROOT / "tools" / "fresh_bridge.js").read_text(encoding="utf-8")
+        page = build_web.inject_before_script(stripped, fresh)
+        page = page.replace("</body>", f"<script>{FRESH_BRIDGE_JS}</script></body>", 1)
+        verdict, _ = render(chrome, page, 1000, scratch, "fresh")
+        status |= report("first run, nothing configured", verdict)
 
     return status
 

--- a/tools/fresh_bridge.js
+++ b/tools/fresh_bridge.js
@@ -1,0 +1,92 @@
+// A bridge that has just been provisioned and rebooted: on the WiFi, admin password set, and
+// no inverter answering yet. Nothing has been configured on the RS485 side at all.
+(function(){
+  const status = {
+    device:{online:false,data_valid:false,data_stale:true,last_successful_poll_seconds_ago:null},
+    bridge:{firmware_version:'0.23.0',board_id:'waveshare-rs485-can',
+      board_name:'Waveshare ESP32-S3-RS485-CAN',hostname:'heliograph-a1b2c3',
+      uptime_seconds:41,wifi_connected:true,wifi_rssi_dbm:-61,mqtt_connected:false,
+      modbus_listening:true,modbus_clients:0,time_synced:true,time:'2026-07-29 09:12:03',
+      devices_configured:1,devices_started:1,devices_polled:1,max_devices:8,
+      device_problems:[],relays:[]},
+    status_text:'',error_code:null,
+    measurements:{},
+    devices:[{id:'eversolar_legacy-unknown',label:'',online:false,data_valid:false,
+      data_stale:true,last_successful_poll_seconds_ago:null,ac_power_w:null,
+      energy_today_kwh:null,ac_voltage_v:null,temperature_c:null,
+      battery_soc_pct:null,battery_power_w:null}],
+    totals:{ac_power_w:0,ac_power_devices:0,energy_today_kwh:0,energy_today_devices:0,
+      energy_total_kwh:0,energy_total_devices:0,devices_polled:1,devices_answering:0},
+    poll_success_total:0,poll_failure_total:37
+  };
+  const config = {
+    bridge_name:'Heliograph',
+    wifi:{ssid:'Zonnehuis',hostname:'heliograph-a1b2c3',password_set:true,ip:'',gateway:'',
+      subnet:'',dns1:'',dns2:''},
+    mqtt:{enabled:false,host:'',port:1883,username_set:false,password_set:false,
+      base_topic:'heliograph',discovery_enabled:true},
+    modbus:{enabled:true,port:502,unit_id:1,max_clients:8,idle_timeout_seconds:120},
+    polling:{interval_seconds:10},
+    serial:{override:false,baud_rate:9600,parity:'none',data_bits:8,stop_bits:1},
+    // What provisioning leaves behind: no driver named at all.
+    driver:{id:'',label:'',options:{}},
+    additional_devices:[],
+    ntp:{enabled:true,use_dhcp:true,server:'pool.ntp.org',
+      timezone:'CET-1CEST,M3.5.0,M10.5.0/3',timezone_name:'Europe/Amsterdam'},
+    security:{password_set:true,read_only_mode:true},
+    logging:{level:'info'}, updates:{check_enabled:true}, relays:{enabled:false,roles:[]}
+  };
+  const driversDoc = {drivers:[
+    {id:'eversolar_legacy',display_name:'EverSolar / Zeversolar legacy',support_level:'beta',
+      description:'AA55 framing over RS485, for TL-series inverters abandoned by their portal.',
+      serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
+      options:[{key:'layout',display_name:'Payload layout',allowed_values:['auto','single','dual'],
+                default_value:'auto',description:'auto derives it from the frame length.'},
+               {key:'address',display_name:'Assigned bus address',default_value:'16',
+                min_value:16,max_value:254,description:'Handed to the inverter at registration.'}]},
+    {id:'growatt_modbus',display_name:'Growatt (Modbus)',support_level:'experimental',
+      description:'Modbus RTU. The register map is a data file.',
+      serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
+      options:[{key:'profile',display_name:'Register map',allowed_values:['','sph_3_6kw','mic_tl_x'],
+                default_value:'',description:'Which model this unit is.'},
+               {key:'unit_id',display_name:'Bus address',default_value:'1',min_value:1,max_value:247,
+                description:'Must match the address in the inverter’s menu.'}]},
+  ]};
+  const diagnostics = {uptime_seconds:41,firmware_version:'0.23.0',
+    board:'Waveshare ESP32-S3-RS485-CAN',free_heap_bytes:201000,minimum_free_heap_bytes:198000,
+    max_alloc_heap_bytes:120000,reset_reason:'power-on',ota_image_state:'valid',
+    coredump_present:false,wifi_connected:true,wifi_rssi_dbm:-61,mqtt_connected:false,
+    time_synced:true,time:'2026-07-29 09:12:03',poll_success_total:0,poll_failure_total:37,
+    consecutive_poll_failures:37,checksum_error_total:0,rs485_timeout_total:37,
+    invalid_frame_total:0,last_error:'no reply from the inverter'};
+
+  const json=(b,s)=>Promise.resolve(new Response(JSON.stringify(b),
+    {status:s||200,headers:{'Content-Type':'application/json'}}));
+  window.__discoveryReport = {status:'done',busy:false,candidates:[]};  // the empty-handed case
+  window.fetch=(url,opts)=>{
+    const u=String(url);
+    const m=u.match(/^\/api\/v1\/devices\/([^/?]+)(\/[a-z]+)?/);
+    if(m){
+      if(m[2]==='/measurements')return json({measurements:{}});
+      if(m[2]==='/capabilities')return json(null,404);
+      return json({id:decodeURIComponent(m[1]),label:'',
+        identity:{driver_id:'eversolar_legacy'},
+        driver:{id:'eversolar_legacy',display_name:'EverSolar / Zeversolar legacy',
+                support_level:'beta',supports_write:false},
+        online:false,data_valid:false,data_stale:true,
+        last_successful_poll_seconds_ago:null,consecutive_poll_failures:37});
+    }
+    if(u.startsWith('/api/v1/status'))return json(status);
+    if(u.startsWith('/api/v1/devices'))return json({devices:status.devices.map(d=>d.id)});
+    if(u.startsWith('/api/v1/config/backup'))return json(config);
+    if(u.startsWith('/api/v1/config'))return json(config);
+    if(u.startsWith('/api/v1/drivers'))return json(driversDoc);
+    if(u.startsWith('/api/v1/diagnostics'))return json(diagnostics);
+    if(u.startsWith('/api/v1/logs'))return json({level:'info',total:0,returned:0,lines:[]});
+    if(u.startsWith('/api/v1/discovery'))return json(window.__discoveryReport);
+    if(u.startsWith('/api/v1/capture'))return json({status:'idle'});
+    if(u.startsWith('/api/v1/'))return json({ok:true},202);
+    return Promise.reject(new Error('fresh bridge stub: no network'));
+  };
+  window.EventSource=function(){this.close=()=>{}};
+})();


### PR DESCRIPTION
The first-run review, and what it found.

## What a new owner actually saw

I simulated a just-provisioned bridge — on the network, admin password set, nothing ever said
about the RS485 side — and rendered the screens.

**The first screen after setup accused them of a wiring fault.** A red card headed
*"eversolar_legacy-unknown has never replied"*, naming three causes with A/B swapped at the top,
about a pair they had not touched yet.

**The Live tab was a dead end.** A dash where the production goes, "not replying", and then a
blank page. Nothing said an inverter still had to be set up, and nothing pointed anywhere.

## Why the page could not tell

The setup portal saves a network and an admin password and nothing else, so `driver.id` stays
empty. The firmware starts its highest-priority driver anyway — something has to be polled — and
that device never answers.

From the poll results alone that is **identical** to a miswired bus. The difference is only in
the config, which is what `neverConfigured()` now reads.

The diagnosis card is unchanged and still exactly right for a bus somebody has connected.

## Four more false alarms on the same screen

| | |
|---|---|
| the heading | counted the placeholder as "1 inverter polled" |
| its device card | listed in red as never having answered — a device nobody chose, directly contradicting the invitation above it |
| the header chip | red dot, "stale", "no data" — now amber and "No inverter set up yet" |
| "Bus & polling" | a permanent amber **needs restart** badge |

That last one is **a plain bug, not a first-run problem**. The markup is static, so it said
"needs restart" on every bridge, always. Its five sibling cards all say *"changes here need a
restart"* — a property of the card. One of the six claimed a state, and the header has a real
restart queue that this undermined.

## The portal now says what is left

It asked for a network and a password and nothing about the inverter, so it read like the end of
the job. One sentence, where the expectation is set.

## Pinned

`tools/fresh_bridge.js` is a stub of a just-provisioned device. The check asserts both tabs say
an inverter is still to be set up, that neither names a wiring fault, that Live offers something
to press, and that the header raises no red dot.

Mutation-tested — make `neverConfigured()` return false:

```
first run, nothing configured: FAIL
  the fresh-bridge stub was not recognised as unconfigured
  live does not say an inverter still has to be set up
  inv does not say an inverter still has to be set up
  inv blames the wiring: "A and B swapped"
  inv blames the wiring: "Termination in the wrong place"
```

## What I found working and did not touch

The **setup portal** is good: network scan with signal strength, admin password required with
the cost of a typo spelled out, backup restore with a preview, and closing instructions.

The **discovery wizard** handles finding nothing well — it names the extended scan and offers
the raw-bus recorder with an explanation that actually helps (a wrong baud rate gives plenty of
bytes and no valid checksums, and that is how you tell).

## Verification

846 native tests, five widths, five battery cases, the interaction pass and the new first-run
pass, layering and JS checks green, firmware builds at 1 543 047 bytes.