### PR TITLE
feat(api): drivers report whether a second one can share the bus

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -35,6 +35,11 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 
 Each driver in `/api/v1/drivers` declares its own options, and the web UI renders them
 generically from that declaration — a new driver's settings appear with no frontend change.
+
+It also declares `supports_multiple_devices`: whether a second row of that driver can run at
+all. A driver that answers `false` polls one device per bridge, and `planDevices()` skips the
+second row at boot — after the restart that was performed to apply it. The field exists so a
+client can refuse that row while the reader is still looking at the form.
 An option is one of three shapes:
 
 | Shape | Declared as | Rendered as | Refused when |

--- a/docs/solax-x1-protocol.md
+++ b/docs/solax-x1-protocol.md
@@ -29,6 +29,21 @@ Line: 9600 8N1. Master = PMU address `01 00`; inverters live at `00 <addr>`.
    established once and kept through timeouts; recovery is a plain offline query
    (sunrise-incident discipline, 2026-07-21).
 
+## One inverter per bridge, for now
+
+The driver declares `supportsMultipleDevices = false`, so a second configured row of it is
+refused at boot. That is **caution, not a protocol limit**. The mechanism the sibling EverSolar
+driver uses is available here in full: step 1 above is the same broadcast that a registered
+inverter ignores, so instances starting in configuration order each register the next
+unregistered unit, and each row already carries its own assigned address. Point 4 makes it
+safer here than there — with no RE_REGISTER frame, a starting instance cannot tell an
+already-polling inverter to forget its address.
+
+What is missing is evidence: this driver has never exchanged a byte with a real inverter (see
+the field findings below). Enabling a second instance would build an untested path on top of an
+unverified one. Turn it on once a single X1 is confirmed working, and note here what confirmed
+it.
+
 ## Status report payload (`11 82`)
 
 Lengths per generation: G2 = 50, G1 = 52 (+CT Pgrid), G3 = 56. First 50 bytes are common;

--- a/src/drivers/solax_x1/descriptor.cpp
+++ b/src/drivers/solax_x1/descriptor.cpp
@@ -28,6 +28,18 @@ const DriverDescriptor& descriptor() {
         // info layout) tell them apart automatically.
         x.probePriority           = 8;
         x.supportsAutoDetection   = true;
+        // The only driver left saying no, and unlike the others it is not saying "impossible".
+        //
+        // The mechanism EverSolar uses looks available here: same AA55 family, same broadcast
+        // offline query that a registered inverter ignores, and the same per-row assigned
+        // address. This driver has no RE_REGISTER at all, so the specific hazard that makes a
+        // second instance dangerous over there -- a starting instance telling the already-polling
+        // inverter to forget its address -- does not exist in this one.
+        //
+        // It stays false because this driver has never exchanged a byte with a real inverter
+        // (the descriptor above says so, and the one field session returned nothing). Enabling a
+        // second instance would be building an untested path on top of an unverified one. Turn it
+        // on when a single X1 is confirmed working, not before.
         x.supportsMultipleDevices = false;
         x.supportsRead            = true;
         x.supportsWrite           = false;

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -527,6 +527,10 @@ bool buildDriversPayload(const std::vector<DriverDescriptor>& drivers, std::stri
         e["supports_read"]   = d.supportsRead;
         e["supports_write"]  = d.supportsWrite;
         e["auto_detection"]  = d.supportsAutoDetection;
+        // Whether a second row of this driver can run at all. planDevices() refuses one that
+        // cannot, at boot, after the restart the owner performed to apply the change -- so
+        // without this field the page could only find out by trying. It guessed instead.
+        e["supports_multiple_devices"] = d.supportsMultipleDevices;
         JsonArray profiles   = e["serial_profiles"].to<JsonArray>();
         for (const auto& p : d.recommendedSerialProfiles) {
             JsonObject pr = profiles.add<JsonObject>();

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -835,7 +835,8 @@ function deviceForm(slot){
     <div class="hint">Shown here and in Home Assistant instead of the id. Renaming never changes the id, so history is kept.</div>
     <label for="dv_drv">Driver</label>
     <select id="dv_drv" onchange="devDraft.drv=this.value;paintInverters()">${list.map(x=>
-      `<option value="${esc(x.id)}" ${x.id===drvId?'selected':''}>${esc(x.display_name)} (${esc(x.support_level)})</option>`).join('')}</select>
+      `<option value="${esc(x.id)}" ${x.id===drvId?'selected':''}>${esc(x.display_name)} (${esc(x.support_level)})${
+        primary||canShare(x.id)?'':' — one inverter per bridge'}</option>`).join('')}</select>
     ${drvId!==storedDrvId?'<div class="hint" style="color:var(--warn)">A different driver from the one running. Its options below start at this driver\u2019s own defaults, not the stored ones.</div>':''}`;
   h+=optionFields(drv,stored,'dv_o_');
   h+=`<div class="acts">
@@ -1487,8 +1488,19 @@ async function saveDevice(slot){
 }
 /// What the firmware would refuse, or accept and then quietly skip at boot -- said here, next
 /// to the field, rather than as `additional_devices[2].driver_id` under a Save button.
+/// Whether a second row of this driver can run at all, straight from the driver list. Absent on
+/// a bridge running firmware from before the field existed, and the benefit of the doubt is the
+/// right default there: the firmware still refuses the row at boot and says why, which is worse
+/// than being told now but better than a page that forbids something the bridge allows.
+function canShare(drvId){
+  const d=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
+  return !d||d.supports_multiple_devices!==false;
+}
 function addressProblem(body){
   const seen={};
+  // Drivers that poll one device per bridge, by row. planDevices() refuses the SECOND one and
+  // lets the first keep the bus, which is the same order this walks in.
+  const exclusive={};
   const rowOf=(drvId,options)=>{
     const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
     for(const o of ((drv&&drv.options)||[])){
@@ -1516,6 +1528,14 @@ function addressProblem(body){
     // No false positives from the protocols that do not address this way: an AA55 device is
     // found by serial number and declares no address option at all, so addressOf() returns ''
     // and it never enters the comparison.
+    // Said here rather than discovered at boot. A row of an exclusive driver is accepted by the
+    // API, persisted, and then skipped by planDevices() -- after the restart the owner performed
+    // to apply it. The refusal was reachable only by doing all of that first.
+    if(!canShare(drvId)){
+      if(exclusive[drvId])return who+' cannot run beside '+exclusive[drvId].toLowerCase()+
+        ': this driver polls one device per bridge. The second row is skipped at boot.';
+      exclusive[drvId]=who;
+    }
     const addr=addressOf(drvId,options);
     if(addr==='')return null;
     const key=addr;
@@ -1595,6 +1615,14 @@ async function addExtra(){
   // picked here, by the same reading of the options that addressProblem() uses to complain.
   const primary=(cfg.driver||{}).id||'';
   if(!primary){alert('Choose a driver for the first inverter before adding a second.');return}
+  // The primary's driver is the guess below. When that driver polls one device per bridge the
+  // guess is guaranteed wrong, and the row would be accepted, persisted, and then skipped at the
+  // restart -- so it is refused here, with the reason, instead of being added.
+  if(!canShare(primary)){
+    alert('This driver polls one inverter per bridge, so a second row of it would never start. '
+      +'Change the first inverter to a driver that shares the bus, or use a second bridge.');
+    return;
+  }
   // The driver list is what says which option holds an address. Without it this would fall
   // through to "no address option" and hand the new row the driver's default -- straight onto
   // the primary. Refusing for a moment beats adding a row that cannot work.

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1486,8 +1486,6 @@ async function saveDevice(slot){
   say('#dv_msg','ok','Saved. Takes effect after a restart.');
   invNextMs=0;loadInverters(true);
 }
-/// What the firmware would refuse, or accept and then quietly skip at boot -- said here, next
-/// to the field, rather than as `additional_devices[2].driver_id` under a Save button.
 /// Whether a second row of this driver can run at all, straight from the driver list. Absent on
 /// a bridge running firmware from before the field existed, and the benefit of the doubt is the
 /// right default there: the firmware still refuses the row at boot and says why, which is worse
@@ -1496,6 +1494,8 @@ function canShare(drvId){
   const d=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
   return !d||d.supports_multiple_devices!==false;
 }
+/// What the firmware would refuse, or accept and then quietly skip at boot -- said here, next
+/// to the field, rather than as `additional_devices[2].driver_id` under a Save button.
 function addressProblem(body){
   const seen={};
   // Drivers that poll one device per bridge, by row. planDevices() refuses the SECOND one and
@@ -1525,17 +1525,18 @@ function addressProblem(body){
     // function had the same hole and kept it a day longer, so the collision stayed reachable by
     // typing the number in by hand and pressing Save.
     //
-    // No false positives from the protocols that do not address this way: an AA55 device is
-    // found by serial number and declares no address option at all, so addressOf() returns ''
-    // and it never enters the comparison.
     // Said here rather than discovered at boot. A row of an exclusive driver is accepted by the
     // API, persisted, and then skipped by planDevices() -- after the restart the owner performed
-    // to apply it. The refusal was reachable only by doing all of that first.
+    // to apply it. The refusal was reachable only by doing all of that first. Checked before the
+    // address, because for such a row the address is beside the point: it cannot start at any.
     if(!canShare(drvId)){
       if(exclusive[drvId])return who+' cannot run beside '+exclusive[drvId].toLowerCase()+
         ': this driver polls one device per bridge. The second row is skipped at boot.';
       exclusive[drvId]=who;
     }
+    // No false positives from the protocols that do not address this way: an AA55 device is
+    // found by serial number and declares no address option at all, so addressOf() returns ''
+    // and it never enters the comparison.
     const addr=addressOf(drvId,options);
     if(addr==='')return null;
     const key=addr;

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1788,10 +1788,24 @@ static void test_drivers_payload_drives_the_wizard() {
     TEST_ASSERT_TRUE(rest::buildDriversPayload(reg.availableDrivers(), json));
     auto doc = parse(json);
 
+    // Both answers must travel, and it matters that a driver saying NO is in the payload too:
+    // the page needs the refusal in order to stop offering a second row of it. Without this
+    // field the only way to learn the answer was to save a row, restart, and read the plan's
+    // complaint -- so the page guessed instead, and guessed from the primary's driver.
+    bool sawExclusive = false, sawShareable = false;
+    for (JsonObject d : doc["drivers"].as<JsonArray>()) {
+        TEST_ASSERT_TRUE_MESSAGE(d["supports_multiple_devices"].is<bool>(),
+                                 d["id"].as<const char*>());
+        if (d["supports_multiple_devices"].as<bool>()) sawShareable = true; else sawExclusive = true;
+    }
+    TEST_ASSERT_TRUE_MESSAGE(sawShareable, "no driver reported that it can share the bus");
+    TEST_ASSERT_TRUE_MESSAGE(sawExclusive, "no driver reported that it cannot");
+
     bool foundEversolar = false;
     for (JsonObject d : doc["drivers"].as<JsonArray>()) {
         if (std::string(d["id"].as<const char*>()) == "eversolar_legacy") {
             foundEversolar = true;
+            TEST_ASSERT_TRUE(d["supports_multiple_devices"].as<bool>());
             TEST_ASSERT_EQUAL_STRING("beta", d["support_level"]);
             TEST_ASSERT_FALSE(d["supports_write"].as<bool>());
             // The wizard shows which line settings will actually be tried.

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -338,6 +338,40 @@ const tick=setInterval(async()=>{
     togglePanel(null); cfg.driver=realDriver; devDraft=null;
     await new Promise(r=>setTimeout(r,100));
 
+    // 1h. A driver that polls one device per bridge must be refused HERE, not at the restart.
+    // planDevices() accepts nothing about it: the API stores the row, the page shows it waiting,
+    // and the boot after the restart skips it. The page used to have no way to know -- the
+    // driver list did not carry the answer -- so it guessed by copying the primary's driver,
+    // which for such a driver is the one guess guaranteed to be wrong.
+    panel=null; devDraft=null;
+    const keepDriver=cfg.driver, keepExtras=cfg.additional_devices;
+    cfg.driver={id:'solax_x1',label:'Vader',options:{address:'10'}};
+    cfg.additional_devices=[];
+    let added=null, said=null;
+    const rp2=window.patch, ra2=window.alert;
+    window.patch=async b=>{added=b;return{ok:true,body:{}}};
+    window.alert=m=>{said=m};
+    await addExtra();
+    window.patch=rp2; window.alert=ra2;
+    if(added) say('a second row was added for a driver that polls one device per bridge');
+    if(!said||!/one inverter per bridge/i.test(said)) say('adding it was refused without saying why: '+said);
+
+    // And typing one in by hand must be refused for the same reason, with the reason. This is
+    // the path the alert cannot cover: an existing row whose driver is changed to an exclusive
+    // one and saved.
+    const twice=addressProblem({additional_devices:[{driver_id:'solax_x1',options:{address:'11'}}]});
+    if(!twice||!/one device per bridge/i.test(twice)){
+      say('two rows of a one-per-bridge driver were accepted: '+twice);
+    }
+    // A single row of it is fine -- it is the SECOND that cannot start. Refusing the first would
+    // make the driver unusable altogether.
+    cfg.additional_devices=[];
+    const once=addressProblem({driver:{id:'solax_x1',options:{address:'10'}},additional_devices:[]});
+    if(once) say('one row of a one-per-bridge driver was refused: '+once);
+    cfg.driver=keepDriver; cfg.additional_devices=keepExtras;
+    panel=null; devDraft=null; paintInverters();
+    await new Promise(r=>setTimeout(r,100));
+
     // 1f. An OPEN PANEL is work in progress. A raw-bus recording runs for thirty seconds and a
     // firmware upload longer, and neither holds focus -- so the focus guard alone left both
     // being rebuilt every few seconds while they ran.

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -60,6 +60,11 @@ def main() -> int:
                 status |= check_auth_fetch_race(script, scratch)
                 status |= check_fleet_mode(script, scratch)
                 status |= check_address_collision(script, scratch)
+    # A final verdict, because the per-check lines are not the last thing printed: a failing
+    # check dumps node's stderr after its own FAIL line, and any tail of this output then shows
+    # a later check's OK. That is not hypothetical -- a real failure was read as green that way
+    # (2026-07-29). check_layering.sh has always ended with a verdict; this now does too.
+    print(f"RESULT: {'PASS' if status == 0 else 'FAIL'}")
     return status
 
 
@@ -272,7 +277,7 @@ def check_address_collision(script, scratch):
     # declared default, and resolving only the first is the blind spot this check exists to keep
     # closed. Pulled in rather than stubbed, so the test exercises the real resolution.
     parts = []
-    for fn in ("addressOptionOf", "addressOf", "addressProblem"):
+    for fn in ("addressOptionOf", "addressOf", "canShare", "addressProblem"):
         piece = extract_function(script, fn)
         if piece is None:
             print(f"FAIL: {fn}() not found in index_html.h; this check needs updating")
@@ -289,6 +294,10 @@ const drivers = {drivers:[
   // Declares an address with a default of 16, exactly as the real descriptor does. An empty
   // options list here would have made the fallback untestable.
   {id:'eversolar_legacy', options:[{key:'address', display_name:'Assigned bus address', default_value:'16'}]},
+  // The one that answers NO. addressProblem() refuses a SECOND row of it whatever the addresses
+  // say, because planDevices() skips that row at boot whatever the addresses say.
+  {id:'solax_x1', supports_multiple_devices:false,
+   options:[{key:'address', display_name:'Assigned bus address', default_value:'10'}]},
 ]};
 const cfg = {driver:{}, additional_devices:[]};
 """
@@ -354,6 +363,33 @@ check('two blank addresses fall back to the same default', {
 check('growatt@2 + sunspec@" 2 "', {
   driver:{id:'growatt_modbus', options:{unit_id:'2'}},
   additional_devices:[{driver_id:'sunspec', options:{unit_id:' 2 '}}]}, true);
+
+// A driver that polls one device per bridge. Distinct addresses do not save it: planDevices()
+// refuses the second row at boot regardless, so saying "no problem" here would be the page
+// blessing a row that cannot start.
+const excl = (label, body, want) => {
+  const got = addressProblem(body);
+  const said = !!got && got.includes('one device per bridge');
+  if (said !== want) {
+    console.error(`${label}: got ${JSON.stringify(got)}, wanted ${want ? 'a refusal' : 'none'}`);
+    bad++;
+  }
+};
+excl('two solax rows on different addresses', {
+  driver:{id:'solax_x1', options:{address:'10'}},
+  additional_devices:[{driver_id:'solax_x1', options:{address:'11'}}]}, true);
+// One of it is the ordinary case and must stay allowed, or the driver is unusable.
+excl('one solax row', {
+  driver:{id:'solax_x1', options:{address:'10'}}, additional_devices:[]}, false);
+// And it must not spill onto drivers that can share.
+excl('two growatt rows', {
+  driver:{id:'growatt_modbus', options:{unit_id:'2'}},
+  additional_devices:[{driver_id:'growatt_modbus', options:{unit_id:'3'}}]}, false);
+// A driver that omits the field -- an older bridge, or any driver added before it existed.
+// The benefit of the doubt is the documented default.
+excl('a driver that says nothing either way', {
+  driver:{id:'eversolar_legacy', options:{address:'16'}},
+  additional_devices:[{driver_id:'eversolar_legacy', options:{address:'17'}}]}, false);
 
 process.exit(bad === 0 ? 0 : 1);
 """

--- a/tools/demo_fleet.js
+++ b/tools/demo_fleet.js
@@ -130,7 +130,7 @@
     relays:{enabled:false,roles:[]}
   };
   const driversDoc = {drivers:[
-    {id:'eversolar_legacy',display_name:'EverSolar / Zeversolar legacy',support_level:'beta',
+    {id:'eversolar_legacy',supports_multiple_devices:true,display_name:'EverSolar / Zeversolar legacy',support_level:'beta',
       description:'AA55 framing over RS485, for TL-series inverters abandoned by their portal.',
       serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
       options:[
@@ -139,7 +139,7 @@
         {key:'address',display_name:'Assigned bus address',default_value:'16',
          min_value:16,max_value:254,
          description:'Address this bridge hands its inverter at registration. Leave at 16 unless more than one shares the loop.'}]},
-    {id:'growatt_modbus',display_name:'Growatt (Modbus)',support_level:'experimental',
+    {id:'growatt_modbus',supports_multiple_devices:true,display_name:'Growatt (Modbus)',support_level:'experimental',
       description:'Modbus RTU. The register map is a data file, so one driver serves several models.',
       serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
       options:[
@@ -147,9 +147,19 @@
          default_value:'',description:'Which model this unit is. It cannot be detected — probing identifies the protocol, never the model.'},
         {key:'unit_id',display_name:'Bus address',default_value:'1',min_value:1,max_value:247,
          description:'Must match the address set in the inverter’s own menu, and be unique on this bus.'}]},
-    {id:'mock',display_name:'Mock Inverter',support_level:'stable',
+    {id:'mock',supports_multiple_devices:true,display_name:'Mock Inverter',support_level:'stable',
       description:'A simulated three-phase hybrid, for UI and integration work with no bus.',
-      serial_profiles:[],options:[{key:'unit_id',display_name:'Bus address',default_value:'1'}]}
+      serial_profiles:[],options:[{key:'unit_id',display_name:'Bus address',default_value:'1'}]},
+    // The one driver that answers NO. It is here because the page must be able to say so BEFORE
+    // a restart -- the firmware refuses the second row at boot, which is the wrong moment to
+    // find out, and until this field existed the page had no way to know.
+    {id:'solax_x1',supports_multiple_devices:false,display_name:'SolaX X1 (AA55)',support_level:'experimental',
+      description:'One inverter per bridge: the address is handed out at registration, not read.',
+      serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
+      options:[
+        {key:'address',display_name:'Assigned bus address',default_value:'10',
+         min_value:10,max_value:254,
+         description:'Address this bridge hands its inverter at registration.'}]}
   ]};
   const diagnostics = {
     uptime_seconds:5061,firmware_version:'0.14.0',board:'Waveshare ESP32-S3-RS485-CAN',


### PR DESCRIPTION
Last of the stack: #134 → #135 → #136 → #137 → #138 → #139 → this one.

## What was wrong

A driver that polls one device per bridge is refused by `planDevices()` — but only **at boot**,
after the restart the owner performed to apply the change. Everything before that succeeds: the
API stores the row, the page shows it waiting for a restart, and the refusal arrives a reboot
later in a log line nobody is reading.

The page had no way to know better. `/api/v1/drivers` did not carry the answer, so "Add one by
hand" guessed the primary's driver — which for such a driver is the one guess guaranteed to be
wrong.

## What changed

`supports_multiple_devices` in the drivers payload, and three uses of it:

- `addExtra()` refuses up front, naming the reason, instead of adding a doomed row
- `addressProblem()` catches a second row typed in by hand — the path the alert cannot reach: an
  existing row whose driver is *changed* to an exclusive one and saved
- the driver select marks such drivers before one is picked for a second row

An absent field reads as "may share", so a bridge on older firmware behaves exactly as it does
today. That is worse than being told now, and better than a page forbidding what the bridge
allows.

## SolaX

The only driver still saying no, and its line said nothing about why — the same defect #138
fixed for SunSpec. It now states what it is and is not claiming:

The mechanism EverSolar uses looks available — same AA55 family, same broadcast offline query
that a registered inverter ignores, same per-row assigned address — and this driver has **no
RE_REGISTER at all**, so the specific hazard that makes a second instance dangerous over there
(a starting instance telling the already-polling inverter to forget its address) does not exist
here.

It stays `false` because the driver has never exchanged a byte with a real inverter. A second
instance would be an untested path built on an unverified one. Worth turning on when a single X1
is confirmed working — **not** on this reasoning alone.

## Verification

Both halves of the new browser check mutation-tested independently: making `canShare` always
true fails it, and so does dropping only the `addressProblem` rule. The host test asserts the
field travels for every driver and that both answers appear in the payload — a driver saying no
has to be in there, since that is the case the page needs.

847 native tests, 16 browser checks, layering green, firmware builds.