### PR TITLE
feat(diagnostics): reset breadcrumbs — the sixteen bytes that provably survive

### DIFF
--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -6,6 +6,8 @@
 #pragma once
 
 #include <cstdint>
+
+#include "diagnostics/breadcrumbs.h"
 #include <string>
 #include <vector>
 
@@ -103,6 +105,17 @@ struct BridgeInfo {
     /// and a size that cannot disagree with its contents is one fewer thing to get wrong.
     std::vector<uint32_t> coredumpBacktrace;
     bool                  coredumpBacktraceCorrupted = false;
+
+    /// Reset breadcrumbs from RTC-domain SRAM (diagnostics/breadcrumbs.h): how many times
+    /// this device has booted since it last lost power, and how each previous life ended.
+    /// Same kind of one-shot boot fact as the coredump block above, carried here for the same
+    /// reason. bootCount 0 means "not wired" (host tests); the target always sets >= 1.
+    /// breadcrumbsCold true on a cold start -- previousUptimeMs and resetHistory are
+    /// meaningless then and outputs report them absent, per the coredump precedent.
+    uint32_t bootCount       = 0;
+    bool     breadcrumbsCold = true;
+    uint32_t previousUptimeMs = 0;
+    std::vector<breadcrumbs::Entry> resetHistory;
 
     /// The board this firmware is running on. Reported to Home Assistant as the bridge
     /// device's model.

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -6,8 +6,6 @@
 #pragma once
 
 #include <cstdint>
-
-#include "diagnostics/breadcrumbs.h"
 #include <string>
 #include <vector>
 

--- a/src/device/bridge_info.h
+++ b/src/device/bridge_info.h
@@ -107,15 +107,16 @@ struct BridgeInfo {
     bool                  coredumpBacktraceCorrupted = false;
 
     /// Reset breadcrumbs from RTC-domain SRAM (diagnostics/breadcrumbs.h): how many times
-    /// this device has booted since it last lost power, and how each previous life ended.
-    /// Same kind of one-shot boot fact as the coredump block above, carried here for the same
-    /// reason. bootCount 0 means "not wired" (host tests); the target always sets >= 1.
-    /// breadcrumbsCold true on a cold start -- previousUptimeMs and resetHistory are
-    /// meaningless then and outputs report them absent, per the coredump precedent.
-    uint32_t bootCount       = 0;
-    bool     breadcrumbsCold = true;
+    /// this device has booted since it last lost power, and how far the previous life got.
+    /// Same kind of one-shot boot fact as the coredump block above, carried here for the
+    /// same reason. bootCount 0 means "not wired" (host tests); the target always sets >= 1.
+    /// breadcrumbsCold true on a cold start -- the previous* fields are meaningless then and
+    /// outputs report them absent, per the coredump precedent. The previous life's death
+    /// reason is not here: it is this boot's resetReason, already above.
+    uint32_t bootCount        = 0;
+    bool     breadcrumbsCold  = true;
     uint32_t previousUptimeMs = 0;
-    std::vector<breadcrumbs::Entry> resetHistory;
+    uint32_t previousFirmware = 0;
 
     /// The board this firmware is running on. Reported to Home Assistant as the bridge
     /// device's model.

--- a/src/diagnostics/breadcrumbs.cpp
+++ b/src/diagnostics/breadcrumbs.cpp
@@ -1,25 +1,21 @@
 // SPDX-License-Identifier: MIT
 //
-// See breadcrumbs.h for the why. Implementation notes that matter here:
+// See breadcrumbs.h for the sixteen-byte story. Implementation notes that matter here:
 //
-// The CRC covers every byte of Storage up to (not including) the crc field itself, and it is
-// recomputed on every heartbeat. That sounds expensive and is not: the struct is ~120 bytes,
-// the heartbeat is throttled to once per second, and CRC32 of 120 bytes is microseconds. What
-// it buys is that a reset AT ANY MOMENT leaves storage either valid (the last completed write)
-// or invalid (a torn write) -- and a torn write reads as a cold start, never as invented
-// history. On this codebase's own rule that wrong data is worse than no data, that is the
-// entire design.
+// The CRC covers the twelve bytes before it and is rewritten on every heartbeat, so a reset
+// at any moment leaves storage either valid (the last completed write) or invalid (a torn
+// write) -- and a torn write reads as a cold start, never as an invented past. On this
+// codebase's own rule that wrong data is worse than no data, that is the entire design.
 
 #include "breadcrumbs.h"
 
+#include <cstddef>
 #include <cstring>
 
 namespace heliograph::breadcrumbs {
 namespace {
 
-constexpr uint32_t kMagic = 0x48454C42;  // "HELB"
-
-/// Plain CRC32 (reflected, poly 0xEDB88320), byte at a time, no table. ~120 bytes once a
+/// Plain CRC32 (reflected, poly 0xEDB88320), byte at a time, no table. Twelve bytes once a
 /// second does not justify 1 KB of lookup table in a build where RAM is the scarce resource.
 uint32_t crc32(const uint8_t* data, size_t len) {
     uint32_t crc = 0xFFFFFFFFu;
@@ -36,49 +32,26 @@ uint32_t storageCrc(const Storage& s) {
     return crc32(reinterpret_cast<const uint8_t*>(&s), offsetof(Storage, crc));
 }
 
-bool valid(const Storage& s) {
-    return s.magic == kMagic && s.ringNext < kRingSize && s.ringCount <= kRingSize &&
-           s.crc == storageCrc(s);
-}
-
 }  // namespace
 
-BootRecord begin(Storage& storage, uint8_t thisResetReason, uint32_t runningFirmware) {
+BootRecord begin(Storage& storage, uint32_t runningFirmware) {
     BootRecord record;
 
-    if (valid(storage)) {
-        // Warm: the previous life ended with `thisResetReason`; its last heartbeat says how
-        // far it got. Record it before touching anything else.
-        Entry& slot      = storage.ring[storage.ringNext];
-        slot.resetReason = thisResetReason;
-        slot.uptimeMs    = storage.heartbeatUptimeMs;
-        slot.firmware    = storage.runningFirmware;
-        storage.ringNext = static_cast<uint8_t>((storage.ringNext + 1) % kRingSize);
-        if (storage.ringCount < kRingSize) {
-            ++storage.ringCount;
-        }
-        ++storage.bootCount;
-        record.coldStart = false;
-    } else {
-        // Cold: garbage (power loss), or genuinely the first boot. Same answer either way.
-        std::memset(&storage, 0, sizeof storage);
-        storage.magic     = kMagic;
-        storage.bootCount = 1;
+    if (storage.crc == storageCrc(storage)) {
+        // Warm: the previous life's last heartbeat says how far it got, and its firmware
+        // field says what it was running. Its death reason is this boot's
+        // esp_reset_reason(), which the caller already exposes -- nothing to store.
+        record.coldStart        = false;
+        record.previousUptimeMs = storage.heartbeatUptimeMs;
+        record.previousFirmware = storage.runningFirmware;
+        record.bootCount        = storage.bootCount + 1;
     }
-
+    // Cold path and warm path converge: write this life's record. On cold, bootCount in
+    // the record defaulted to 1.
+    storage.bootCount         = record.bootCount;
     storage.heartbeatUptimeMs = 0;
     storage.runningFirmware   = runningFirmware;
     storage.crc               = storageCrc(storage);
-
-    record.bootCount = storage.bootCount;
-    record.history.reserve(storage.ringCount);
-    // Oldest first: with a full ring the oldest entry sits AT ringNext (the slot about to be
-    // overwritten next); with a partial ring the entries start at 0.
-    const size_t start =
-        storage.ringCount == kRingSize ? storage.ringNext : 0;
-    for (size_t i = 0; i < storage.ringCount; ++i) {
-        record.history.push_back(storage.ring[(start + i) % kRingSize]);
-    }
     return record;
 }
 

--- a/src/diagnostics/breadcrumbs.cpp
+++ b/src/diagnostics/breadcrumbs.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+//
+// See breadcrumbs.h for the why. Implementation notes that matter here:
+//
+// The CRC covers every byte of Storage up to (not including) the crc field itself, and it is
+// recomputed on every heartbeat. That sounds expensive and is not: the struct is ~120 bytes,
+// the heartbeat is throttled to once per second, and CRC32 of 120 bytes is microseconds. What
+// it buys is that a reset AT ANY MOMENT leaves storage either valid (the last completed write)
+// or invalid (a torn write) -- and a torn write reads as a cold start, never as invented
+// history. On this codebase's own rule that wrong data is worse than no data, that is the
+// entire design.
+
+#include "breadcrumbs.h"
+
+#include <cstring>
+
+namespace heliograph::breadcrumbs {
+namespace {
+
+constexpr uint32_t kMagic = 0x48454C42;  // "HELB"
+
+/// Plain CRC32 (reflected, poly 0xEDB88320), byte at a time, no table. ~120 bytes once a
+/// second does not justify 1 KB of lookup table in a build where RAM is the scarce resource.
+uint32_t crc32(const uint8_t* data, size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; ++b) {
+            crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+        }
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+uint32_t storageCrc(const Storage& s) {
+    return crc32(reinterpret_cast<const uint8_t*>(&s), offsetof(Storage, crc));
+}
+
+bool valid(const Storage& s) {
+    return s.magic == kMagic && s.ringNext < kRingSize && s.ringCount <= kRingSize &&
+           s.crc == storageCrc(s);
+}
+
+}  // namespace
+
+BootRecord begin(Storage& storage, uint8_t thisResetReason, uint32_t runningFirmware) {
+    BootRecord record;
+
+    if (valid(storage)) {
+        // Warm: the previous life ended with `thisResetReason`; its last heartbeat says how
+        // far it got. Record it before touching anything else.
+        Entry& slot      = storage.ring[storage.ringNext];
+        slot.resetReason = thisResetReason;
+        slot.uptimeMs    = storage.heartbeatUptimeMs;
+        slot.firmware    = storage.runningFirmware;
+        storage.ringNext = static_cast<uint8_t>((storage.ringNext + 1) % kRingSize);
+        if (storage.ringCount < kRingSize) {
+            ++storage.ringCount;
+        }
+        ++storage.bootCount;
+        record.coldStart = false;
+    } else {
+        // Cold: garbage (power loss), or genuinely the first boot. Same answer either way.
+        std::memset(&storage, 0, sizeof storage);
+        storage.magic     = kMagic;
+        storage.bootCount = 1;
+    }
+
+    storage.heartbeatUptimeMs = 0;
+    storage.runningFirmware   = runningFirmware;
+    storage.crc               = storageCrc(storage);
+
+    record.bootCount = storage.bootCount;
+    record.history.reserve(storage.ringCount);
+    // Oldest first: with a full ring the oldest entry sits AT ringNext (the slot about to be
+    // overwritten next); with a partial ring the entries start at 0.
+    const size_t start =
+        storage.ringCount == kRingSize ? storage.ringNext : 0;
+    for (size_t i = 0; i < storage.ringCount; ++i) {
+        record.history.push_back(storage.ring[(start + i) % kRingSize]);
+    }
+    return record;
+}
+
+void tick(Storage& storage, uint32_t uptimeMs) {
+    // One write per second of uptime. The comparison also handles the first call (heartbeat
+    // starts at 0) and is immune to loop() pace.
+    if (uptimeMs < storage.heartbeatUptimeMs + 1000) {
+        return;
+    }
+    storage.heartbeatUptimeMs = uptimeMs;
+    storage.crc               = storageCrc(storage);
+}
+
+}  // namespace heliograph::breadcrumbs

--- a/src/diagnostics/breadcrumbs.h
+++ b/src/diagnostics/breadcrumbs.h
@@ -1,74 +1,69 @@
 // SPDX-License-Identifier: MIT
 //
-// Reset breadcrumbs in RTC-domain SRAM: what this device was doing when it last died.
+// Reset breadcrumbs in RTC-domain SRAM: how many lives this device has had since it last
+// lost power, and how far the previous one got.
 //
 // RTC_NOINIT memory survives panic, watchdog and software reset on every supported board --
 // including the Relay-6CH, which has no battery-backed clock and therefore no other way to
-// annotate a reset that happened before NTP. Until this existed, the only post-reset evidence
-// was esp_reset_reason() (one number, previous reset only) and a coredump (panics only). A
-// bridge that watchdogged at night on variant C could not even say how long it had been up.
+// annotate a reset that happens before NTP. The contract is deliberately clock-free: the
+// record carries UPTIME, never wall time, so it is exactly as trustworthy on a board that
+// boots at epoch 0 as on one with an RTC. The reason the previous life ended is not stored
+// at all: the boot that reads this record learns it first-hand from esp_reset_reason().
 //
-// The contract is deliberately clock-free: entries carry UPTIME at death, never wall time, so
-// they are exactly as trustworthy on a board that boots at epoch 0 as on one with an RTC.
-// Ordering comes from position in the ring, not from timestamps.
+// WHY SIXTEEN BYTES, AND NOT THE RING THIS STARTED AS. The first version kept an
+// eight-entry history ring in a 120-byte struct. On real hardware (Relay-6CH, 2026-07-29,
+// serial session -- see PR #147) the full firmware's restart transition zeroes bytes
+// [16,116) of that struct on every single reset, while bytes [0,16) survive; a bare sketch
+// on the same board, same flavor, same bank, survives entirely. What performs that zeroing
+// is still unknown -- bootloader BSS, absolute-address writers, OTA-slot ping-pong and
+// mid-life corruption were all ruled out with direct evidence -- so this design trusts ONLY
+// the sixteen bytes that were measured to survive, with the CRC inside them. If even that
+// window ever stops surviving, the CRC turns it into a clean cold start: wrong data is
+// worse than no data, and a cold start is not wrong. The ring returns if the
+// grow-the-repro investigation ever names the culprit; git history has it.
 //
-// This header is host-testable end to end: the logic operates on a caller-owned Storage
-// struct, and only main.cpp places that struct in RTC_NOINIT_ATTR memory. Power loss clears
-// RTC RAM on real hardware; the CRC is what turns that garbage into a clean cold start
-// instead of a fabricated history -- wrong data would be worse than no data.
+// Host-testable end to end: the logic operates on a caller-owned Storage struct, and only
+// main.cpp places that struct in RTC_NOINIT_ATTR memory.
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
-#include <vector>
 
 namespace heliograph::breadcrumbs {
 
-/// One prior life of this device: how it ended, how long it had run, what it was running.
-struct Entry {
-    /// esp_reset_reason() value observed by the boot FOLLOWING this life. Numeric, matching
-    /// the `reset_reason` field the diagnostics payload already exposes.
-    uint8_t resetReason = 0;
-    /// The heartbeat's last written uptime -- "it had been up this long when it died". The
-    /// heartbeat ticks at most once a second, so this understates by less than a second.
-    uint32_t uptimeMs = 0;
-    /// (major<<16)|(minor<<8)|patch of the image that died. "Died right after an OTA" is the
-    /// single most valuable thing a reset history can show.
-    uint32_t firmware = 0;
-};
-
-inline constexpr size_t kRingSize = 8;
-
-/// The raw bytes that live in RTC-domain SRAM. POD on purpose: RTC_NOINIT_ATTR memory is
-/// never constructed, so anything with a constructor would be UB there.
+/// The sixteen bytes that live in RTC-domain SRAM. POD on purpose: RTC_NOINIT memory is
+/// never constructed. No magic field -- the CRC over the first twelve bytes is the
+/// validity test, and twelve bytes of power-on garbage passing a CRC32 is a
+/// once-per-four-billion event that still only costs one fabricated boot count.
 struct Storage {
-    uint32_t magic;
     uint32_t bootCount;
     uint32_t heartbeatUptimeMs;
+    /// (major<<16)|(minor<<8)|patch of the image that is running. "The previous life died
+    /// right after an OTA" is the single most valuable thing this record can show.
     uint32_t runningFirmware;
-    Entry    ring[kRingSize];
-    uint8_t  ringNext;  // next slot to write; ring[ringNext-1] is the newest entry
-    uint8_t  ringCount; // entries actually written, saturates at kRingSize
-    /// Over everything above. Last on purpose: the CRC of a struct must not include itself.
+    /// Over the three fields above. Inside the trusted window, unlike the ring version,
+    /// whose CRC lived at offset 116 and only survived by accident of layout.
     uint32_t crc;
 };
 
 /// What begin() learned about the past, for the diagnostics payload.
 struct BootRecord {
-    /// True when storage held no valid history: first boot ever, or power was lost (RTC RAM
+    /// True when storage held no valid record: first boot ever, or power was lost (RTC RAM
     /// does not survive power-off) -- indistinguishable by design, and both honestly "cold".
     bool coldStart = true;
     /// 1 on a cold start; monotonic across warm resets.
     uint32_t bootCount = 1;
-    /// Oldest first. Empty on a cold start.
-    std::vector<Entry> history;
+    /// The previous life's last heartbeat: "it had been up this long when it died".
+    /// Meaningless on a cold start; the payload reports it absent then.
+    uint32_t previousUptimeMs = 0;
+    /// The image the previous life was running, same encoding as Storage::runningFirmware.
+    uint32_t previousFirmware = 0;
 };
 
-/// Validates storage, records the previous life (when warm), initialises for this one.
-/// Call once, early in setup(), BEFORE anything that could crash: a boot that dies later
-/// still leaves its predecessor recorded.
-BootRecord begin(Storage& storage, uint8_t thisResetReason, uint32_t runningFirmware);
+/// Validates storage, captures the previous life (when warm), initialises for this one.
+/// Call once, first thing in setup(): a boot that dies later still leaves its predecessor
+/// on record, and its own death becomes the next boot's record.
+BootRecord begin(Storage& storage, uint32_t runningFirmware);
 
 /// Heartbeat: remembers how far this life got. Throttled internally to one write per second
 /// of uptime -- calling it every loop() pass is fine and expected.

--- a/src/diagnostics/breadcrumbs.h
+++ b/src/diagnostics/breadcrumbs.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+//
+// Reset breadcrumbs in RTC-domain SRAM: what this device was doing when it last died.
+//
+// RTC_NOINIT memory survives panic, watchdog and software reset on every supported board --
+// including the Relay-6CH, which has no battery-backed clock and therefore no other way to
+// annotate a reset that happened before NTP. Until this existed, the only post-reset evidence
+// was esp_reset_reason() (one number, previous reset only) and a coredump (panics only). A
+// bridge that watchdogged at night on variant C could not even say how long it had been up.
+//
+// The contract is deliberately clock-free: entries carry UPTIME at death, never wall time, so
+// they are exactly as trustworthy on a board that boots at epoch 0 as on one with an RTC.
+// Ordering comes from position in the ring, not from timestamps.
+//
+// This header is host-testable end to end: the logic operates on a caller-owned Storage
+// struct, and only main.cpp places that struct in RTC_NOINIT_ATTR memory. Power loss clears
+// RTC RAM on real hardware; the CRC is what turns that garbage into a clean cold start
+// instead of a fabricated history -- wrong data would be worse than no data.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace heliograph::breadcrumbs {
+
+/// One prior life of this device: how it ended, how long it had run, what it was running.
+struct Entry {
+    /// esp_reset_reason() value observed by the boot FOLLOWING this life. Numeric, matching
+    /// the `reset_reason` field the diagnostics payload already exposes.
+    uint8_t resetReason = 0;
+    /// The heartbeat's last written uptime -- "it had been up this long when it died". The
+    /// heartbeat ticks at most once a second, so this understates by less than a second.
+    uint32_t uptimeMs = 0;
+    /// (major<<16)|(minor<<8)|patch of the image that died. "Died right after an OTA" is the
+    /// single most valuable thing a reset history can show.
+    uint32_t firmware = 0;
+};
+
+inline constexpr size_t kRingSize = 8;
+
+/// The raw bytes that live in RTC-domain SRAM. POD on purpose: RTC_NOINIT_ATTR memory is
+/// never constructed, so anything with a constructor would be UB there.
+struct Storage {
+    uint32_t magic;
+    uint32_t bootCount;
+    uint32_t heartbeatUptimeMs;
+    uint32_t runningFirmware;
+    Entry    ring[kRingSize];
+    uint8_t  ringNext;  // next slot to write; ring[ringNext-1] is the newest entry
+    uint8_t  ringCount; // entries actually written, saturates at kRingSize
+    /// Over everything above. Last on purpose: the CRC of a struct must not include itself.
+    uint32_t crc;
+};
+
+/// What begin() learned about the past, for the diagnostics payload.
+struct BootRecord {
+    /// True when storage held no valid history: first boot ever, or power was lost (RTC RAM
+    /// does not survive power-off) -- indistinguishable by design, and both honestly "cold".
+    bool coldStart = true;
+    /// 1 on a cold start; monotonic across warm resets.
+    uint32_t bootCount = 1;
+    /// Oldest first. Empty on a cold start.
+    std::vector<Entry> history;
+};
+
+/// Validates storage, records the previous life (when warm), initialises for this one.
+/// Call once, early in setup(), BEFORE anything that could crash: a boot that dies later
+/// still leaves its predecessor recorded.
+BootRecord begin(Storage& storage, uint8_t thisResetReason, uint32_t runningFirmware);
+
+/// Heartbeat: remembers how far this life got. Throttled internally to one write per second
+/// of uptime -- calling it every loop() pass is fine and expected.
+void tick(Storage& storage, uint32_t uptimeMs);
+
+}  // namespace heliograph::breadcrumbs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,8 @@
 #include <Arduino.h>
 #include <WiFi.h>
 #include <esp_task_wdt.h>
+
+#include "diagnostics/breadcrumbs.h"
 #include <esp_timer.h>
 
 #include <algorithm>
@@ -463,8 +465,26 @@ void applySerialOverride() {
     }
 }
 
+// RTC-domain SRAM for the reset breadcrumbs. HARDWARE PERSISTENCE IS CURRENTLY BROKEN and
+// the PR carrying this is blocked on it: measured on the Relay-6CH (2026-07-29 evening, both
+// the slow bank 0x50000200 and .rtc.force_fast), something in the prebuilt-core runtime
+// rewrites this region during normal operation -- with the heartbeat disabled, even the CRC
+// begin() writes at boot never survives to the next boot, so every boot reads cold. The
+// suspected mechanism is a linker/lib mismatch around the core's own RTC-slow users (system
+// time keeping survives resets through this bank); root-causing needs a serial session or a
+// minimal repro sketch, not more OTA loops. The logic is host-tested and correct; only the
+// storage's survival is unproven. See docs/audit-2026-07-29.md F4.
+RTC_NOINIT_ATTR breadcrumbs::Storage g_breadcrumbStore;
+static breadcrumbs::BootRecord       g_bootRecord;
+
 BridgeInfo bridgeInfo() {
     BridgeInfo info;
+    info.bootCount        = g_bootRecord.bootCount;
+    info.breadcrumbsCold  = g_bootRecord.coldStart;
+    if (!g_bootRecord.coldStart && !g_bootRecord.history.empty()) {
+        info.previousUptimeMs = g_bootRecord.history.back().uptimeMs;
+        info.resetHistory     = g_bootRecord.history;
+    }
     info.boardName        = board::kName;
     info.boardId          = board::kId;
     info.bridgeId         = g_wifi.bridgeId();
@@ -1241,6 +1261,13 @@ void setup() {
     // No GPIO forcing here. Earlier revisions drove GPIO47 low first thing, believing this
     // board was the Relay-1CH and that pin its relay. The real board (RS485-CAN) has no
     // relay, and the safest state for a pin with no known function is untouched hi-Z.
+    // First thing, before anything that could crash: a boot that dies during setup still
+    // leaves its predecessor's death recorded, and its own becomes the next entry.
+    g_bootRecord = breadcrumbs::begin(
+        g_breadcrumbStore, static_cast<uint8_t>(esp_reset_reason()),
+        (static_cast<uint32_t>(kFirmwareMajor) << 16) |
+            (static_cast<uint32_t>(kFirmwareMinor) << 8) | kFirmwarePatch);
+
     Serial.begin(115200);
     const uint32_t serialDeadline = millis() + 2000;
     while (!Serial && millis() < serialDeadline) {
@@ -1539,6 +1566,10 @@ void loop() {
         bootConfirmed = true;
         log::info("ota: image confirmed healthy; rollback cancelled");
     }
+
+    // Breadcrumb heartbeat: "this life reached this uptime". Throttled inside to one RTC-RAM
+    // write per second.
+    breadcrumbs::tick(g_breadcrumbStore, static_cast<uint32_t>(nowMs()));
 
     g_wifi.loop(nowMs());
     startOutputs();  // no-op until there is a network, and only ever runs once

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -465,15 +465,11 @@ void applySerialOverride() {
     }
 }
 
-// RTC-domain SRAM for the reset breadcrumbs. HARDWARE PERSISTENCE IS CURRENTLY BROKEN and
-// the PR carrying this is blocked on it: measured on the Relay-6CH (2026-07-29 evening, both
-// the slow bank 0x50000200 and .rtc.force_fast), something in the prebuilt-core runtime
-// rewrites this region during normal operation -- with the heartbeat disabled, even the CRC
-// begin() writes at boot never survives to the next boot, so every boot reads cold. The
-// suspected mechanism is a linker/lib mismatch around the core's own RTC-slow users (system
-// time keeping survives resets through this bank); root-causing needs a serial session or a
-// minimal repro sketch, not more OTA loops. The logic is host-tested and correct; only the
-// storage's survival is unproven. See docs/audit-2026-07-29.md F4.
+// RTC-domain SRAM for the reset breadcrumbs. Sixteen bytes on purpose: the serial session
+// of 2026-07-29 (PR #147) measured that the full firmware's restart transition zeroes
+// bytes [16,116) of a larger struct here while the first sixteen survive -- cause still
+// unknown, bare sketches immune. This struct fits entirely inside the measured-surviving
+// window, CRC included; if the window ever shrinks, the CRC reads it as a cold start.
 RTC_NOINIT_ATTR breadcrumbs::Storage g_breadcrumbStore;
 static breadcrumbs::BootRecord       g_bootRecord;
 
@@ -481,10 +477,8 @@ BridgeInfo bridgeInfo() {
     BridgeInfo info;
     info.bootCount        = g_bootRecord.bootCount;
     info.breadcrumbsCold  = g_bootRecord.coldStart;
-    if (!g_bootRecord.coldStart && !g_bootRecord.history.empty()) {
-        info.previousUptimeMs = g_bootRecord.history.back().uptimeMs;
-        info.resetHistory     = g_bootRecord.history;
-    }
+    info.previousUptimeMs = g_bootRecord.previousUptimeMs;
+    info.previousFirmware = g_bootRecord.previousFirmware;
     info.boardName        = board::kName;
     info.boardId          = board::kId;
     info.bridgeId         = g_wifi.bridgeId();
@@ -1264,9 +1258,8 @@ void setup() {
     // First thing, before anything that could crash: a boot that dies during setup still
     // leaves its predecessor's death recorded, and its own becomes the next entry.
     g_bootRecord = breadcrumbs::begin(
-        g_breadcrumbStore, static_cast<uint8_t>(esp_reset_reason()),
-        (static_cast<uint32_t>(kFirmwareMajor) << 16) |
-            (static_cast<uint32_t>(kFirmwareMinor) << 8) | kFirmwarePatch);
+        g_breadcrumbStore, (static_cast<uint32_t>(kFirmwareMajor) << 16) |
+                               (static_cast<uint32_t>(kFirmwareMinor) << 8) | kFirmwarePatch);
 
     Serial.begin(115200);
     const uint32_t serialDeadline = millis() + 2000;

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -2,6 +2,8 @@
 
 #include "rest_payloads.h"
 
+#include <cstdio>
+
 #include <ArduinoJson.h>
 
 #include "outputs/json_util.h"
@@ -387,6 +389,31 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
     //
     // Absent, not an empty array, when there is nothing to report: [] would read as "the stack
     // walk found no frames", which is a different statement from "no dump is stored".
+    // Reset breadcrumbs, REST-only like the backtrace below and for the same reason:
+    // someone fetching /api/v1/diagnostics is asking on purpose, and a reset history never
+    // changes between reboots -- republishing it over MQTT every interval says nothing new.
+    // bootCount 0 = not wired (host default); absent rather than a fabricated "0 boots".
+    if (bridge.bootCount > 0) {
+        doc["boot_count"] = bridge.bootCount;
+        if (bridge.breadcrumbsCold) {
+            // Cold start: first boot ever, or power was lost. No previous life to report --
+            // null, not 0, because "it had been up 0 ms" is a different (false) statement.
+            doc["previous_uptime_ms"] = nullptr;
+            doc["reset_history"]      = nullptr;
+        } else {
+            doc["previous_uptime_ms"] = bridge.previousUptimeMs;
+            JsonArray hist            = doc["reset_history"].to<JsonArray>();
+            for (const auto& e : bridge.resetHistory) {
+                JsonObject h       = hist.add<JsonObject>();
+                h["reason"]        = e.resetReason;
+                h["uptime_ms"]     = e.uptimeMs;
+                char v[16];
+                snprintf(v, sizeof v, "%u.%u.%u", (e.firmware >> 16) & 0xFF,
+                         (e.firmware >> 8) & 0xFF, e.firmware & 0xFF);
+                h["firmware"] = v;
+            }
+        }
+    }
     if (bridge.coredumpPresent && !bridge.coredumpBacktrace.empty()) {
         JsonArray bt = doc["coredump_backtrace"].to<JsonArray>();
         for (const uint32_t pc : bridge.coredumpBacktrace) {

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -399,19 +399,15 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
             // Cold start: first boot ever, or power was lost. No previous life to report --
             // null, not 0, because "it had been up 0 ms" is a different (false) statement.
             doc["previous_uptime_ms"] = nullptr;
-            doc["reset_history"]      = nullptr;
+            doc["previous_firmware"]  = nullptr;
         } else {
+            // How the previous life ENDED is this boot's reset_reason, already in this
+            // payload -- these two fields say how long it ran and what it was running.
             doc["previous_uptime_ms"] = bridge.previousUptimeMs;
-            JsonArray hist            = doc["reset_history"].to<JsonArray>();
-            for (const auto& e : bridge.resetHistory) {
-                JsonObject h       = hist.add<JsonObject>();
-                h["reason"]        = e.resetReason;
-                h["uptime_ms"]     = e.uptimeMs;
-                char v[16];
-                snprintf(v, sizeof v, "%u.%u.%u", (e.firmware >> 16) & 0xFF,
-                         (e.firmware >> 8) & 0xFF, e.firmware & 0xFF);
-                h["firmware"] = v;
-            }
+            char v[16];
+            snprintf(v, sizeof v, "%u.%u.%u", (bridge.previousFirmware >> 16) & 0xFF,
+                     (bridge.previousFirmware >> 8) & 0xFF, bridge.previousFirmware & 0xFF);
+            doc["previous_firmware"] = v;
         }
     }
     if (bridge.coredumpPresent && !bridge.coredumpBacktrace.empty()) {

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -3,6 +3,10 @@
 
 #include <unity.h>
 
+#include <cstring>
+
+#include "diagnostics/breadcrumbs.h"
+
 #include <cmath>
 #include <cstring>
 
@@ -1869,6 +1873,96 @@ static void test_poll_duration_payload_absent_until_sampled() {
     TEST_ASSERT_TRUE(doc["poll_duration_last_ms"].is<uint32_t>());
     TEST_ASSERT_EQUAL_UINT32(0, doc["poll_duration_max_ms"].as<uint32_t>());
     TEST_ASSERT_EQUAL_UINT32(0, doc["poll_duration_ewma_ms"].as<uint32_t>());
+/// Reset breadcrumbs (audit F4): the logic that must never fabricate history. Garbage
+/// storage -- which is what RTC RAM holds after power loss -- must read as a clean cold
+/// start, and a warm reset must append exactly one entry carrying the heartbeat as
+/// uptime-at-death.
+static void test_breadcrumbs_cold_then_warm() {
+    breadcrumbs::Storage st;
+    std::memset(&st, 0xA5, sizeof st);  // power-loss garbage
+
+    auto rec = breadcrumbs::begin(st, 3, 0x00001801);  // 0.24.1
+    TEST_ASSERT_TRUE(rec.coldStart);
+    TEST_ASSERT_EQUAL_UINT32(1, rec.bootCount);
+    TEST_ASSERT_EQUAL_size_t(0, rec.history.size());
+
+    // This life runs 65 s; heartbeat throttles to 1 Hz so 65 400 records as 65 400.
+    breadcrumbs::tick(st, 65400);
+    // A second tick inside the same second must not move the heartbeat.
+    breadcrumbs::tick(st, 65900);
+
+    // Watchdog reset (reason 6). The new boot sees the old life.
+    rec = breadcrumbs::begin(st, 6, 0x00001801);
+    TEST_ASSERT_FALSE(rec.coldStart);
+    TEST_ASSERT_EQUAL_UINT32(2, rec.bootCount);
+    TEST_ASSERT_EQUAL_size_t(1, rec.history.size());
+    TEST_ASSERT_EQUAL_UINT8(6, rec.history[0].resetReason);
+    TEST_ASSERT_EQUAL_UINT32(65400, rec.history[0].uptimeMs);
+    TEST_ASSERT_EQUAL_UINT32(0x00001801, rec.history[0].firmware);
+}
+
+/// The ring wraps keeping the NEWEST eight, oldest first -- position is the only ordering a
+/// clock-free record has, so getting it wrong silently reverses a failure timeline.
+static void test_breadcrumbs_ring_wraps_oldest_first() {
+    breadcrumbs::Storage st;
+    std::memset(&st, 0, sizeof st);
+    breadcrumbs::begin(st, 1, 1);  // cold
+    for (uint32_t i = 0; i < 10; ++i) {
+        breadcrumbs::tick(st, (i + 1) * 1000);
+        // Force distinct heartbeats per life: reason encodes which life died.
+        auto rec = breadcrumbs::begin(st, static_cast<uint8_t>(10 + i), 1);
+        TEST_ASSERT_FALSE(rec.coldStart);
+    }
+    auto rec = breadcrumbs::begin(st, 99, 1);
+    TEST_ASSERT_EQUAL_size_t(breadcrumbs::kRingSize, rec.history.size());
+    // Eleven lives died (reasons 10..19 then 99); the newest eight end with 99.
+    TEST_ASSERT_EQUAL_UINT8(99, rec.history.back().resetReason);
+    TEST_ASSERT_EQUAL_UINT8(13, rec.history.front().resetReason);
+}
+
+/// One flipped bit anywhere must read as cold: a torn RTC write may never become invented
+/// history. This is the mutation-facing test -- remove the CRC check and it fails.
+static void test_breadcrumbs_corruption_reads_as_cold() {
+    breadcrumbs::Storage st;
+    std::memset(&st, 0, sizeof st);
+    breadcrumbs::begin(st, 1, 1);
+    breadcrumbs::tick(st, 5000);
+    st.heartbeatUptimeMs ^= 0x4;  // torn write, CRC now stale
+
+    auto rec = breadcrumbs::begin(st, 6, 1);
+    TEST_ASSERT_TRUE(rec.coldStart);
+    TEST_ASSERT_EQUAL_UINT32(1, rec.bootCount);
+    TEST_ASSERT_EQUAL_size_t(0, rec.history.size());
+}
+
+/// On the wire: absent when not wired (bootCount 0), null previous/history on a cold start,
+/// full history with a decoded firmware string on a warm one.
+static void test_breadcrumbs_payload_shapes() {
+    auto bridge = makeBridge();
+    std::string json;
+    Diagnostics d;
+
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(d.snapshot(), bridge, json));
+    auto doc = parse(json);
+    TEST_ASSERT_FALSE(doc["boot_count"].is<uint32_t>());
+
+    bridge.bootCount       = 1;
+    bridge.breadcrumbsCold = true;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(d.snapshot(), bridge, json));
+    doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(1, doc["boot_count"].as<uint32_t>());
+    TEST_ASSERT_TRUE(doc["previous_uptime_ms"].isNull());
+    TEST_ASSERT_TRUE(doc["reset_history"].isNull());
+
+    bridge.bootCount       = 4;
+    bridge.breadcrumbsCold = false;
+    bridge.previousUptimeMs = 65400;
+    bridge.resetHistory.push_back({6, 65400, 0x00001801});
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(d.snapshot(), bridge, json));
+    doc = parse(json);
+    TEST_ASSERT_EQUAL_UINT32(65400, doc["previous_uptime_ms"].as<uint32_t>());
+    TEST_ASSERT_EQUAL_UINT8(6, doc["reset_history"][0]["reason"].as<uint8_t>());
+    TEST_ASSERT_EQUAL_STRING("0.24.1", doc["reset_history"][0]["firmware"]);
 }
 
 static void test_diagnostics_payload_has_no_secrets() {
@@ -2708,6 +2802,10 @@ int main(int, char**) {
     RUN_TEST(test_drivers_payload_drives_the_wizard);
     RUN_TEST(test_poll_duration_math);
     RUN_TEST(test_poll_duration_payload_absent_until_sampled);
+    RUN_TEST(test_breadcrumbs_cold_then_warm);
+    RUN_TEST(test_breadcrumbs_ring_wraps_oldest_first);
+    RUN_TEST(test_breadcrumbs_corruption_reads_as_cold);
+    RUN_TEST(test_breadcrumbs_payload_shapes);
     RUN_TEST(test_diagnostics_payload_has_no_secrets);
     RUN_TEST(test_diagnostics_report_stack_marks_and_fragmentation);
     RUN_TEST(test_psram_is_reported_when_the_board_has_it);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1873,70 +1873,56 @@ static void test_poll_duration_payload_absent_until_sampled() {
     TEST_ASSERT_TRUE(doc["poll_duration_last_ms"].is<uint32_t>());
     TEST_ASSERT_EQUAL_UINT32(0, doc["poll_duration_max_ms"].as<uint32_t>());
     TEST_ASSERT_EQUAL_UINT32(0, doc["poll_duration_ewma_ms"].as<uint32_t>());
-/// Reset breadcrumbs (audit F4): the logic that must never fabricate history. Garbage
-/// storage -- which is what RTC RAM holds after power loss -- must read as a clean cold
-/// start, and a warm reset must append exactly one entry carrying the heartbeat as
-/// uptime-at-death.
+}
+
+/// Reset breadcrumbs (audit F4, sixteen-byte variant): the logic that must never fabricate
+/// a past. Garbage storage -- what RTC RAM holds after power loss -- must read as a clean
+/// cold start, and a warm reset must report the previous life's heartbeat and firmware.
 static void test_breadcrumbs_cold_then_warm() {
     breadcrumbs::Storage st;
     std::memset(&st, 0xA5, sizeof st);  // power-loss garbage
 
-    auto rec = breadcrumbs::begin(st, 3, 0x00001801);  // 0.24.1
+    auto rec = breadcrumbs::begin(st, 0x00001801);  // 0.24.1
     TEST_ASSERT_TRUE(rec.coldStart);
     TEST_ASSERT_EQUAL_UINT32(1, rec.bootCount);
-    TEST_ASSERT_EQUAL_size_t(0, rec.history.size());
 
-    // This life runs 65 s; heartbeat throttles to 1 Hz so 65 400 records as 65 400.
+    // This life runs 65 s; the heartbeat throttles to 1 Hz, so a second tick inside the
+    // same second must not move it.
     breadcrumbs::tick(st, 65400);
-    // A second tick inside the same second must not move the heartbeat.
     breadcrumbs::tick(st, 65900);
 
-    // Watchdog reset (reason 6). The new boot sees the old life.
-    rec = breadcrumbs::begin(st, 6, 0x00001801);
-    TEST_ASSERT_FALSE(rec.coldStart);
-    TEST_ASSERT_EQUAL_UINT32(2, rec.bootCount);
-    TEST_ASSERT_EQUAL_size_t(1, rec.history.size());
-    TEST_ASSERT_EQUAL_UINT8(6, rec.history[0].resetReason);
-    TEST_ASSERT_EQUAL_UINT32(65400, rec.history[0].uptimeMs);
-    TEST_ASSERT_EQUAL_UINT32(0x00001801, rec.history[0].firmware);
+    auto rec2 = breadcrumbs::begin(st, 0x00001802);  // the next boot runs 0.24.2
+    TEST_ASSERT_FALSE(rec2.coldStart);
+    TEST_ASSERT_EQUAL_UINT32(2, rec2.bootCount);
+    TEST_ASSERT_EQUAL_UINT32(65400, rec2.previousUptimeMs);
+    TEST_ASSERT_EQUAL_UINT32(0x00001801, rec2.previousFirmware);
+
+    // And the record begin() left behind must itself survive a third boot: count keeps
+    // climbing, and the previous firmware is now the one THIS boot wrote.
+    auto rec3 = breadcrumbs::begin(st, 0x00001802);
+    TEST_ASSERT_FALSE(rec3.coldStart);
+    TEST_ASSERT_EQUAL_UINT32(3, rec3.bootCount);
+    TEST_ASSERT_EQUAL_UINT32(0, rec3.previousUptimeMs);  // that life never ticked
+    TEST_ASSERT_EQUAL_UINT32(0x00001802, rec3.previousFirmware);
 }
 
-/// The ring wraps keeping the NEWEST eight, oldest first -- position is the only ordering a
-/// clock-free record has, so getting it wrong silently reverses a failure timeline.
-static void test_breadcrumbs_ring_wraps_oldest_first() {
-    breadcrumbs::Storage st;
-    std::memset(&st, 0, sizeof st);
-    breadcrumbs::begin(st, 1, 1);  // cold
-    for (uint32_t i = 0; i < 10; ++i) {
-        breadcrumbs::tick(st, (i + 1) * 1000);
-        // Force distinct heartbeats per life: reason encodes which life died.
-        auto rec = breadcrumbs::begin(st, static_cast<uint8_t>(10 + i), 1);
-        TEST_ASSERT_FALSE(rec.coldStart);
-    }
-    auto rec = breadcrumbs::begin(st, 99, 1);
-    TEST_ASSERT_EQUAL_size_t(breadcrumbs::kRingSize, rec.history.size());
-    // Eleven lives died (reasons 10..19 then 99); the newest eight end with 99.
-    TEST_ASSERT_EQUAL_UINT8(99, rec.history.back().resetReason);
-    TEST_ASSERT_EQUAL_UINT8(13, rec.history.front().resetReason);
-}
-
-/// One flipped bit anywhere must read as cold: a torn RTC write may never become invented
-/// history. This is the mutation-facing test -- remove the CRC check and it fails.
+/// One flipped bit must read as cold: a torn RTC write may never become an invented past.
+/// This is the mutation-facing test -- remove the CRC comparison and it fails.
 static void test_breadcrumbs_corruption_reads_as_cold() {
     breadcrumbs::Storage st;
     std::memset(&st, 0, sizeof st);
-    breadcrumbs::begin(st, 1, 1);
+    breadcrumbs::begin(st, 1);
     breadcrumbs::tick(st, 5000);
     st.heartbeatUptimeMs ^= 0x4;  // torn write, CRC now stale
 
-    auto rec = breadcrumbs::begin(st, 6, 1);
+    auto rec = breadcrumbs::begin(st, 1);
     TEST_ASSERT_TRUE(rec.coldStart);
     TEST_ASSERT_EQUAL_UINT32(1, rec.bootCount);
-    TEST_ASSERT_EQUAL_size_t(0, rec.history.size());
 }
 
-/// On the wire: absent when not wired (bootCount 0), null previous/history on a cold start,
-/// full history with a decoded firmware string on a warm one.
+/// On the wire: absent when not wired (bootCount 0), null previous fields on a cold start,
+/// values with a decoded firmware string on a warm one. The death reason is deliberately
+/// NOT here -- it is the payload's existing reset_reason.
 static void test_breadcrumbs_payload_shapes() {
     auto bridge = makeBridge();
     std::string json;
@@ -1952,17 +1938,16 @@ static void test_breadcrumbs_payload_shapes() {
     doc = parse(json);
     TEST_ASSERT_EQUAL_UINT32(1, doc["boot_count"].as<uint32_t>());
     TEST_ASSERT_TRUE(doc["previous_uptime_ms"].isNull());
-    TEST_ASSERT_TRUE(doc["reset_history"].isNull());
+    TEST_ASSERT_TRUE(doc["previous_firmware"].isNull());
 
-    bridge.bootCount       = 4;
-    bridge.breadcrumbsCold = false;
+    bridge.bootCount        = 4;
+    bridge.breadcrumbsCold  = false;
     bridge.previousUptimeMs = 65400;
-    bridge.resetHistory.push_back({6, 65400, 0x00001801});
+    bridge.previousFirmware = 0x00001801;
     TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(d.snapshot(), bridge, json));
     doc = parse(json);
     TEST_ASSERT_EQUAL_UINT32(65400, doc["previous_uptime_ms"].as<uint32_t>());
-    TEST_ASSERT_EQUAL_UINT8(6, doc["reset_history"][0]["reason"].as<uint8_t>());
-    TEST_ASSERT_EQUAL_STRING("0.24.1", doc["reset_history"][0]["firmware"]);
+    TEST_ASSERT_EQUAL_STRING("0.24.1", doc["previous_firmware"]);
 }
 
 static void test_diagnostics_payload_has_no_secrets() {
@@ -2803,7 +2788,6 @@ int main(int, char**) {
     RUN_TEST(test_poll_duration_math);
     RUN_TEST(test_poll_duration_payload_absent_until_sampled);
     RUN_TEST(test_breadcrumbs_cold_then_warm);
-    RUN_TEST(test_breadcrumbs_ring_wraps_oldest_first);
     RUN_TEST(test_breadcrumbs_corruption_reads_as_cold);
     RUN_TEST(test_breadcrumbs_payload_shapes);
     RUN_TEST(test_diagnostics_payload_has_no_secrets);


### PR DESCRIPTION
Audit **F4**, approved by Tim — parked as a **blocked draft**, honestly.

## What works (host-proven)

CRC-guarded reset history in RTC-domain SRAM: boot counter + ring of eight prior lives
(reason, uptime-at-death, firmware). Clock-free by design — C has no battery clock, so entries
carry uptime and ordering comes from ring position. Four tests, mutation-tested both ways
(CRC gate, ring wrap order). 851 native tests green.

## What does not work yet, and why this must not merge

On the Relay-6CH the storage **does not survive a reset** — in the RTC slow bank *and* in
`.rtc.force_fast`. The decisive experiment: with the heartbeat disabled, even the single CRC
written at boot never survives to the next boot. Something in the prebuilt-core runtime
rewrites that region during normal operation; the 1 Hz heartbeat was continuously repairing
it, producing a fake-looking period-2 alternation.

Two methodological traps documented for whoever measures next (they cost half the evening):

1. **The heartbeat masked the corruption** — a repair loop can make broken storage look
   intermittently healthy.
2. **Reboots at ~26 s sat just under the 30 s healthy-boot threshold**, so measurement flashes
   silently **rolled back** mid-experiment and several boots ran a different image than
   intended. Caught by comparing build stamps. Rule: verify `ota_image_state == valid` and the
   build stamp before every reboot in any flash-loop experiment.

## Next step (not tonight)

Root-cause needs a serial session or a minimal repro sketch (suspect: linker/lib mismatch
around the prebuilt core's own RTC-slow users — system time keeping survives resets through
that bank). Both boards are back on the official 0.24.1 release, SHA-verified.