### PR TITLE
docs(audit): F5 corrected — the outbox guard measures the wrong pool on A/B

### DIFF
--- a/docs/audit-2026-07-29.md
+++ b/docs/audit-2026-07-29.md
@@ -447,8 +447,59 @@ no change should land before the measurement.
   an outbox/heap threshold) — but design after measurement. **Risk:** low.
   **Confidence:** medium — the growth *rate* (~1-2 KB per device per 10 s cycle)
   and the teardown timing are the unknowns.
-- **Measure first (A, then C):** hostile-broker test — accept TCP, stop ACKing
-  (iptables/toxiproxy) — watch free-heap slope and recovery.
+- **CORRECTED 2026-07-30 by reading the library, and the correction changes the
+  finding's shape.** The outbox is not an unguarded free-for-all: every PUBLISH packet
+  is allocated through `Packet::_allocate(remainingLength, true)`
+  (`Packets/Packet.cpp:189`), and with `check=true` that refuses when
+  `EMC_GET_FREE_MEMORY() < EMC_MIN_FREE_MEMORY` (16384, default, we override nothing).
+  A refusal sets `Error::OUT_OF_MEMORY`, `_addPacket` returns false, `publish()` returns
+  0, and our `publishTracked()` already counts that as
+  `mqtt_publish_failure_total` (`mqtt_output.cpp:40-46`). So the graceful path exists
+  and is observable — the original framing ("unbounded, weak failure path") was wrong.
+
+  **But the guard measures the wrong pool on A and B, and that is a new finding.**
+  `EMC_GET_FREE_MEMORY()` is a hard `#define` (no `#ifndef`, so not overridable from
+  `platformio.ini`) and on ESP32 reads
+  `std::max(ESP.getMaxAllocHeap(), ESP.getMaxAllocPsram())` (`Helpers.h:18`).
+
+  | | `getMaxAllocPsram()` | guard compares against | guard effective? |
+  |---|---|---|---|
+  | A, B (8 MB PSRAM, measured 8 378 140 B free) | megabytes | ~8 MB vs 16 KB | **no — never fires** |
+  | C (no PSRAM) | 0 | internal heap vs 16 KB | yes |
+
+  A publish is small — a measurement topic plus a numeric payload is ~100-200 bytes,
+  far under `SPIRAM_MALLOC_ALWAYSINTERNAL` (4096), so `malloc` serves it from
+  **internal** SRAM. On A/B the guard therefore inspects a pool the allocation never
+  touches. Net effect, and it is counter-intuitive: **variant C — the constraint floor —
+  is the only variant where this safety net works.** On A/B the outbox can consume
+  internal SRAM toward genuine exhaustion while `mqtt_publish_failure_total` stays at
+  zero, which is the silent version of the failure rather than the counted one.
+
+  **Proven from source:** the guard, the threshold, the `check=true` call site, the hard
+  `#define`, the propagation into our counter, and that we override no `EMC_*` define.
+  **Measured earlier this session:** A/B PSRAM free 8 378 140 B; C reports
+  `psram_size_bytes: null`. **UNVERIFIED:** the growth *rate* and the time-to-danger on
+  A/B, because the hostile-broker test is blocked — see below.
+
+- **Recommended remedy (Tim's call, not taken):** a guard in our own
+  `publishTracked()` — refuse and count when `ESP.getMaxAllocHeap()` is below a floor,
+  before calling `g_client.publish()`. Five lines, no dependency fork, identical policy
+  on all three variants, reuses the counter that already exists, and it applies the
+  library's own 16 KB intent to the pool the allocation actually comes from. Fits the
+  stability-first rule: it converts a silent exhaustion into a counted refusal.
+  Alternative considered and rejected: raising `EMC_MIN_FREE_MEMORY` (which *is*
+  overridable) does nothing on A/B, because the value it is compared against is PSRAM's
+  8 MB regardless.
+
+- **Measurement still owed, and why it did not run (2026-07-30):** the hostile broker
+  (accept TCP, complete the MQTT handshake so `connected()` stays true, then never read
+  again with a deliberately small `SO_RCVBUF`) works locally but never received the
+  bridge's connection. Cause: the macOS application firewall on the dev machine is set
+  to block all non-essential incoming connections, so port 1883 was unreachable from the
+  LAN. Changing that is a security setting and was left to Tim. Note that VLAN routing
+  from the IoT subnet to the dev subnet is *also* untested and may be a second barrier.
+  The script is kept at `scratchpad/hostile_broker.py`; the test needs one of: an
+  inbound allowance for `python3`, or a listener on the IoT subnet itself.
 
 ### F6 · Nagle on Modbus TCP / SSE / web: non-issue, verified
 
@@ -577,8 +628,14 @@ trades robustness margin for speed is out.
    the grow-the-repro/upstream follow-up is closed. PR #149 corrects the comments and adds a
    `static_assert`, which is the only form the guard can take: the failure needs
    `.init_array` and RTC memory to be distinct, which they are not on the host.
-5. **F5 hostile-broker test**: approve method (temporarily black-holing the
-   broker's ACKs on your network) and on which bridge.
+5. **F5** — investigated 2026-07-30, and the finding changed shape: the library DOES
+   guard allocations and our counter DOES see refusals, but on A/B the guard measures
+   PSRAM while the allocation comes from internal SRAM, so it never fires there. Two
+   decisions now: (a) add the five-line guard in `publishTracked()` (recommended — it
+   turns a silent exhaustion into a counted refusal on every variant), and (b) whether
+   to unblock the hostile-broker measurement, which needs an inbound firewall allowance
+   on the dev Mac or a listener on the IoT subnet. The remedy does not depend on the
+   measurement; the measurement would size the risk it removes.
 6. **F3 PSRAM**: accept idle (recommended) or pursue option (b) divergence?
 7. **F9 cosmetic**: leave 1970 log prefixes, or prefix "(unsynced)" until NTP?
 8. **`storage` partitions**: declare claimable for future proposals, or keep

--- a/docs/audit-2026-07-29.md
+++ b/docs/audit-2026-07-29.md
@@ -481,6 +481,24 @@ no change should land before the measurement.
   `psram_size_bytes: null`. **UNVERIFIED:** the growth *rate* and the time-to-danger on
   A/B, because the hostile-broker test is blocked — see below.
 
+  **A second correction, caught in review (2026-07-30) and worth being just as honest
+  about: the reload-storm figures this document already leans on for reassurance are
+  the WRONG metric for this specific guard.** F2's 93 KB "transient depth" on the 6CH
+  is `ESP.getMinFreeHeap()` — total free heap's since-boot low-water mark. The remedy
+  below reads `ESP.getMaxAllocHeap()` — the largest *contiguous* block, which is what
+  actually decides whether a ~100–200 byte publish allocation succeeds. These two
+  numbers are not interchangeable and this document's own §4 shows them diverging in a
+  single snapshot (`min_free_heap 78 744 B` next to `max_alloc_block 102 388 B`).
+  Nobody has captured `max_alloc_block` *during* a reload storm on any variant, so the
+  16 KB threshold below is validated only against the **resting** figure (90 100 B,
+  measured 2026-07-30), not against a load transient in the metric the guard reads.
+  Fragmentation from AsyncTCP send buffers and JSON churn during a storm could plausibly
+  push the largest block meaningfully lower than the 32.6 KB total-free floor already
+  measured — possibly close to, or under, 16 KB. Re-running the reload-storm protocol
+  capturing `max_alloc_heap_bytes` (already exposed by `/api/v1/diagnostics`), not just
+  `free_heap_bytes`/`minimum_free_heap_bytes`, is the measurement that would actually
+  close this out.
+
 - **Recommended remedy (Tim's call, not taken):** a guard in our own
   `publishTracked()` — refuse and count when `ESP.getMaxAllocHeap()` is below a floor,
   before calling `g_client.publish()`. Five lines, no dependency fork, identical policy


### PR DESCRIPTION
Investigated F5 by reading espMqttClient rather than assuming. **The original finding was wrong,
and what replaces it is variant-dependent in a counter-intuitive direction.**

## What was wrong

F5 claimed an unbounded outbox with a weak failure path. Both halves are false:

- Every PUBLISH allocation goes through `Packet::_allocate(len, check=true)`
  (`Packets/Packet.cpp:189`), which refuses below `EMC_MIN_FREE_MEMORY` (16384, we override
  nothing).
- A refusal → `Error::OUT_OF_MEMORY` → `publish()` returns 0 → our `publishTracked()` already
  counts `mqtt_publish_failure_total` (`mqtt_output.cpp:40-46`).

The graceful path exists and is observable.

## What is actually wrong

`EMC_GET_FREE_MEMORY()` is a hard `#define` — no `#ifndef`, so **not** overridable from
`platformio.ini` — and on ESP32 reads `std::max(ESP.getMaxAllocHeap(), ESP.getMaxAllocPsram())`
(`Helpers.h:18`).

| | `getMaxAllocPsram()` | comparison | guard effective? |
|---|---|---|---|
| A, B (8 MB PSRAM, measured 8 378 140 B free) | megabytes | ~8 MB vs 16 KB | **no — never fires** |
| C (no PSRAM) | 0 | internal heap vs 16 KB | yes |

A publish is ~100–200 bytes, far under `SPIRAM_MALLOC_ALWAYSINTERNAL` (4096), so `malloc`
serves it from **internal** SRAM. On A/B the guard inspects a pool the allocation never touches.

**Variant C — the constraint floor — is the only variant where this safety net works.** A and B,
with more memory, are the ones that can exhaust internal SRAM while the failure counter reads
zero: the silent version of the failure instead of the counted one.

## Recommendation (not taken — your call)

A guard in our own `publishTracked()` on `ESP.getMaxAllocHeap()`: five lines, no dependency
fork, same policy on all three variants, reuses the existing counter, and applies the library's
own 16 KB intent to the right pool. Rejected alternative: raising `EMC_MIN_FREE_MEMORY` (which
*is* overridable) does nothing while the comparison value is PSRAM's 8 MB.

## Measurement still owed

The hostile broker (accept TCP, complete the handshake so `connected()` stays true, then never
read, small `SO_RCVBUF`) works locally but never received the bridge's connection: this Mac's
application firewall blocks inbound 1883. That is a security setting, so I left it alone. VLAN
routing from the IoT subnet is a possible second barrier, untested. Script kept in the
scratchpad; it needs either an inbound allowance for `python3` or a listener on the IoT subnet.

Docs only — no code changes. The 6CH's MQTT config was pointed at the test broker and has been
restored to its original disabled state.