### PR TITLE
fix(web): a row waiting for a restart could be deleted but not corrected

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1463,6 +1463,10 @@ async function saveAccess(){
   paintBridge();
 }
 async function saveDevice(slot){
+  // A slot the bridge could not name. Every started device is in the plan, so this should not
+  // happen -- but the arithmetic below would quietly write nothing and report success, and a
+  // Save that says "Saved" and changes nothing is the worst of the available failures.
+  if(slot<0){say('#dv_msg','err','The bridge did not say which configured row this inverter came from, so this cannot be saved. Restarting it will re-establish that.');return}
   const opts=readOpts('dv_o_');
   const body=slot===0
     ?{driver:{id:val('dv_drv'),label:val('dv_label'),...(Object.keys(opts).length?{options:opts}:{})}}

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -736,7 +736,7 @@ function paintInverters(){
         ${groupsFor(m,false)||'<div class="dim">Nothing published yet.</div>'}
         ${caps&&(caps.write||[]).length===0?'<div class="hint">This driver cannot write to the inverter. Nothing in this build can.</div>':''}
       </div>`:''}
-      ${panel==='s:'+id?deviceForm(id,dev):''}
+      ${panel==='s:'+id?deviceForm(slotOf(id)):''}
     </div>`;
   }
 
@@ -757,13 +757,21 @@ function paintInverters(){
       if(claimed.has(i+1))continue;  // a device of its own is running for this row  // this row has a device of its own
       const e=extras[i], addr=addressOf(e.driver_id,e.options);
       const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===e.driver_id);
+      // The same form a running inverter gets, on the same configuration row. A pending row is
+      // where the settings are most likely to still be WRONG -- it is usually one address or one
+      // register map away from working -- and until now it was the one row that could not be
+      // corrected without a restart first.
       h+=`<div class="card" style="border-color:var(--warn)">
         <div class="between"><div><b>${esc(e.label||'Inverter '+(i+2))}</b>
           <span class="tag warn">starts after a restart</span></div>
-          <button class="dangerAlt sm" onclick="removeExtraAt(${i})">Remove</button></div>
+          ${panel==='x:'+i?'':`<button class="dangerAlt sm" onclick="removeExtraAt(${i})">Remove</button>`}</div>
         <div class="hint">${esc((drv&&drv.display_name)||e.driver_id||'no driver chosen')}${
-          addr?' · address '+esc(addr):''} — added to the configuration, not polled yet. Restart
-          the bridge to start it, or remove it here.</div>
+          addr?' · address '+esc(addr):''} — added to the configuration, not polled yet. Correct it
+          here before the restart if anything is off, or remove it.</div>
+        <div class="acts">
+          <button class="alt sm" onclick="togglePanel('x:${i}')">${panel==='x:'+i?'Close settings':'Name, driver and address'}</button>
+        </div>
+        ${panel==='x:'+i?deviceForm(i+1):''}
       </div>`;
     }
   }
@@ -779,6 +787,9 @@ function paintInverters(){
     ${panel==='bus'?busForm(c):''}
   </div>`;
   $('#inv').innerHTML=h;
+  // The gate ran on change only, so a form just opened with an unset must-pick option offered an
+  // enabled Save. addressProblem() still refused it, but the button said otherwise first.
+  gateForms();
   if(panel==='bus')wireBusForm();
   if(panel==='wiz'&&wizStep===4)wizLoadDrivers();
 }
@@ -788,18 +799,35 @@ function paintInverters(){
 // the new driver's options never appeared -- so a driver could not be changed here at all.
 let devDraft=null;
 
-function deviceForm(id,dev){
-  const primary=isPrimary(id);
-  const storedDrvId=(dev.identity||{}).driver_id||(dev.driver||{}).id||'';
-  if(!devDraft||devDraft.id!==id)devDraft={id,drv:storedDrvId,label:dev.label||''};
+/// What is STORED for a configuration row: slot 0 is `driver`, 1..N are additional_devices[0..].
+///
+/// One lookup for both kinds of card, and that is what makes a row that has not started
+/// editable at all -- it has a slot even though it has no device id, no identity and no entry
+/// in devCache. Everything the form needs comes from the configuration, which is also the only
+/// thing Save writes.
+function storedRow(slot){
+  const d=slot===0?((cfg&&cfg.driver)||{}):((((cfg&&cfg.additional_devices)||[])[slot-1])||{});
+  return {drv:(slot===0?d.id:d.driver_id)||'',label:d.label||'',options:d.options||{}};
+}
+/// The form for one configuration row, started or not.
+///
+/// It reads the CONFIGURATION, not the running device. Reading the running device was both the
+/// reason a pending row could not be edited and a quiet revert: after changing a driver and
+/// saving, `identity.driver_id` still named the old one until the restart, so reopening the
+/// card to fix the label and pressing Save wrote the old driver back over the pending change.
+function deviceForm(slot){
+  const primary=slot===0;
+  const st=storedRow(slot);
+  const storedDrvId=st.drv;
+  if(!devDraft||devDraft.slot!==slot)devDraft={slot,drv:storedDrvId,label:st.label};
   const drvId=devDraft.drv;
   const list=(drivers&&drivers.drivers)||[];
   // Stored option values apply only while the selection IS the configured driver. Otherwise the
   // declared defaults do -- rendering one driver's options under another driver's id is how an
   // option once got saved into the wrong driver's config.
-  const stored=drvId===storedDrvId?(primary?((cfg&&cfg.driver&&cfg.driver.options)||{}):extraOptionsFor(id)):{};
+  const stored=drvId===storedDrvId?st.options:{};
   const drv=list.find(x=>x.id===drvId);
-  let h=`<div class="hair" data-form="dev:${esc(id)}">
+  let h=`<div class="hair" data-form="dev:${esc(slot)}">
     <span class="tag warn">changes here need a restart</span>
     <label for="dv_label">Name</label>
     <input id="dv_label" value="${esc(devDraft.label)}" placeholder="Schuur" autocomplete="off"
@@ -811,10 +839,10 @@ function deviceForm(id,dev){
     ${drvId!==storedDrvId?'<div class="hint" style="color:var(--warn)">A different driver from the one running. Its options below start at this driver\u2019s own defaults, not the stored ones.</div>':''}`;
   h+=optionFields(drv,stored,'dv_o_');
   h+=`<div class="acts">
-      <button onclick="saveDevice('${esc(id)}',${primary?'true':'false'})">Save</button>
+      <button onclick="saveDevice(${slot})">Save</button>
       <button class="alt" onclick="togglePanel(null)">Cancel</button>
       <span style="flex:1"></span>
-      ${primary?'':`<button class="dangerAlt" onclick="removeDevice('${esc(id)}')">Remove this inverter</button>`}
+      ${primary?'':`<button class="dangerAlt" onclick="removeExtraAt(${slot-1})">Remove this inverter</button>`}
     </div>
     <div class="hint">${primary?'This is the first inverter, which every build has. Point it at a different driver rather than removing it.'
       :'Removing it does not remove what it already published: the old entities stay in Home Assistant, available, showing their last value.'}</div>
@@ -857,10 +885,22 @@ function gateForms(){
 // Which /devices entry is the one configured under `driver`, as opposed to additional_devices.
 // Order is the boot order, and the primary is always first.
 function isPrimary(id){return invIds[0]===id}
-function extraOptionsFor(id){
-  const idx=extraIndexOf(id);
-  const arr=(cfg&&cfg.additional_devices)||[];
-  return (arr[idx]||{}).options||{};
+/// The configuration row a running device came from: 0 is the primary driver, 1..N are
+/// additional_devices[0..N-1], and -1 when it cannot be placed.
+///
+/// The firmware plans the rows, starts them, and refuses some -- a driver that cannot share a
+/// bus, or a row resolving to an id another row already took, which skips the LATER one. So the
+/// running devices are not the configured rows minus a suffix, and every attempt to re-derive
+/// the mapping in here got it wrong: first by counting, then by matching driver ids. Both put a
+/// Remove button on a working inverter.
+///
+/// config_slot is that mapping, handed over by the only code that knows it. The fallback covers
+/// a bridge still on firmware from before that field existed, where only the first device can be
+/// placed with any confidence at all.
+function slotOf(id){
+  const v=(devCache[id]||{}).config_slot;
+  if(typeof v==='number'&&v>=0)return v;
+  return isPrimary(id)?0:-1;
 }
 function readOpts(prefix){
   const out={};
@@ -1422,15 +1462,15 @@ async function saveAccess(){
   say('#ac_msg','ok','Saved and applied.');
   paintBridge();
 }
-async function saveDevice(id,primary){
+async function saveDevice(slot){
   const opts=readOpts('dv_o_');
-  const body=primary
+  const body=slot===0
     ?{driver:{id:val('dv_drv'),label:val('dv_label'),...(Object.keys(opts).length?{options:opts}:{})}}
     :(()=>{
       // The array is replaced wholesale by the API, so it travels whole -- built from the
       // stored list with this one row rewritten, never from the DOM of the other rows.
       const arr=((cfg.additional_devices)||[]).map(d=>({driver_id:d.driver_id,label:d.label||'',options:{...(d.options||{})}}));
-      const idx=extraIndexOf(id);
+      const idx=slot-1;
       if(idx>=0&&idx<arr.length)arr[idx]={driver_id:val('dv_drv'),label:val('dv_label'),options:opts};
       return {additional_devices:arr};
     })();
@@ -1490,7 +1530,6 @@ function addressProblem(body){
   }
   return null;
 }
-async function removeDevice(id){ return removeExtraAt(extraIndexOf(id)) }
 /// Removes an extra device by its position in the CONFIGURATION, which is the only handle a row
 /// that has not started yet has.
 ///
@@ -1518,20 +1557,6 @@ async function removeExtraAt(idx){
 }
 /// The option a driver uses to hold its bus address, or null when it addresses some other way
 /// (an AA55 device is found by serial number and declares none).
-/// The additional_devices index a running device came from, or -1 when the bridge did not say.
-///
-/// The firmware plans the rows, starts them, and refuses some -- a driver that cannot share a
-/// bus, or a row resolving to an id another row already took, which skips the LATER one. So the
-/// running devices are not the configured rows minus a suffix, and every attempt to re-derive
-/// the mapping in here got it wrong: first by counting, then by matching driver ids. Both put a
-/// Remove button on a working inverter.
-///
-/// config_slot is that mapping, handed over by the only code that knows it. Slot 0 is the
-/// primary driver; 1..N are additional_devices[0..N-1].
-function extraIndexOf(id){
-  const slot=(devCache[id]||{}).config_slot;
-  return typeof slot==='number'&&slot>0?slot-1:-1;
-}
 function addressOptionOf(drvId){
   const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
   return ((drv&&drv.options)||[]).find(o=>o.key==='unit_id'||o.key==='address')||null;

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -274,7 +274,71 @@ const tick=setInterval(async()=>{
       }
     }
 
-    // 1d. An OPEN PANEL is work in progress. A raw-bus recording runs for thirty seconds and a
+    // 1d. A pending row must be CORRECTABLE, not merely removable. It is the row most likely to
+    // still be wrong -- usually one address or one register map away from working -- and it was
+    // the only row that could not be fixed without restarting first, then fixing, then
+    // restarting again. It gets the same form a running inverter gets, keyed on the
+    // configuration slot, which is the only handle a row without a device id has.
+    cfg.additional_devices=[{driver_id:'growatt_modbus',label:'Garage',options:{profile:'sph_3_6kw',unit_id:'2'}},
+                            {driver_id:'eversolar_legacy',label:'Refused',options:{address:'17'}},
+                            {driver_id:'growatt_modbus',label:'Dak achter',options:{profile:'mic_tl_x',unit_id:'3'}}];
+    devCache['growatt_modbus-GW2400ABC'].config_slot=1;
+    devCache['growatt_modbus-GW3300XYZ'].config_slot=3;
+    panel=null; devDraft=null; paintInverters();
+    await new Promise(r=>setTimeout(r,120));
+    const pcard=[...document.querySelectorAll('#inv .card')]
+      .find(c=>c.textContent.includes('starts after a restart'));
+    const open=pcard&&[...pcard.querySelectorAll('button')]
+      .find(b=>/togglePanel\('x:/.test(b.getAttribute('onclick')||''));
+    if(!open) say('a pending row offers no way to correct it, only to delete it');
+    else{
+      open.click();
+      await new Promise(r=>setTimeout(r,150));
+      const drv=document.getElementById('dv_drv'), lab=document.getElementById('dv_label');
+      if(!drv||!lab) say('opening a pending row drew no form');
+      else{
+        // What is STORED for THAT row -- not the first row's values, which is what a form
+        // hanging off a running device would have had to fall back to.
+        if(drv.value!=='eversolar_legacy') say('the pending form shows the wrong driver: '+drv.value);
+        if(lab.value!=='Refused') say('the pending form shows the wrong name: '+lab.value);
+        const addr=document.getElementById('dv_o_address');
+        if(!addr) say('the pending form offers no address field');
+        else if(addr.value!=='17') say('the pending form shows the wrong address: '+addr.value);
+
+        // And Save must rewrite that slot and leave its siblings exactly as stored.
+        lab.value='Corrected';
+        let body=null; const rp=window.patch;
+        window.patch=async b=>{body=b;return{ok:true,body:{}}};
+        await saveDevice(2);
+        window.patch=rp;
+        const arr=body&&body.additional_devices;
+        if(!arr||arr.length!==3) say('saving a pending row did not send the whole device list');
+        else{
+          if(arr[1].label!=='Corrected') say('the edit landed on row '+arr.findIndex(d=>d.label==='Corrected')+', not row 1');
+          if(arr[0].label!=='Garage'||arr[2].label!=='Dak achter') say('saving one row rewrote its siblings');
+          if(arr[0].options.profile!=='sph_3_6kw') say('a sibling row lost its stored options');
+        }
+      }
+    }
+
+    // 1e. The form edits the CONFIGURATION, not the running device. Those differ for exactly as
+    // long as a saved change is waiting for a restart -- which is when someone is most likely to
+    // open the card again. Reading identity.driver_id showed the OLD driver there, so correcting
+    // a typo in the name and pressing Save wrote the old driver back over the pending change.
+    panel=null; devDraft=null;
+    const realDriver=cfg.driver;
+    cfg.driver={id:'mock',label:'Schuur',options:{unit_id:'4'}};
+    togglePanel('s:eversolar_legacy-EU00T112345678');
+    await new Promise(r=>setTimeout(r,150));
+    const psel=document.getElementById('dv_drv');
+    if(!psel) say('the primary settings panel drew no form');
+    else if(psel.value!=='mock'){
+      say('the form shows the running driver ('+psel.value+') instead of the saved one, so Save would revert the pending change');
+    }
+    togglePanel(null); cfg.driver=realDriver; devDraft=null;
+    await new Promise(r=>setTimeout(r,100));
+
+    // 1f. An OPEN PANEL is work in progress. A raw-bus recording runs for thirty seconds and a
     // firmware upload longer, and neither holds focus -- so the focus guard alone left both
     // being rebuilt every few seconds while they ran.
     togglePanel('cap');
@@ -292,7 +356,7 @@ const tick=setInterval(async()=>{
     await new Promise(r=>setTimeout(r,60));
     if(document.getElementById('panel-probe-2')) say('the tab never repainted again after closing the panel');
 
-    // 1e. A refusal must reach the reader from a PENDING card too. That card has no form, so
+    // 1g. A refusal must reach the reader from a PENDING card too. That card has no form, so
     // no #dv_msg, and say() begins with `if(!m)return` -- a 400 produced nothing at all: no
     // message, no alert, the row still sitting there. The firmware revalidates every remaining
     // row on any change to the array, so a legacy value in a SIBLING row refuses the removal of


### PR DESCRIPTION
Sixth in the stack: #134 → #135 → #136 → #137 → #138 → this one.

## What was wrong

A configured row that has not started yet is the row most likely to still be **wrong** — it is
usually one address or one register map away from working. It was the only row that could not be
fixed in place. The sequence was: restart, discover the mistake, correct it, restart again.

The form hung off a running device: driver from `/devices`, label from the device, options
through a `config_slot` only a started device carries, saved by looking that slot back up. A
pending row has none of those, so it got a Remove button and nothing else.

## What changed

It hangs off the **configuration row** instead — slot 0 is `driver`, 1..N are
`additional_devices[0..N-1]` — which both kinds of card have. One lookup (`storedRow`), one save
path. That removes `extraOptionsFor` and `extraIndexOf` entirely: they existed only to translate
a device id back into the slot the form should have been keyed on from the start.

Two functions gone (`extraOptionsFor`, `extraIndexOf`), one added (`storedRow`). The net is
+5 lines of code for a card that does more — I claimed "fewer" here first and then counted.

## Two things that fell out of it

**A quiet revert.** After changing a driver and saving, the device goes on running the old one
until the restart, so `identity.driver_id` still named it. Reopening the card to fix a typo in
the name and pressing Save wrote the old driver back over the pending change. Check 1e.

**The must-pick gate never ran at paint time**, only on change — so a form just opened with an
unset register map offered an *enabled* Save. `addressProblem()` still refused it, but the button
said otherwise first, and a pending row is exactly the row that has one unset. `gateForms()` now
runs after the paint.

## Verification

Both new checks mutation-tested: taking the panel back off the pending card fails 1d; reading
`identity.driver_id` again fails 1e. 847 native tests, 16 browser checks, layering green,
firmware builds.

Rendered against the demo fleet and read back out of the live DOM: the pending card's Save points
at `saveDevice(2)`, both Remove buttons at `removeExtraAt(1)`, and the fields show that row's
stored address (17) and driver rather than the primary's. The browser pane returned blank
screenshots for this page, so that check is DOM-level, not a look at pixels.
