### PR TITLE
fix(web): the collision check could not see an address nobody had stored

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1463,11 +1463,18 @@ function addressProblem(body){
     // keying on driver+address let the likeliest real collision through unreported -- in the
     // card built to report exactly that (review, 2026-07-28).
     //
+    // Resolved through addressOf(), which falls back to the DECLARED DEFAULT the way
+    // DriverDescriptor::optionOr does. Reading stored options only was the blind spot that let
+    // addExtra hand a second inverter the address the first was already answering at; this
+    // function had the same hole and kept it a day longer, so the collision stayed reachable by
+    // typing the number in by hand and pressing Save.
+    //
     // No false positives from the protocols that do not address this way: an AA55 device is
-    // found by serial number and declares no unit_id, so addr is undefined and it is skipped.
-    const addr=(options||{}).unit_id??(options||{}).address;
-    if(addr===undefined||String(addr).trim()==='')return null;
-    const key=String(addr).trim();
+    // found by serial number and declares no address option at all, so addressOf() returns ''
+    // and it never enters the comparison.
+    const addr=addressOf(drvId,options);
+    if(addr==='')return null;
+    const key=addr;
     if(seen[key])return who+' has the same address as '+seen[key]+'. Each inverter on the bus needs its own.';
     seen[key]=who;
     return null;

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -268,20 +268,27 @@ def check_address_collision(script, scratch):
     serial number and declares no unit_id -- must not be dragged into a collision it cannot
     have, or the card cries wolf on a perfectly good bus.
     """
-    body = extract_function(script, "addressProblem")
-    if body is None:
-        print(
-            "FAIL: addressProblem() not found in index_html.h; this check needs updating"
-        )
-        return 1
+    # addressProblem leans on both of these now: an address is the stored option OR the driver's
+    # declared default, and resolving only the first is the blind spot this check exists to keep
+    # closed. Pulled in rather than stubbed, so the test exercises the real resolution.
+    parts = []
+    for fn in ("addressOptionOf", "addressOf", "addressProblem"):
+        piece = extract_function(script, fn)
+        if piece is None:
+            print(f"FAIL: {fn}() not found in index_html.h; this check needs updating")
+            return 1
+        parts.append(piece)
+    body = "\n".join(parts)
     harness = (
         """
 // Only what addressProblem reads. `sunspec` and `growatt_modbus` both declare unit_id;
 // `eversolar_legacy` declares none, which is what makes it the false-positive case.
 const drivers = {drivers:[
-  {id:'growatt_modbus', options:[{key:'unit_id', display_name:'Modbus unit id'}]},
-  {id:'sunspec',        options:[{key:'unit_id', display_name:'Modbus unit id'}]},
-  {id:'eversolar_legacy', options:[]},
+  {id:'growatt_modbus', options:[{key:'unit_id', display_name:'Modbus unit id', default_value:'1'}]},
+  {id:'sunspec',        options:[{key:'unit_id', display_name:'Modbus unit id', default_value:'1'}]},
+  // Declares an address with a default of 16, exactly as the real descriptor does. An empty
+  // options list here would have made the fallback untestable.
+  {id:'eversolar_legacy', options:[{key:'address', display_name:'Assigned bus address', default_value:'16'}]},
 ]};
 const cfg = {driver:{}, additional_devices:[]};
 """
@@ -297,7 +304,19 @@ const check = (label, body, wantCollision) => {
   }
 };
 
-// THE case: two different Modbus drivers, one bus, one address.
+// THE case this was blind to: the primary stores NOTHING and answers at its declared default,
+// which is how a bridge configured through the wizard looks. Typing that number into an extra by
+// hand was accepted, and the two then collided on the bus.
+check('primary at its default + extra typed to match', {
+  driver:{id:'growatt_modbus', options:{}},
+  additional_devices:[{driver_id:'growatt_modbus', options:{unit_id:'1'}}]}, true);
+
+// And across two drivers, since the bus does not care which one is polling.
+check('eversolar primary at default 16 + growatt@16', {
+  driver:{id:'eversolar_legacy', options:{}},
+  additional_devices:[{driver_id:'growatt_modbus', options:{unit_id:'16'}}]}, true);
+
+// Two different Modbus drivers, one bus, one address.
 check('growatt@2 + sunspec@2', {
   driver:{id:'growatt_modbus', options:{unit_id:'2'}},
   additional_devices:[{driver_id:'sunspec', options:{unit_id:'2'}}]}, true);
@@ -317,16 +336,19 @@ check('eversolar + growatt@2', {
   driver:{id:'eversolar_legacy', options:{}},
   additional_devices:[{driver_id:'growatt_modbus', options:{unit_id:'2'}}]}, false);
 
-// Two of them: neither has an address, so there is nothing to compare.
-check('eversolar + eversolar', {
+// Two of them, neither storing an address -- so BOTH answer at the declared default of 16, and
+// that is a real collision on a real bus. This case expected "no collision" until the check
+// learned to resolve defaults, which is exactly the misconfiguration it could not see.
+check('eversolar + eversolar, both at the default', {
   driver:{id:'eversolar_legacy', options:{}},
-  additional_devices:[{driver_id:'eversolar_legacy', options:{}}]}, false);
+  additional_devices:[{driver_id:'eversolar_legacy', options:{}}]}, true);
 
-// An empty address field is unanswered, not address "". Two blanks are not a collision --
-// the firmware has not been told a number yet.
-check('two blank addresses', {
+// An empty field is not address "": the firmware falls back to the declared default, so two
+// blanks are two devices on the SAME default. Also flipped by resolving defaults, and for the
+// better -- leaving both blank is a bus where nothing answers, which is worth being told.
+check('two blank addresses fall back to the same default', {
   driver:{id:'growatt_modbus', options:{unit_id:''}},
-  additional_devices:[{driver_id:'sunspec', options:{unit_id:''}}]}, false);
+  additional_devices:[{driver_id:'sunspec', options:{unit_id:''}}]}, true);
 
 // Whitespace is not a different address.
 check('growatt@2 + sunspec@" 2 "', {


### PR DESCRIPTION
Second follow-up. Stacked on #136.

`addressProblem()` read **stored** options only. A primary configured through the wizard stores
`options:{}` and answers at its driver's declared default — so to this check it looked like a
device with no address at all.

Type that number into an extra by hand, press Save: **accepted**. The two then collide on the
bus, or the second is skipped at boot with nothing but a log line.

This is the same blind spot `addExtra` had. That one was fixed a day earlier; this function —
whose docblock promises to say *"what the firmware would refuse, or accept and then quietly
skip"* — kept it. So the collision stayed reachable in one PATCH; only the auto-assign path was
repaired.

It resolves through `addressOf()` now, the way `DriverDescriptor::optionOr` does.

## Four expectations flipped, and they were the wrong ones

| case | was | is |
|---|---|---|
| two eversolars, neither storing an address | no collision | **collision** — both answer at 16 |
| two blank address fields | no collision | **collision** — both fall back to the same default |

Both are real collisions that were simply invisible. The old cases asserted the bug. Each now
says where it sits *why* it flipped, so the next reader does not flip it back.

## Harness

Pulls in `addressOptionOf` and `addressOf` rather than stubbing them, so the test exercises the
real resolution. The stub drivers now declare their defaults — an empty options list made the
fallback untestable, which is how this survived the last round.

## Mutation-tested

```
primary at its default + extra typed to match:        got null, wanted a collision
eversolar primary at default 16 + growatt@16:         got null, wanted a collision
eversolar + eversolar, both at the default:           got null, wanted a collision
two blank addresses fall back to the same default:    got null, wanted a collision
```

846 native tests, 16 browser checks, layering green.