### PR TITLE
Release 0.25.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,9 +332,50 @@ namespace {
 // directions on hardware, one character apart. The struct shipped in 0.24.2 was already
 // written without that mistake, so nothing about what a bridge reports changes here; a
 // compile-time check now exists so the mistake cannot return unnoticed.
+// 0.25.0 makes a register map a data file. Six new inverter families answer this bridge, and
+// not one of them needed a line of C++.
+//
+// SIX NEW FAMILIES, five of them from makers this bridge had never spoken to. They are not
+// named here -- brand knowledge belongs in src/drivers/ and the rule holds for comments too;
+// docs/drivers/coverage.md is the list. Every register traces to a named source: a vendor
+// protocol document, or two mature open-source implementations that agree. Where the sources
+// disagreed the row was dropped and the conflict written down rather than settled by picking a
+// favourite, so several channels are deliberately absent. A battery power whose direction
+// nobody states is worse mapped than missing.
+//
+// THE DRIVER LOST ITS BRAND. One driver now serves seven manufacturers and cannot honestly be
+// named after one of them, so it is `modbus_profile`. Stored configurations migrate themselves
+// on first boot, including every extra device on a shared bus, and a restored backup takes the
+// same path. Nobody has to retype anything.
+//
+// FOUR SCHEMA FEATURES, EACH FORCED BY ONE REAL REGISTER, none added because it seemed useful:
+// a scaling `offset`, for a vendor that stores temperature biased so it never goes negative on
+// the wire; a negative `scale`, for a vendor that states the opposite battery sign convention
+// to ours; `word_order`, for families that put the low half of a 32-bit value at the lower
+// address; and `invalid` sentinels, for devices that answer an unreadable channel with 0xFFFF
+// rather than an error -- without which an inverter asleep at night reports 3276.7 degrees.
+//
+// EVERY MAP SAYS HOW FAR IT HAS BEEN PROVEN, and says it for itself. A profile carries its own
+// status, shown at the moment somebody picks it, because one driver reads all eight tables and
+// a driver-level badge can only ever describe the least-proven map in the build. Left that way,
+// the first map confirmed on hardware would have promoted every unconfirmed map with it.
+//
+// ALL EIGHT MAPS ARE EXPERIMENTAL, and that is not a formality. Each is transcribed from
+// documents; none has been confirmed against the device it describes. The one defect found in
+// review proves why the distinction matters: six rows of one map decoded with their halves swapped
+// -- a factor of 65536, four kilowatts of sun reported as 262 megawatts -- sitting behind two
+// sources that agreed with each other and a test written from the map it was meant to check.
+// Agreement between readers is not confirmation from a device. Check the readings against the
+// inverter's own display before trusting an energy total, and report back either way: a map
+// that turned out wrong is as useful to the next person as one that worked.
+//
+// NOTHING HERE CAN OPERATE AN INVERTER. Every setpoint these profiles record stays dormant --
+// unverified by construction, and two of them need a Modbus function this firmware does not
+// implement. A wrong map can report a wrong number; it cannot put a device into an untested
+// state.
 #define HELIOGRAPH_VERSION_MAJOR 0
-#define HELIOGRAPH_VERSION_MINOR 24
-#define HELIOGRAPH_VERSION_PATCH 3
+#define HELIOGRAPH_VERSION_MINOR 25
+#define HELIOGRAPH_VERSION_PATCH 0
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -29,7 +29,10 @@ if [ "$marked" -gt 1 ]; then
     grep -rn 'LEGACY-CONFIG-ID' src/ --exclude-dir=drivers
     status=1
 fi
-if hits=$(grep -rniE 'eversolar|zeversolar|growatt|solax|deye|sunsynk|solis|goodwe' \
+# Keep this list in step with profiles/: two vendors were added to the tree while this grep
+# still listed only the older ones, so the rule it enforces had a hole exactly where the
+# newest brand knowledge was most likely to leak.
+if hits=$(grep -rniE 'eversolar|zeversolar|growatt|solax|deye|sunsynk|solis|goodwe|sungrow|huawei' \
         src/ --exclude-dir=drivers 2>/dev/null | grep -v 'LEGACY-CONFIG-ID'); then
     echo "FAIL: manufacturer names found outside src/drivers/:"
     echo "$hits"


### PR DESCRIPTION
A register map is a data file now. Six new inverter families answer this bridge, none of which
needed a line of C++ — see [the coverage matrix](docs/drivers/coverage.md) for which.

Everything in this release already landed on main via #157. This PR is the version bump, the
in-firmware release note, and one guard fix.

## What a user gets

- Six new families, five from makers this bridge had never spoken to. Every register traces to
  a named source: a vendor protocol document, or two mature open-source implementations that
  agree. Where sources disagreed the row was dropped and the conflict recorded rather than
  settled by picking a favourite.
- The driver is `modbus_profile` — one driver serving seven manufacturers cannot honestly be
  named after one of them. **Stored configurations migrate themselves on first boot**, including
  extra devices on a shared bus; a restored backup takes the same path. Nothing to retype.
- Every map states how far *it* has been proven, shown at the moment you pick one.

## What it does not give you

**All eight maps are `experimental`.** Each is transcribed from documents; none has been
confirmed against the device it describes. The defect found in review shows why that distinction
is not a formality: six rows of one map decoded with their halves swapped — a factor of 65536,
four kilowatts of sun as 262 megawatts — behind two sources that agreed with each other and a
test written from the map it was supposed to check.

Check readings against the inverter's own display before trusting an energy total, and report
back either way.

**Nothing here can operate an inverter.** Every setpoint these profiles record stays dormant:
unverified by construction, and two need a Modbus function this firmware does not implement. A
wrong map can report a wrong number; it cannot put a device into an untested state.

## The guard fix

Layering rule 1 keeps brand knowledge inside `src/drivers/`, comments included — it caught the
first draft of the release note naming vendors. But its brand list had not kept up with the
tree, so it passed two of the five vendors this release adds. Both are listed now, proved by
planting a mention outside `src/drivers/` and watching the check fail.

## Verification

928 native tests, all four builds, layering, both ruff gates, web/dashboard/measurement checks.
Flash 1580099 bytes (24.1%), static RAM 22.4% — unchanged from 0.24.3 apart from the profiles.