### PR TITLE
fix(web): the SunSpec flag, the editable pending card, and the drivers-can-share field

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -35,6 +35,11 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 
 Each driver in `/api/v1/drivers` declares its own options, and the web UI renders them
 generically from that declaration — a new driver's settings appear with no frontend change.
+
+It also declares `supports_multiple_devices`: whether a second row of that driver can run at
+all. A driver that answers `false` polls one device per bridge, and `planDevices()` skips the
+second row at boot — after the restart that was performed to apply it. The field exists so a
+client can refuse that row while the reader is still looking at the form.
 An option is one of three shapes:
 
 | Shape | Declared as | Rendered as | Refused when |

--- a/docs/solax-x1-protocol.md
+++ b/docs/solax-x1-protocol.md
@@ -29,6 +29,21 @@ Line: 9600 8N1. Master = PMU address `01 00`; inverters live at `00 <addr>`.
    established once and kept through timeouts; recovery is a plain offline query
    (sunrise-incident discipline, 2026-07-21).
 
+## One inverter per bridge, for now
+
+The driver declares `supportsMultipleDevices = false`, so a second configured row of it is
+refused at boot. That is **caution, not a protocol limit**. The mechanism the sibling EverSolar
+driver uses is available here in full: step 1 above is the same broadcast that a registered
+inverter ignores, so instances starting in configuration order each register the next
+unregistered unit, and each row already carries its own assigned address. Point 4 makes it
+safer here than there — with no RE_REGISTER frame, a starting instance cannot tell an
+already-polling inverter to forget its address.
+
+What is missing is evidence: this driver has never exchanged a byte with a real inverter (see
+the field findings below). Enabling a second instance would build an untested path on top of an
+unverified one. Turn it on once a single X1 is confirmed working, and note here what confirmed
+it.
+
 ## Status report payload (`11 82`)
 
 Lengths per generation: G2 = 50, G1 = 52 (+CT Pgrid), G3 = 56. First 50 bytes are common;

--- a/docs/sunspec.md
+++ b/docs/sunspec.md
@@ -127,6 +127,11 @@ produced nothing yet — so a zero accumulator is published as a reading.
 | `unit_id` | `1` | Modbus slave address on the RS485 bus, 1–247 |
 | `base_address` | `40000` | Where the `SunS` marker lives |
 
+**Several SunSpec devices on one bus.** Supported since 0.24.1: add a row per device and give
+each its own `unit_id`. That is how Modbus RTU addresses devices, so it is the ordinary
+arrangement rather than a special mode — but it has not been tried on real hardware here, only
+in a host test. If you run two and it misbehaves, that is worth an issue.
+
 **About the base address.** 40000 covers most devices; **50000** is the other common choice, and
 some vendors sit elsewhere entirely. It is a setting rather than a search on purpose: every
 extra guess costs a discovery round trip on a shared bus, and you know your device better than

--- a/src/drivers/solax_x1/descriptor.cpp
+++ b/src/drivers/solax_x1/descriptor.cpp
@@ -28,6 +28,18 @@ const DriverDescriptor& descriptor() {
         // info layout) tell them apart automatically.
         x.probePriority           = 8;
         x.supportsAutoDetection   = true;
+        // The only driver left saying no, and unlike the others it is not saying "impossible".
+        //
+        // The mechanism EverSolar uses looks available here: same AA55 family, same broadcast
+        // offline query that a registered inverter ignores, and the same per-row assigned
+        // address. This driver has no RE_REGISTER at all, so the specific hazard that makes a
+        // second instance dangerous over there -- a starting instance telling the already-polling
+        // inverter to forget its address -- does not exist in this one.
+        //
+        // It stays false because this driver has never exchanged a byte with a real inverter
+        // (the descriptor above says so, and the one field session returned nothing). Enabling a
+        // second instance would be building an untested path on top of an unverified one. Turn it
+        // on when a single X1 is confirmed working, not before.
         x.supportsMultipleDevices = false;
         x.supportsRead            = true;
         x.supportsWrite           = false;

--- a/src/drivers/sunspec/descriptor.cpp
+++ b/src/drivers/sunspec/descriptor.cpp
@@ -31,7 +31,20 @@ const DriverDescriptor& descriptor() {
         // any register-shape heuristic, so when a device answers it, it is not a guess.
         x.probePriority           = 20;
         x.supportsAutoDetection   = true;
-        x.supportsMultipleDevices = false;
+        // Modbus RTU addresses by unit id, so several SunSpec devices on one bus is the
+        // ordinary arrangement rather than an exception -- and this driver already carries what
+        // that needs: a unit_id option and an addressOptionKey. The sibling Modbus driver says
+        // true for the same reason.
+        //
+        // It said false until 2026-07-29. Traced: the line arrived uncommented with the driver's
+        // first commit, docs/sunspec.md says nothing about it, and no later commit ever set it
+        // over a finding. Every neighbouring decision in this file carries its reasoning; this
+        // one carried none, which is what made it look like an oversight rather than a limit.
+        //
+        // NOT hardware-verified. Two SunSpec devices have never shared a real bus here -- the
+        // driver is Experimental and has only ever met one. What is verified is that the plan
+        // starts both rows (test/test_device_plan) and that the protocol permits it.
+        x.supportsMultipleDevices = true;
         x.supportsRead            = true;
         // The driver has a write path; whether a given DEVICE has one is a separate question,
         // answered by capabilities() after model 123 has been read. This flag is the static

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -527,6 +527,10 @@ bool buildDriversPayload(const std::vector<DriverDescriptor>& drivers, std::stri
         e["supports_read"]   = d.supportsRead;
         e["supports_write"]  = d.supportsWrite;
         e["auto_detection"]  = d.supportsAutoDetection;
+        // Whether a second row of this driver can run at all. planDevices() refuses one that
+        // cannot, at boot, after the restart the owner performed to apply the change -- so
+        // without this field the page could only find out by trying. It guessed instead.
+        e["supports_multiple_devices"] = d.supportsMultipleDevices;
         JsonArray profiles   = e["serial_profiles"].to<JsonArray>();
         for (const auto& p : d.recommendedSerialProfiles) {
             JsonObject pr = profiles.add<JsonObject>();

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1463,6 +1463,10 @@ async function saveAccess(){
   paintBridge();
 }
 async function saveDevice(slot){
+  // A slot the bridge could not name. Every started device is in the plan, so this should not
+  // happen -- but the arithmetic below would quietly write nothing and report success, and a
+  // Save that says "Saved" and changes nothing is the worst of the available failures.
+  if(slot<0){say('#dv_msg','err','The bridge did not say which configured row this inverter came from, so this cannot be saved. Restarting it will re-establish that.');return}
   const opts=readOpts('dv_o_');
   const body=slot===0
     ?{driver:{id:val('dv_drv'),label:val('dv_label'),...(Object.keys(opts).length?{options:opts}:{})}}

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -835,7 +835,8 @@ function deviceForm(slot){
     <div class="hint">Shown here and in Home Assistant instead of the id. Renaming never changes the id, so history is kept.</div>
     <label for="dv_drv">Driver</label>
     <select id="dv_drv" onchange="devDraft.drv=this.value;paintInverters()">${list.map(x=>
-      `<option value="${esc(x.id)}" ${x.id===drvId?'selected':''}>${esc(x.display_name)} (${esc(x.support_level)})</option>`).join('')}</select>
+      `<option value="${esc(x.id)}" ${x.id===drvId?'selected':''}>${esc(x.display_name)} (${esc(x.support_level)})${
+        primary||canShare(x.id)?'':' — one inverter per bridge'}</option>`).join('')}</select>
     ${drvId!==storedDrvId?'<div class="hint" style="color:var(--warn)">A different driver from the one running. Its options below start at this driver\u2019s own defaults, not the stored ones.</div>':''}`;
   h+=optionFields(drv,stored,'dv_o_');
   h+=`<div class="acts">
@@ -1487,8 +1488,19 @@ async function saveDevice(slot){
 }
 /// What the firmware would refuse, or accept and then quietly skip at boot -- said here, next
 /// to the field, rather than as `additional_devices[2].driver_id` under a Save button.
+/// Whether a second row of this driver can run at all, straight from the driver list. Absent on
+/// a bridge running firmware from before the field existed, and the benefit of the doubt is the
+/// right default there: the firmware still refuses the row at boot and says why, which is worse
+/// than being told now but better than a page that forbids something the bridge allows.
+function canShare(drvId){
+  const d=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
+  return !d||d.supports_multiple_devices!==false;
+}
 function addressProblem(body){
   const seen={};
+  // Drivers that poll one device per bridge, by row. planDevices() refuses the SECOND one and
+  // lets the first keep the bus, which is the same order this walks in.
+  const exclusive={};
   const rowOf=(drvId,options)=>{
     const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
     for(const o of ((drv&&drv.options)||[])){
@@ -1516,6 +1528,14 @@ function addressProblem(body){
     // No false positives from the protocols that do not address this way: an AA55 device is
     // found by serial number and declares no address option at all, so addressOf() returns ''
     // and it never enters the comparison.
+    // Said here rather than discovered at boot. A row of an exclusive driver is accepted by the
+    // API, persisted, and then skipped by planDevices() -- after the restart the owner performed
+    // to apply it. The refusal was reachable only by doing all of that first.
+    if(!canShare(drvId)){
+      if(exclusive[drvId])return who+' cannot run beside '+exclusive[drvId].toLowerCase()+
+        ': this driver polls one device per bridge. The second row is skipped at boot.';
+      exclusive[drvId]=who;
+    }
     const addr=addressOf(drvId,options);
     if(addr==='')return null;
     const key=addr;
@@ -1595,6 +1615,14 @@ async function addExtra(){
   // picked here, by the same reading of the options that addressProblem() uses to complain.
   const primary=(cfg.driver||{}).id||'';
   if(!primary){alert('Choose a driver for the first inverter before adding a second.');return}
+  // The primary's driver is the guess below. When that driver polls one device per bridge the
+  // guess is guaranteed wrong, and the row would be accepted, persisted, and then skipped at the
+  // restart -- so it is refused here, with the reason, instead of being added.
+  if(!canShare(primary)){
+    alert('This driver polls one inverter per bridge, so a second row of it would never start. '
+      +'Change the first inverter to a driver that shares the bus, or use a second bridge.');
+    return;
+  }
   // The driver list is what says which option holds an address. Without it this would fall
   // through to "no address option" and hand the new row the driver's default -- straight onto
   // the primary. Refusing for a moment beats adding a row that cannot work.

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1486,8 +1486,6 @@ async function saveDevice(slot){
   say('#dv_msg','ok','Saved. Takes effect after a restart.');
   invNextMs=0;loadInverters(true);
 }
-/// What the firmware would refuse, or accept and then quietly skip at boot -- said here, next
-/// to the field, rather than as `additional_devices[2].driver_id` under a Save button.
 /// Whether a second row of this driver can run at all, straight from the driver list. Absent on
 /// a bridge running firmware from before the field existed, and the benefit of the doubt is the
 /// right default there: the firmware still refuses the row at boot and says why, which is worse
@@ -1496,6 +1494,8 @@ function canShare(drvId){
   const d=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
   return !d||d.supports_multiple_devices!==false;
 }
+/// What the firmware would refuse, or accept and then quietly skip at boot -- said here, next
+/// to the field, rather than as `additional_devices[2].driver_id` under a Save button.
 function addressProblem(body){
   const seen={};
   // Drivers that poll one device per bridge, by row. planDevices() refuses the SECOND one and
@@ -1525,17 +1525,18 @@ function addressProblem(body){
     // function had the same hole and kept it a day longer, so the collision stayed reachable by
     // typing the number in by hand and pressing Save.
     //
-    // No false positives from the protocols that do not address this way: an AA55 device is
-    // found by serial number and declares no address option at all, so addressOf() returns ''
-    // and it never enters the comparison.
     // Said here rather than discovered at boot. A row of an exclusive driver is accepted by the
     // API, persisted, and then skipped by planDevices() -- after the restart the owner performed
-    // to apply it. The refusal was reachable only by doing all of that first.
+    // to apply it. The refusal was reachable only by doing all of that first. Checked before the
+    // address, because for such a row the address is beside the point: it cannot start at any.
     if(!canShare(drvId)){
       if(exclusive[drvId])return who+' cannot run beside '+exclusive[drvId].toLowerCase()+
         ': this driver polls one device per bridge. The second row is skipped at boot.';
       exclusive[drvId]=who;
     }
+    // No false positives from the protocols that do not address this way: an AA55 device is
+    // found by serial number and declares no address option at all, so addressOf() returns ''
+    // and it never enters the comparison.
     const addr=addressOf(drvId,options);
     if(addr==='')return null;
     const key=addr;

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -750,7 +750,7 @@ function paintInverters(){
   if(!neverConfigured()){
     const extras=(cfg&&cfg.additional_devices)||[];
     // Claimed slots, straight from the bridge. Guessing this by counting started devices, and
-    // then by matching driver ids, was wrong both times -- see extraIndexOf().
+    // then by matching driver ids, was wrong both times -- see slotOf().
     const claimed=new Set(invIds.map(id=>(devCache[id]||{}).config_slot)
                                 .filter(v=>typeof v==='number'));
     for(let i=0;i<extras.length;i++){
@@ -1558,7 +1558,8 @@ function addressProblem(body){
 /// Removes an extra device by its position in the CONFIGURATION, which is the only handle a row
 /// that has not started yet has.
 ///
-/// removeDevice() went through invIds -- the devices that actually started at boot -- so a row
+/// The removeDevice() this replaced went through invIds -- the devices that actually started at
+/// boot -- so a row
 /// added since the last restart was not in it, had no card, and therefore had no button either.
 /// The alert offering to "open Name, driver and address on the new inverter" pointed at
 /// something that did not exist, and the configuration could not be undone from the UI at all

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -736,7 +736,7 @@ function paintInverters(){
         ${groupsFor(m,false)||'<div class="dim">Nothing published yet.</div>'}
         ${caps&&(caps.write||[]).length===0?'<div class="hint">This driver cannot write to the inverter. Nothing in this build can.</div>':''}
       </div>`:''}
-      ${panel==='s:'+id?deviceForm(id,dev):''}
+      ${panel==='s:'+id?deviceForm(slotOf(id)):''}
     </div>`;
   }
 
@@ -757,13 +757,21 @@ function paintInverters(){
       if(claimed.has(i+1))continue;  // a device of its own is running for this row  // this row has a device of its own
       const e=extras[i], addr=addressOf(e.driver_id,e.options);
       const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===e.driver_id);
+      // The same form a running inverter gets, on the same configuration row. A pending row is
+      // where the settings are most likely to still be WRONG -- it is usually one address or one
+      // register map away from working -- and until now it was the one row that could not be
+      // corrected without a restart first.
       h+=`<div class="card" style="border-color:var(--warn)">
         <div class="between"><div><b>${esc(e.label||'Inverter '+(i+2))}</b>
           <span class="tag warn">starts after a restart</span></div>
-          <button class="dangerAlt sm" onclick="removeExtraAt(${i})">Remove</button></div>
+          ${panel==='x:'+i?'':`<button class="dangerAlt sm" onclick="removeExtraAt(${i})">Remove</button>`}</div>
         <div class="hint">${esc((drv&&drv.display_name)||e.driver_id||'no driver chosen')}${
-          addr?' · address '+esc(addr):''} — added to the configuration, not polled yet. Restart
-          the bridge to start it, or remove it here.</div>
+          addr?' · address '+esc(addr):''} — added to the configuration, not polled yet. Correct it
+          here before the restart if anything is off, or remove it.</div>
+        <div class="acts">
+          <button class="alt sm" onclick="togglePanel('x:${i}')">${panel==='x:'+i?'Close settings':'Name, driver and address'}</button>
+        </div>
+        ${panel==='x:'+i?deviceForm(i+1):''}
       </div>`;
     }
   }
@@ -779,6 +787,9 @@ function paintInverters(){
     ${panel==='bus'?busForm(c):''}
   </div>`;
   $('#inv').innerHTML=h;
+  // The gate ran on change only, so a form just opened with an unset must-pick option offered an
+  // enabled Save. addressProblem() still refused it, but the button said otherwise first.
+  gateForms();
   if(panel==='bus')wireBusForm();
   if(panel==='wiz'&&wizStep===4)wizLoadDrivers();
 }
@@ -788,18 +799,35 @@ function paintInverters(){
 // the new driver's options never appeared -- so a driver could not be changed here at all.
 let devDraft=null;
 
-function deviceForm(id,dev){
-  const primary=isPrimary(id);
-  const storedDrvId=(dev.identity||{}).driver_id||(dev.driver||{}).id||'';
-  if(!devDraft||devDraft.id!==id)devDraft={id,drv:storedDrvId,label:dev.label||''};
+/// What is STORED for a configuration row: slot 0 is `driver`, 1..N are additional_devices[0..].
+///
+/// One lookup for both kinds of card, and that is what makes a row that has not started
+/// editable at all -- it has a slot even though it has no device id, no identity and no entry
+/// in devCache. Everything the form needs comes from the configuration, which is also the only
+/// thing Save writes.
+function storedRow(slot){
+  const d=slot===0?((cfg&&cfg.driver)||{}):((((cfg&&cfg.additional_devices)||[])[slot-1])||{});
+  return {drv:(slot===0?d.id:d.driver_id)||'',label:d.label||'',options:d.options||{}};
+}
+/// The form for one configuration row, started or not.
+///
+/// It reads the CONFIGURATION, not the running device. Reading the running device was both the
+/// reason a pending row could not be edited and a quiet revert: after changing a driver and
+/// saving, `identity.driver_id` still named the old one until the restart, so reopening the
+/// card to fix the label and pressing Save wrote the old driver back over the pending change.
+function deviceForm(slot){
+  const primary=slot===0;
+  const st=storedRow(slot);
+  const storedDrvId=st.drv;
+  if(!devDraft||devDraft.slot!==slot)devDraft={slot,drv:storedDrvId,label:st.label};
   const drvId=devDraft.drv;
   const list=(drivers&&drivers.drivers)||[];
   // Stored option values apply only while the selection IS the configured driver. Otherwise the
   // declared defaults do -- rendering one driver's options under another driver's id is how an
   // option once got saved into the wrong driver's config.
-  const stored=drvId===storedDrvId?(primary?((cfg&&cfg.driver&&cfg.driver.options)||{}):extraOptionsFor(id)):{};
+  const stored=drvId===storedDrvId?st.options:{};
   const drv=list.find(x=>x.id===drvId);
-  let h=`<div class="hair" data-form="dev:${esc(id)}">
+  let h=`<div class="hair" data-form="dev:${esc(slot)}">
     <span class="tag warn">changes here need a restart</span>
     <label for="dv_label">Name</label>
     <input id="dv_label" value="${esc(devDraft.label)}" placeholder="Schuur" autocomplete="off"
@@ -811,10 +839,10 @@ function deviceForm(id,dev){
     ${drvId!==storedDrvId?'<div class="hint" style="color:var(--warn)">A different driver from the one running. Its options below start at this driver\u2019s own defaults, not the stored ones.</div>':''}`;
   h+=optionFields(drv,stored,'dv_o_');
   h+=`<div class="acts">
-      <button onclick="saveDevice('${esc(id)}',${primary?'true':'false'})">Save</button>
+      <button onclick="saveDevice(${slot})">Save</button>
       <button class="alt" onclick="togglePanel(null)">Cancel</button>
       <span style="flex:1"></span>
-      ${primary?'':`<button class="dangerAlt" onclick="removeDevice('${esc(id)}')">Remove this inverter</button>`}
+      ${primary?'':`<button class="dangerAlt" onclick="removeExtraAt(${slot-1})">Remove this inverter</button>`}
     </div>
     <div class="hint">${primary?'This is the first inverter, which every build has. Point it at a different driver rather than removing it.'
       :'Removing it does not remove what it already published: the old entities stay in Home Assistant, available, showing their last value.'}</div>
@@ -857,10 +885,22 @@ function gateForms(){
 // Which /devices entry is the one configured under `driver`, as opposed to additional_devices.
 // Order is the boot order, and the primary is always first.
 function isPrimary(id){return invIds[0]===id}
-function extraOptionsFor(id){
-  const idx=extraIndexOf(id);
-  const arr=(cfg&&cfg.additional_devices)||[];
-  return (arr[idx]||{}).options||{};
+/// The configuration row a running device came from: 0 is the primary driver, 1..N are
+/// additional_devices[0..N-1], and -1 when it cannot be placed.
+///
+/// The firmware plans the rows, starts them, and refuses some -- a driver that cannot share a
+/// bus, or a row resolving to an id another row already took, which skips the LATER one. So the
+/// running devices are not the configured rows minus a suffix, and every attempt to re-derive
+/// the mapping in here got it wrong: first by counting, then by matching driver ids. Both put a
+/// Remove button on a working inverter.
+///
+/// config_slot is that mapping, handed over by the only code that knows it. The fallback covers
+/// a bridge still on firmware from before that field existed, where only the first device can be
+/// placed with any confidence at all.
+function slotOf(id){
+  const v=(devCache[id]||{}).config_slot;
+  if(typeof v==='number'&&v>=0)return v;
+  return isPrimary(id)?0:-1;
 }
 function readOpts(prefix){
   const out={};
@@ -1422,15 +1462,15 @@ async function saveAccess(){
   say('#ac_msg','ok','Saved and applied.');
   paintBridge();
 }
-async function saveDevice(id,primary){
+async function saveDevice(slot){
   const opts=readOpts('dv_o_');
-  const body=primary
+  const body=slot===0
     ?{driver:{id:val('dv_drv'),label:val('dv_label'),...(Object.keys(opts).length?{options:opts}:{})}}
     :(()=>{
       // The array is replaced wholesale by the API, so it travels whole -- built from the
       // stored list with this one row rewritten, never from the DOM of the other rows.
       const arr=((cfg.additional_devices)||[]).map(d=>({driver_id:d.driver_id,label:d.label||'',options:{...(d.options||{})}}));
-      const idx=extraIndexOf(id);
+      const idx=slot-1;
       if(idx>=0&&idx<arr.length)arr[idx]={driver_id:val('dv_drv'),label:val('dv_label'),options:opts};
       return {additional_devices:arr};
     })();
@@ -1490,7 +1530,6 @@ function addressProblem(body){
   }
   return null;
 }
-async function removeDevice(id){ return removeExtraAt(extraIndexOf(id)) }
 /// Removes an extra device by its position in the CONFIGURATION, which is the only handle a row
 /// that has not started yet has.
 ///
@@ -1518,20 +1557,6 @@ async function removeExtraAt(idx){
 }
 /// The option a driver uses to hold its bus address, or null when it addresses some other way
 /// (an AA55 device is found by serial number and declares none).
-/// The additional_devices index a running device came from, or -1 when the bridge did not say.
-///
-/// The firmware plans the rows, starts them, and refuses some -- a driver that cannot share a
-/// bus, or a row resolving to an id another row already took, which skips the LATER one. So the
-/// running devices are not the configured rows minus a suffix, and every attempt to re-derive
-/// the mapping in here got it wrong: first by counting, then by matching driver ids. Both put a
-/// Remove button on a working inverter.
-///
-/// config_slot is that mapping, handed over by the only code that knows it. Slot 0 is the
-/// primary driver; 1..N are additional_devices[0..N-1].
-function extraIndexOf(id){
-  const slot=(devCache[id]||{}).config_slot;
-  return typeof slot==='number'&&slot>0?slot-1:-1;
-}
 function addressOptionOf(drvId){
   const drv=((drivers&&drivers.drivers)||[]).find(x=>x.id===drvId);
   return ((drv&&drv.options)||[]).find(o=>o.key==='unit_id'||o.key==='address')||null;

--- a/test/test_device_plan/test_main.cpp
+++ b/test/test_device_plan/test_main.cpp
@@ -190,6 +190,34 @@ static void test_describe_row_names_the_label_when_there_is_one() {
     TEST_ASSERT_EQUAL_STRING("device 2 (Schuur)", app::describeRow(2, "Schuur").c_str());
 }
 
+/// The cases above use hand-built descriptors, which test the PLANNER. This one uses the real
+/// registry, because what it is about is one real driver's answer to "may I share a bus?".
+///
+/// SunSpec said no until 2026-07-29, with no comment and nothing in the docs explaining it,
+/// while declaring a unit_id option that only means something if several devices can differ in
+/// it. Modbus RTU addresses by unit id; several SunSpec devices on one bus is the ordinary
+/// arrangement. This test is what keeps that answer from quietly reverting.
+///
+/// It is not a hardware claim. Two SunSpec devices have never shared a real bus here.
+static void test_two_sunspec_devices_on_different_unit_ids_both_start() {
+    DriverRegistry registry;
+    registerBuiltinDrivers(registry);
+
+    Configuration config;
+    config.driver.id                 = "sunspec";
+    config.driver.options["unit_id"] = "1";
+    DriverSettings second;
+    second.id                 = "sunspec";
+    second.options["unit_id"] = "2";
+    config.additionalDevices.push_back(second);
+
+    const auto plan = app::planDevices(config, "sunspec", registry);
+
+    TEST_ASSERT_EQUAL_UINT32(2, plan.size());
+    TEST_ASSERT_TRUE(plan[0].shouldStart());
+    TEST_ASSERT_TRUE_MESSAGE(plan[1].shouldStart(), plan[1].problem.c_str());
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_a_driver_that_shares_the_bus_may_appear_many_times);
@@ -202,5 +230,6 @@ int main() {
     RUN_TEST(test_rows_are_numbered_as_the_settings_page_shows_them);
     RUN_TEST(test_the_options_pointer_reaches_the_configured_options);
     RUN_TEST(test_describe_row_names_the_label_when_there_is_one);
+    RUN_TEST(test_two_sunspec_devices_on_different_unit_ids_both_start);
     return UNITY_END();
 }

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1788,10 +1788,24 @@ static void test_drivers_payload_drives_the_wizard() {
     TEST_ASSERT_TRUE(rest::buildDriversPayload(reg.availableDrivers(), json));
     auto doc = parse(json);
 
+    // Both answers must travel, and it matters that a driver saying NO is in the payload too:
+    // the page needs the refusal in order to stop offering a second row of it. Without this
+    // field the only way to learn the answer was to save a row, restart, and read the plan's
+    // complaint -- so the page guessed instead, and guessed from the primary's driver.
+    bool sawExclusive = false, sawShareable = false;
+    for (JsonObject d : doc["drivers"].as<JsonArray>()) {
+        TEST_ASSERT_TRUE_MESSAGE(d["supports_multiple_devices"].is<bool>(),
+                                 d["id"].as<const char*>());
+        if (d["supports_multiple_devices"].as<bool>()) sawShareable = true; else sawExclusive = true;
+    }
+    TEST_ASSERT_TRUE_MESSAGE(sawShareable, "no driver reported that it can share the bus");
+    TEST_ASSERT_TRUE_MESSAGE(sawExclusive, "no driver reported that it cannot");
+
     bool foundEversolar = false;
     for (JsonObject d : doc["drivers"].as<JsonArray>()) {
         if (std::string(d["id"].as<const char*>()) == "eversolar_legacy") {
             foundEversolar = true;
+            TEST_ASSERT_TRUE(d["supports_multiple_devices"].as<bool>());
             TEST_ASSERT_EQUAL_STRING("beta", d["support_level"]);
             TEST_ASSERT_FALSE(d["supports_write"].as<bool>());
             // The wizard shows which line settings will actually be tried.

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -274,7 +274,71 @@ const tick=setInterval(async()=>{
       }
     }
 
-    // 1d. An OPEN PANEL is work in progress. A raw-bus recording runs for thirty seconds and a
+    // 1d. A pending row must be CORRECTABLE, not merely removable. It is the row most likely to
+    // still be wrong -- usually one address or one register map away from working -- and it was
+    // the only row that could not be fixed without restarting first, then fixing, then
+    // restarting again. It gets the same form a running inverter gets, keyed on the
+    // configuration slot, which is the only handle a row without a device id has.
+    cfg.additional_devices=[{driver_id:'growatt_modbus',label:'Garage',options:{profile:'sph_3_6kw',unit_id:'2'}},
+                            {driver_id:'eversolar_legacy',label:'Refused',options:{address:'17'}},
+                            {driver_id:'growatt_modbus',label:'Dak achter',options:{profile:'mic_tl_x',unit_id:'3'}}];
+    devCache['growatt_modbus-GW2400ABC'].config_slot=1;
+    devCache['growatt_modbus-GW3300XYZ'].config_slot=3;
+    panel=null; devDraft=null; paintInverters();
+    await new Promise(r=>setTimeout(r,120));
+    const pcard=[...document.querySelectorAll('#inv .card')]
+      .find(c=>c.textContent.includes('starts after a restart'));
+    const open=pcard&&[...pcard.querySelectorAll('button')]
+      .find(b=>/togglePanel\('x:/.test(b.getAttribute('onclick')||''));
+    if(!open) say('a pending row offers no way to correct it, only to delete it');
+    else{
+      open.click();
+      await new Promise(r=>setTimeout(r,150));
+      const drv=document.getElementById('dv_drv'), lab=document.getElementById('dv_label');
+      if(!drv||!lab) say('opening a pending row drew no form');
+      else{
+        // What is STORED for THAT row -- not the first row's values, which is what a form
+        // hanging off a running device would have had to fall back to.
+        if(drv.value!=='eversolar_legacy') say('the pending form shows the wrong driver: '+drv.value);
+        if(lab.value!=='Refused') say('the pending form shows the wrong name: '+lab.value);
+        const addr=document.getElementById('dv_o_address');
+        if(!addr) say('the pending form offers no address field');
+        else if(addr.value!=='17') say('the pending form shows the wrong address: '+addr.value);
+
+        // And Save must rewrite that slot and leave its siblings exactly as stored.
+        lab.value='Corrected';
+        let body=null; const rp=window.patch;
+        window.patch=async b=>{body=b;return{ok:true,body:{}}};
+        await saveDevice(2);
+        window.patch=rp;
+        const arr=body&&body.additional_devices;
+        if(!arr||arr.length!==3) say('saving a pending row did not send the whole device list');
+        else{
+          if(arr[1].label!=='Corrected') say('the edit landed on row '+arr.findIndex(d=>d.label==='Corrected')+', not row 1');
+          if(arr[0].label!=='Garage'||arr[2].label!=='Dak achter') say('saving one row rewrote its siblings');
+          if(arr[0].options.profile!=='sph_3_6kw') say('a sibling row lost its stored options');
+        }
+      }
+    }
+
+    // 1e. The form edits the CONFIGURATION, not the running device. Those differ for exactly as
+    // long as a saved change is waiting for a restart -- which is when someone is most likely to
+    // open the card again. Reading identity.driver_id showed the OLD driver there, so correcting
+    // a typo in the name and pressing Save wrote the old driver back over the pending change.
+    panel=null; devDraft=null;
+    const realDriver=cfg.driver;
+    cfg.driver={id:'mock',label:'Schuur',options:{unit_id:'4'}};
+    togglePanel('s:eversolar_legacy-EU00T112345678');
+    await new Promise(r=>setTimeout(r,150));
+    const psel=document.getElementById('dv_drv');
+    if(!psel) say('the primary settings panel drew no form');
+    else if(psel.value!=='mock'){
+      say('the form shows the running driver ('+psel.value+') instead of the saved one, so Save would revert the pending change');
+    }
+    togglePanel(null); cfg.driver=realDriver; devDraft=null;
+    await new Promise(r=>setTimeout(r,100));
+
+    // 1f. An OPEN PANEL is work in progress. A raw-bus recording runs for thirty seconds and a
     // firmware upload longer, and neither holds focus -- so the focus guard alone left both
     // being rebuilt every few seconds while they ran.
     togglePanel('cap');
@@ -292,7 +356,7 @@ const tick=setInterval(async()=>{
     await new Promise(r=>setTimeout(r,60));
     if(document.getElementById('panel-probe-2')) say('the tab never repainted again after closing the panel');
 
-    // 1e. A refusal must reach the reader from a PENDING card too. That card has no form, so
+    // 1g. A refusal must reach the reader from a PENDING card too. That card has no form, so
     // no #dv_msg, and say() begins with `if(!m)return` -- a 400 produced nothing at all: no
     // message, no alert, the row still sitting there. The firmware revalidates every remaining
     // row on any change to the array, so a legacy value in a SIBLING row refuses the removal of

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -338,6 +338,40 @@ const tick=setInterval(async()=>{
     togglePanel(null); cfg.driver=realDriver; devDraft=null;
     await new Promise(r=>setTimeout(r,100));
 
+    // 1h. A driver that polls one device per bridge must be refused HERE, not at the restart.
+    // planDevices() accepts nothing about it: the API stores the row, the page shows it waiting,
+    // and the boot after the restart skips it. The page used to have no way to know -- the
+    // driver list did not carry the answer -- so it guessed by copying the primary's driver,
+    // which for such a driver is the one guess guaranteed to be wrong.
+    panel=null; devDraft=null;
+    const keepDriver=cfg.driver, keepExtras=cfg.additional_devices;
+    cfg.driver={id:'solax_x1',label:'Vader',options:{address:'10'}};
+    cfg.additional_devices=[];
+    let added=null, said=null;
+    const rp2=window.patch, ra2=window.alert;
+    window.patch=async b=>{added=b;return{ok:true,body:{}}};
+    window.alert=m=>{said=m};
+    await addExtra();
+    window.patch=rp2; window.alert=ra2;
+    if(added) say('a second row was added for a driver that polls one device per bridge');
+    if(!said||!/one inverter per bridge/i.test(said)) say('adding it was refused without saying why: '+said);
+
+    // And typing one in by hand must be refused for the same reason, with the reason. This is
+    // the path the alert cannot cover: an existing row whose driver is changed to an exclusive
+    // one and saved.
+    const twice=addressProblem({additional_devices:[{driver_id:'solax_x1',options:{address:'11'}}]});
+    if(!twice||!/one device per bridge/i.test(twice)){
+      say('two rows of a one-per-bridge driver were accepted: '+twice);
+    }
+    // A single row of it is fine -- it is the SECOND that cannot start. Refusing the first would
+    // make the driver unusable altogether.
+    cfg.additional_devices=[];
+    const once=addressProblem({driver:{id:'solax_x1',options:{address:'10'}},additional_devices:[]});
+    if(once) say('one row of a one-per-bridge driver was refused: '+once);
+    cfg.driver=keepDriver; cfg.additional_devices=keepExtras;
+    panel=null; devDraft=null; paintInverters();
+    await new Promise(r=>setTimeout(r,100));
+
     // 1f. An OPEN PANEL is work in progress. A raw-bus recording runs for thirty seconds and a
     // firmware upload longer, and neither holds focus -- so the focus guard alone left both
     // being rebuilt every few seconds while they ran.

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -60,6 +60,11 @@ def main() -> int:
                 status |= check_auth_fetch_race(script, scratch)
                 status |= check_fleet_mode(script, scratch)
                 status |= check_address_collision(script, scratch)
+    # A final verdict, because the per-check lines are not the last thing printed: a failing
+    # check dumps node's stderr after its own FAIL line, and any tail of this output then shows
+    # a later check's OK. That is not hypothetical -- a real failure was read as green that way
+    # (2026-07-29). check_layering.sh has always ended with a verdict; this now does too.
+    print(f"RESULT: {'PASS' if status == 0 else 'FAIL'}")
     return status
 
 
@@ -272,7 +277,7 @@ def check_address_collision(script, scratch):
     # declared default, and resolving only the first is the blind spot this check exists to keep
     # closed. Pulled in rather than stubbed, so the test exercises the real resolution.
     parts = []
-    for fn in ("addressOptionOf", "addressOf", "addressProblem"):
+    for fn in ("addressOptionOf", "addressOf", "canShare", "addressProblem"):
         piece = extract_function(script, fn)
         if piece is None:
             print(f"FAIL: {fn}() not found in index_html.h; this check needs updating")
@@ -289,6 +294,10 @@ const drivers = {drivers:[
   // Declares an address with a default of 16, exactly as the real descriptor does. An empty
   // options list here would have made the fallback untestable.
   {id:'eversolar_legacy', options:[{key:'address', display_name:'Assigned bus address', default_value:'16'}]},
+  // The one that answers NO. addressProblem() refuses a SECOND row of it whatever the addresses
+  // say, because planDevices() skips that row at boot whatever the addresses say.
+  {id:'solax_x1', supports_multiple_devices:false,
+   options:[{key:'address', display_name:'Assigned bus address', default_value:'10'}]},
 ]};
 const cfg = {driver:{}, additional_devices:[]};
 """
@@ -354,6 +363,33 @@ check('two blank addresses fall back to the same default', {
 check('growatt@2 + sunspec@" 2 "', {
   driver:{id:'growatt_modbus', options:{unit_id:'2'}},
   additional_devices:[{driver_id:'sunspec', options:{unit_id:' 2 '}}]}, true);
+
+// A driver that polls one device per bridge. Distinct addresses do not save it: planDevices()
+// refuses the second row at boot regardless, so saying "no problem" here would be the page
+// blessing a row that cannot start.
+const excl = (label, body, want) => {
+  const got = addressProblem(body);
+  const said = !!got && got.includes('one device per bridge');
+  if (said !== want) {
+    console.error(`${label}: got ${JSON.stringify(got)}, wanted ${want ? 'a refusal' : 'none'}`);
+    bad++;
+  }
+};
+excl('two solax rows on different addresses', {
+  driver:{id:'solax_x1', options:{address:'10'}},
+  additional_devices:[{driver_id:'solax_x1', options:{address:'11'}}]}, true);
+// One of it is the ordinary case and must stay allowed, or the driver is unusable.
+excl('one solax row', {
+  driver:{id:'solax_x1', options:{address:'10'}}, additional_devices:[]}, false);
+// And it must not spill onto drivers that can share.
+excl('two growatt rows', {
+  driver:{id:'growatt_modbus', options:{unit_id:'2'}},
+  additional_devices:[{driver_id:'growatt_modbus', options:{unit_id:'3'}}]}, false);
+// A driver that omits the field -- an older bridge, or any driver added before it existed.
+// The benefit of the doubt is the documented default.
+excl('a driver that says nothing either way', {
+  driver:{id:'eversolar_legacy', options:{address:'16'}},
+  additional_devices:[{driver_id:'eversolar_legacy', options:{address:'17'}}]}, false);
 
 process.exit(bad === 0 ? 0 : 1);
 """

--- a/tools/demo_fleet.js
+++ b/tools/demo_fleet.js
@@ -130,7 +130,7 @@
     relays:{enabled:false,roles:[]}
   };
   const driversDoc = {drivers:[
-    {id:'eversolar_legacy',display_name:'EverSolar / Zeversolar legacy',support_level:'beta',
+    {id:'eversolar_legacy',supports_multiple_devices:true,display_name:'EverSolar / Zeversolar legacy',support_level:'beta',
       description:'AA55 framing over RS485, for TL-series inverters abandoned by their portal.',
       serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
       options:[
@@ -139,7 +139,7 @@
         {key:'address',display_name:'Assigned bus address',default_value:'16',
          min_value:16,max_value:254,
          description:'Address this bridge hands its inverter at registration. Leave at 16 unless more than one shares the loop.'}]},
-    {id:'growatt_modbus',display_name:'Growatt (Modbus)',support_level:'experimental',
+    {id:'growatt_modbus',supports_multiple_devices:true,display_name:'Growatt (Modbus)',support_level:'experimental',
       description:'Modbus RTU. The register map is a data file, so one driver serves several models.',
       serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
       options:[
@@ -147,9 +147,19 @@
          default_value:'',description:'Which model this unit is. It cannot be detected — probing identifies the protocol, never the model.'},
         {key:'unit_id',display_name:'Bus address',default_value:'1',min_value:1,max_value:247,
          description:'Must match the address set in the inverter’s own menu, and be unique on this bus.'}]},
-    {id:'mock',display_name:'Mock Inverter',support_level:'stable',
+    {id:'mock',supports_multiple_devices:true,display_name:'Mock Inverter',support_level:'stable',
       description:'A simulated three-phase hybrid, for UI and integration work with no bus.',
-      serial_profiles:[],options:[{key:'unit_id',display_name:'Bus address',default_value:'1'}]}
+      serial_profiles:[],options:[{key:'unit_id',display_name:'Bus address',default_value:'1'}]},
+    // The one driver that answers NO. It is here because the page must be able to say so BEFORE
+    // a restart -- the firmware refuses the second row at boot, which is the wrong moment to
+    // find out, and until this field existed the page had no way to know.
+    {id:'solax_x1',supports_multiple_devices:false,display_name:'SolaX X1 (AA55)',support_level:'experimental',
+      description:'One inverter per bridge: the address is handed out at registration, not read.',
+      serial_profiles:[{baud_rate:9600,parity:'none',data_bits:8,stop_bits:1}],
+      options:[
+        {key:'address',display_name:'Assigned bus address',default_value:'10',
+         min_value:10,max_value:254,
+         description:'Address this bridge hands its inverter at registration.'}]}
   ]};
   const diagnostics = {
     uptime_seconds:5061,firmware_version:'0.14.0',board:'Waveshare ESP32-S3-RS485-CAN',


### PR DESCRIPTION
Carries the content of **#138**, **#139** and **#140**, which were merged into their own stacked
base branches instead of into `main`. Same failure that took #135 off course earlier today, and
this time I caused it: my merge loop merged each PR *before* retargeting it, so each landed on the
branch below it. Those three PRs are closed as merged and cannot be reopened, so the work comes
back as one PR.

Nothing was lost. This branch is `fix/drivers-report-sharing` rebased onto the current `main`,
dropping the commits `main` already carries as squashes of #135–#137. **The rebased tree is
byte-identical to the old branch tip** — a `git diff` between them is empty — so what is here is
exactly the seven commits of the three PRs, unchanged.

## What is in it

**#138 — SunSpec may share a bus.** The flag said `false` with no comment anywhere, while the
driver declared a `unit_id` option and an `addressOptionKey`. Modbus RTU addresses by unit id.
Now `true`, with what it does *not* claim written down: two SunSpec devices have never shared a
real bus here. Test uses the real registry, not a fixture.

**#139 — a row waiting for a restart could be deleted but not corrected.** The form hung off a
running device; it now hangs off the configuration row (slot 0 = `driver`, 1..N =
`additional_devices`), which both kinds of card have. Removes `extraOptionsFor` and
`extraIndexOf`. Two things fell out: a quiet revert (reopening the card after a driver change
showed the *running* driver, so saving wrote it back over the pending change) and a must-pick gate
that never ran at paint time.

**#140 — `supports_multiple_devices` in `/api/v1/drivers`.** A driver that polls one device per
bridge was refused only at boot, after the restart performed to apply the change. The page now
refuses it up front in three places. SolaX stays `false` but its line finally says why.

## Verification

847 native tests, 16 browser checks, layering, web build and firmware all green on this exact
tree. Every check added across the three PRs was mutation-tested when written.