### PR TITLE
feat(eversolar): Stable, on eight unassisted sunrises

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ picture:
 
 | Inverter family | Connection | Status |
 |---|---|---|
-| EverSolar / Zeversolar legacy (TL series) | RS485 | **Beta** — running in production, in a multi-day soak toward Stable. Several inverters on one loop are supported but **not yet confirmed on hardware** — read [the pitfalls](docs/eversolar-protocol.md#several-inverters-on-one-bus) first, and report what happens on [#82](https://github.com/Timdebruijn/heliograph/issues/82) |
+| EverSolar / Zeversolar legacy (TL series) | RS485 | **Stable** — the only driver at this level. Running in production and validated over **eight consecutive unassisted sunrises**, the transition where its one known bug lived. Several inverters on one loop are supported but **not yet confirmed on hardware** — read [the pitfalls](docs/eversolar-protocol.md#several-inverters-on-one-bus) first, and report what happens on [#82](https://github.com/Timdebruijn/heliograph/issues/82) |
 | Growatt SPH hybrid (3–6 kW) | Modbus RTU over RS485 | **Experimental** — register map transcribed from documentation, not yet confirmed against real hardware |
 | Growatt MIC TL-X (0.6–3.3 kW, single phase) | Modbus RTU over RS485 | **Experimental** — map cross-checked against two independent sources that agree, not yet confirmed against real hardware; see [docs/growatt-mic-tl-x-protocol.md](docs/growatt-mic-tl-x-protocol.md) |
 | SolaX X1 series (X1 Mini G1/G2/G3) | RS485 | **Experimental** — the first attempt on real hardware (an X1-Mini-G1) returned no data at all. Read [docs/solax-x1-protocol.md](docs/solax-x1-protocol.md) before you buy or wire anything |

--- a/src/drivers/eversolar_legacy/descriptor.cpp
+++ b/src/drivers/eversolar_legacy/descriptor.cpp
@@ -19,21 +19,30 @@ const DriverDescriptor& descriptor() {
         // 9600 8N1 is hardcoded in the reference implementation and is the only profile
         // known to work. Offering more would be guessing on a live bus.
         x.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3}};
-        // Beta since 2026-07-19: Phase 3 exit criteria met against a real TL3000-20 -- stable
+        // Beta from 2026-07-19: Phase 3 exit criteria met against a real TL3000-20 -- stable
         // reads over hours, values matching eversolar-monitor within the documented tolerance
         // (energy.total exactly +HI*0.1 kWh, hours/status/impedance/serial exact), and both
-        // captured frames committed as fixtures. Stable only after the Phase 9 soak test.
-        x.supportLevel            = DriverSupportLevel::Beta;
+        // captured frames committed as fixtures.
+        //
+        // STABLE from 2026-07-29. What Beta was withholding is in the enum above: "not yet run
+        // long enough to trust unattended". The thing that had to be trusted is the sunrise
+        // path, because the bug this driver was carrying only ever appeared at the night->morning
+        // transition -- a flash or a reboot hides it by starting cold, so no test on the bench
+        // could close it. The gate was ~7 clean unassisted sunrises on the production bridge.
+        //
+        // Eight, counted from Home Assistant's recorder (2026-07-22 through 2026-07-29), each an
+        // evening standby followed by an unattended recovery at first light: standby 06:20:33 ->
+        // grid-connected 06:23:57, 06:04:11 -> 06:06:23, 06:09:44 -> 06:12:06 on the last three.
+        // Recovery got FASTER over the run, ~5 min at first and ~2 min by the end, and no morning
+        // showed a stuck timeout. An overnight soak alongside it measured 515 poll failures that
+        // were ALL plain RS485 timeouts -- zero checksum errors, zero invalid frames -- with the
+        // back-off behaving as designed, so first light is always picked up within 60 s.
+        //
+        // Not covered by this level, and deliberately: two inverters on one bus (see below), and
+        // any write path, which this protocol does not define at all.
+        x.supportLevel            = DriverSupportLevel::Stable;
         x.probePriority           = 10;
         x.supportsAutoDetection   = true;
-        // False, and not as a limitation of the application: this DRIVER cannot share a bus
-        // with a second instance of itself, in three separate ways (#63).
-        //
-        // begin() broadcasts RE_REGISTER, which tells every inverter on the line to forget its
-        // address -- so a second instance starting up de-registers the first, already-polling
-        // one. registerDevice() runs the enumeration loop exactly once, so a second inverter is
-        // never discovered anyway. And `assignedAddress` has no option wired to it, so both
-        // instances would claim the same bus address regardless.
         // True, with one device per inverter and each holding its own bus address.
         //
         // The enumeration needs no loop of its own: a registered inverter ignores the broadcast

--- a/test/test_driver_registry/test_main.cpp
+++ b/test/test_driver_registry/test_main.cpp
@@ -130,9 +130,10 @@ static void test_eversolar_descriptor_states_the_truth() {
     TEST_ASSERT_FALSE(d->supportsWrite);  // the protocol defines no write operation
     TEST_ASSERT_TRUE(d->supportsRead);
     TEST_ASSERT_TRUE(d->supportsAutoDetection);
-    // Beta since the Phase 3 exit criteria were met on real hardware (2026-07-19); may not
-    // claim Stable until the Phase 9 soak test passes.
-    TEST_ASSERT_EQUAL(DriverSupportLevel::Beta, d->supportLevel);
+    // Stable since 2026-07-29: eight clean unassisted sunrises on the production bridge, which
+    // is the only way the recovery path can be observed -- see the descriptor for the count and
+    // what the level still does not claim.
+    TEST_ASSERT_EQUAL(DriverSupportLevel::Stable, d->supportLevel);
     // Exactly one profile: 9600 8N1 is all the reference implementation ever uses.
     TEST_ASSERT_EQUAL_size_t(1, d->recommendedSerialProfiles.size());
     TEST_ASSERT_EQUAL_UINT32(9600, d->recommendedSerialProfiles[0].baudRate);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1698,7 +1698,7 @@ static void test_status_payload() {
     TEST_ASSERT_EQUAL_STRING("0.1.0", doc["bridge"]["firmware_version"]);
     TEST_ASSERT_EQUAL_INT(-57, doc["bridge"]["wifi_rssi_dbm"].as<int>());
     TEST_ASSERT_EQUAL_STRING("eversolar_legacy", doc["device"]["driver_id"]);
-    TEST_ASSERT_EQUAL_STRING("beta", doc["device"]["support_level"]);
+    TEST_ASSERT_EQUAL_STRING("stable", doc["device"]["support_level"]);
     TEST_ASSERT_TRUE(doc["device"]["online"].as<bool>());
     TEST_ASSERT_DOUBLE_WITHIN(0.01, fx::expected::kAcPowerW,
                               doc["measurements"]["ac.power.total"]["value"].as<double>());
@@ -1806,7 +1806,7 @@ static void test_drivers_payload_drives_the_wizard() {
         if (std::string(d["id"].as<const char*>()) == "eversolar_legacy") {
             foundEversolar = true;
             TEST_ASSERT_TRUE(d["supports_multiple_devices"].as<bool>());
-            TEST_ASSERT_EQUAL_STRING("beta", d["support_level"]);
+            TEST_ASSERT_EQUAL_STRING("stable", d["support_level"]);
             TEST_ASSERT_FALSE(d["supports_write"].as<bool>());
             // The wizard shows which line settings will actually be tried.
             TEST_ASSERT_EQUAL_size_t(1, d["serial_profiles"].as<JsonArray>().size());


### PR DESCRIPTION
The first driver to reach **Stable**.

## Why the gate was sunrises

`DriverSupportLevel::Beta` means "not yet run long enough to trust unattended". What had to be
trusted here is the sunrise path: the bug this driver carried only ever appeared at the
night→morning transition, and a flash or a reboot hides it by starting cold. No test on the bench
could close it — the gate was ~7 clean unassisted sunrises on the production bridge.

## The evidence

Eight, counted from Home Assistant's recorder over 2026-07-22 … 2026-07-29. Each is an evening
standby followed by an unattended recovery at first light:

| # | Date | Standby | Grid-connected | Recovery |
|---|---|---|---|---|
| 6 | Mon 2026-07-27 | 06:20:33 | 06:23:57 | 3m24 |
| 7 | Tue 2026-07-28 | 06:04:11 | 06:06:23 | 2m12 |
| 8 | Wed 2026-07-29 | 06:09:44 | 06:12:06 | 2m22 |

Recovery got **faster** across the run — ~5 min at #5, ~2 min by #8 — and no morning showed a
stuck timeout. The overnight soak alongside it measured 515 poll failures that were **all** plain
RS485 timeouts: zero checksum errors, zero invalid frames, back-off behaving as designed.

## What Stable still does not claim

Written into the descriptor so the next reader does not have to infer it: **two inverters on one
bus** (supported in code since #63, never confirmed on hardware — [#82](https://github.com/Timdebruijn/heliograph/issues/82)),
and **any write path**, which this protocol does not define at all.

## One thing found while editing

Three lines above the level, a paragraph explained in convincing detail why
`supportsMultipleDevices` is `false`. It has said `true` since #63 — the new reasoning was added
*below* the old text instead of over it, so the file argued against its own code. Removed.
Comment-only, no behaviour.

## Note for merge order

This branches off **main**, independent of the #136–#140 stack. It touches one line in
`test_drivers_payload_drives_the_wizard` that #140 also edits (adjacent lines), so whichever
merges second may need a one-line resolution there.

846 native tests, layering green, firmware builds.