### PR TITLE
docs(audit): F9 corrected (was inaccurate), storage partitions decided claimable

### DIFF
--- a/docs/audit-2026-07-29.md
+++ b/docs/audit-2026-07-29.md
@@ -570,14 +570,21 @@ flash-stall, far above NVS/OTA cache-disabled windows. One UNVERIFIED edge —
 worst-case NVS page GC during an active poll — parked as a low-priority
 measurement (config-save storm during polling, watch for one timeout tick).
 
-### F9 · Wall-clock on C: contained, one cosmetic choice left
+### F9 · Wall-clock on C: contained — CORRECTED 2026-07-30, this finding was wrong
 
 The core is monotonic ms-since-boot end to end (`clock.h:13`,
-`measurement.h:72`); payload builders emit no epochs (grep-verified). What remains:
-log-line prefixes print 1970 dates before NTP (documented fallback,
-`log_timestamp.cpp:16`) and reset events carry no wall time — which F4 addresses
-without needing a clock at all. "Wrong data" exposure = log ordering across a
-reboot, nothing else found.
+`measurement.h:72`); payload builders emit no epochs (grep-verified). Reset events
+carry no wall time — F4 addresses that without needing a clock at all.
+
+**"Log-line prefixes print 1970 dates before NTP" was inaccurate, not merely
+already fixed.** Checked 2026-07-30: `log_timestamp.cpp`'s unsynced path has
+printed the uptime form (`+123.4s`), never a date, since the first public commit
+(`c2b44cd`, 2026-07-22) — a week before this audit was written. The API fields
+(`time`, `ntp_last_sync`) are `null` before sync (`json_util.h:addClockFields`,
+whose own comment states the same "never a fabricated 1970 date" rule), and the
+RTC-restore boot line only formats a timestamp when the RTC itself returns one.
+There was no cosmetic choice to make; the earlier text describing one was wrong.
+No code change. "Wrong data" exposure on C: none found, log ordering included.
 
 ### F10 · Stack sizing: roughly right, C unconfirmed
 
@@ -680,9 +687,13 @@ trades robustness margin for speed is out.
    firewall — lower priority now that the guard's margin under load is confirmed.
 6. **F3 PSRAM** — DECIDED 2026-07-30: **accept (option a)**. PSRAM stays idle on A/B;
    one heap behaviour on all three variants, no divergence, no code change.
-7. **F9 cosmetic**: leave 1970 log prefixes, or prefix "(unsynced)" until NTP?
-8. **`storage` partitions**: declare claimable for future proposals, or keep
-   reserved as-is?
+7. **F9** — CORRECTED 2026-07-30: not a real finding. The 1970-prefix claim was
+   inaccurate; the uptime-form fallback has been in place since the first public
+   commit. Nothing to decide, no code change.
+8. **`storage` partitions** — DECIDED 2026-07-30: **claimable**. Nothing today
+   mounts them or reserves them for a named purpose (born as speculative
+   'littlefs' space, per the §8 answer above); a future proposal needing scratch
+   flash space may use them without that being a new finding first.
 9. **C measurement round** — DONE 2026-07-29 (6CH at .140, firmware 0.24.1): boot
    baseline 126.5 KB free / min 95.7 KB / largest block 81.9 KB with four mock
    devices; floor under dashboard load 107 KB; ~800 polls with 0 failures; stack


### PR DESCRIPTION
Two of the audit's remaining open items, closed.

**F9 — corrected, not fixed.** Before writing a "prefix (unsynced)" patch for the stated
cosmetic choice, I checked the actual code. The 1970-prefix claim in the original finding was
inaccurate: `log_timestamp.cpp`'s unsynced path has printed the uptime form (`+123.4s`), never
a date, since the first public commit — a week before the audit was written. The API's
`time`/`ntp_last_sync` fields and the RTC-restore boot line already follow the same rule. There
was never a choice to make here; the finding itself was wrong, and that's what this records.

**`storage` partitions — decided claimable.** Nothing mounts or reserves them for a named
purpose today. A future proposal needing scratch flash space can use them without that being a
new finding first.

Docs only.