### PR TITLE
fix(web): the added row landed on the primary's address and could not be taken back

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -746,7 +746,16 @@ function paintInverters(){
   // started is still waiting. Each carries the one thing it needs, which is a way back out.
   if(!neverConfigured()){
     const extras=(cfg&&cfg.additional_devices)||[];
-    for(let i=Math.max(0,invIds.length-1);i<extras.length;i++){
+    // Matched by DRIVER, not by position. Position holds only while every row starts in order,
+    // and planDevices refuses a row whose driver cannot share a bus while letting later ones
+    // through -- so [X, X, Y] starts X and Y, and counting would have called Y the pending one.
+    // Y is running; the Remove button on that card would have taken out the wrong inverter.
+    const running=invIds.slice(1).map(id=>((devCache[id]||{}).driver||{}).id
+                                       ||((devCache[id]||{}).identity||{}).driver_id||'');
+    const unmatched=[...running];
+    for(let i=0;i<extras.length;i++){
+      const at=unmatched.indexOf(extras[i].driver_id);
+      if(at>=0){unmatched.splice(at,1);continue}  // this row has a device of its own
       const e=extras[i], addr=addressOf(e.driver_id,e.options);
       const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===e.driver_id);
       h+=`<div class="card" style="border-color:var(--warn)">

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -736,6 +736,29 @@ function paintInverters(){
       ${panel==='s:'+id?deviceForm(id,dev):''}
     </div>`;
   }
+
+  // Rows that are in the configuration but did not start: added since the last restart. They
+  // have no device id, so they get no card above and nothing else on this page mentions them
+  // except the "N configured" count -- which is how a freshly added row became impossible to
+  // edit OR remove without a reboot.
+  //
+  // Sliced by position: extras start in configuration order, so anything past the ones that
+  // started is still waiting. Each carries the one thing it needs, which is a way back out.
+  if(!neverConfigured()){
+    const extras=(cfg&&cfg.additional_devices)||[];
+    for(let i=Math.max(0,invIds.length-1);i<extras.length;i++){
+      const e=extras[i], addr=addressOf(e.driver_id,e.options);
+      const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===e.driver_id);
+      h+=`<div class="card" style="border-color:var(--warn)">
+        <div class="between"><div><b>${esc(e.label||'Inverter '+(i+2))}</b>
+          <span class="tag warn">starts after a restart</span></div>
+          <button class="dangerAlt sm" onclick="removeExtraAt(${i})">Remove</button></div>
+        <div class="hint">${esc((drv&&drv.display_name)||e.driver_id||'no driver chosen')}${
+          addr?' · address '+esc(addr):''} — added to the configuration, not polled yet. Restart
+          the bridge to start it, or remove it here.</div>
+      </div>`;
+    }
+  }
   h+='</div>';
 
   // Bus and polling. One card, because the interval and the line are the same subject: both
@@ -1440,11 +1463,20 @@ function addressProblem(body){
   }
   return null;
 }
-async function removeDevice(id){
+async function removeDevice(id){ return removeExtraAt(invIds.indexOf(id)-1) }
+/// Removes an extra device by its position in the CONFIGURATION, which is the only handle a row
+/// that has not started yet has.
+///
+/// removeDevice() went through invIds -- the devices that actually started at boot -- so a row
+/// added since the last restart was not in it, had no card, and therefore had no button either.
+/// The alert offering to "open Name, driver and address on the new inverter" pointed at
+/// something that did not exist, and the configuration could not be undone from the UI at all
+/// (hardware, 2026-07-29).
+async function removeExtraAt(idx){
+  const arr=(cfg.additional_devices)||[];
+  if(idx<0||idx>=arr.length){alert('That row is no longer in the configuration.');return}
   if(!confirm('Remove this inverter from the configuration? Its entities stay in Home Assistant showing their last value.'))return;
-  const idx=invIds.indexOf(id)-1;
-  const arr=((cfg.additional_devices)||[]).filter((_,i)=>i!==idx);
-  const r=await patch({additional_devices:arr});
+  const r=await patch({additional_devices:arr.filter((_,i)=>i!==idx)});
   if(!r.ok){say('#dv_msg','err',esc(r.why));return}
   panel=null;invNextMs=0;loadInverters(true);
 }
@@ -1453,6 +1485,20 @@ async function removeDevice(id){
 function addressOptionOf(drvId){
   const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
   return ((drv&&drv.options)||[]).find(o=>o.key==='unit_id'||o.key==='address')||null;
+}
+/// The address a device actually answers at, resolved the way the FIRMWARE resolves it: the
+/// stored option when there is one, and otherwise the option's declared default. See
+/// DriverDescriptor::optionOr -- an absent key is not an absent address.
+///
+/// Reading only the stored options is what put a second inverter straight on top of the first.
+/// A primary configured through the wizard carries options:{} and answers at its driver's
+/// default of 16, so a search over stored values alone saw nothing taken and handed out 16
+/// (found on hardware, 2026-07-29, by adding a row and watching it collide).
+function addressOf(driverId,options){
+  const opt=addressOptionOf(driverId);
+  if(!opt)return '';
+  const stored=String((options||{})[opt.key]??'').trim();
+  return stored!==''?stored:String(opt.default_value??'').trim();
 }
 async function addExtra(){
   const arr=((cfg.additional_devices)||[]).map(d=>({driver_id:d.driver_id,label:d.label||'',options:{...(d.options||{})}}));
@@ -1477,8 +1523,9 @@ async function addExtra(){
   const opt=addressOptionOf(primary);
   const options={};
   if(opt){
-    const taken=new Set([cfg.driver,...arr]
-      .map(d=>String((d.options||{})[opt.key]??'').trim()).filter(v=>v!==''));
+    const taken=new Set([[primary,(cfg.driver||{}).options],
+                         ...arr.map(d=>[d.driver_id,d.options])]
+      .map(([id,o])=>addressOf(id,o)).filter(v=>v!==''));
     let next=Number(opt.default_value||1);
     const ceiling=Number(opt.max_value||247);
     while(taken.has(String(next))&&next<=ceiling)next++;

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -208,12 +208,43 @@ const tick=setInterval(async()=>{
       if(!row.driver_id) say('the new row names no driver, which the firmware refuses outright');
       // And it must not land on an address something else already answers at: two units
       // sharing one destroy each other's replies, and the row would be skipped at boot.
-      const addrOf=d=>String((d.options||{}).unit_id??(d.options||{}).address??'').trim();
-      const mine=addrOf(row);
+      // Resolved the way the FIRMWARE resolves it: stored option, else the declared default
+      // (DriverDescriptor::optionOr). Written out here rather than calling the page's own
+      // addressOf(), so that a page which resolves it wrongly cannot agree with itself.
+      //
+      // The earlier version of this assertion read stored options only -- the same blind spot as
+      // the code it was testing -- so it watched a real bridge hand a second inverter the
+      // address the first was already answering at, and said nothing.
+      const addrOf=(driverId,options)=>{
+        const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===driverId)||{};
+        const opt=(drv.options||[]).find(o=>o.key==='unit_id'||o.key==='address');
+        if(!opt)return '';
+        const stored=String((options||{})[opt.key]??'').trim();
+        return stored!==''?stored:String(opt.default_value??'').trim();
+      };
+      const mine=addrOf(row.driver_id,row.options);
       if(mine!==''){
-        const others=[cfg.driver,...sent.additional_devices.slice(0,-1)].map(addrOf);
+        const others=[[cfg.driver.id,cfg.driver.options],
+                      ...sent.additional_devices.slice(0,-1).map(d=>[d.driver_id,d.options])]
+          .map(([i,o])=>addrOf(i,o));
         if(others.includes(mine)) say('the new row was given address '+mine+', already in use');
       }
+    }
+
+    // 1b. A row that is in the configuration but has not started must be VISIBLE and must
+    // offer a way back out. It has no device id, so it gets no ordinary card -- which is how a
+    // freshly added row became impossible to remove without a reboot, on a bridge whose owner
+    // had just been told to open a panel that did not exist.
+    cfg.additional_devices=[...(cfg.additional_devices||[]),
+                            {driver_id:'growatt_modbus',label:'',options:{unit_id:'9'}}];
+    paintInverters();
+    await new Promise(r=>setTimeout(r,100));
+    const inv=document.getElementById('inv');
+    if(!inv.textContent.includes('starts after a restart')){
+      say('a configured row that has not started is nowhere on the page');
+    }
+    if(![...inv.querySelectorAll('button')].some(b=>/removeExtraAt/.test(b.getAttribute('onclick')||''))){
+      say('a configured row that has not started offers no way to remove it');
     }
 
     // 2. A control being used must survive the five-second refresh. Every paint replaces the

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -247,6 +247,28 @@ const tick=setInterval(async()=>{
       say('a configured row that has not started offers no way to remove it');
     }
 
+    // 1c. Which rows are pending is decided by DRIVER, not by position. planDevices refuses a
+    // row whose driver cannot share a bus and lets later ones through, so counting started
+    // devices names the wrong row -- and its Remove button would take out an inverter that is
+    // running perfectly well.
+    cfg.additional_devices=[{driver_id:'growatt_modbus',label:'Garage',options:{unit_id:'2'}},
+                            {driver_id:'eversolar_legacy',label:'Refused',options:{address:'17'}},
+                            {driver_id:'growatt_modbus',label:'Dak achter',options:{unit_id:'3'}}];
+    paintInverters();
+    await new Promise(r=>setTimeout(r,150));
+    const pend=[...document.querySelectorAll('#inv .card')]
+      .filter(c=>c.textContent.includes('starts after a restart'));
+    if(pend.length!==1) say('expected one pending row, drew '+pend.length);
+    else{
+      if(!pend[0].textContent.includes('Refused')){
+        say('the pending card names a running inverter: "'+pend[0].querySelector('b').textContent+'"');
+      }
+      const btn=pend[0].querySelector('button[onclick^="removeExtraAt"]');
+      if(!btn||btn.getAttribute('onclick')!=='removeExtraAt(1)'){
+        say('the remove button points at the wrong configuration row: '+(btn&&btn.getAttribute('onclick')));
+      }
+    }
+
     // 2. A control being used must survive the five-second refresh. Every paint replaces the
     // tab's innerHTML, which shuts an open <select> -- so the driver list could not be read to
     // the bottom before it closed itself.

--- a/tools/demo_fleet.js
+++ b/tools/demo_fleet.js
@@ -113,7 +113,12 @@
     modbus:{enabled:true,port:502,unit_id:1,max_clients:8,idle_timeout_seconds:120},
     polling:{interval_seconds:10},
     serial:{override:false,baud_rate:9600,parity:'none',data_bits:8,stop_bits:1},
-    driver:{id:'eversolar_legacy',label:'Schuur',options:{layout:'auto',address:'16'}},
+    // options:{} ON PURPOSE, and it is what a real bridge carries. A primary configured through
+    // the wizard stores nothing here and answers at its driver's declared default -- exactly how
+    // 192.168.20.254 is set up. Giving it an explicit address made this stub "realistic" in the
+    // one way that hid a collision: the free-address search read stored options only, saw
+    // nothing taken, and handed the new row the address the primary was already using.
+    driver:{id:'eversolar_legacy',label:'Schuur',options:{}},
     additional_devices:[
       {driver_id:'growatt_modbus',label:'Garage',options:{profile:'sph_3_6kw',unit_id:'2'}},
       {driver_id:'growatt_modbus',label:'Dak achter',options:{profile:'mic_tl_x',unit_id:'3'}}],


### PR DESCRIPTION
Both found by pressing the button on a real bridge, minutes after 0.24.0 shipped it.

## 1. It handed the new row the address the running inverter answers at

The search for a free address read **stored** options only. A primary configured through the
wizard stores nothing:

```
$ curl -s http://192.168.20.254/api/v1/config
primary driver: eversolar_legacy | options: {}
additional_devices:
  [0] driver_id='eversolar_legacy' label='' options={'address': '16'}
```

That primary answers at its driver's **declared default of 16** — its device id is
`eversolar_legacy-16`. The search saw nothing taken, started at 16, and handed the new row the
same one. Two units on one address destroy each other's replies, which is the collision this
code was written to prevent and the one the diagnosis card exists to explain.

Resolved the way the firmware resolves it now — stored option, else the declared default,
exactly as `DriverDescriptor::optionOr` does it. On that bridge the row gets **17**.

## 2. There was no way to take it back

`removeDevice()` found its config index through `invIds` — the devices that actually **started**
at boot. A row added since the last restart is not in that list, so it had no card, so it had no
Remove button. The alert offered to let the owner *"open Name, driver and address on the new
inverter"*, which did not exist either.

The configuration could not be undone from the UI at all. `configured: 2, started: 1`, and
nothing on the page to act on.

Rows that are configured but not started are now their own amber card, saying they start after a
restart and carrying the one control they need. Removal goes by **configuration index**, which is
the only handle such a row has.

## Why the check in #131 missed both

Two reasons, and both are mine.

**The assertion had the same blind spot as the code.** It read stored options only, so it agreed
with the bug and reported nothing.

**I made the stub unrealistic while trying to make it realistic.** In #131 I gave
`demo_fleet.js` an explicit `address:'16'` on the primary, arguing the real descriptor declares
one. The descriptor does — but a real bridge *stores* `{}` and relies on the default. That one
detail is exactly what hid this.

The stub now carries `options:{}` like `.254`, and the assertion resolves defaults **independently**
rather than by calling the page's own `addressOf()`, so a page that resolves them wrongly cannot
agree with itself.

## Mutation-tested

| mutation | what the check says |
|---|---|
| read stored options only again | `the new row was given address 16, already in use` |
| stop rendering pending rows | `a configured row that has not started is nowhere on the page` |
| | `a configured row that has not started offers no way to remove it` |

## Verification

846 native tests, all five widths, every battery case, the three interaction passes, layering and
JS checks green, firmware builds at 1 543 411 bytes.

## Still true

The bridge itself is healthy on 0.24.0 — 1 440 W, answering every five seconds. This is a web-UI
fix only; no firmware behaviour changed.