### PR TITLE
fix(diagnostics): the RTC "platform fault" was a default member initialiser

### DIFF
--- a/docs/audit-2026-07-29.md
+++ b/docs/audit-2026-07-29.md
@@ -567,6 +567,16 @@ trades robustness margin for speed is out.
    API reboots **and across an OTA with slot switch** (count 4→5). The eight-deep
    ring is parked until a grow-the-repro session names the zeroer (upstream-issue
    material). PR #147, unblocked.
+
+   **SUPERSEDED 2026-07-30 — the root cause was ours, not the platform's.** The ring's
+   `Entry` carried default member initialisers, which make the type
+   non-trivially-default-constructible; the compiler then emits a static initialiser that
+   runs from `.init_array` on every boot and zeroes the object. `RTC_NOINIT_ATTR` guards
+   against a *reset*, not against our own startup code. Reproduced both directions on the
+   6CH, one character apart. The sixteen-byte shape is therefore a choice, not a limit, and
+   the grow-the-repro/upstream follow-up is closed. PR #149 corrects the comments and adds a
+   `static_assert`, which is the only form the guard can take: the failure needs
+   `.init_array` and RTC memory to be distinct, which they are not on the host.
 5. **F5 hostile-broker test**: approve method (temporarily black-holing the
    broker's ACKs on your network) and on which bridge.
 6. **F3 PSRAM**: accept idle (recommended) or pursue option (b) divergence?

--- a/src/diagnostics/breadcrumbs.h
+++ b/src/diagnostics/breadcrumbs.h
@@ -32,9 +32,10 @@
 // wrong. If the ring ever returns, the rule above is what makes it work.
 //
 // Host-testable end to end: the logic operates on a caller-owned Storage struct, and only
-// main.cpp places that struct in RTC_NOINIT_ATTR memory. Note that the host tests cannot
-// catch a violation of the rule above -- there is no .init_array/RTC split on the host, so
-// a reintroduced initialiser passes every test and fails only on the device.
+// main.cpp places that struct in RTC_NOINIT_ATTR memory. The host tests cannot detect a
+// violation of the rule above by RUNNING -- there is no .init_array/RTC split on the host --
+// which is why the guard below is a compile-time assertion rather than a test case. It does
+// fire on the native build too, since the test suite includes this header.
 
 #pragma once
 
@@ -58,13 +59,17 @@ struct Storage {
     uint32_t crc;
 };
 
-// The guard for the rule at the top of this file, and the only one that can exist: the host
-// tests cannot catch this, because the failure needs .init_array and RTC memory to be
-// different things. Adding an initialiser to any member of Storage -- or nesting a type that
-// has one -- breaks this build instead of silently zeroing the record on every boot of every
-// device. Both traits are needed: `trivially_default_constructible` is what stops the
-// compiler emitting a startup initialiser, and `trivially_copyable` keeps memcpy/CRC over the
-// raw bytes well-defined.
+// The guard for the rule at the top of this file. Adding an initialiser to any member of
+// Storage -- or nesting a type that has one, the trait is transitive -- breaks the build
+// instead of silently zeroing the record on every boot of every device. Both traits earn
+// their place: `trivially_default_constructible` is exactly the property that decides static
+// versus dynamic initialisation, and `trivially_copyable` keeps the memcpy/CRC over raw bytes
+// well-defined.
+//
+// What it does NOT cover, so nobody reads more safety into it than is there: it guards this
+// TYPE, not the storage. A stray write to the object from code running before begin() is an
+// ordering bug that compiles cleanly, and any FUTURE object placed in RTC memory needs its
+// own assertion -- this one says nothing about it.
 static_assert(std::is_trivially_default_constructible_v<Storage>,
               "Storage must have no default member initialisers: a non-trivial default "
               "constructor emits a static initialiser that zeroes RTC_NOINIT memory on every "

--- a/src/diagnostics/breadcrumbs.h
+++ b/src/diagnostics/breadcrumbs.h
@@ -10,24 +10,36 @@
 // boots at epoch 0 as on one with an RTC. The reason the previous life ended is not stored
 // at all: the boot that reads this record learns it first-hand from esp_reset_reason().
 //
-// WHY SIXTEEN BYTES, AND NOT THE RING THIS STARTED AS. The first version kept an
-// eight-entry history ring in a 120-byte struct. On real hardware (Relay-6CH, 2026-07-29,
-// serial session -- see PR #147) the full firmware's restart transition zeroes bytes
-// [16,116) of that struct on every single reset, while bytes [0,16) survive; a bare sketch
-// on the same board, same flavor, same bank, survives entirely. What performs that zeroing
-// is still unknown -- bootloader BSS, absolute-address writers, OTA-slot ping-pong and
-// mid-life corruption were all ruled out with direct evidence -- so this design trusts ONLY
-// the sixteen bytes that were measured to survive, with the CRC inside them. If even that
-// window ever stops surviving, the CRC turns it into a clean cold start: wrong data is
-// worse than no data, and a cold start is not wrong. The ring returns if the
-// grow-the-repro investigation ever names the culprit; git history has it.
+// EVERY MEMBER HERE IS A PLAIN INTEGER WITH NO INITIALISER, AND THAT IS LOAD-BEARING.
+// A default member initialiser -- `uint32_t bootCount = 0;` -- makes the type
+// non-trivially-default-constructible, and the compiler then emits a static initialiser
+// that runs from .init_array on EVERY boot and zeroes the object. `RTC_NOINIT_ATTR` places
+// the storage where a reset cannot clear it; it does not stop our own startup code from
+// clearing it. The section attribute and the type's triviality have to agree, and only the
+// type is checked by the compiler.
+//
+// This is not theoretical. The first version of this file kept an eight-entry history ring
+// whose Entry struct had `= 0` on its three members. On hardware the ring came back zeroed
+// after every reset while the surrounding integers survived, which looked exactly like a
+// platform fault and was chased as one for an evening (PR #147). It was this rule. Proven
+// by A/B on a Relay-6CH, 2026-07-30: the identical struct without the initialisers survives
+// six consecutive reboots with its ring intact; add the three `= 0` back and the corruption
+// returns on the very next boot, deterministically.
+//
+// The sixteen-byte shape is therefore a choice, not a limit -- the ring could come back. It
+// stays small because a boot counter, the previous life's uptime and its firmware answer
+// the question this exists for, and a smaller trusted surface is a smaller thing to get
+// wrong. If the ring ever returns, the rule above is what makes it work.
 //
 // Host-testable end to end: the logic operates on a caller-owned Storage struct, and only
-// main.cpp places that struct in RTC_NOINIT_ATTR memory.
+// main.cpp places that struct in RTC_NOINIT_ATTR memory. Note that the host tests cannot
+// catch a violation of the rule above -- there is no .init_array/RTC split on the host, so
+// a reintroduced initialiser passes every test and fails only on the device.
 
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 namespace heliograph::breadcrumbs {
 
@@ -45,6 +57,20 @@ struct Storage {
     /// whose CRC lived at offset 116 and only survived by accident of layout.
     uint32_t crc;
 };
+
+// The guard for the rule at the top of this file, and the only one that can exist: the host
+// tests cannot catch this, because the failure needs .init_array and RTC memory to be
+// different things. Adding an initialiser to any member of Storage -- or nesting a type that
+// has one -- breaks this build instead of silently zeroing the record on every boot of every
+// device. Both traits are needed: `trivially_default_constructible` is what stops the
+// compiler emitting a startup initialiser, and `trivially_copyable` keeps memcpy/CRC over the
+// raw bytes well-defined.
+static_assert(std::is_trivially_default_constructible_v<Storage>,
+              "Storage must have no default member initialisers: a non-trivial default "
+              "constructor emits a static initialiser that zeroes RTC_NOINIT memory on every "
+              "boot. See the note at the top of this file.");
+static_assert(std::is_trivially_copyable_v<Storage>,
+              "Storage is CRC'd and memcpy'd as raw bytes.");
 
 /// What begin() learned about the past, for the diagnostics payload.
 struct BootRecord {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -485,11 +485,11 @@ void applySerialOverride() {
     }
 }
 
-// RTC-domain SRAM for the reset breadcrumbs. Sixteen bytes on purpose: the serial session
-// of 2026-07-29 (PR #147) measured that the full firmware's restart transition zeroes
-// bytes [16,116) of a larger struct here while the first sixteen survive -- cause still
-// unknown, bare sketches immune. This struct fits entirely inside the measured-surviving
-// window, CRC included; if the window ever shrinks, the CRC reads it as a cold start.
+// RTC-domain SRAM for the reset breadcrumbs. The type must stay trivially default
+// constructible or this object gets zeroed on every boot -- breadcrumbs.h explains why and
+// a static_assert there enforces it. Measured, in case someone reaches for one: a `{}` here
+// is harmless (constant initialisation, no startup write); it is an initialiser on a MEMBER
+// that generates the .init_array entry which defeats the whole point.
 RTC_NOINIT_ATTR breadcrumbs::Storage g_breadcrumbStore;
 static breadcrumbs::BootRecord       g_bootRecord;
 


### PR DESCRIPTION
Root cause found for the F4 investigation, and it corrects a wrong conclusion that shipped in
0.24.2.

## What was concluded, and why it was wrong

The serial session of 2026-07-29 concluded: *"something in the prebuilt-core runtime zeroes
bytes [16,116) of the struct across every restart, cause unknown, upstream material."* That
comment is in `breadcrumbs.h` on main right now.

It was **our own code**. The ring's `Entry` had `= 0` on its three members. A default member
initialiser makes the type non-trivially-default-constructible → the compiler emits a static
initialiser → it runs from `.init_array` on **every boot** → it zeroes the object.
`RTC_NOINIT_ATTR` places the storage where a *reset* cannot clear it; it does nothing about our
own startup code. The section attribute and the type's triviality must agree, and only the type
is checked by the compiler, so the mismatch is silent.

## Proof — one character, both directions, on the 6CH

| build | result |
|---|---|
| `Entry` without initialisers | six consecutive reboots, ring intact, `valid=1` every time |
| add `= 0` back | next boot: `next=1 count=1` (entry was written) + `slot0=[00 00000000 00000000]` (gone), CRC mismatch → cold |

The 256-byte plain-array probe at the *same address* survived throughout — which is what broke
the platform hypothesis open: same memory, same firmware, different C++ type.

**Why the platform story was so convincing:** a cold start memsets the struct, so its CRC covers
a zeroed ring and the *next* boot validates; that boot writes an entry, which the boot after
finds zeroed and rejects. Perfect period-2 alternation, generated by a plain bug.

## What this PR changes

- The comment in `breadcrumbs.h` tells the true story, including that the rule is load-bearing.
- A `static_assert` enforces it. **No host test can** — the failure needs `.init_array` and RTC
  memory to be different things, and on the host they are not. Mutation-tested: adding `= 0`
  now fails the build with the explanation attached, instead of silently zeroing the record on
  every boot of every device.
- Recorded that the sixteen-byte shape is a *choice*, not a platform limit: the ring could come
  back. Not doing that here — separate decision.

No behaviour change: the shipped struct was already correct by construction.

852 native tests, layering, all three board firmwares green.