### PR TITLE
docs(audit): F3 decided — accept PSRAM idle on A/B

### DIFF
--- a/docs/audit-2026-07-29.md
+++ b/docs/audit-2026-07-29.md
@@ -404,7 +404,7 @@ no change should land before the measurement.
   concurrency guard on page streams is the future option if multi-viewer dashboards
   ever become normal — nothing needs to change today.
 
-### F3 · PSRAM does nothing on A/B — by policy, and that is a choice to make
+### F3 · PSRAM does nothing on A/B — DECIDED 2026-07-30: accept, no change
 
 - **Mechanism:** `SPIRAM_MALLOC_ALWAYSINTERNAL 4096` + a codebase that allocates
   small (log ring static, responses ≤ 8 KB, bodies ≤ 4 KB, ArduinoJson pooled)
@@ -678,7 +678,8 @@ trades robustness margin for speed is out.
    sampled through the whole storm. Only the hostile-broker measurement (a genuinely
    stalled broker rather than a memory squeeze) remains blocked on the dev Mac's
    firewall — lower priority now that the guard's margin under load is confirmed.
-6. **F3 PSRAM**: accept idle (recommended) or pursue option (b) divergence?
+6. **F3 PSRAM** — DECIDED 2026-07-30: **accept (option a)**. PSRAM stays idle on A/B;
+   one heap behaviour on all three variants, no divergence, no code change.
 7. **F9 cosmetic**: leave 1970 log prefixes, or prefix "(unsynced)" until NTP?
 8. **`storage` partitions**: declare claimable for future proposals, or keep
    reserved as-is?


### PR DESCRIPTION
Records Tim's decision: option (a), accept PSRAM staying idle on A/B rather than pursue option (b)'s divergence. No code change, docs only.