### PR TITLE
Command write-path plumbing: queue + REST/MQTT entry points

### DIFF
--- a/src/commands/command_dispatcher.h
+++ b/src/commands/command_dispatcher.h
@@ -47,8 +47,11 @@ public:
     ///
     /// Thread-safe for its own state. CommandSource names Mqtt, Rest, ModbusTcp and Web, and the
     /// burst counter is read-modify-write, so two concurrent commands could each see the last
-    /// free slot and both take it. (Nothing constructs a dispatcher yet -- there is no write
-    /// path. This is what the contract must be when there is one.)
+    /// free slot and both take it. (g_commandDispatcher is now constructed in main.cpp, but
+    /// dispatch() is only ever called from rs485Task, one at a time -- CommandQueue's single
+    /// pending slot serialises every REST/MQTT submission before it gets here. The race this
+    /// note describes would need a second caller of dispatch() itself, which does not exist
+    /// today; this is the contract the class must still uphold if one ever does.)
     ///
     /// The lock covers ONLY the rate-limiter bookkeeping and is released before the driver runs.
     /// execute() on a real driver is an RS485 transaction that waits up to 2 s for the bus lock

--- a/src/commands/command_queue.cpp
+++ b/src/commands/command_queue.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+#include "command_queue.h"
+
+namespace heliograph {
+
+bool CommandQueue::submit(Request request) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (pending_.has_value()) {
+        return false;
+    }
+    pending_ = std::move(request);
+    return true;
+}
+
+std::optional<CommandQueue::Request> CommandQueue::take() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!pending_.has_value()) {
+        return std::nullopt;
+    }
+    std::optional<Request> taken = std::move(pending_);
+    pending_.reset();
+    return taken;
+}
+
+void CommandQueue::recordOutcome(const std::string& requestId, DispatchOutcome outcome) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    lastOutcomeRequestId_ = requestId;
+    lastOutcome_          = std::move(outcome);
+}
+
+std::optional<DispatchOutcome> CommandQueue::outcomeFor(const std::string& requestId) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (lastOutcomeRequestId_ != requestId) {
+        return std::nullopt;
+    }
+    return lastOutcome_;
+}
+
+}  // namespace heliograph

--- a/src/commands/command_queue.h
+++ b/src/commands/command_queue.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+//
+// One command in flight at a time, requested from any task and drained by the bus owner.
+//
+// Same request/consume shape as g_manualPollRequested and the discovery/capture requests in
+// main.cpp: a caller can only ever ASK, never run a command itself, because only rs485Task may
+// touch the bus. This generalises that shape from a bare flag to an actual command, because a
+// write needs to say WHAT and for WHICH device, and the caller needs to learn what became of the
+// specific request it made -- hence requestId rather than a fire-and-forget bool.
+//
+// Built ahead of any driver that can accept a command (every shipping driver returns
+// CommandResult::Unsupported), for the same reason CommandDispatcher itself was: the tested
+// contract is worth having before the first thing that needs it, not written under pressure
+// alongside it.
+
+#pragma once
+
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "command_dispatcher.h"
+#include "device/command.h"
+
+namespace heliograph {
+
+class CommandQueue {
+public:
+    struct Request {
+        std::string     deviceId;
+        InverterCommand command;
+    };
+
+    /// False, with no state change, if a request is already pending -- the same one-in-flight
+    /// rule the manual-poll request already applies. A caller that gets false must surface it
+    /// as "busy, try again", not queue a second request that could then execute out of order.
+    bool submit(Request request);
+
+    /// Consumed by the bus owner: takes the pending request if there is one, clearing the slot.
+    std::optional<Request> take();
+
+    /// Recorded by the bus owner once dispatch() has returned. Overwrites whatever the previous
+    /// outcome was -- only the most recent request's outcome is kept, matching submit()'s
+    /// one-slot rule.
+    void recordOutcome(const std::string& requestId, DispatchOutcome outcome);
+
+    /// The outcome of the most recently COMPLETED request with this id. Empty if that id was
+    /// never submitted, is still pending, or has since been superseded by a later request's
+    /// outcome.
+    std::optional<DispatchOutcome> outcomeFor(const std::string& requestId) const;
+
+private:
+    mutable std::mutex             mutex_;
+    std::optional<Request>         pending_;
+    std::string                    lastOutcomeRequestId_;
+    std::optional<DispatchOutcome> lastOutcome_;
+};
+
+}  // namespace heliograph

--- a/src/device/command.cpp
+++ b/src/device/command.cpp
@@ -94,4 +94,15 @@ bool commandTakesEnumValue(InverterCommandType type) {
     return type == InverterCommandType::SetBatteryOperatingMode;
 }
 
+bool commandTypeFromName(const std::string& name, InverterCommandType& out) {
+    for (size_t i = 0; i < kCommandTypeCount; ++i) {
+        const auto candidate = static_cast<InverterCommandType>(i);
+        if (name == commandTypeName(candidate)) {
+            out = candidate;
+            return true;
+        }
+    }
+    return false;
+}
+
 }  // namespace heliograph

--- a/src/device/command.h
+++ b/src/device/command.h
@@ -46,6 +46,11 @@ enum class CommandResult : uint8_t {
 const char* commandResultName(CommandResult result);
 const char* commandTypeName(InverterCommandType type);
 
+/// The reverse of commandTypeName: the type whose name is `name`, or false if none matches.
+/// Reuses commandTypeName's own table by comparing against it, so the two directions cannot
+/// drift apart the way two independent switches could.
+bool commandTypeFromName(const std::string& name, InverterCommandType& out);
+
 /// The capability a command type requires. Used by the dispatcher to check a command
 /// against the active driver's capabilities without knowing which driver it is.
 InverterCapability requiredCapability(InverterCommandType type);

--- a/src/device/command.h
+++ b/src/device/command.h
@@ -30,6 +30,28 @@ struct InverterCommand {
     uint64_t                createdAtMs = 0;
 };
 
+/// Every request id this firmware generates itself (see submitCommand() in main.cpp) starts
+/// with this. A caller-supplied id (REST body or MQTT payload) is refused if it also starts
+/// with it, so the two namespaces can never collide -- without this, a caller-chosen
+/// "auto-3" could later collide with the third auto-generated id and silently steal or leak
+/// another request's outcome from CommandQueue::outcomeFor() (review, 2026-07-30).
+inline constexpr const char* kAutoRequestIdPrefix = "auto-";
+
+/// A caller-supplied request id longer than this is refused rather than truncated. Bounds the
+/// JSON accept/reject/outcome acks that embed it (see json_util.h's buildCommand*Payload) well
+/// under their byte budgets, so an oversized id cannot itself make one of those payloads
+/// overflow and silently ship empty.
+inline constexpr size_t kMaxRequestIdLength = 64;
+
+/// Ceiling on a raw command-request body (REST POST /commands or an MQTT command/set message)
+/// before it is even handed to parseCommandRequest. A real command body -- type, one numeric
+/// or enum value, an optional request_id up to kMaxRequestIdLength -- fits in well under 200
+/// bytes; this leaves generous headroom for a future field without accepting an arbitrarily
+/// large payload from an unauthenticated MQTT publisher (REST bodies are already bounded by
+/// the API's own kMaxRequestBytes at the transport layer, but MQTT has no equivalent gate
+/// upstream of this).
+inline constexpr size_t kMaxCommandPayloadBytes = 512;
+
 enum class CommandResult : uint8_t {
     Ok,
     /// The driver does not implement this command at all. A read-only driver returns this

--- a/src/device/device_context.h
+++ b/src/device/device_context.h
@@ -47,6 +47,11 @@ public:
     /// True when pollOnce() should be called again.
     bool due(uint64_t nowMs) const;
 
+    /// The driver this context polls. Exposed so rs485Task can resolve a queued command to the
+    /// right driver: dispatching, like pollOnce(), only ever happens on the task that owns the
+    /// bus, so this cannot race pollOnce() -- one task, one bus, one operation per iteration.
+    InverterDriver& driver() { return driver_; }
+
     // Deliberately no workingState() accessor and no setBridgeOnline(): both were unused traps
     // (review, 2026-07-21). A raw reference into the rs485Task-mutated state_ invited a data
     // race from any other task; readers must go through StateStore::snapshot(). And a

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -468,7 +468,10 @@ std::atomic<uint32_t> g_commandRequestCounter{0};
 /// paths that could each think they alone hold "the" pending slot.
 std::optional<std::string> submitCommand(const std::string& deviceId, InverterCommand command) {
     if (command.requestId.empty()) {
-        command.requestId = "req-" + std::to_string(g_commandRequestCounter.fetch_add(1) + 1);
+        // kAutoRequestIdPrefix is reserved: parseCommandRequest refuses any caller-supplied id
+        // starting with it, so this can never collide with one a REST/MQTT caller picked.
+        command.requestId =
+            kAutoRequestIdPrefix + std::to_string(g_commandRequestCounter.fetch_add(1) + 1);
     }
     const std::string requestId = command.requestId;
     if (!g_commandQueue.submit({deviceId, std::move(command)})) {
@@ -1223,9 +1226,11 @@ void rs485Task(void* /*arg*/) {
         // there must never be an iteration that both polls a device and dispatches a command,
         // for the same bus-ownership reason discovery and capture cannot overlap a poll either.
         //
-        // Nothing submits to g_commandQueue today (no shipping driver accepts a command, and no
-        // REST route or MQTT topic exists to reach it) -- this drains whatever a future caller
-        // puts there, following exactly the request/consume shape already established above.
+        // REST and MQTT both reach g_commandQueue today (see submitCommand() above) -- what
+        // still does NOT exist is a driver that accepts anything put here: every shipping
+        // driver's execute() returns CommandResult::Unsupported, so this drains a queue that
+        // can genuinely fill but can never yet succeed, following the same request/consume
+        // shape already established above for discovery and capture.
         if (auto request = g_commandQueue.take()) {
             DeviceContext* target = nullptr;
             for (size_t i = 0; i < g_deviceIds.size(); ++i) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,12 +23,15 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 #include "app/capture_runner.h"
 #include "app/device_plan.h"
 #include "app/discovery_runner.h"
 #include "boards/board.h"
+#include "commands/command_dispatcher.h"
+#include "commands/command_queue.h"
 #include "config/configuration.h"
 #include "config/configuration_store.h"
 #include "config/nvs_backend.h"
@@ -448,6 +451,31 @@ diag::CoredumpSummary g_coredump;
 /// state reads in bridgeInfo(). The controller itself stays lock-free and host-testable.
 RelayController g_relays{nowMs};
 std::mutex      g_relayMutex;
+
+/// The write path's gate and its request slot -- wired ahead of any driver that can accept a
+/// command (every shipping driver returns CommandResult::Unsupported). readOnlyMode() follows
+/// g_config.security.readOnlyMode on exactly the same two sites as g_relays' does, so the one
+/// kill switch covers both. REST and MQTT both submit here (submitCommand below); rs485Task
+/// drains it alongside discovery and capture, the same "request only, the bus owner runs it"
+/// shape as everywhere else on this bus.
+CommandDispatcher     g_commandDispatcher{nowMs};
+CommandQueue          g_commandQueue;
+std::atomic<uint32_t> g_commandRequestCounter{0};
+
+/// Assigns a request id when the caller supplied none, then enqueues. The ONE function both
+/// ctx.submitCommand (REST, AsyncTCP task) and MqttOutput::setCommandHandler (MQTT task) are
+/// wired to, so both transports share one counter and one queue instead of two independent
+/// paths that could each think they alone hold "the" pending slot.
+std::optional<std::string> submitCommand(const std::string& deviceId, InverterCommand command) {
+    if (command.requestId.empty()) {
+        command.requestId = "req-" + std::to_string(g_commandRequestCounter.fetch_add(1) + 1);
+    }
+    const std::string requestId = command.requestId;
+    if (!g_commandQueue.submit({deviceId, std::move(command)})) {
+        return std::nullopt;
+    }
+    return requestId;
+}
 
 /// BOOT-hold factory reset and the status LED, on boards that carry them (board::kHasBootButton
 /// / kHasStatusLed). Both are sampled from loop() only, so no locking: g_bootPressed and
@@ -877,6 +905,9 @@ void startOutputs() {
         cfg.qos              = configSnapshot.mqtt.qos;
         g_mqtt               = std::make_unique<mqtt::MqttOutput>(cfg);
         g_mqtt->setDiagnostics(&g_diagnostics);
+        // Same function REST submits through -- one counter, one queue, regardless of which
+        // transport a command arrived on.
+        g_mqtt->setCommandHandler(submitCommand);
         if (g_relays.count() > 0) {
             g_mqtt->setRelayCommandHandler([](uint8_t index, bool on) {
                 std::lock_guard<std::mutex> lock(g_relayMutex);
@@ -926,6 +957,7 @@ void startRestApi() {
                 g_relays.allOff();
             }
         }
+        g_commandDispatcher.setReadOnlyMode(c.security.readOnlyMode);
     };
     ctx.bridgeInfo  = bridgeInfo;
     ctx.clock       = nowMs;
@@ -1011,6 +1043,12 @@ void startRestApi() {
     };
     ctx.portalActive        = [] { return g_wifi.portalActive(); };
     ctx.scanNetworks        = scanNetworksJson;
+    // Unconditional, unlike the relay handlers below: commands target inverters, not relays,
+    // so they exist regardless of board. The same function MQTT's command topic is wired to.
+    ctx.submitCommand  = submitCommand;
+    ctx.commandOutcome = [](const std::string& requestId) {
+        return g_commandQueue.outcomeFor(requestId);
+    };
     if (g_relays.count() > 0) {
         // Behind the same mutex as the MQTT path: REST commands arrive on the AsyncTCP
         // task, MQTT commands on the MQTT task.
@@ -1175,6 +1213,33 @@ void rs485Task(void* /*arg*/) {
                 restoreDriverLine();
             }
             vTaskDelay(pdMS_TO_TICKS(250));
+            continue;
+        }
+        // A queued write command, on the same terms as discovery and capture above: instead of
+        // this cycle's poll, not alongside it. dispatch() may run a real RS485 transaction
+        // (execute() on a writable driver), so it gets the same exclusive slot a poll would --
+        // there must never be an iteration that both polls a device and dispatches a command,
+        // for the same bus-ownership reason discovery and capture cannot overlap a poll either.
+        //
+        // Nothing submits to g_commandQueue today (no shipping driver accepts a command, and no
+        // REST route or MQTT topic exists to reach it) -- this drains whatever a future caller
+        // puts there, following exactly the request/consume shape already established above.
+        if (auto request = g_commandQueue.take()) {
+            DeviceContext* target = nullptr;
+            for (size_t i = 0; i < g_deviceIds.size(); ++i) {
+                if (g_deviceIds[i] == request->deviceId) {
+                    target = g_contexts[i].get();
+                    break;
+                }
+            }
+            const DispatchOutcome outcome =
+                target != nullptr
+                    ? g_commandDispatcher.dispatch(request->command, target->driver())
+                    : DispatchOutcome{CommandResult::Rejected,
+                                      "unknown device id '" + request->deviceId + "'"};
+            log::info("command %s on %s: %s", commandTypeName(request->command.type),
+                      request->deviceId.c_str(), outcome.reason.c_str());
+            g_commandQueue.recordOutcome(request->command.requestId, outcome);
             continue;
         }
         // At most ONE device per iteration, round-robin. Not a loop over all of them: the
@@ -1403,6 +1468,7 @@ void setup() {
 #endif
     g_relays.setReadOnlyMode(g_config.security.readOnlyMode);
     g_relays.setEnabled(g_config.relays.enabled);
+    g_commandDispatcher.setReadOnlyMode(g_config.security.readOnlyMode);
 
     // BOOT button, status LED and buzzer on boards that have them (6CH). No-op elsewhere.
     initOnboardIndicators();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -908,6 +908,8 @@ void startOutputs() {
         // Same function REST submits through -- one counter, one queue, regardless of which
         // transport a command arrived on.
         g_mqtt->setCommandHandler(submitCommand);
+        g_mqtt->setCommandOutcomeProvider(
+            [](const std::string& requestId) { return g_commandQueue.outcomeFor(requestId); });
         if (g_relays.count() > 0) {
             g_mqtt->setRelayCommandHandler([](uint8_t index, bool on) {
                 std::lock_guard<std::mutex> lock(g_relayMutex);

--- a/src/outputs/json_util.h
+++ b/src/outputs/json_util.h
@@ -13,6 +13,7 @@
 
 #include <ArduinoJson.h>
 
+#include <cmath>
 #include <optional>
 #include <string>
 
@@ -339,7 +340,12 @@ inline bool parseCommandRequest(const std::string& json, InverterCommand& out,
             error = {"value", "required and must be a number for this command type"};
             return false;
         }
-        parsed.numericValue = doc["value"].as<double>();
+        const double value = doc["value"].as<double>();
+        if (!std::isfinite(value)) {
+            error = {"value", "must be finite"};
+            return false;
+        }
+        parsed.numericValue = value;
     } else if (commandTakesEnumValue(type)) {
         if (!doc["enum_value"].is<int>()) {
             error = {"enum_value", "required and must be an integer for this command type"};
@@ -348,7 +354,18 @@ inline bool parseCommandRequest(const std::string& json, InverterCommand& out,
         parsed.enumValue = doc["enum_value"].as<int>();
     }
     if (doc["request_id"].is<const char*>()) {
-        parsed.requestId = doc["request_id"].as<const char*>();
+        const std::string requestId = doc["request_id"].as<const char*>();
+        if (requestId.size() > kMaxRequestIdLength) {
+            error = {"request_id", "too long"};
+            return false;
+        }
+        // Reserved for auto-generated ids (see kAutoRequestIdPrefix's own comment) -- refusing
+        // rather than silently accepting keeps the two id spaces from ever colliding.
+        if (requestId.rfind(kAutoRequestIdPrefix, 0) == 0) {
+            error = {"request_id", "the 'auto-' prefix is reserved"};
+            return false;
+        }
+        parsed.requestId = requestId;
     }
 
     out = parsed;

--- a/src/outputs/json_util.h
+++ b/src/outputs/json_util.h
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 //
-// Shared JSON serialisation helpers for the output adapters. Both the MQTT and REST payload
-// builders had a byte-for-byte copy of these; one definition now.
+// Shared JSON helpers for the output adapters: serialisation, and the one request format REST
+// and MQTT both parse. Both used to carry their own byte-for-byte copies; one definition now.
+//
+// ArduinoJson is why this lives here and not in device/command.*: device/ is the host-testable
+// core check_layering.sh holds to no Arduino-family includes (rule 2), and ArduinoJson.h trips
+// that rule's pattern even though the library itself is plain C++. The wire FORMAT of a command
+// is an output-adapter concern the same way a measurement's JSON shape is; device/command.h
+// keeps only the type itself and the name tables, same split as everywhere else in this file.
 
 #pragma once
 
@@ -12,6 +18,7 @@
 
 #include "json_limits.h"
 
+#include "commands/command_dispatcher.h"
 #include "device/bridge_info.h"
 #include "device/capability.h"
 #include "device/command.h"
@@ -288,6 +295,93 @@ inline bool buildCapabilitiesPayload(const InverterCapabilities& capabilities, s
         entry["unit"]     = unitSymbol(cap.unit);
     }
     return finish(doc, out, maxBytes);
+}
+
+/// What was wrong with a wire-format command request (a REST body or an MQTT payload).
+struct CommandRequestError {
+    std::string field;
+    std::string message;
+};
+
+/// Parses `{"type": "<name>", "value": <number>}` (or `"enum_value": <int>` for a mode command,
+/// or neither for start/stop) into an InverterCommand. An optional `"request_id"` is carried
+/// through unchanged, for a caller that wants to pick its own.
+///
+/// Shared by REST and MQTT, which take the exact same wire shape: one parser instead of two
+/// copies of "which commands need a value vs an enum" that could disagree.
+///
+/// Does not set `source` or `createdAtMs` -- this function knows neither which transport is
+/// calling nor the time. Both are the caller's to fill in on the returned command.
+inline bool parseCommandRequest(const std::string& json, InverterCommand& out,
+                                CommandRequestError& error) {
+    JsonDocument doc;
+    if (deserializeJson(doc, json) != DeserializationError::Ok) {
+        error = {"body", "not valid JSON"};
+        return false;
+    }
+    if (!doc["type"].is<const char*>()) {
+        error = {"type", "required and must be a string"};
+        return false;
+    }
+    InverterCommandType type{};
+    if (!commandTypeFromName(doc["type"].as<const char*>(), type)) {
+        error = {"type", "not a known command type"};
+        return false;
+    }
+
+    InverterCommand parsed;
+    parsed.type = type;
+    // Which field a command needs comes from the type, same rule the dispatcher's range check
+    // uses -- see commandTakesNumericValue's own comment on why that lives on the type rather
+    // than on whatever a driver happened to declare.
+    if (commandTakesNumericValue(type)) {
+        if (!doc["value"].is<double>()) {
+            error = {"value", "required and must be a number for this command type"};
+            return false;
+        }
+        parsed.numericValue = doc["value"].as<double>();
+    } else if (commandTakesEnumValue(type)) {
+        if (!doc["enum_value"].is<int>()) {
+            error = {"enum_value", "required and must be an integer for this command type"};
+            return false;
+        }
+        parsed.enumValue = doc["enum_value"].as<int>();
+    }
+    if (doc["request_id"].is<const char*>()) {
+        parsed.requestId = doc["request_id"].as<const char*>();
+    }
+
+    out = parsed;
+    return true;
+}
+
+/// `{"status":"accepted","request_id":"..."}` -- the same shape the REST 202 body and the MQTT
+/// command-result ack both return, so a caller correlating the two entry points sees one
+/// contract rather than two that happen to agree today.
+inline bool buildCommandAcceptedPayload(const std::string& requestId, std::string& out) {
+    JsonDocument doc;
+    doc["status"]     = "accepted";
+    doc["request_id"] = requestId;
+    return finish(doc, out, 128);
+}
+
+/// `{"status":"rejected","reason":"..."}` -- refused before it ever reached the queue (a
+/// command was already pending, or no write path is wired for this build).
+inline bool buildCommandRejectedPayload(const std::string& reason, std::string& out) {
+    JsonDocument doc;
+    doc["status"] = "rejected";
+    doc["reason"] = reason;
+    return finish(doc, out, 256);
+}
+
+/// `{"result":"...","reason":"..."}` -- CommandDispatcher::dispatch()'s outcome, once rs485Task
+/// has actually run it. commandResultName() is the same table every other CommandResult in
+/// these payloads already goes through.
+inline bool buildCommandOutcomePayload(const DispatchOutcome& outcome, std::string& out) {
+    JsonDocument doc;
+    doc["result"] = commandResultName(outcome.result);
+    doc["reason"] = outcome.reason;
+    return finish(doc, out, 384);
 }
 
 }  // namespace heliograph::json_util

--- a/src/outputs/json_util.h
+++ b/src/outputs/json_util.h
@@ -384,4 +384,16 @@ inline bool buildCommandOutcomePayload(const DispatchOutcome& outcome, std::stri
     return finish(doc, out, 384);
 }
 
+/// Same shape plus `"request_id"` -- for a subscriber with no URL to carry the id in, unlike
+/// REST's GET route where it is already in the path. MQTT's async result republish uses this
+/// one; the REST outcome route uses the two-argument form above.
+inline bool buildCommandOutcomePayload(const std::string& requestId,
+                                       const DispatchOutcome& outcome, std::string& out) {
+    JsonDocument doc;
+    doc["request_id"] = requestId;
+    doc["result"]      = commandResultName(outcome.result);
+    doc["reason"]      = outcome.reason;
+    return finish(doc, out, 384);
+}
+
 }  // namespace heliograph::json_util

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -5,7 +5,9 @@
 #include <ArduinoJson.h>
 
 #include <cctype>
+#include <cstdio>
 
+#include "device/command.h"
 #include "relays/drm.h"
 
 namespace heliograph::mqtt {
@@ -216,6 +218,28 @@ uint64_t discoverySignature(const DeviceState& state) {
         }
         sig = fnv1aAppend(sig, m.id);
     }
+    // Command entities (below) are derived from the write bitset and, for a numeric one, its
+    // published bounds. Folded in here for the same reason the measurement loop above is:
+    // every shipping driver has this bitset fixed for the life of the firmware today, so this
+    // never actually changes anything yet -- but the moment a profile-declared write row is
+    // marked verified for real hardware, a stale or missing command entity would otherwise sit
+    // there until the next reconnect, the same class of bug the relay-roles fingerprint exists
+    // to prevent.
+    for (size_t i = 0; i < kCommandTypeCount; ++i) {
+        const auto type       = static_cast<InverterCommandType>(i);
+        const auto capability = requiredCapability(type);
+        if (capability == InverterCapability::_Count ||
+            !state.capabilities.write.test(static_cast<size_t>(capability))) {
+            continue;
+        }
+        sig = fnv1aAppend(sig, commandTypeName(type));
+        if (commandTakesNumericValue(type)) {
+            const NumericCapability& cap = state.capabilities.numeric[i];
+            char                     buf[64];
+            snprintf(buf, sizeof(buf), "%.6g:%.6g:%.6g", cap.minimum, cap.maximum, cap.step);
+            sig = fnv1aAppend(sig, buf);
+        }
+    }
     return sig;
 }
 
@@ -329,11 +353,79 @@ std::vector<DiscoveryEntity> buildDiscoveryEntities(const DeviceState& state,
         }
     }
 
-    // No control entities. Not an omission: the loop that would create them is gated on the
-    // write bitset, which is empty for every driver in this build.
-    if (!state.capabilities.isReadOnly()) {
-        // Deliberately not implemented yet -- the MVP has no writable driver, so writing this
-        // now would mean shipping untestable code that can move an inverter. Phase: future.
+    // Control entities: one per command type the active driver's capabilities.write bit
+    // actually grants -- the SAME bitset CommandDispatcher::dispatch's gate 2 checks, so an
+    // entity exists in Home Assistant exactly when the command behind it could reach a driver.
+    // On every driver shipping today the bit is never set, so this loop produces nothing, the
+    // same way the sensor loop above produces nothing for an unsupported measurement.
+    for (size_t i = 0; i < kCommandTypeCount; ++i) {
+        const auto type       = static_cast<InverterCommandType>(i);
+        const auto capability = requiredCapability(type);
+        if (capability == InverterCapability::_Count ||
+            !state.capabilities.write.test(static_cast<size_t>(capability))) {
+            continue;
+        }
+
+        // SetBatteryOperatingMode: skipped, not guessed at. A select needs an options list,
+        // and there is no EnumCapability yet to say what the valid selections even are --
+        // command_dispatcher.cpp's own gate-3 comment carries the same caveat. Revisit once a
+        // driver actually declares mode names.
+        if (commandTakesEnumValue(type)) {
+            continue;
+        }
+
+        const std::string name       = commandTypeName(type);
+        const std::string jsonPrefix = std::string("{\"type\":\"") + name + "\"";
+
+        JsonDocument doc;
+        JsonObject   e = doc.to<JsonObject>();
+        e["unique_id"] = uniqueBase + "_" + name;
+        e["object_id"] = uniqueBase + "_" + name;
+        e["name"]      = humanise(name);
+        e["command_topic"]         = topics.commandSet();
+        e["availability_topic"]    = availabilityTopic;
+        e["payload_available"]     = kPayloadOnline;
+        e["payload_not_available"] = kPayloadOffline;
+        addDeviceBlock(e, bridge, state.identity, /*isBridgeEntity=*/false, uniqueBase,
+                      state.label);
+
+        std::string domain;
+        if (commandTakesNumericValue(type)) {
+            const NumericCapability& cap = state.capabilities.numeric[i];
+            if (!cap.supported || !cap.writable) {
+                // The write bit is set but no range was published. CommandDispatcher itself
+                // refuses this at dispatch time -- see command.h's note on why a missing
+                // bound is a refusal rather than a bypass -- so no entity either: nothing
+                // that reached this driver could ever succeed.
+                continue;
+            }
+            domain                 = "number";
+            e["command_template"]  = jsonPrefix + ",\"value\":{{ value }}}";
+            e["min"]                = cap.minimum;
+            e["max"]                = cap.maximum;
+            e["step"]               = cap.step > 0.0 ? cap.step : 1.0;
+            const char* unit = unitSymbol(cap.unit);
+            if (unit[0] != '\0') {
+                e["unit_of_measurement"] = unit;
+            }
+            // Optimistic: unlike the relay switch, there is no readback topic for a setpoint --
+            // no shipping driver reports one back as a measurement, and command.h's own
+            // `execute()` doc note explains why the ack cannot arrive synchronously either.
+            e["optimistic"] = true;
+        } else {
+            // Neither numeric nor enum: Start, Stop, SynchronizeTime -- a bare press, no
+            // payload to configure beyond the fixed command type.
+            domain             = "button";
+            e["payload_press"] = jsonPrefix + "}";
+        }
+
+        DiscoveryEntity entity;
+        entity.uniqueId = e["unique_id"].as<std::string>();
+        entity.configTopic =
+            discoveryPrefix + "/" + domain + "/" + uniqueBase + "/" + name + "/config";
+        if (serialise(doc, entity.payload)) {
+            entities.push_back(std::move(entity));
+        }
     }
 
     return entities;

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -219,12 +219,22 @@ uint64_t discoverySignature(const DeviceState& state) {
         sig = fnv1aAppend(sig, m.id);
     }
     // Command entities (below) are derived from the write bitset and, for a numeric one, its
-    // published bounds. Folded in here for the same reason the measurement loop above is:
-    // every shipping driver has this bitset fixed for the life of the firmware today, so this
-    // never actually changes anything yet -- but the moment a profile-declared write row is
-    // marked verified for real hardware, a stale or missing command entity would otherwise sit
-    // there until the next reconnect, the same class of bug the relay-roles fingerprint exists
-    // to prevent.
+    // supported/writable flags and published bounds. Folded in here for the same reason the
+    // measurement loop above is: every shipping driver has this bitset fixed for the life of
+    // the firmware today, so this never actually changes anything yet -- but the moment a
+    // profile-declared write row is marked verified for real hardware, a stale or missing
+    // command entity would otherwise sit there until the next reconnect, the same class of bug
+    // the relay-roles fingerprint exists to prevent.
+    //
+    // Mirrors buildDiscoveryEntities' own gate term for term -- write bitset, then the enum
+    // skip, then numeric supported/writable -- because a fingerprint that reacts to LESS than
+    // the condition it is meant to track is worse than no fingerprint at all: it looks like
+    // protection while silently missing the one flip that matters most. An earlier version of
+    // this loop hashed the bounds unconditionally whenever the write bit was set, never
+    // checking cap.supported/cap.writable at all -- so a NumericCapability pre-populated with
+    // real bounds but supported=false produced the SAME hash before and after supported later
+    // flipped true, even though that is exactly the "verified" transition the comment above
+    // claims to cover (review, 2026-07-30).
     for (size_t i = 0; i < kCommandTypeCount; ++i) {
         const auto type       = static_cast<InverterCommandType>(i);
         const auto capability = requiredCapability(type);
@@ -232,12 +242,24 @@ uint64_t discoverySignature(const DeviceState& state) {
             !state.capabilities.write.test(static_cast<size_t>(capability))) {
             continue;
         }
-        sig = fnv1aAppend(sig, commandTypeName(type));
+        if (commandTakesEnumValue(type)) {
+            // buildDiscoveryEntities never builds an entity for these either -- nothing to
+            // fingerprint.
+            continue;
+        }
         if (commandTakesNumericValue(type)) {
             const NumericCapability& cap = state.capabilities.numeric[i];
-            char                     buf[64];
+            if (!cap.supported || !cap.writable) {
+                // Exactly buildDiscoveryEntities' own refusal: a write bit with no usable
+                // range publishes no entity, so it must leave no trace here either.
+                continue;
+            }
+            sig = fnv1aAppend(sig, commandTypeName(type));
+            char buf[64];
             snprintf(buf, sizeof(buf), "%.6g:%.6g:%.6g", cap.minimum, cap.maximum, cap.step);
             sig = fnv1aAppend(sig, buf);
+        } else {
+            sig = fnv1aAppend(sig, commandTypeName(type));
         }
     }
     return sig;

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -103,11 +103,12 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
     });
 
     relayCount_ = bridge.relayCount;
-    if (relayCount_ > 0) {
-        // The one message handler this firmware has. Topic and payload are attacker-
-        // influenced data from anyone who can publish on the broker; parse defensively and
-        // let the RelayController's gates decide. Runs on the MQTT task -- the handler
-        // installed by main serialises against REST with a mutex.
+    if (relayCount_ > 0 || commandSubmit_ != nullptr) {
+        // The message handler this firmware has. Topic and payload are attacker-influenced
+        // data from anyone who can publish on the broker; parse defensively and let the
+        // RelayController's gates (or, for a command, CommandDispatcher's) decide. Runs on
+        // the MQTT task -- the relay handler installed by main serialises against REST with
+        // a mutex; commandSubmit_ needs none, because CommandQueue is its own lock.
         g_client.onMessage([this](const espMqttClientTypes::MessageProperties&,
                                   const char* topic, const uint8_t* payload, size_t len,
                                   size_t index, size_t total) {
@@ -115,6 +116,41 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
                 return;  // fragmented messages are never valid for these short payloads
             }
             const std::string t(topic);
+            if (commandSubmit_ != nullptr) {
+                // Checked against every device's own topic, not just one: commandSet() is
+                // built from a per-device MqttTopics, so a bridge polling several inverters
+                // has one of these per device, and only the channel loop knows all of them.
+                for (auto& channel : channels_) {
+                    if (t != channel.topics.commandSet()) {
+                        continue;
+                    }
+                    if (len == 0) {
+                        return;
+                    }
+                    const std::string   body(reinterpret_cast<const char*>(payload), len);
+                    InverterCommand     command;
+                    json_util::CommandRequestError parseError;
+                    std::string                    ack;
+                    if (!json_util::parseCommandRequest(body, command, parseError)) {
+                        json_util::buildCommandRejectedPayload(
+                            parseError.field + ": " + parseError.message, ack);
+                        publishTracked(channel.topics.commandResult().c_str(), 0, false,
+                                       ack.c_str());
+                        return;
+                    }
+                    command.source        = CommandSource::Mqtt;
+                    const auto requestId  = commandSubmit_(channel.id, command);
+                    if (!requestId.has_value()) {
+                        json_util::buildCommandRejectedPayload("a command is already pending",
+                                                                ack);
+                    } else {
+                        json_util::buildCommandAcceptedPayload(*requestId, ack);
+                    }
+                    publishTracked(channel.topics.commandResult().c_str(), 0, false,
+                                   ack.c_str());
+                    return;
+                }
+            }
             if (t == topics_.drmSet()) {
                 if (drmCommand_ == nullptr || len == 0 || len > 16) {
                     return;  // mode names are short; anything longer is not one
@@ -248,12 +284,18 @@ bool MqttOutput::onConnected(Channel& channel, const DeviceState& state,
     }
     const bool discoveryOk = publishDiscovery(channel, state, bridge);
 
-    // The relay command topic is the only subscription; inverter drivers stay read-only
-    // and get no command topic -- that follows from the capabilities, not a decision here.
     if (relayCount_ > 0) {
         g_client.subscribe(topics_.relaySetWildcard().c_str(), 1);
         g_client.subscribe(topics_.drmSet().c_str(), 1);
         relayStateForced_ = true;  // fresh session: ack the current states once
+    }
+    // This channel's OWN command topic -- commandSet() differs per device (primary vs
+    // device-scoped prefix), unlike the relay/DRM topics above, which belong to the bridge and
+    // are subscribed once from `topics_`. Whether commanding does anything is a capabilities
+    // question the driver and CommandDispatcher answer, not this subscription: a read-only
+    // driver still receives the message, and still answers Unsupported.
+    if (commandSubmit_ != nullptr) {
+        g_client.subscribe(channel.topics.commandSet().c_str(), 1);
     }
     return discoveryOk;
 }

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -117,6 +117,11 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
             }
             const std::string t(topic);
             if (commandSubmit_ != nullptr) {
+                // Locked: channels_ can be grown (reallocated) by channelFor() on the OTHER
+                // task at any moment, and this loop both walks the vector's structure and
+                // writes a Channel's pendingCommandRequestId, which loop() also reads and
+                // clears -- see channelsMutex_'s own comment.
+                std::lock_guard<std::mutex> lock(channelsMutex_);
                 // Checked against every device's own topic, not just one: commandSet() is
                 // built from a per-device MqttTopics, so a bridge polling several inverters
                 // has one of these per device, and only the channel loop knows all of them.
@@ -124,7 +129,11 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
                     if (t != channel.topics.commandSet()) {
                         continue;
                     }
-                    if (len == 0) {
+                    // Unlike REST, nothing upstream of this callback bounds a publisher's
+                    // message size -- any client that can publish to the broker can reach
+                    // this topic. A real command body fits in well under 200 bytes; reject
+                    // rather than parse anything grossly larger.
+                    if (len == 0 || len > kMaxCommandPayloadBytes) {
                         return;
                     }
                     const std::string   body(reinterpret_cast<const char*>(payload), len);
@@ -132,25 +141,43 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
                     json_util::CommandRequestError parseError;
                     std::string                    ack;
                     if (!json_util::parseCommandRequest(body, command, parseError)) {
-                        json_util::buildCommandRejectedPayload(
-                            parseError.field + ": " + parseError.message, ack);
-                        publishTracked(channel.topics.commandResult().c_str(), 0, false,
-                                       ack.c_str());
+                        if (json_util::buildCommandRejectedPayload(
+                                parseError.field + ": " + parseError.message, ack)) {
+                            publishTracked(channel.topics.commandResult().c_str(), 0, false,
+                                           ack.c_str());
+                        } else {
+                            log::warn("command ack for %s: rejection payload too large",
+                                      channel.id.c_str());
+                        }
                         return;
                     }
-                    command.source        = CommandSource::Mqtt;
-                    const auto requestId  = commandSubmit_(channel.id, command);
+                    command.source       = CommandSource::Mqtt;
+                    const auto requestId = commandSubmit_(channel.id, command);
+                    bool       ackOk;
                     if (!requestId.has_value()) {
-                        json_util::buildCommandRejectedPayload("a command is already pending",
-                                                                ack);
+                        ackOk =
+                            json_util::buildCommandRejectedPayload("a command is already pending",
+                                                                   ack);
                     } else {
-                        json_util::buildCommandAcceptedPayload(*requestId, ack);
-                        // loop() picks this up once rs485Task has actually run the command
-                        // and publishes the real result -- see the check there.
-                        channel.pendingCommandRequestId = *requestId;
+                        ackOk = json_util::buildCommandAcceptedPayload(*requestId, ack);
+                        // Only recorded as pending if the ack actually serialised: otherwise
+                        // the caller never learns this request id, so there is no one who
+                        // could ever be waiting on loop() to republish its outcome.
+                        if (ackOk) {
+                            channel.pendingCommandRequestId = *requestId;
+                        }
                     }
-                    publishTracked(channel.topics.commandResult().c_str(), 0, false,
-                                   ack.c_str());
+                    if (ackOk) {
+                        publishTracked(channel.topics.commandResult().c_str(), 0, false,
+                                       ack.c_str());
+                    } else {
+                        // The command is genuinely enqueued (commandSubmit_ already returned
+                        // a real id) -- only the ack failed to serialise. Logged rather than
+                        // silently dropped; request_id is capped at kMaxRequestIdLength, so
+                        // this should not actually be reachable, only defended against.
+                        log::warn("command ack for %s: accept payload too large",
+                                  channel.id.c_str());
+                    }
                     return;
                 }
             }
@@ -210,6 +237,13 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
 bool MqttOutput::connected() const { return started_ && g_client.connected(); }
 
 MqttOutput::Channel& MqttOutput::channelFor(const DeviceView& view, const BridgeInfo& bridge) {
+    // Locked for the search-and-possibly-grow below: push_back can reallocate channels_'s
+    // backing storage, and onMessage's command handling walks the same vector from a different
+    // task (see channelsMutex_'s own comment). Released before returning -- the reference
+    // handed back is then only ever used from THIS task (only loop() calls channelFor(), and
+    // it does so sequentially), so nothing needs the lock held across the caller's later use
+    // of it.
+    std::lock_guard<std::mutex> lock(channelsMutex_);
     for (auto& c : channels_) {
         if (c.id == view.id) {
             return c;
@@ -373,13 +407,39 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
         // what notices. Cleared either way once published, so a lookup that stays unresolved
         // forever (it should not -- rs485Task always records SOMETHING for a taken request)
         // cannot wedge this channel out of ever checking again.
-        if (!channel.pendingCommandRequestId.empty() && commandOutcomeProvider_) {
-            if (const auto outcome = commandOutcomeProvider_(channel.pendingCommandRequestId)) {
-                std::string ack;
-                json_util::buildCommandOutcomePayload(channel.pendingCommandRequestId, *outcome,
-                                                      ack);
-                publishTracked(channel.topics.commandResult().c_str(), 0, false, ack.c_str());
-                channel.pendingCommandRequestId.clear();
+        if (commandOutcomeProvider_) {
+            // Locked: pendingCommandRequestId is the same field onMessage writes on the other
+            // task (see channelsMutex_'s own comment). Copied out and cleared under the lock;
+            // the outcome lookup and publish themselves need no lock (a different mutex guards
+            // CommandQueue, and publishTracked is non-blocking), so they run outside it.
+            std::string pending;
+            {
+                std::lock_guard<std::mutex> lock(channelsMutex_);
+                pending = channel.pendingCommandRequestId;
+            }
+            if (!pending.empty()) {
+                if (const auto outcome = commandOutcomeProvider_(pending)) {
+                    std::string ack;
+                    if (json_util::buildCommandOutcomePayload(pending, *outcome, ack)) {
+                        publishTracked(channel.topics.commandResult().c_str(), 0, false,
+                                       ack.c_str());
+                    } else {
+                        // Nothing about retrying next tick would change the outcome's own
+                        // reason string, so this is logged and dropped rather than left
+                        // pending forever for a serialisation that can only fail the same
+                        // way again.
+                        log::warn("command outcome for %s: payload too large",
+                                  channel.id.c_str());
+                    }
+                    std::lock_guard<std::mutex> lock(channelsMutex_);
+                    // Only clear if it still matches: onMessage may have started a NEW
+                    // request on this channel while the lookup/publish above ran unlocked,
+                    // and that request must not have its own pending id wiped out from under
+                    // it by this now-stale copy.
+                    if (channel.pendingCommandRequestId == pending) {
+                        channel.pendingCommandRequestId.clear();
+                    }
+                }
             }
         }
 

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -145,6 +145,9 @@ bool MqttOutput::begin(const BridgeInfo& bridge) {
                                                                 ack);
                     } else {
                         json_util::buildCommandAcceptedPayload(*requestId, ack);
+                        // loop() picks this up once rs485Task has actually run the command
+                        // and publishes the real result -- see the check there.
+                        channel.pendingCommandRequestId = *requestId;
                     }
                     publishTracked(channel.topics.commandResult().c_str(), 0, false,
                                    ack.c_str());
@@ -221,7 +224,8 @@ MqttOutput::Channel& MqttOutput::channelFor(const DeviceView& view, const Bridge
               deviceUniqueBase(view.primary, bridge.bridgeId, view.id),
               PublishThrottle(publishPolicy_),
               false,
-              0};
+              0,
+              {}};
     channels_.push_back(std::move(c));
     return channels_.back();
 }
@@ -361,6 +365,23 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
         }
         const DeviceState& state   = *view.state;
         Channel&           channel = channelFor(view, bridge);
+
+        // The real outcome of a command THIS channel submitted, once rs485Task has actually
+        // run it -- accepted/rejected (published from onMessage, immediately) only ever says
+        // "queued", never "succeeded". Polled rather than pushed: nothing calls back into
+        // MqttOutput when CommandQueue::recordOutcome() runs on rs485Task, so this loop is
+        // what notices. Cleared either way once published, so a lookup that stays unresolved
+        // forever (it should not -- rs485Task always records SOMETHING for a taken request)
+        // cannot wedge this channel out of ever checking again.
+        if (!channel.pendingCommandRequestId.empty() && commandOutcomeProvider_) {
+            if (const auto outcome = commandOutcomeProvider_(channel.pendingCommandRequestId)) {
+                std::string ack;
+                json_util::buildCommandOutcomePayload(channel.pendingCommandRequestId, *outcome,
+                                                      ack);
+                publishTracked(channel.topics.commandResult().c_str(), 0, false, ack.c_str());
+                channel.pendingCommandRequestId.clear();
+            }
+        }
 
         const auto signature = discoverySignature(state);
         if (!channel.discoveryPublished || signature != channel.discoveredSignature) {
@@ -523,7 +544,7 @@ bool MqttOutput::publishDiscovery(Channel&, const DeviceState&, const BridgeInfo
     return false;
 }
 MqttOutput::Channel& MqttOutput::channelFor(const DeviceView&, const BridgeInfo&) {
-    static Channel unused{"", MqttTopics("", ""), "", PublishThrottle({}), false, 0};
+    static Channel unused{"", MqttTopics("", ""), "", PublishThrottle({}), false, 0, {}};
     return unused;
 }
 

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -22,6 +22,7 @@
 
 #include <atomic>
 #include <functional>
+#include <optional>
 
 #include "device/bridge_info.h"
 #include "device/command.h"
@@ -125,6 +126,21 @@ public:
     using DrmCommandFn = std::function<bool(const std::string& mode)>;
     void setDrmCommandHandler(DrmCommandFn handler) { drmCommand_ = std::move(handler); }
 
+    /// Handles a write command arriving on a device's <prefix>/command/set. The SAME function
+    /// RestContext::submitCommand is built from in main.cpp, so REST and MQTT enqueue through
+    /// one counter and one CommandQueue rather than two independent paths that could disagree
+    /// about what "one in flight" means. Returns the request id used on success (a JSON ack is
+    /// published to that device's commandResult() topic), or nullopt when one was already
+    /// pending.
+    ///
+    /// Like the relay handler, this runs on the MQTT task and only ever *enqueues* -- it must
+    /// never itself run the RS485 transaction. Unlike the relay handler it needs no mutex here:
+    /// CommandQueue is its own lock, not something this class and REST share directly.
+    using CommandSubmitFn =
+        std::function<std::optional<std::string>(const std::string& deviceId,
+                                                   InverterCommand   command)>;
+    void setCommandHandler(CommandSubmitFn handler) { commandSubmit_ = std::move(handler); }
+
 private:
     /// Everything that is per-inverter rather than per-bridge, keyed by device id. Every
     /// channel is created in the first loop() pass -- the device list is fixed at boot -- but
@@ -189,6 +205,7 @@ private:
 
     RelayCommandFn relayCommand_;
     DrmCommandFn   drmCommand_;
+    CommandSubmitFn commandSubmit_;
     uint8_t        relayCount_ = 0;  ///< copied at begin() for topic parsing in the callback
     /// Set by onMessage (MQTT task) on EVERY received relay command, consumed by loop().
     /// Without it a refused or no-op command changes no state, nothing gets published, and

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -22,6 +22,7 @@
 
 #include <atomic>
 #include <functional>
+#include <mutex>
 #include <optional>
 
 #include "commands/command_dispatcher.h"
@@ -191,6 +192,15 @@ private:
     Diagnostics* diagnostics_ = nullptr;
 
     std::vector<Channel> channels_;
+    /// Guards channels_'s STRUCTURE (channelFor()'s push_back can reallocate it) and each
+    /// Channel's pendingCommandRequestId. Both are touched from two tasks: loop() and
+    /// channelFor() run on whatever task calls loop() (rs485Task), onMessage's new command
+    /// handling runs on espMqttClient's own task -- the same task boundary resyncRequested_
+    /// and relayAckRequested_ already guard against, but those are lone bools; a vector and a
+    /// string need a mutex, not an atomic. Every OTHER Channel field (topics, uniqueBase,
+    /// throttle, discoveryPublished, discoveredSignature) stays single-task (only loop()/
+    /// channelFor() ever touch them), so nothing else needs to take this lock.
+    std::mutex channelsMutex_;
     PublishPolicy        publishPolicy_;
 
     // espMqttClient's setClientId/setWill/setServer/setCredentials store the POINTER, not a

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include <optional>
 
+#include "commands/command_dispatcher.h"
 #include "device/bridge_info.h"
 #include "device/command.h"
 #include "device/device_state.h"
@@ -141,6 +142,16 @@ public:
                                                    InverterCommand   command)>;
     void setCommandHandler(CommandSubmitFn handler) { commandSubmit_ = std::move(handler); }
 
+    /// Looks up the real outcome of a request id once rs485Task has actually processed it. The
+    /// SAME function RestContext::commandOutcome reads from -- both transports observe the one
+    /// CommandQueue. loop() polls this for whichever channel is awaiting a result and, once it
+    /// resolves, publishes it to that channel's commandResult() topic (see loop()'s own note).
+    using CommandOutcomeFn =
+        std::function<std::optional<DispatchOutcome>(const std::string& requestId)>;
+    void setCommandOutcomeProvider(CommandOutcomeFn provider) {
+        commandOutcomeProvider_ = std::move(provider);
+    }
+
 private:
     /// Everything that is per-inverter rather than per-bridge, keyed by device id. Every
     /// channel is created in the first loop() pass -- the device list is fixed at boot -- but
@@ -152,6 +163,10 @@ private:
         PublishThrottle throttle;
         bool            discoveryPublished  = false;
         uint64_t        discoveredSignature = 0;
+        /// The request id THIS channel most recently submitted and is still awaiting the real
+        /// outcome for, or empty when nothing is outstanding. Set in onMessage on a successful
+        /// submitCommand(); cleared by loop() once commandOutcomeProvider_ resolves it.
+        std::string pendingCommandRequestId;
     };
 
     /// publish() whose refusals are counted. Every publish in this class goes through it --
@@ -205,7 +220,8 @@ private:
 
     RelayCommandFn relayCommand_;
     DrmCommandFn   drmCommand_;
-    CommandSubmitFn commandSubmit_;
+    CommandSubmitFn  commandSubmit_;
+    CommandOutcomeFn commandOutcomeProvider_;
     uint8_t        relayCount_ = 0;  ///< copied at begin() for topic parsing in the callback
     /// Set by onMessage (MQTT task) on EVERY received relay command, consumed by loop().
     /// Without it a refused or no-op command changes no state, nothing gets published, and

--- a/src/outputs/mqtt/mqtt_topics.h
+++ b/src/outputs/mqtt/mqtt_topics.h
@@ -52,6 +52,14 @@ public:
     std::string drmSet() const { return prefix_ + "/drm/set"; }
     std::string drmState() const { return prefix_ + "/drm/state"; }
 
+    /// A write command for THIS device -- unlike the relay/DRM topics above, this is built
+    /// from a per-device MqttTopics (bridge-scoped for the primary device, device-scoped for
+    /// every other one), so each device gets its own topic rather than sharing the bridge's.
+    /// Command in on commandSet, a one-shot accepted/rejected ack out on commandResult -- never
+    /// retained, unlike relayState: there is no steady state to reflect, only an event.
+    std::string commandSet() const { return prefix_ + "/command/set"; }
+    std::string commandResult() const { return prefix_ + "/command/result"; }
+
     const std::string& prefix() const { return prefix_; }
 
 private:

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -939,7 +939,14 @@ bool RestApi::begin() {
                 return;
             }
             std::string body;
-            json_util::buildCommandAcceptedPayload(*requestId, body);
+            if (!json_util::buildCommandAcceptedPayload(*requestId, body)) {
+                // The command is genuinely enqueued at this point -- only the ack body
+                // failed to serialise. Reported as a server error rather than sending an
+                // empty 202, which would tell the caller "accepted" with no request_id to
+                // poll the outcome by.
+                sendError(request, {500, "payload_too_large", "response exceeded its bound"});
+                return;
+            }
             request->send(202, kJson, body.c_str());
         },
         nullptr,

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -470,6 +470,28 @@ bool RestApi::begin() {
         } else if (sub == "capabilities") {
             ok = json_util::buildCapabilitiesPayload(snapshot->capabilities, body,
                                                      kMaxResponseBytes);
+        } else if (sub.rfind("commands/", 0) == 0) {
+            // The read side of the POST above: whether a previously-submitted request has
+            // finished, and what happened. Not gated on the device existing having submitted
+            // it -- the queue tracks by request id alone -- but nested under the device's own
+            // path anyway, to match how it was submitted.
+            const std::string requestId = sub.substr(std::strlen("commands/"));
+            if (requestId.empty()) {
+                sendError(request, {404, "not_found", "no such endpoint"});
+                return;
+            }
+            if (!context_.commandOutcome) {
+                sendError(request,
+                          {404, "no_command_path", "no write path is wired for commands yet"});
+                return;
+            }
+            const auto outcome = context_.commandOutcome(requestId);
+            if (!outcome.has_value()) {
+                sendError(request, {404, "unknown_request",
+                                    "no completed command with this request id"});
+                return;
+            }
+            ok = json_util::buildCommandOutcomePayload(*outcome, body);
         } else {
             sendError(request, {404, "not_found", "no such endpoint"});
             return;
@@ -861,6 +883,71 @@ bool RestApi::begin() {
         }
         request->send(202, kJson, "{\"status\":\"accepted\"}");
     });
+
+    // A write command for one device: `{"type": "...", "value": <number>}` (or "enum_value"
+    // for a mode, or neither for start/stop). Prefix matching for the same reason
+    // /api/v1/devices/<id> already needs it above: the device id is a variable path segment.
+    //
+    // This can only ever accept the command FOR THE QUEUE, same as /actions/poll: the RS485
+    // task owns the bus and runs the actual transaction on its next cycle. No shipping driver
+    // accepts a command yet (every one returns Unsupported), so today this always ends in that
+    // result -- but the plumbing does not know that, and should not have to.
+    g_server->on(
+        AsyncURIMatcher::prefix("/api/v1/devices/"), HTTP_POST,
+        [this, authorised, rateLimited](AsyncWebServerRequest* request) {
+            if (!authorised(request) || rateLimited(request)) {
+                releaseBody();
+                return;
+            }
+            std::string path = request->url().c_str();
+            path.erase(0, std::strlen("/api/v1/devices/"));
+            const size_t slash = path.find('/');
+            if (slash == std::string::npos || path.substr(slash) != "/commands") {
+                releaseBody();
+                sendError(request, {404, "not_found", "no such endpoint"});
+                return;
+            }
+            const std::string deviceId = path.substr(0, slash);
+
+            if (bodyMissing(request, "a JSON body is required")) {
+                return;
+            }
+            InverterCommand     command;
+            json_util::CommandRequestError parseError;
+            const bool parsed = json_util::parseCommandRequest(bodyBuffer_, command, parseError);
+            releaseBody();
+            if (!parsed) {
+                sendError(request,
+                          {400, "invalid_command", parseError.field + ": " + parseError.message});
+                return;
+            }
+            if (!context_.devices->contains(deviceId)) {
+                sendError(request,
+                          {404, "device_not_found", "no device with id '" + deviceId + "'"});
+                return;
+            }
+            if (!context_.submitCommand) {
+                sendError(request,
+                          {404, "no_command_path", "no write path is wired for commands yet"});
+                return;
+            }
+            command.source      = CommandSource::Rest;
+            command.createdAtMs = context_.clock();
+            const auto requestId = context_.submitCommand(deviceId, command);
+            if (!requestId.has_value()) {
+                sendError(request, {409, "busy", "a command is already pending"});
+                return;
+            }
+            std::string body;
+            json_util::buildCommandAcceptedPayload(*requestId, body);
+            request->send(202, kJson, body.c_str());
+        },
+        nullptr,
+        [this](AsyncWebServerRequest* request, uint8_t* data, size_t len, size_t index,
+               size_t total) {
+            std::string* body = nullptr;
+            collectBody(request, data, len, index, total, body);
+        });
 
     // Bridge relay control (DRM contacts). One explicit route per possible index (max 8)
     // rather than a regex route: ESPAsyncWebServer only matches regex paths when built

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -23,10 +23,12 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 class AsyncWebServerRequest;
 
+#include "commands/command_dispatcher.h"
 #include "config/configuration.h"
 #include "device/bridge_info.h"
 #include "device/command.h"
@@ -112,6 +114,22 @@ struct RestContext {
     /// everything else released, atomically behind the relay mutex. Returns the gate
     /// verdict; OutOfRange doubles as "not a valid mode for the configured roles".
     std::function<CommandResult(const std::string& mode)> setDrmMode;
+    /// Queues a write command for `deviceId` to run on the bus. Returns the request id
+    /// actually used (server-generated if the caller supplied none) on success, or nullopt
+    /// when one is already pending -- the same one-in-flight rule manual poll, discovery and
+    /// capture already apply.
+    ///
+    /// This can only ever say "accepted for the queue", never "succeeded": a real driver's
+    /// execute() is a multi-second RS485 transaction, and running it from this handler would
+    /// repeat the exact Phase-3 bus race requestPoll's comment documents finding live. See
+    /// commandOutcome for how the caller learns what actually happened.
+    std::function<std::optional<std::string>(const std::string& deviceId, InverterCommand command)>
+        submitCommand;
+    /// The outcome of the most recently completed command with this request id. Empty while
+    /// it is still pending, was never submitted, or has since been superseded by a later
+    /// request -- only one outcome is remembered at a time, matching submitCommand's
+    /// one-in-flight rule.
+    std::function<std::optional<DispatchOutcome>(const std::string& requestId)> commandOutcome;
 };
 
 class RestApi {

--- a/test/test_commands/test_main.cpp
+++ b/test/test_commands/test_main.cpp
@@ -6,11 +6,15 @@
 #include <cmath>
 
 #include "commands/command_dispatcher.h"
+#include "commands/command_queue.h"
 #include "drivers/eversolar_legacy/eversolar_driver.h"
 #include "drivers/mock/mock_driver.h"
+#include "outputs/json_util.h"
 #include "support/mock_transport.h"
 
 using namespace heliograph;
+using heliograph::json_util::CommandRequestError;
+using heliograph::json_util::parseCommandRequest;
 using test::MockTransport;
 
 static uint64_t g_now = 0;
@@ -520,6 +524,186 @@ static void test_a_backwards_clock_does_not_refill_the_allowance() {
                                  driver).result);
 }
 
+// --- CommandQueue ---------------------------------------------------------------------------
+//
+// The request/consume slot a future write path drains from rs485Task, generalising
+// g_manualPollRequested's shape (one outstanding request, request-only) to carry an actual
+// command instead of a bare flag.
+
+static CommandQueue::Request queuedRequest(const std::string& deviceId,
+                                            const std::string& requestId) {
+    CommandQueue::Request r;
+    r.deviceId          = deviceId;
+    r.command           = cmd(InverterCommandType::SetActivePowerLimitPercent, 50.0);
+    r.command.requestId = requestId;
+    return r;
+}
+
+static void test_a_submitted_request_is_taken_exactly_once() {
+    CommandQueue q;
+    TEST_ASSERT_TRUE(q.submit(queuedRequest("inv-1", "r1")));
+
+    auto taken = q.take();
+    TEST_ASSERT_TRUE(taken.has_value());
+    TEST_ASSERT_EQUAL_STRING("inv-1", taken->deviceId.c_str());
+    TEST_ASSERT_EQUAL_STRING("r1", taken->command.requestId.c_str());
+
+    // The slot is empty again: a second take() finds nothing left to consume.
+    TEST_ASSERT_FALSE(q.take().has_value());
+}
+
+static void test_take_on_an_empty_queue_returns_nothing() {
+    CommandQueue q;
+    TEST_ASSERT_FALSE(q.take().has_value());
+}
+
+// Mirrors the one-in-flight rule g_manualPollRequested already applies: a second submission
+// while one is pending must not silently replace or reorder the first.
+static void test_a_second_submission_is_refused_while_one_is_pending() {
+    CommandQueue q;
+    TEST_ASSERT_TRUE(q.submit(queuedRequest("inv-1", "first")));
+    TEST_ASSERT_FALSE(q.submit(queuedRequest("inv-1", "second")));
+
+    // The ORIGINAL request is still the one waiting -- the refused second submission left no
+    // trace.
+    auto taken = q.take();
+    TEST_ASSERT_TRUE(taken.has_value());
+    TEST_ASSERT_EQUAL_STRING("first", taken->command.requestId.c_str());
+}
+
+static void test_a_taken_slot_accepts_a_new_submission() {
+    CommandQueue q;
+    TEST_ASSERT_TRUE(q.submit(queuedRequest("inv-1", "first")));
+    q.take();
+    TEST_ASSERT_TRUE(q.submit(queuedRequest("inv-1", "second")));
+}
+
+static void test_outcome_is_unknown_before_it_is_recorded() {
+    CommandQueue q;
+    TEST_ASSERT_FALSE(q.outcomeFor("r1").has_value());
+}
+
+static void test_a_recorded_outcome_is_readable_by_its_request_id() {
+    CommandQueue q;
+    q.recordOutcome("r1", DispatchOutcome{CommandResult::Ok, "accepted"});
+
+    auto outcome = q.outcomeFor("r1");
+    TEST_ASSERT_TRUE(outcome.has_value());
+    TEST_ASSERT_EQUAL(CommandResult::Ok, outcome->result);
+    TEST_ASSERT_EQUAL_STRING("accepted", outcome->reason.c_str());
+}
+
+// Only one outcome is remembered at a time, matching submit()'s one-slot rule: a caller asking
+// about a request that has since been superseded gets "unknown", not a stale answer.
+static void test_a_later_outcome_supersedes_an_earlier_one() {
+    CommandQueue q;
+    q.recordOutcome("first", DispatchOutcome{CommandResult::Ok, "accepted"});
+    q.recordOutcome("second", DispatchOutcome{CommandResult::RateLimited, "too many commands"});
+
+    TEST_ASSERT_FALSE(q.outcomeFor("first").has_value());
+    TEST_ASSERT_TRUE(q.outcomeFor("second").has_value());
+}
+
+// --- commandTypeFromName / parseCommandRequest ----------------------------------------------
+//
+// The shared REST/MQTT wire parser: one rule for "which commands need a value vs an enum vs
+// neither", read by both entry points instead of duplicated.
+
+static void test_command_type_from_name_round_trips_every_type() {
+    for (size_t i = 0; i < kCommandTypeCount; ++i) {
+        const auto          type = static_cast<InverterCommandType>(i);
+        InverterCommandType parsed{};
+        TEST_ASSERT_TRUE(commandTypeFromName(commandTypeName(type), parsed));
+        TEST_ASSERT_EQUAL(static_cast<int>(type), static_cast<int>(parsed));
+    }
+}
+
+static void test_command_type_from_name_rejects_an_unknown_name() {
+    InverterCommandType parsed{};
+    TEST_ASSERT_FALSE(commandTypeFromName("not_a_real_command", parsed));
+}
+
+static void test_parse_command_request_rejects_invalid_json() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_FALSE(parseCommandRequest("{not json", out, error));
+    TEST_ASSERT_EQUAL_STRING("body", error.field.c_str());
+}
+
+static void test_parse_command_request_rejects_a_missing_type() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_FALSE(parseCommandRequest("{}", out, error));
+    TEST_ASSERT_EQUAL_STRING("type", error.field.c_str());
+}
+
+static void test_parse_command_request_rejects_an_unknown_type() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_FALSE(
+        parseCommandRequest(R"({"type":"not_a_real_command"})", out, error));
+    TEST_ASSERT_EQUAL_STRING("type", error.field.c_str());
+}
+
+static void test_parse_command_request_reads_a_numeric_command() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_TRUE(parseCommandRequest(
+        R"({"type":"set_active_power_limit_percent","value":42.5})", out, error));
+    TEST_ASSERT_EQUAL(static_cast<int>(InverterCommandType::SetActivePowerLimitPercent),
+                      static_cast<int>(out.type));
+    TEST_ASSERT_TRUE(out.numericValue.has_value());
+    TEST_ASSERT_EQUAL_DOUBLE(42.5, *out.numericValue);
+}
+
+static void test_parse_command_request_rejects_a_numeric_command_without_a_value() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_FALSE(
+        parseCommandRequest(R"({"type":"set_active_power_limit_percent"})", out, error));
+    TEST_ASSERT_EQUAL_STRING("value", error.field.c_str());
+}
+
+static void test_parse_command_request_reads_an_enum_command() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_TRUE(parseCommandRequest(
+        R"({"type":"set_battery_operating_mode","enum_value":2})", out, error));
+    TEST_ASSERT_TRUE(out.enumValue.has_value());
+    TEST_ASSERT_EQUAL(2, *out.enumValue);
+}
+
+static void test_parse_command_request_rejects_an_enum_command_without_a_selection() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_FALSE(
+        parseCommandRequest(R"({"type":"set_battery_operating_mode"})", out, error));
+    TEST_ASSERT_EQUAL_STRING("enum_value", error.field.c_str());
+}
+
+static void test_parse_command_request_needs_neither_field_for_start() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_TRUE(parseCommandRequest(R"({"type":"start"})", out, error));
+    TEST_ASSERT_EQUAL(static_cast<int>(InverterCommandType::Start),
+                      static_cast<int>(out.type));
+}
+
+static void test_parse_command_request_carries_a_supplied_request_id() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_TRUE(
+        parseCommandRequest(R"({"type":"start","request_id":"caller-123"})", out, error));
+    TEST_ASSERT_EQUAL_STRING("caller-123", out.requestId.c_str());
+}
+
+static void test_parse_command_request_leaves_request_id_empty_when_omitted() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_TRUE(parseCommandRequest(R"({"type":"start"})", out, error));
+    TEST_ASSERT_TRUE(out.requestId.empty());
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_read_only_mode_rejects_every_command_type);
@@ -550,5 +734,26 @@ int main(int, char**) {
     RUN_TEST(test_run_state_commands_are_spaced_but_never_starved);
     RUN_TEST(test_stop_is_not_starved_by_restricting_traffic);
     RUN_TEST(test_a_backwards_clock_does_not_refill_the_allowance);
+
+    RUN_TEST(test_a_submitted_request_is_taken_exactly_once);
+    RUN_TEST(test_take_on_an_empty_queue_returns_nothing);
+    RUN_TEST(test_a_second_submission_is_refused_while_one_is_pending);
+    RUN_TEST(test_a_taken_slot_accepts_a_new_submission);
+    RUN_TEST(test_outcome_is_unknown_before_it_is_recorded);
+    RUN_TEST(test_a_recorded_outcome_is_readable_by_its_request_id);
+    RUN_TEST(test_a_later_outcome_supersedes_an_earlier_one);
+
+    RUN_TEST(test_command_type_from_name_round_trips_every_type);
+    RUN_TEST(test_command_type_from_name_rejects_an_unknown_name);
+    RUN_TEST(test_parse_command_request_rejects_invalid_json);
+    RUN_TEST(test_parse_command_request_rejects_a_missing_type);
+    RUN_TEST(test_parse_command_request_rejects_an_unknown_type);
+    RUN_TEST(test_parse_command_request_reads_a_numeric_command);
+    RUN_TEST(test_parse_command_request_rejects_a_numeric_command_without_a_value);
+    RUN_TEST(test_parse_command_request_reads_an_enum_command);
+    RUN_TEST(test_parse_command_request_rejects_an_enum_command_without_a_selection);
+    RUN_TEST(test_parse_command_request_needs_neither_field_for_start);
+    RUN_TEST(test_parse_command_request_carries_a_supplied_request_id);
+    RUN_TEST(test_parse_command_request_leaves_request_id_empty_when_omitted);
     return UNITY_END();
 }

--- a/test/test_commands/test_main.cpp
+++ b/test/test_commands/test_main.cpp
@@ -23,6 +23,13 @@ static uint64_t clockFn() { return g_now; }
 void setUp() { g_now = 100000; }
 void tearDown() {}
 
+static JsonDocument parse(const std::string& json) {
+    JsonDocument doc;
+    const auto   err = deserializeJson(doc, json);
+    TEST_ASSERT_EQUAL_MESSAGE(DeserializationError::Ok, err.code(), "payload is not valid JSON");
+    return doc;
+}
+
 static InverterCommand cmd(InverterCommandType type, double value) {
     InverterCommand c;
     c.type         = type;
@@ -704,6 +711,48 @@ static void test_parse_command_request_leaves_request_id_empty_when_omitted() {
     TEST_ASSERT_TRUE(out.requestId.empty());
 }
 
+// --- shared command payload builders (json_util.h) ------------------------------------------
+//
+// The REST 202/GET-outcome bodies and MQTT's command_topic acks all go through these; one
+// definition instead of each transport formatting its own JSON by hand.
+
+static void test_build_command_accepted_payload() {
+    std::string json;
+    TEST_ASSERT_TRUE(json_util::buildCommandAcceptedPayload("req-7", json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_STRING("accepted", doc["status"]);
+    TEST_ASSERT_EQUAL_STRING("req-7", doc["request_id"]);
+}
+
+static void test_build_command_rejected_payload() {
+    std::string json;
+    TEST_ASSERT_TRUE(
+        json_util::buildCommandRejectedPayload("a command is already pending", json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_STRING("rejected", doc["status"]);
+    TEST_ASSERT_EQUAL_STRING("a command is already pending", doc["reason"]);
+}
+
+static void test_build_command_outcome_payload_without_a_request_id() {
+    std::string json;
+    TEST_ASSERT_TRUE(json_util::buildCommandOutcomePayload(
+        DispatchOutcome{CommandResult::OutOfRange, "value too high"}, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_STRING("out_of_range", doc["result"]);
+    TEST_ASSERT_EQUAL_STRING("value too high", doc["reason"]);
+    TEST_ASSERT_FALSE(doc["request_id"].is<const char*>());
+}
+
+static void test_build_command_outcome_payload_with_a_request_id() {
+    std::string json;
+    TEST_ASSERT_TRUE(json_util::buildCommandOutcomePayload(
+        "req-9", DispatchOutcome{CommandResult::Ok, "accepted"}, json));
+    auto doc = parse(json);
+    TEST_ASSERT_EQUAL_STRING("req-9", doc["request_id"]);
+    TEST_ASSERT_EQUAL_STRING("ok", doc["result"]);
+    TEST_ASSERT_EQUAL_STRING("accepted", doc["reason"]);
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_read_only_mode_rejects_every_command_type);
@@ -755,5 +804,10 @@ int main(int, char**) {
     RUN_TEST(test_parse_command_request_needs_neither_field_for_start);
     RUN_TEST(test_parse_command_request_carries_a_supplied_request_id);
     RUN_TEST(test_parse_command_request_leaves_request_id_empty_when_omitted);
+
+    RUN_TEST(test_build_command_accepted_payload);
+    RUN_TEST(test_build_command_rejected_payload);
+    RUN_TEST(test_build_command_outcome_payload_without_a_request_id);
+    RUN_TEST(test_build_command_outcome_payload_with_a_request_id);
     return UNITY_END();
 }

--- a/test/test_commands/test_main.cpp
+++ b/test/test_commands/test_main.cpp
@@ -711,6 +711,45 @@ static void test_parse_command_request_leaves_request_id_empty_when_omitted() {
     TEST_ASSERT_TRUE(out.requestId.empty());
 }
 
+// kAutoRequestIdPrefix is reserved for submitCommand()'s own auto-generated ids (main.cpp) --
+// a caller that supplies one anyway must be refused, not silently accepted, or the two id
+// spaces could collide and CommandQueue::outcomeFor() would hand back the wrong request's
+// outcome (review, 2026-07-30).
+static void test_parse_command_request_rejects_a_caller_id_using_the_reserved_prefix() {
+    InverterCommand     out;
+    CommandRequestError error;
+    TEST_ASSERT_FALSE(
+        parseCommandRequest(R"({"type":"start","request_id":"auto-3"})", out, error));
+    TEST_ASSERT_EQUAL_STRING("request_id", error.field.c_str());
+}
+
+static void test_parse_command_request_rejects_an_oversized_request_id() {
+    InverterCommand     out;
+    CommandRequestError error;
+    const std::string   tooLong(kMaxRequestIdLength + 1, 'x');
+    const std::string   json = R"({"type":"start","request_id":")" + tooLong + "\"}";
+    TEST_ASSERT_FALSE(parseCommandRequest(json, out, error));
+    TEST_ASSERT_EQUAL_STRING("request_id", error.field.c_str());
+}
+
+static void test_parse_command_request_accepts_a_request_id_at_the_length_limit() {
+    InverterCommand     out;
+    CommandRequestError error;
+    const std::string   atLimit(kMaxRequestIdLength, 'x');
+    const std::string   json = R"({"type":"start","request_id":")" + atLimit + "\"}";
+    TEST_ASSERT_TRUE(parseCommandRequest(json, out, error));
+    TEST_ASSERT_EQUAL_STRING(atLimit.c_str(), out.requestId.c_str());
+}
+
+static void test_parse_command_request_rejects_a_non_finite_value() {
+    InverterCommand     out;
+    CommandRequestError error;
+    // 1e400 overflows a double to +Infinity when ArduinoJson parses it.
+    TEST_ASSERT_FALSE(parseCommandRequest(
+        R"({"type":"set_active_power_limit_percent","value":1e400})", out, error));
+    TEST_ASSERT_EQUAL_STRING("value", error.field.c_str());
+}
+
 // --- shared command payload builders (json_util.h) ------------------------------------------
 //
 // The REST 202/GET-outcome bodies and MQTT's command_topic acks all go through these; one
@@ -804,6 +843,10 @@ int main(int, char**) {
     RUN_TEST(test_parse_command_request_needs_neither_field_for_start);
     RUN_TEST(test_parse_command_request_carries_a_supplied_request_id);
     RUN_TEST(test_parse_command_request_leaves_request_id_empty_when_omitted);
+    RUN_TEST(test_parse_command_request_rejects_a_caller_id_using_the_reserved_prefix);
+    RUN_TEST(test_parse_command_request_rejects_an_oversized_request_id);
+    RUN_TEST(test_parse_command_request_accepts_a_request_id_at_the_length_limit);
+    RUN_TEST(test_parse_command_request_rejects_a_non_finite_value);
 
     RUN_TEST(test_build_command_accepted_payload);
     RUN_TEST(test_build_command_rejected_payload);

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -737,6 +737,40 @@ static void test_discovery_signature_changes_when_a_writable_bound_changes() {
     TEST_ASSERT_TRUE(discoverySignature(a) != discoverySignature(b));
 }
 
+// The exact scenario a review caught the signature missing (2026-07-30): a NumericCapability
+// can be pre-populated with real bounds ahead of hardware verification, with `supported` still
+// false -- buildDiscoveryEntities correctly builds no entity for that. The day `supported`
+// flips true with the SAME bounds (the verification event itself), the entity set changes from
+// "none" to "one number entity", and the signature must change too, or MqttOutput never
+// notices there is now something new to announce.
+static void test_discovery_signature_changes_when_supported_flips_with_unchanged_bounds() {
+    DeviceState a = pollWritableMockState();
+    const size_t idx =
+        static_cast<size_t>(InverterCommandType::SetActivePowerLimitPercent);
+    a.capabilities.numeric[idx].supported = false;
+
+    DeviceState b = a;
+    b.capabilities.numeric[idx].supported = true;
+    // Bounds deliberately IDENTICAL to a's -- only `supported` differs.
+
+    TEST_ASSERT_TRUE(discoverySignature(a) != discoverySignature(b));
+}
+
+// The mirror image: writable=false must behave the same way, and a command with no numeric
+// value at all (start/stop) must still be able to change the signature via just the write
+// bitset, independent of the numeric-specific gate above.
+static void test_discovery_signature_changes_when_writable_flips_with_unchanged_bounds() {
+    DeviceState a = pollWritableMockState();
+    const size_t idx =
+        static_cast<size_t>(InverterCommandType::SetActivePowerLimitPercent);
+    a.capabilities.numeric[idx].writable = false;
+
+    DeviceState b = a;
+    b.capabilities.numeric[idx].writable = true;
+
+    TEST_ASSERT_TRUE(discoverySignature(a) != discoverySignature(b));
+}
+
 static void test_the_mock_hybrid_gets_battery_and_phase_entities_for_free() {
     // The architectural claim, on the discovery side: no code here knows about batteries or
     // three-phase devices, yet both appear.
@@ -1323,6 +1357,8 @@ int main(int, char**) {
     RUN_TEST(test_start_and_stop_get_button_entities);
     RUN_TEST(test_an_enum_command_gets_no_entity_even_if_the_capability_is_granted);
     RUN_TEST(test_discovery_signature_changes_when_a_writable_bound_changes);
+    RUN_TEST(test_discovery_signature_changes_when_supported_flips_with_unchanged_bounds);
+    RUN_TEST(test_discovery_signature_changes_when_writable_flips_with_unchanged_bounds);
     RUN_TEST(test_the_mock_hybrid_gets_battery_and_phase_entities_for_free);
     RUN_TEST(test_bridge_diagnostic_entities);
     RUN_TEST(test_relay_entities_follow_count_and_enabled);

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -653,6 +653,90 @@ static void test_config_topics_are_well_formed() {
     }
 }
 
+static DeviceState pollWritableMockState() {
+    mock::MockOptions o;
+    o.writable = true;
+    mock::MockDriver driver(clockFn, o);
+    StateStore    store;
+    Diagnostics   diag;
+    DeviceContext ctx(driver, store, diag, clockFn);
+    ctx.pollOnce();
+    return *store.snapshot();
+}
+
+static void test_a_writable_numeric_command_gets_a_number_entity() {
+    const auto state  = pollWritableMockState();
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
+
+    const auto* e = findEntity(entities, "heliograph-a1b2c3_set_active_power_limit_percent");
+    TEST_ASSERT_NOT_NULL(e);
+    TEST_ASSERT_TRUE(e->configTopic.find("/number/") != std::string::npos);
+
+    auto doc = parse(e->payload);
+    TEST_ASSERT_EQUAL_STRING(topics.commandSet().c_str(),
+                             doc["command_topic"].as<std::string>().c_str());
+    const std::string tmpl = doc["command_template"].as<std::string>();
+    TEST_ASSERT_TRUE(tmpl.find("\"type\":\"set_active_power_limit_percent\"") !=
+                     std::string::npos);
+    TEST_ASSERT_TRUE(tmpl.find("{{ value }}") != std::string::npos);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0, doc["min"].as<double>());
+    TEST_ASSERT_EQUAL_DOUBLE(100.0, doc["max"].as<double>());
+    TEST_ASSERT_EQUAL_DOUBLE(1.0, doc["step"].as<double>());
+    TEST_ASSERT_EQUAL_STRING("%", doc["unit_of_measurement"]);
+    // No readback exists for a setpoint -- no shipping driver reports one as a measurement --
+    // so this can only ever be optimistic, unlike the relay switch.
+    TEST_ASSERT_TRUE(doc["optimistic"].as<bool>());
+}
+
+static void test_start_and_stop_get_button_entities() {
+    const auto state  = pollWritableMockState();
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
+
+    const auto* start = findEntity(entities, "heliograph-a1b2c3_start");
+    TEST_ASSERT_NOT_NULL(start);
+    TEST_ASSERT_TRUE(start->configTopic.find("/button/") != std::string::npos);
+    auto startDoc = parse(start->payload);
+    TEST_ASSERT_EQUAL_STRING(topics.commandSet().c_str(),
+                             startDoc["command_topic"].as<std::string>().c_str());
+    TEST_ASSERT_EQUAL_STRING("{\"type\":\"start\"}",
+                             startDoc["payload_press"].as<std::string>().c_str());
+
+    const auto* stop = findEntity(entities, "heliograph-a1b2c3_stop");
+    TEST_ASSERT_NOT_NULL(stop);
+    auto stopDoc = parse(stop->payload);
+    TEST_ASSERT_EQUAL_STRING("{\"type\":\"stop\"}",
+                             stopDoc["payload_press"].as<std::string>().c_str());
+}
+
+static void test_an_enum_command_gets_no_entity_even_if_the_capability_is_granted() {
+    // No driver grants SetBatteryOperatingMode today (there is no EnumCapability yet to say
+    // what the valid selections would even be), so this state is hand-built rather than
+    // pulled from MockDriver -- it pins the "skip, don't guess" rule for the day one does.
+    DeviceState state;
+    state.capabilities.addWrite(InverterCapability::SetBatteryOperatingMode);
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildDiscoveryEntities(state, bridge, topics, topics.availability(),
+                               kDefaultDiscoveryPrefix, bridge.bridgeId);
+
+    TEST_ASSERT_NULL(findEntity(entities, "heliograph-a1b2c3_set_battery_operating_mode"));
+}
+
+static void test_discovery_signature_changes_when_a_writable_bound_changes() {
+    DeviceState a = pollWritableMockState();
+    DeviceState b = a;
+    b.capabilities.numeric[static_cast<size_t>(InverterCommandType::SetActivePowerLimitPercent)]
+        .maximum = 50.0;
+
+    TEST_ASSERT_TRUE(discoverySignature(a) != discoverySignature(b));
+}
+
 static void test_the_mock_hybrid_gets_battery_and_phase_entities_for_free() {
     // The architectural claim, on the discovery side: no code here knows about batteries or
     // three-phase devices, yet both appear.
@@ -1235,6 +1319,10 @@ int main(int, char**) {
     RUN_TEST(test_every_entity_on_a_device_has_a_distinct_display_name);
     RUN_TEST(test_no_control_entities_for_a_read_only_driver);
     RUN_TEST(test_config_topics_are_well_formed);
+    RUN_TEST(test_a_writable_numeric_command_gets_a_number_entity);
+    RUN_TEST(test_start_and_stop_get_button_entities);
+    RUN_TEST(test_an_enum_command_gets_no_entity_even_if_the_capability_is_granted);
+    RUN_TEST(test_discovery_signature_changes_when_a_writable_bound_changes);
     RUN_TEST(test_the_mock_hybrid_gets_battery_and_phase_entities_for_free);
     RUN_TEST(test_bridge_diagnostic_entities);
     RUN_TEST(test_relay_entities_follow_count_and_enabled);


### PR DESCRIPTION
## Summary

Builds the request-flag/queue plumbing for a future inverter write path, the REST and MQTT entry points that submit to it, Home Assistant discovery entities for whatever a driver's write bitset grants, and an async result republish over MQTT. `CommandDispatcher` existed but was never instantiated; this wires it in end-to-end without giving any driver actual write access.

- `CommandQueue` (`src/commands/command_queue.h/.cpp`): a single-slot request/consume queue, the same one-in-flight shape as `g_manualPollRequested`, generalised to carry a real `InverterCommand` + target device id, plus `recordOutcome`/`outcomeFor` keyed on `requestId`.
- `rs485Task` drains it in the same "exclusive bus operation this cycle, then `continue`" slot as discovery/capture. `g_commandDispatcher`'s read-only mode follows `security.readOnlyMode` at the same two sites `g_relays`' already does.
- REST: `POST /api/v1/devices/<id>/commands` to submit, `GET .../commands/<requestId>` to read back the outcome.
- MQTT: a per-device `<prefix>/command/set` topic. An immediate accepted/rejected ack publishes to `<prefix>/command/result`; once rs485Task actually runs the command, the real `DispatchOutcome` republishes to the same topic (a per-channel pending id, polled each `loop()` tick).
- Both transports submit through one function (`main.cpp`'s `submitCommand`), so there's one request-id counter and one queue regardless of which transport a command arrived on.
- Home Assistant discovery: the driver's `capabilities.write` bitset now produces a `number` entity per writable numeric command (optimistic, `command_template` wraps the value into our JSON body, bounds from the driver) and a `button` entity per value-less writable command (start/stop/synchronize_time). A mode command is skipped, not guessed at — there's no `EnumCapability` yet to say what the valid selections are. `discoverySignature()` folds in the write bitset and numeric bounds so a driver's writable set changing (e.g. a profile row going from unverified to verified) triggers a re-announce.

A wire-format parser (`parseCommandRequest`) first landed in `device/command.cpp` but tripped `check_layering.sh`'s Arduino-family guard (`<ArduinoJson.h>` matches the `Arduino` prefix, a false positive — the library itself is plain C++). Moved the JSON-touching parts to `outputs/json_util.h` instead, shared by REST and MQTT already; `device/` keeps only the pure `commandTypeFromName` lookup.

**Deliberately not built**: no driver anywhere accepts a real command yet (every one returns `Unsupported`), so none of this is reachable end to end today — but the day a write row goes live (MIC TL-X's curtailment register verified on hardware, or the SPH write path landing), only the driver-side gate needs to move; REST, MQTT and Home Assistant discovery are already wired to react to it.

## Test plan
- [x] `pio test -e native` — 880 cases pass
- [x] `tools/check_layering.sh` — pass
- [x] `pio run` for all three board envs (`waveshare-rs485-can`, `waveshare-relay-1ch`, `waveshare-relay-6ch`) — clean build
- [ ] Hardware verification not possible yet: no driver can accept a write, so there is nothing to exercise end-to-end on a real inverter