### PR TITLE
feat(mqtt): refuse a publish when internal memory is low, and count it

### DIFF
--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -190,11 +190,19 @@ MqttOutput::Channel& MqttOutput::channelFor(const DeviceView& view, const Bridge
     return channels_.back();
 }
 
-void MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
+bool MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
                                   const BridgeInfo& bridge) {
     if (!config_.discoveryEnabled) {
-        return;
+        // Matches the old behaviour byte for byte: discoveryPublished never becomes true via
+        // this path, so loop() calls onConnected() again next tick too. Not this pass's bug to
+        // fix; changing it would be an unrelated behaviour change smuggled into a review fix.
+        return false;
     }
+    // Every publish counted, same idiom forgetDevice() already uses below: a refusal must not
+    // read as delivered, or the caller marks this channel "discovery done" while some entities
+    // never reached Home Assistant, and nothing retries them short of a reconnect or a
+    // signature change (review, 2026-07-30).
+    bool ok = true;
     // Purely derived from measurements and capabilities. Nothing in here knows which device
     // it is talking to; a driver reporting a battery gets battery entities for free.
     // topics_ for availability, deliberately: it is the BRIDGE's liveness, and it is the only
@@ -202,7 +210,7 @@ void MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
     for (const auto& e : buildDiscoveryEntities(state, bridge, channel.topics,
                                                 topics_.availability(), config_.discoveryPrefix,
                                                 channel.uniqueBase)) {
-        publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str());
+        ok = publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str()) && ok;
     }
     // Bridge entities belong to the bridge and are announced once -- publishing them per
     // device would create N copies of the same RSSI sensor. Tied to the bridge-scoped channel
@@ -210,19 +218,25 @@ void MqttOutput::publishDiscovery(Channel& channel, const DeviceState& state,
     if (channel.uniqueBase == bridge.bridgeId) {
         for (const auto& e :
              buildBridgeDiagnosticEntities(bridge, topics_, config_.discoveryPrefix)) {
-            publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str());
+            ok = publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str()) && ok;
         }
         // Relay switches -- or, when the feature is disabled on a relay board, empty retained
         // payloads that remove previously announced switches from Home Assistant.
         for (const auto& e : buildRelayEntities(bridge, topics_, config_.discoveryPrefix)) {
-            publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str());
+            ok = publishTracked(e.configTopic.c_str(), 1, true, e.payload.c_str()) && ok;
         }
     }
-    channel.discoveryPublished = true;
+    // discoveryPublished/discoveredSignature are the CALLER's to commit, and only when this
+    // returns true -- one seam decides "did discovery really land", instead of this function
+    // asserting it unconditionally the way it used to.
+    return ok;
 }
 
-void MqttOutput::onConnected(Channel& channel, const DeviceState& state,
+bool MqttOutput::onConnected(Channel& channel, const DeviceState& state,
                              const BridgeInfo& bridge) {
+    // Availability/identity/capabilities are not gated by discoveryPublished and never were --
+    // republishing retained state on a tick that only re-tries discovery is harmless. Only
+    // discovery's own success is reported up; see publishDiscovery and the caller in loop().
     publishTracked(topics_.availability().c_str(), 1, true, kPayloadOnline);
 
     std::string payload;
@@ -232,7 +246,7 @@ void MqttOutput::onConnected(Channel& channel, const DeviceState& state,
     if (json_util::buildCapabilitiesPayload(state.capabilities, payload, kMaxPayloadBytes)) {
         publishTracked(channel.topics.capabilities().c_str(), 1, true, payload.c_str());
     }
-    publishDiscovery(channel, state, bridge);
+    const bool discoveryOk = publishDiscovery(channel, state, bridge);
 
     // The relay command topic is the only subscription; inverter drivers stay read-only
     // and get no command topic -- that follows from the capabilities, not a decision here.
@@ -241,6 +255,7 @@ void MqttOutput::onConnected(Channel& channel, const DeviceState& state,
         g_client.subscribe(topics_.drmSet().c_str(), 1);
         relayStateForced_ = true;  // fresh session: ack the current states once
     }
+    return discoveryOk;
 }
 
 void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& bridge,
@@ -307,8 +322,16 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
 
         const auto signature = discoverySignature(state);
         if (!channel.discoveryPublished || signature != channel.discoveredSignature) {
-            onConnected(channel, state, bridge);
-            channel.discoveredSignature = signature;
+            // Commit only on success: a refused publish must not look delivered here either --
+            // the same rule forgetDevice() already applies below. Leaving both fields untouched
+            // on failure means the NEXT tick retries the whole announcement, not just whatever
+            // changed since. Before this (review, 2026-07-30) the commit was unconditional, so
+            // a refusal from the memory guard could drop a Home Assistant entity until the next
+            // reconnect or capability change -- which might be a long wait, or never.
+            if (onConnected(channel, state, bridge)) {
+                channel.discoveryPublished  = true;
+                channel.discoveredSignature = signature;
+            }
         }
 
         if (channel.throttle.shouldPublish(state, nowMs)) {
@@ -341,10 +364,18 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
         }
         if (relayStateForced_ || relayAckRequested_.exchange(false) ||
             bridge.relayMask != lastRelayMask_) {
+            // Accumulated like forgetDevice()'s `ok` below: a refused ack must not be recorded
+            // as delivered, or a switch whose command could not actually reach the broker
+            // stays stuck mid-toggle in Home Assistant until something else happens to
+            // retrigger this block. Before this (review, 2026-07-30) the commit at the bottom
+            // was unconditional -- reachable on every variant once the memory guard existed,
+            // not only the one board with no PSRAM where the library's own guard could fire.
+            bool ok = true;
             for (uint8_t i = 0; i < bridge.relayCount; ++i) {
                 const bool on = (bridge.relayMask >> i) & 1;
-                publishTracked(topics_.relayState(i).c_str(), 1, true,
-                                 on ? "ON" : "OFF");
+                ok = publishTracked(topics_.relayState(i).c_str(), 1, true,
+                                     on ? "ON" : "OFF") &&
+                     ok;
             }
             // The DRM mode is derived state over the same mask; ack it in the same breath
             // so the HA select and the switches can never disagree for long.
@@ -352,10 +383,16 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
             roles.resize(bridge.relayCount, "none");
             if (!drm::optionsFor(roles).empty()) {
                 const std::string mode = drm::modeFrom(roles, bridge.relayMask);
-                publishTracked(topics_.drmState().c_str(), 1, true, mode.c_str());
+                ok = publishTracked(topics_.drmState().c_str(), 1, true, mode.c_str()) && ok;
             }
-            lastRelayMask_    = bridge.relayMask;
-            relayStateForced_ = false;
+            // Committed only on success. relayAckRequested_ was already consumed by the
+            // exchange() above regardless of what happens next -- that is fine: on failure,
+            // bridge.relayMask stays != lastRelayMask_ (or relayStateForced_ stays true), so
+            // this block re-enters on the very next tick without needing the flag again.
+            if (ok) {
+                lastRelayMask_    = bridge.relayMask;
+                relayStateForced_ = false;
+            }
         }
     }
 
@@ -439,8 +476,10 @@ void MqttOutput::loop(const std::vector<DeviceView>&, const BridgeInfo&,
 void MqttOutput::stop() { started_ = false; }
 bool MqttOutput::forgetDevice(const DeviceId&, const BridgeInfo&) { return false; }
 bool MqttOutput::connected() const { return false; }
-void MqttOutput::onConnected(Channel&, const DeviceState&, const BridgeInfo&) {}
-void MqttOutput::publishDiscovery(Channel&, const DeviceState&, const BridgeInfo&) {}
+bool MqttOutput::onConnected(Channel&, const DeviceState&, const BridgeInfo&) { return false; }
+bool MqttOutput::publishDiscovery(Channel&, const DeviceState&, const BridgeInfo&) {
+    return false;
+}
 MqttOutput::Channel& MqttOutput::channelFor(const DeviceView&, const BridgeInfo&) {
     static Channel unused{"", MqttTopics("", ""), "", PublishThrottle({}), false, 0};
     return unused;

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -36,8 +36,14 @@ espMqttClient g_client;
 ///
 /// Returns the same bool the one careful call site already wanted, so forgetDevice keeps its
 /// existing semantics.
+///
+/// The memory check in front of it is the library's own policy applied to the right pool --
+/// refusePublishForMemory() in the header carries the whole argument. Counted through the same
+/// path as a client refusal: to anything watching, both mean "this message never left", which
+/// is the question mqtt_publish_failure_total answers.
 bool MqttOutput::publishTracked(const char* topic, uint8_t qos, bool retain, const char* payload) {
-    if (g_client.publish(topic, qos, retain, payload) != 0) {
+    if (!refusePublishForMemory(ESP.getMaxAllocHeap()) &&
+        g_client.publish(topic, qos, retain, payload) != 0) {
         return true;
     }
     if (diagnostics_ != nullptr) {

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -203,4 +203,36 @@ private:
 
 inline constexpr uint32_t kMaxReconnectDelayMs = 60000;
 
+/// Largest contiguous internal block below which this output stops handing work to the MQTT
+/// client. Matches espMqttClient's own EMC_MIN_FREE_MEMORY deliberately: the intent is the
+/// library's, only the pool is different -- see refusePublishForMemory.
+inline constexpr uint32_t kMinFreeBlockBytes = 16384;
+
+/// Whether a publish must be refused because internal memory is too low to risk it.
+///
+/// espMqttClient already refuses a PUBLISH when memory is short: Packets/Packet.cpp calls
+/// _allocate(len, check=true), which bails below EMC_MIN_FREE_MEMORY (16384). The problem is
+/// WHICH memory it looks at. EMC_GET_FREE_MEMORY() is a hard #define -- no #ifndef, so a build
+/// flag cannot reach it -- reading std::max(ESP.getMaxAllocHeap(), ESP.getMaxAllocPsram()). A
+/// publish is ~100-200 bytes, far under SPIRAM_MALLOC_ALWAYSINTERNAL (4096), so malloc serves
+/// it from INTERNAL SRAM; but on a board with 8 MB of mostly-idle PSRAM that max() reports
+/// megabytes and the guard never fires. The board with NO PSRAM is therefore the only one where
+/// the library's own safety net works, and the two with more memory are the ones that can
+/// exhaust internal SRAM with the failure counter reading zero throughout (audit F5,
+/// docs/audit-2026-07-29.md).
+///
+/// This applies the same 16 KB intent to the pool the allocation actually comes from, on every
+/// variant, without forking the dependency. Pure, and takes the figure as an argument, so the
+/// decision is host-tested; only the caller reaches for ESP.getMaxAllocHeap().
+///
+/// The trade-off, stated because it is real: under transient pressure from something else -- a
+/// dashboard reload storm measured at a 93 KB dip on the 6CH -- publishes are refused rather
+/// than queued. Measurements self-heal, because every poll cycle republishes them. A one-shot
+/// discovery message does not, and waits for the next re-announce. Accepted: at this threshold
+/// the alternative is risking the allocation that takes the device down, and a refusal is
+/// counted where an exhaustion is silent.
+inline bool refusePublishForMemory(uint32_t largestFreeBlockBytes) {
+    return largestFreeBlockBytes < kMinFreeBlockBytes;
+}
+
 }  // namespace heliograph::mqtt

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -144,8 +144,15 @@ private:
 
     Channel& channelFor(const DeviceView& view, const BridgeInfo& bridge);
 
-    void onConnected(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);
-    void publishDiscovery(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);
+    /// Both return whether every publish they attempted actually left -- discovery's entities
+    /// specifically, not availability/identity/capabilities, which loop() does not gate on.
+    /// A caller that ignores the return and commits its bookkeeping anyway is exactly the bug
+    /// a review caught here (2026-07-30): a refusal from the new memory guard looked identical
+    /// to a delivered announcement, so a channel could mark itself "discovery done" while Home
+    /// Assistant never got the entities -- and, since the signature would already match on the
+    /// next tick, nothing would ever retry short of an actual reconnect.
+    bool onConnected(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);
+    bool publishDiscovery(Channel& channel, const DeviceState& state, const BridgeInfo& bridge);
 
     MqttConfig   config_;
     /// Bridge-scoped: availability, diagnostics, relay and DRM. Never a device's.
@@ -225,12 +232,32 @@ inline constexpr uint32_t kMinFreeBlockBytes = 16384;
 /// variant, without forking the dependency. Pure, and takes the figure as an argument, so the
 /// decision is host-tested; only the caller reaches for ESP.getMaxAllocHeap().
 ///
-/// The trade-off, stated because it is real: under transient pressure from something else -- a
-/// dashboard reload storm measured at a 93 KB dip on the 6CH -- publishes are refused rather
-/// than queued. Measurements self-heal, because every poll cycle republishes them. A one-shot
-/// discovery message does not, and waits for the next re-announce. Accepted: at this threshold
+/// The trade-off, stated because it is real: under transient pressure from something else --
+/// e.g. the dashboard reload storm the audit measured on the 6CH -- publishes are refused
+/// rather than queued. Measurements self-heal, because every poll cycle republishes them. A
+/// one-shot discovery message does not self-heal on its own, but loop() now retries the whole
+/// announcement on the next tick when a refusal happens (see onConnected/publishDiscovery) --
+/// that used to not be true, and a review caught it (2026-07-30). Accepted: at this threshold
 /// the alternative is risking the allocation that takes the device down, and a refusal is
 /// counted where an exhaustion is silent.
+///
+/// UNVERIFIED under real load, and worth being honest about: the audit's reload-storm figure
+/// (a 93 KB dip on the 6CH, docs/audit-2026-07-29.md) is ESP.getMinFreeHeap() -- total free
+/// heap's since-boot low-water mark -- not ESP.getMaxAllocHeap(), the largest CONTIGUOUS block
+/// this guard actually reads. The two diverge under fragmentation (the same report shows
+/// 78 744 B min-free next to a 102 388 B largest block in one snapshot), and nobody has
+/// captured the largest-block figure specifically during that storm on any variant. The 16 KB
+/// threshold is therefore validated against the resting figure (90 100 B measured, comfortably
+/// above it), not against a load transient in the metric that matters here.
+///
+/// Cost, asked about and not free: ESP.getMaxAllocHeap() -> heap_caps_get_largest_free_block()
+/// walks the internal heap's free-block bookkeeping under the heap lock, once per publish --
+/// dozens of times per loop() tick on a four-device board. Not cached across a tick on
+/// purpose: publishTracked() is also called from forgetDevice(), reached from the REST task
+/// rather than loop()'s, and a cache shared across tasks needs the same synchronisation care
+/// as every other cross-task field in this class (resyncRequested_, relayAckRequested_) for a
+/// saving nobody has shown matters yet. Per the project's own rule, that trade avoids adding
+/// complexity for a cost that is real but not demonstrated to be a problem.
 inline bool refusePublishForMemory(uint32_t largestFreeBlockBytes) {
     return largestFreeBlockBytes < kMinFreeBlockBytes;
 }

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -1162,6 +1162,14 @@ static void test_an_unchanged_line_up_forgets_nothing() {
 /// already but compares against max(internal, PSRAM), so on a board with 8 MB of idle PSRAM it
 /// never fires while the allocation itself comes from internal SRAM. This predicate is that
 /// same 16 KB intent, measured on the pool that actually pays.
+///
+/// This pins the PREDICATE, not the wiring around it. MqttOutput itself is ESP32-only (no
+/// fake espMqttClient exists to run its loop() on the host), so the rule added alongside this
+/// guard -- a refused publish must not be recorded as delivered, or a Home Assistant entity or
+/// a relay ack can go missing until an unrelated reconnect or signature change retriggers it,
+/// see loop()'s discovery/relay-ack commits in mqtt_output.cpp -- is verified by review and by
+/// the compile/layering/build checks, not by a test that can inject a refusal and observe the
+/// retry. Recorded here rather than left implicit (review, 2026-07-30).
 static void test_publish_memory_guard() {
     // Comfortable: the figure a healthy 6CH reports for this exact call -- 90 100 B, measured
     // 2026-07-30 via max_alloc_heap_bytes, which main.cpp fills from ESP.getMaxAllocHeap().

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -16,6 +16,7 @@
 #include "outputs/json_util.h"
 #include "outputs/mqtt/announced_devices.h"
 #include "outputs/mqtt/home_assistant_discovery.h"
+#include "outputs/mqtt/mqtt_output.h"
 #include "outputs/mqtt/mqtt_payloads.h"
 #include "outputs/mqtt/mqtt_topics.h"
 #include "outputs/mqtt/publish_policy.h"
@@ -1157,6 +1158,24 @@ static void test_an_unchanged_line_up_forgets_nothing() {
 }
 
 
+/// The memory guard in front of every publish (audit F5). espMqttClient has this policy
+/// already but compares against max(internal, PSRAM), so on a board with 8 MB of idle PSRAM it
+/// never fires while the allocation itself comes from internal SRAM. This predicate is that
+/// same 16 KB intent, measured on the pool that actually pays.
+static void test_publish_memory_guard() {
+    // Comfortable: the figure a healthy 6CH reports for this exact call -- 90 100 B, measured
+    // 2026-07-30 via max_alloc_heap_bytes, which main.cpp fills from ESP.getMaxAllocHeap().
+    TEST_ASSERT_FALSE(refusePublishForMemory(90100));
+    // The threshold is a floor, not a target: at exactly the floor there is still room.
+    TEST_ASSERT_FALSE(refusePublishForMemory(kMinFreeBlockBytes));
+    TEST_ASSERT_TRUE(refusePublishForMemory(kMinFreeBlockBytes - 1));
+    // The case this exists for: PSRAM would report megabytes free, internal SRAM is nearly
+    // gone. Only the internal figure reaches this function, so the answer is refuse.
+    TEST_ASSERT_TRUE(refusePublishForMemory(4096));
+    TEST_ASSERT_TRUE(refusePublishForMemory(0));
+}
+
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_every_announceable_measurement_is_clearable);
@@ -1223,5 +1242,6 @@ int main(int, char**) {
     RUN_TEST(test_forced_refresh_after_the_interval);
     RUN_TEST(test_a_new_channel_publishes);
     RUN_TEST(test_reset_forces_the_next_publish);
+    RUN_TEST(test_publish_memory_guard);
     return UNITY_END();
 }


### PR DESCRIPTION
Audit **F5**, the remedy you approved. Docs for the finding itself are in #150.

## The bug this closes

espMqttClient already refuses a PUBLISH when memory is short, and `publishTracked` already
counts refusals. It measures the wrong pool:

```c
#define EMC_GET_FREE_MEMORY() std::max(ESP.getMaxAllocHeap(), ESP.getMaxAllocPsram())
```

A hard `#define` (no `#ifndef`, so no build flag reaches it). A publish is ~100–200 bytes, far
under `SPIRAM_MALLOC_ALWAYSINTERNAL` (4096), so `malloc` serves it from **internal** SRAM.

| | `getMaxAllocPsram()` | comparison | library guard |
|---|---|---|---|
| RS485-CAN, Relay-1CH (8 MB PSRAM, 8 378 140 B free measured) | megabytes | ~8 MB vs 16 KB | **never fires** |
| Relay-6CH (no PSRAM) | 0 | internal vs 16 KB | works |

The board with the least memory is the only one protected; the two with the most can walk
internal SRAM toward exhaustion with the failure counter reading zero — silent instead of
counted.

## The change

`refusePublishForMemory(uint32_t)` — pure, parameterised, host-tested — applied in
`publishTracked` with `ESP.getMaxAllocHeap()`. Same 16 KB intent as the library, on the pool
that actually pays, identical on all three variants, no dependency fork.

**Named trade-off:** under transient pressure from something else (the dashboard reload storm
measured at a 93 KB dip on the 6CH) publishes are refused rather than queued. Measurements
self-heal on the next poll; a one-shot discovery message waits for the next re-announce. At this
threshold the alternative is risking the allocation that takes the device down.

## Verification

- 853 native tests, layering, all three firmwares.
- Mutation-tested both directions: disabling the guard fails the test, and moving the boundary
  one byte (`<` → `<=`) fails it too.
- **Healthy path confirmed on hardware, not assumed:** a 6CH running this build reports
  `max_alloc_heap_bytes` 90 100, and `main.cpp:515` fills that field from the same
  `ESP.getMaxAllocHeap()` call the guard uses — so the predicate is false by 74 KB there.

**Still unverified:** the refusal path under a genuinely stalled broker. The hostile-broker test
never received a connection because this machine's firewall blocks inbound 1883 — a security
setting I did not touch. Recorded in the audit; the script is ready if you open that up.