### PR TITLE
docs(audit): F5 closed — reload-storm floor measured against the guard's own metric

### DIFF
--- a/docs/audit-2026-07-29.md
+++ b/docs/audit-2026-07-29.md
@@ -499,6 +499,31 @@ no change should land before the measurement.
   `free_heap_bytes`/`minimum_free_heap_bytes`, is the measurement that would actually
   close this out.
 
+  **CLOSED 2026-07-30 — measured, and the margin holds.** Re-ran the reload-storm
+  protocol on both A and C, this time on 0.24.3 (with the guard shipped) and sampling
+  `max_alloc_heap_bytes` every 0.5 s continuously through idle → storm → aftercare,
+  not just before/after — fragmentation can be transient and a single before/after pair
+  would miss a dip that recovers between samples.
+
+  | | idle min | **storm floor** | margin to the 16 KB guard |
+  |---|---|---|---|
+  | A (rs485-can, 8 MB PSRAM) | 102 388 B | **32 756 B** (t=207s into the storm) | 16 372 B — **2.0×** the threshold |
+  | C (relay-6ch, no PSRAM) | 73 716 B | **31 732 B** (t=64s) | 15 348 B — **1.9×** the threshold |
+
+  Zero samples on either board, across 579 storm-phase readings total, went below the
+  threshold. The largest-contiguous-block figure tracks noticeably lower than the
+  total-free figure under load (as suspected), but not far enough to threaten the
+  guard even at the worst instant captured. **The remedy in the guard PR is validated
+  against the metric it actually reads, under the heaviest load this audit tested.**
+
+  Measurement note, for whoever runs this protocol again: the storm-runner script
+  hung after finishing (fixed after the fact, not before) — a bare `wait` after the
+  three tab subshells also waited on the sampler's own long-running background loop,
+  which never exits on its own. Both processes were still doing useful work when
+  killed eleven minutes later (the storm itself completed on schedule; only the
+  script's own exit was stuck), so the data above is unaffected — but scope any
+  future `wait` to the specific PIDs being waited on, not the shell's full job list.
+
 - **Recommended remedy (Tim's call, not taken):** a guard in our own
   `publishTracked()` — refuse and count when `ESP.getMaxAllocHeap()` is below a floor,
   before calling `g_client.publish()`. Five lines, no dependency fork, identical policy
@@ -646,14 +671,13 @@ trades robustness margin for speed is out.
    the grow-the-repro/upstream follow-up is closed. PR #149 corrects the comments and adds a
    `static_assert`, which is the only form the guard can take: the failure needs
    `.init_array` and RTC memory to be distinct, which they are not on the host.
-5. **F5** — investigated 2026-07-30, and the finding changed shape: the library DOES
-   guard allocations and our counter DOES see refusals, but on A/B the guard measures
-   PSRAM while the allocation comes from internal SRAM, so it never fires there. Two
-   decisions now: (a) add the five-line guard in `publishTracked()` (recommended — it
-   turns a silent exhaustion into a counted refusal on every variant), and (b) whether
-   to unblock the hostile-broker measurement, which needs an inbound firewall allowance
-   on the dev Mac or a listener on the IoT subnet. The remedy does not depend on the
-   measurement; the measurement would size the risk it removes.
+5. **F5** — CLOSED. Investigated 2026-07-30 (library measures the wrong pool on A/B),
+   remedied the same day (`refusePublishForMemory()`, shipped in 0.24.3), and the
+   remedy's own margin measured under the heaviest load this audit tested: the
+   reload-storm floor on both A and C sits at ~2× the 16 KB threshold, continuously
+   sampled through the whole storm. Only the hostile-broker measurement (a genuinely
+   stalled broker rather than a memory squeeze) remains blocked on the dev Mac's
+   firewall — lower priority now that the guard's margin under load is confirmed.
 6. **F3 PSRAM**: accept idle (recommended) or pursue option (b) divergence?
 7. **F9 cosmetic**: leave 1970 log prefixes, or prefix "(unsynced)" until NTP?
 8. **`storage` partitions**: declare claimable for future proposals, or keep


### PR DESCRIPTION
Closes the one loose end from F5/#151: the guard's 16 KB threshold was validated against the
*resting* `max_alloc_heap_bytes` figure and, separately, against the *wrong metric*
(`min_free_heap`) under load. This re-runs the reload-storm protocol on the metric that
actually matters, on both A and C, on 0.24.3.

## Method

Continuous sampling (2/s) of `max_alloc_heap_bytes` through idle → 3-min reload-storm →
aftercare, not just before/after — a transient dip could recover between two point samples and
never show up.

## Result

| | idle min | storm floor | margin to 16 KB |
|---|---|---|---|
| A (8 MB PSRAM) | 102 388 B | **32 756 B** | **2.0×** |
| C (no PSRAM) | 73 716 B | **31 732 B** | **1.9×** |

Zero of 579 storm-phase samples on either board went below the threshold. The guard has real
margin under the heaviest load this audit tested, on the constraint-floor board included.

## Honest note

The measurement script hung for ~11 minutes after the storm itself finished on schedule — a
bare `wait` also waited on the sampler's own infinite background loop. No effect on the data
(the storm ran its full course; only the script's exit was stuck), but recorded so the next
person scoping a `wait` doesn't repeat it.

Docs only.