### PR TITLE
chore(tools): one browser finder instead of two drifting copies

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -61,6 +61,11 @@ jobs:
               - 'platformio.ini'
               - 'partitions_*.csv'
               - 'tools/gen_profiles.py'
+              # A pre: extra_script in every `pio run`: it strips and gzips the web page into
+              # the header the firmware compiles in. Missing from this list until 2026-07-29,
+              # which let a PR changing only this file go green without one firmware build --
+              # found when exactly such a PR skipped all four boards.
+              - 'tools/build_web.py'
               - '.github/workflows/firmware.yml'
       - id: envs
         env:

--- a/tools/build_web.py
+++ b/tools/build_web.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import gzip
 import pathlib
 import re
+import shutil
 import sys
 
 ROOT = pathlib.Path.cwd()
@@ -44,6 +45,28 @@ PAGES = [
 ]
 
 RAW = re.compile(r'R"HTML\((.*?)\)HTML"', re.S)
+
+
+def find_chrome() -> str | None:
+    """A Chrome or Chromium binary to render with, or None.
+
+    Lives here because this is the module every page-rendering tool already imports; it
+    existed twice, in check_dashboard_layout and make_screenshots, each with its own browser
+    list -- the drift that invites is two tools disagreeing about which browser they found.
+    Returning None rather than raising keeps the softer contract; a caller that cannot
+    continue without a browser raises at its own call site, with its own message.
+    """
+    for name in (
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+    ):
+        found = shutil.which(name)
+        if found:
+            return found
+    mac = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    return mac if pathlib.Path(mac).exists() else None
 
 
 def set_root(root: pathlib.Path) -> None:

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -26,7 +26,6 @@
 
 import pathlib
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -649,20 +648,6 @@ const tick=setInterval(async()=>{
 """
 
 
-def find_chrome() -> str | None:
-    for name in (
-        "google-chrome",
-        "google-chrome-stable",
-        "chromium",
-        "chromium-browser",
-    ):
-        found = shutil.which(name)
-        if found:
-            return found
-    mac = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-    return mac if pathlib.Path(mac).exists() else None
-
-
 def build_page(stripped: str, stub: str, battery: str, extra_js: str) -> str:
     """The served page with the stub attached, and the assertions after it.
 
@@ -717,7 +702,7 @@ def main() -> int:
     stripped = build_web.served_page()
     stub = (ROOT / "tools" / "demo_fleet.js").read_text(encoding="utf-8")
 
-    chrome = find_chrome()
+    chrome = build_web.find_chrome()
     if chrome is None:
         print("dashboard layout: FAIL (no Chrome/Chromium on PATH to render with)")
         return 1

--- a/tools/make_screenshots.py
+++ b/tools/make_screenshots.py
@@ -28,7 +28,6 @@ import http.server
 import json
 import pathlib
 import re
-import shutil
 import socketserver
 import subprocess
 import sys
@@ -215,22 +214,6 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         self.wfile.write(encoded)
 
 
-def find_chrome() -> str:
-    for name in (
-        "google-chrome",
-        "google-chrome-stable",
-        "chromium",
-        "chromium-browser",
-    ):
-        found = shutil.which(name)
-        if found:
-            return found
-    mac = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-    if pathlib.Path(mac).exists():
-        return mac
-    raise SystemExit("no Chrome or Chromium on PATH to render with")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -279,7 +262,9 @@ def main() -> int:
 
     Handler.page = extract_page()
     Handler.data = data
-    chrome = find_chrome()
+    chrome = build_web.find_chrome()
+    if chrome is None:
+        raise SystemExit("no Chrome or Chromium on PATH to render with")
 
     with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
         port = server.server_address[1]


### PR DESCRIPTION
The single actionable finding of a full cleanup audit (2026-07-29, three days after the 0.23.0
cleanup pass — the discipline held).

## The audit, for the record

| Category | Result |
|---|---|
| Own-code warnings (cold native + cold firmware, `-Wall -Wextra`) | **0** |
| Deprecations in own code | **0** — 4 sit in eModbus, 44 in the framework; fixing those means forking a dependency this project decided to keep, and they stay visible in build output rather than suppressed |
| Dead code | none — all 109 page functions referenced, no commented-out blocks, no orphan headers, no unused defines (the four suspects are consumed by the framework/Unity, not `src/`) |
| Duplication | **this PR**; declined: the ~8-line transact guard shared by the two PMU drivers (hoisting couples two drivers for marginal gain) |
| Hand-rolled vs stdlib | already `tomllib`/`gzip`; the page's own JS helpers cannot become a library — it serves self-contained from the ESP32 |
| Dependency pins | all verified against upstream **today**: ESPAsyncWebServer 3.12.0, AsyncTCP 3.5.0, eModbus 1.7.4, ArduinoJson 7.4.3 — each the latest release |
| Ruff | clean, local pin == CI pin (0.15.18) |
| Docs | no broken links; every tool referenced somewhere |

## Second finding — surfaced by this PR's own first CI run

The first run skipped all four board builds, and reading *why* exposed a gap: `tools/build_web.py`
is a `pre:` extra_script in every `pio run` — it produces the gzipped page header the firmware
compiles in — but it was missing from the paths-filter's positive list. A PR changing only that
file altered the shipped bytes while building nothing; the first real build of such a change
would have been the release. The filter's own comment states the rule ("keep this in step with
what `pio run` actually consumes"); the second commit makes the list match it. This PR's second
CI run is the demonstration: same tools-only diff, four board builds now run.

## This change

`find_chrome()` existed twice with separate browser lists and different contracts. One
definition now, in `build_web` — both callers already import it, so no new coupling. Both
CLI behaviours byte-identical: the dashboard check prints its FAIL line on None, the
screenshot tool raises with its existing message.

Verified: ruff clean, `build_web --self-test`, all 16 browser checks green through the shared
function, `make_screenshots --help` loads, and a mutation test (empty which + absent mac path
→ `None`). 847 native tests, layering, firmware build green — untouched by a tools-only
change, run anyway.

No external behaviour changes.
