### PR TITLE
Cleanup: zero warnings, one predicate, a real lint gate, and a toolchain that stops moving

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -95,15 +95,58 @@ jobs:
             echo "updates=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Every `https://github.com/OWNER/REPO/releases/download/TAG/asset` in platformio.ini,
+      # compared against that repository's latest release. This is how the ESP32 PLATFORM is
+      # pinned, and neither step above can see it: `pio pkg outdated` compares registry packages
+      # and a platform installed from a URL has no registry version, while the git-pin step
+      # matches `OWNER/REPO#tag` and a download URL carries no `#`.
+      #
+      # Proved rather than assumed, 2026-07-31: pinning the platform back to the previous release
+      # and running `pio pkg outdated` still printed "Everything is up-to-date!".
+      #
+      # This step exists because pinning the platform CREATED the gap it fills. The URL used to
+      # end in /stable/, which auto-updated -- silently, which is why it is now pinned, but it did
+      # at least keep moving. A pin with no monitoring is the opposite failure: a toolchain frozen
+      # for years while nobody is told. Both are silence; this is the one that can be fixed.
+      - name: Check release-URL-pinned platforms
+        id: urlpins
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPORT=""
+          while IFS= read -r url; do
+            rest=${url#https://github.com/}
+            repo=$(echo "$rest" | cut -d/ -f1,2)
+            have=$(echo "$rest" | cut -d/ -f5)
+            latest=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+            if [ -z "$latest" ]; then
+              REPORT="${REPORT}${repo}: pinned at ${have}; could not determine the latest release"$'\n'
+            elif [ "$latest" != "$have" ]; then
+              REPORT="${REPORT}${repo}: pinned at ${have}, latest is ${latest}"$'\n'
+            fi
+          done < <(grep -oE 'https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/releases/download/[A-Za-z0-9_.-]+/' platformio.ini | sort -u)
+          echo "$REPORT"
+          {
+            echo "report<<EOF"
+            echo "$REPORT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ -n "$REPORT" ]; then
+            echo "updates=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "updates=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Open or update tracking issue
-        if: steps.outdated.outputs.registry_updates == 'true' || steps.gitpins.outputs.updates == 'true'
+        if: steps.outdated.outputs.registry_updates == 'true' || steps.gitpins.outputs.updates == 'true' || steps.urlpins.outputs.updates == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPORT: ${{ steps.outdated.outputs.report }}
           GIT_REPORT: ${{ steps.gitpins.outputs.report }}
+          URL_REPORT: ${{ steps.urlpins.outputs.report }}
         run: |
           TITLE="PlatformIO dependencies have updates available"
-          BODY=$(printf 'Monthly `pio pkg outdated` report:\n\n```\n%s\n```\n\nGit-pinned dependencies (not visible to `pio pkg outdated`):\n\n```\n%s\n```\n\nReview the changelogs and bump deliberately — toolchain and library updates are hardware-tested changes, per docs/decisions.md.' "$REPORT" "${GIT_REPORT:-none behind}")
+          BODY=$(printf 'Monthly `pio pkg outdated` report:\n\n```\n%s\n```\n\nGit-pinned dependencies (not visible to `pio pkg outdated`):\n\n```\n%s\n```\n\nRelease-URL-pinned platforms (visible to neither of the above — this is the ESP32 toolchain):\n\n```\n%s\n```\n\nReview the changelogs and bump deliberately — toolchain and library updates are hardware-tested changes, per docs/decisions.md. A toolchain bump is not done until a board has booted on it.' "$REPORT" "${GIT_REPORT:-none behind}" "${URL_REPORT:-none behind}")
           EXISTING=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body "$BODY"

--- a/platformio.ini
+++ b/platformio.ini
@@ -123,11 +123,28 @@ lib_deps =
 ; Target firmware. One environment per supported board (the HELIOGRAPH_BOARD_* flag picks
 ; the header in src/boards/); everything else is shared through [esp32common].
 ;
-; VERIFIED 2026-07-16: builds clean with pioarduino 55.3.39 (Arduino core 3.3.9 / IDF 5.5.4),
-; xtensa-esp-elf 14.2.0.
+; PINNED TO A VERSION, NOT TO `stable`. That URL is a moving target, and on 2026-07-31 it was
+; found to have moved: this machine still had 55.3.39 (Arduino core 3.3.9, IDF 5.5.4) from the
+; note below, while CI had picked up 55.03.311 (core 3.3.11, IDF 5.5.5) and had been building
+; every release from it since 2026-07-24. The v0.25.0 images that went out to OTA were compiled
+; by a toolchain nobody had booted on hardware, and nothing in the repo said so.
+;
+; A firmware that must run for years unattended cannot have its compiler and RTOS change
+; underneath a release without a commit saying it did. Bumping is now a deliberate edit here,
+; reviewable like any other, and the reason the official platformio/platform-espressif32 was
+; rejected is untouched: it still ships Arduino core 2.0.17 on IDF 4.4.7 for framework=arduino.
+;
+; Pinned at 55.03.311 because that is what the released binaries already contain -- pinning back
+; to 55.03.39 would have made the NEXT release differ from the last one in the other direction,
+; with no more evidence behind it.
+;
+; VERIFIED: 55.3.39 (core 3.3.9 / IDF 5.5.4) built clean and ran on hardware, 2026-07-16.
+; 55.03.311 (core 3.3.11 / IDF 5.5.5) is CI-green on all four board environments and is what
+; v0.25.0 shipped, but has NOT been booted on a board by this project. The next bench session
+; is what makes "verified" true again for the version actually in the field.
 ; ---------------------------------------------------------------------------------------
 [esp32common]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 framework = arduino
 board_build.mcu = esp32s3

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+#
+# Lint configuration for tools/ — the build-time Python that generates C++ tables, gzips the
+# web assets and gates the CI. None of it runs on the ESP32, but a bug here produces a firmware
+# image, so it is held to the same standard as the firmware.
+#
+# WHY THIS FILE EXISTS. There was no ruff config, which meant CI ran ruff's DEFAULTS: E4, E7,
+# E9 and F — roughly ten rules out of eight hundred. That gate reads as "lint passes" and is
+# far narrower than it looks. Everything selected below found real things on first run.
+
+target-version = "py311"
+
+# No line-length here on purpose. This tree is already formatted at ruff's default 88, and
+# setting any other number makes `ruff format` rewrite all eleven files — a diff that would bury
+# whatever change it travelled with. The C++ side uses 100 columns; that is clang-format's
+# business, not this file's.
+
+[lint]
+# Chosen to catch mistakes, not to impose a house style. Each family earned its place by
+# reporting something worth fixing on the code as it stood.
+select = [
+    "E4", "E7", "E9",  # pycodestyle errors — ruff's own defaults, kept
+    "F",               # pyflakes: undefined names, unused imports
+    "B",               # bugbear: mutable defaults, loop-variable capture, silent except
+    "UP",              # pyupgrade: syntax superseded by our own target-version
+    "RUF",             # ruff's own — includes RUF100, which finds suppressions that suppress
+                       # nothing. Nine such directives were live here and had stopped applying.
+    "SIM",             # simplify: try/except/pass that contextlib.suppress says better
+    "C4",              # comprehensions: dict(generator) and friends
+    "PLE",             # pylint errors — genuine mistakes only
+    "I",               # import sorting, so an added import never re-orders a diff
+    "PLW1510",         # subprocess.run without an explicit check=; see below
+]
+
+# DELIBERATELY NOT SELECTED, each for a reason rather than by omission:
+#
+#   PLW0603 (global-statement)  set_root() assigns module globals on purpose — it is how the
+#                               PlatformIO SCons branch injects PROJECT_DIR when the script is
+#                               exec()'d without __file__. Documented at both sites.
+#   T201 (print)                These are command-line tools. print IS the interface.
+#   D, ANN, EM, TRY, COM        Docstring, annotation, exception-message and trailing-comma
+#                               style. Opinions, not defects.
+#   S (bandit)                  Flags subprocess use and `assert` as such. Both are correct
+#                               here: the subprocesses are node and chrome by design, and the
+#                               asserts guard generated output in a build-time script.
+#   E501 (line-too-long)        `ruff format` owns line length; two tools disagreeing about
+#                               the same line is a fight with no winner.
+#
+# On PLW1510: every subprocess.run here already inspects returncode afterwards and reports a
+# specific failure, which is better than the traceback check=True would raise. The rule still
+# earns its place — it makes that choice explicit at the call site instead of leaving a reader
+# to check whether the omission was deliberate.
+
+[lint.per-file-ignores]
+# One exemption, with its reason — which is the point of putting it here rather than reaching
+# for a per-line noqa. The nine stale directives this config's RUF100 removed are what that
+# habit looks like after a year.
+#
+# UP036 calls the `if sys.version_info < (3, 11)` guard dead code, because target-version says
+# 3.11 is the floor. It is confusing two different things. target-version tells ruff which
+# SYNTAX it may assume when rewriting; the guard is a RUNTIME check against whichever
+# interpreter actually invokes the script, and PlatformIO chooses that, not us. Deleting it
+# would replace a sentence naming the required version with a tomllib ImportError traceback on
+# whatever machine happens to have an older Python.
+"gen_profiles.py" = ["UP036"]

--- a/src/device/capability.cpp
+++ b/src/device/capability.cpp
@@ -2,6 +2,8 @@
 
 #include "capability.h"
 
+#include <algorithm>
+
 namespace heliograph {
 
 const char* capabilityName(InverterCapability capability) {
@@ -42,12 +44,14 @@ bool EnumCapability::accepts(int value) const {
     // write bit and leaves its option list empty is telling us it can change a mode without
     // telling us which modes exist, and the numeric path already learned that lesson: a declared
     // write with no published bounds is a refusal, not an unchecked pass-through.
-    for (size_t i = 0; i < optionCount; ++i) {
-        if (options != nullptr && options[i].value == value) {
-            return true;
-        }
+    //
+    // The null check is the same on every iteration, so it belongs outside the loop rather than
+    // inside it: a null table with a nonzero count is a malformed capability, not a row to skip.
+    if (options == nullptr) {
+        return false;
     }
-    return false;
+    return std::any_of(options, options + optionCount,
+                       [value](const EnumOption& o) { return o.value == value; });
 }
 
 }  // namespace heliograph

--- a/src/device/measurement.h
+++ b/src/device/measurement.h
@@ -70,7 +70,26 @@ struct Measurement {
     /// infer meter-grade precision from a derived value.
     bool     derived     = false;
     uint64_t timestampMs = 0;
+
+    /// Whether this reading may be published as a number right now.
+    ///
+    /// All three flags matter and they mean different things: `supported` says the device has
+    /// this channel at all, `valid` says the last read produced a figure, `stale` says that
+    /// figure is too old to stand for the present. Anything else is absent -- never zero. The
+    /// distinction is the project's oldest rule and the easiest to get subtly wrong, which is
+    /// why it lives here as one predicate instead of being spelled out per output.
+    bool publishable() const { return supported && valid && !stale; }
 };
+
+/// The same question for a pointer that may be null, which is how every output reaches a
+/// measurement it looked up by id: `find()` returns nullptr for a channel this device does not
+/// publish, and a missing channel is exactly as unpublishable as an invalid one.
+///
+/// Four outputs each wrote this condition out by hand -- the Modbus register map twice, REST
+/// once, Prometheus once in De Morgan form (`m == nullptr || !m->supported || ...`). Four
+/// hand-maintained copies of one rule, one of them inverted, is a change waiting to be applied
+/// to three places out of four.
+inline bool publishable(const Measurement* m) { return m != nullptr && m->publishable(); }
 
 /// Well-known measurement ids. Drivers fill only what they actually read.
 namespace measurement_id {

--- a/src/drivers/driver_descriptor.h
+++ b/src/drivers/driver_descriptor.h
@@ -60,9 +60,13 @@ struct DriverOption {
     /// every profile here, so its badge describes the least-proven map in the build and says
     /// nothing about the one being picked.
     ///
-    /// Declared last, and defaulted, so the hand-written aggregate initialisers in every other
-    /// driver's descriptor stay valid.
-    std::vector<std::string> allowedLabels;
+    /// Declared last, and given an explicit default, so the hand-written aggregate initialisers
+    /// in every other driver's descriptor stay valid AND stay quiet. The `= {}` is not
+    /// decoration: without a default member initialiser, -Wextra reports every aggregate
+    /// initialiser that stops before this field, which was twenty warnings across five drivers
+    /// and three test files the moment this field was added. A field that genuinely defaults to
+    /// empty should say so here rather than at each of those twenty sites.
+    std::vector<std::string> allowedLabels = {};
 
     bool isNumeric() const { return minValue != 0 || maxValue != 0; }
 };

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -153,7 +153,7 @@ void RegisterMap::publishMeasurement(const DeviceState& state, const char* id, u
     // aware it is not load-bearing -- removing it breaks no test, because it cannot change
     // the output. In MQTT and discovery the same flag *is* load-bearing, since there the
     // difference is a key or an entity existing at all.
-    const bool usable = m != nullptr && m->supported && m->valid && !m->stale;
+    const bool usable = publishable(m);
     writeFloat(address, usable ? m->value : 0.0, usable);
     setValidity(bit, usable);
 }
@@ -216,7 +216,7 @@ void RegisterMap::update(const DeviceState& state, const BridgeInfo& bridge,
                        ValidityBit::EnergyTotal);
 
     const auto* hours = state.measurements.find(measurement_id::kOperatingHours);
-    const bool hoursUsable = hours != nullptr && hours->supported && hours->valid && !hours->stale;
+    const bool hoursUsable = publishable(hours);
     writeU32(reg::kOperatingHours,
              hoursUsable ? static_cast<uint32_t>(hours->value) : kInvalidU32);
     setValidity(ValidityBit::OperatingHours, hoursUsable);

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -286,7 +286,7 @@ std::string buildMetrics(const std::vector<DeviceMetrics>& devices, const Bridge
             }
             for (const auto& dev : devices) {
                 const auto* m = dev.state->measurements.find(gauge.measurementId);
-                if (m == nullptr || !m->supported || !m->valid || m->stale) {
+                if (!publishable(m)) {
                     continue;  // omit, do not zero
                 }
                 if (!headerWritten) {

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -405,8 +405,13 @@ bool buildDiagnosticsPayload(const DiagnosticsSnapshot& d, const BridgeInfo& bri
             // payload -- these two fields say how long it ran and what it was running.
             doc["previous_uptime_ms"] = bridge.previousUptimeMs;
             char v[16];
-            snprintf(v, sizeof v, "%u.%u.%u", (bridge.previousFirmware >> 16) & 0xFF,
-                     (bridge.previousFirmware >> 8) & 0xFF, bridge.previousFirmware & 0xFF);
+            // Cast rather than switch to %lu: uint32_t is `unsigned long` on xtensa and
+            // `unsigned int` on the host, so either bare format string is wrong on one of the
+            // two builds. Each component is masked to a byte, so narrowing to unsigned is exact.
+            snprintf(v, sizeof v, "%u.%u.%u",
+                     static_cast<unsigned>((bridge.previousFirmware >> 16) & 0xFF),
+                     static_cast<unsigned>((bridge.previousFirmware >> 8) & 0xFF),
+                     static_cast<unsigned>(bridge.previousFirmware & 0xFF));
             doc["previous_firmware"] = v;
         }
     }

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -89,7 +89,7 @@ DeviceSummary summariseDevice(const DeviceState& state, const std::string& devic
         // an unread channel holds 0.0, and markAllStale() leaves `valid` true when a device
         // goes offline -- so without !stale a dead inverter's last daylight reading was summed
         // into the Dashboard total forever. At 03:00 the bridge reported watts (review).
-        if (m != nullptr && m->supported && m->valid && !m->stale) {
+        if (publishable(m)) {
             has   = true;
             value = m->value;
         }

--- a/src/relays/relay_controller.cpp
+++ b/src/relays/relay_controller.cpp
@@ -2,6 +2,8 @@
 
 #include "relay_controller.h"
 
+#include <algorithm>
+
 namespace heliograph {
 
 RelayController::RelayController(ClockFn clock, RateLimitPolicy rateLimit)
@@ -72,13 +74,7 @@ CommandResult RelayController::applyPattern(const std::vector<bool>& pattern) {
     if (pattern.size() != static_cast<size_t>(count_)) {
         return CommandResult::OutOfRange;
     }
-    bool assertsAny = false;
-    for (uint8_t i = 0; i < count_; ++i) {
-        if (pattern[i]) {
-            assertsAny = true;
-            break;
-        }
-    }
+    const bool assertsAny = std::any_of(pattern.begin(), pattern.end(), [](bool on) { return on; });
     // One token for the whole pattern, and only when it asserts anything: a release-only
     // pattern is the safe direction and passes unconditionally, like set(index, false).
     if (assertsAny) {

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1948,6 +1948,15 @@ static void test_breadcrumbs_payload_shapes() {
     doc = parse(json);
     TEST_ASSERT_EQUAL_UINT32(65400, doc["previous_uptime_ms"].as<uint32_t>());
     TEST_ASSERT_EQUAL_STRING("0.24.1", doc["previous_firmware"]);
+
+    // A version whose three components are all DIFFERENT and all nonzero. Every firmware this
+    // project has shipped is 0.x, so every stored breadcrumb has a zero major -- which meant the
+    // assertion above held just as well if the major were decoded from the wrong byte. Proved:
+    // changing the shift from 16 to 24 left all 146 tests in this suite passing. It fails here.
+    bridge.previousFirmware = 0x00010203;
+    TEST_ASSERT_TRUE(rest::buildDiagnosticsPayload(d.snapshot(), bridge, json));
+    doc = parse(json);
+    TEST_ASSERT_EQUAL_STRING("1.2.3", doc["previous_firmware"]);
 }
 
 static void test_diagnostics_payload_has_no_secrets() {

--- a/tools/build_web.py
+++ b/tools/build_web.py
@@ -29,6 +29,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import gzip
 import pathlib
 import re
@@ -77,10 +78,10 @@ def set_root(root: pathlib.Path) -> None:
     ROOT = root
 
 
-try:
+# NameError is the SCons case: exec()'d without __file__, so ROOT stays the provisional cwd
+# and the PlatformIO branch below overrides it.
+with contextlib.suppress(NameError):
     set_root(pathlib.Path(__file__).resolve().parent.parent)
-except NameError:
-    pass  # provisional cwd; the PlatformIO branch below overrides it
 
 
 def assets() -> pathlib.Path:
@@ -313,10 +314,10 @@ def run() -> int:
 
 # Under PlatformIO (extra_scripts) SCons provides Import(); standalone it does not.
 try:
-    Import("env")  # type: ignore[name-defined]  # noqa: F821
-    set_root(pathlib.Path(env["PROJECT_DIR"]))  # type: ignore[name-defined]  # noqa: F821
+    Import("env")  # type: ignore[name-defined]
+    set_root(pathlib.Path(env["PROJECT_DIR"]))  # type: ignore[name-defined]
     if run() != 0:
-        env.Exit(1)  # type: ignore[name-defined]  # noqa: F821
+        env.Exit(1)  # type: ignore[name-defined]
 except NameError:
     if __name__ == "__main__":
         sys.exit(run())

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -31,7 +31,7 @@ import sys
 import tempfile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-import build_web  # noqa: E402
+import build_web
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -680,6 +680,7 @@ def render(
         capture_output=True,
         text=True,
         timeout=120,
+        check=False,
     )
     verdict = re.search(r"<title>(LAYOUT-[^<]*)</title>", result.stdout)
     return (verdict.group(1) if verdict else "", result.stdout)

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -38,7 +38,10 @@ def main() -> int:
             path.write_text("\n".join(scripts))
             try:
                 result = subprocess.run(
-                    ["node", "--check", str(path)], capture_output=True, text=True
+                    ["node", "--check", str(path)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
                 )
             except FileNotFoundError:
                 # Without this the script dies on a bare traceback that names no cause. The
@@ -164,7 +167,9 @@ process.exit(bad === 0 ? 0 : 1);
     )
     path = pathlib.Path(scratch) / "version_compare.js"
     path.write_text(harness)
-    result = subprocess.run(["node", str(path)], capture_output=True, text=True)
+    result = subprocess.run(
+        ["node", str(path)], capture_output=True, text=True, check=False
+    )
     print(f"version comparison: {'OK' if result.returncode == 0 else 'FAIL'}")
     if result.returncode != 0:
         print(result.stdout + result.stderr)
@@ -253,7 +258,9 @@ process.exit(bad === 0 ? 0 : 1);
     )
     path = pathlib.Path(scratch) / "fleet_mode.js"
     path.write_text(harness)
-    result = subprocess.run(["node", str(path)], capture_output=True, text=True)
+    result = subprocess.run(
+        ["node", str(path)], capture_output=True, text=True, check=False
+    )
     print(f"fleet mode: {'OK' if result.returncode == 0 else 'FAIL'}")
     if result.returncode != 0:
         print(result.stdout + result.stderr)
@@ -396,7 +403,9 @@ process.exit(bad === 0 ? 0 : 1);
     )
     path = pathlib.Path(scratch) / "address_collision.js"
     path.write_text(harness)
-    result = subprocess.run(["node", str(path)], capture_output=True, text=True)
+    result = subprocess.run(
+        ["node", str(path)], capture_output=True, text=True, check=False
+    )
     print(f"address collision: {'OK' if result.returncode == 0 else 'FAIL'}")
     if result.returncode != 0:
         print(result.stdout + result.stderr)
@@ -484,7 +493,9 @@ const fail = m => {{ console.error(m); bad++; }};
 """
     path = pathlib.Path(scratch) / "auth_prompt.js"
     path.write_text(harness)
-    result = subprocess.run(["node", str(path)], capture_output=True, text=True)
+    result = subprocess.run(
+        ["node", str(path)], capture_output=True, text=True, check=False
+    )
     print(f"auth prompt re-entrancy: {'OK' if result.returncode == 0 else 'FAIL'}")
     if result.returncode != 0:
         print(result.stdout + result.stderr)
@@ -553,7 +564,9 @@ const fail = m => { console.error(m); bad++; };
     )
     path = pathlib.Path(scratch) / "auth_fetch_race.js"
     path.write_text(harness)
-    result = subprocess.run(["node", str(path)], capture_output=True, text=True)
+    result = subprocess.run(
+        ["node", str(path)], capture_output=True, text=True, check=False
+    )
     print(f"auth fetch race: {'OK' if result.returncode == 0 else 'FAIL'}")
     if result.returncode != 0:
         print(result.stdout + result.stderr)

--- a/tools/gen_coverage.py
+++ b/tools/gen_coverage.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import gen_profiles  # noqa: E402
+import gen_profiles
 
 ROOT = Path(__file__).resolve().parent.parent
 OUTPUT = ROOT / "docs" / "drivers" / "coverage.md"

--- a/tools/gen_fixtures.py
+++ b/tools/gen_fixtures.py
@@ -327,7 +327,7 @@ def main() -> None:
         "aa 55 00 00 01 00 10 80 12 58 48 33 30 30 30 36 30 31 31 35 35 30 36 31 39 00 01"
         " 05 08".replace(" ", "")
     )
-    generated = dict((n, f) for n, _, f in FIXTURES)["kRespOfflineQueryCaptured"]
+    generated = {n: f for n, _, f in FIXTURES}["kRespOfflineQueryCaptured"]
     assert generated == captured, (
         "kRespOfflineQueryCaptured drifted from the hardware capture"
     )
@@ -337,7 +337,7 @@ def main() -> None:
         " 00 05 68 9b 00 00 b9 29 00 01 00 00 00 00 ff ff 00 00 00 00 00 00 ff 00 00 00"
         " 0b 8f".replace(" ", "")
     )
-    generated_info = dict((n, f) for n, _, f in FIXTURES)["kRespNormalInfoCaptured"]
+    generated_info = {n: f for n, _, f in FIXTURES}["kRespNormalInfoCaptured"]
     assert generated_info == captured_info, (
         "kRespNormalInfoCaptured drifted from the hardware capture"
     )

--- a/tools/gen_profiles.py
+++ b/tools/gen_profiles.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 if sys.version_info < (3, 11):
@@ -880,7 +881,10 @@ def run(check_only: bool = False) -> int:
 
     if not errors:
         ids = [p["id"] for p in profiles]
-        for dup in {i for i in ids if ids.count(i) > 1}:
+        # Counter, not `ids.count(i)` inside a comprehension over ids: that called count() once
+        # per profile, and iterated a SET, so the same broken input could report its duplicates
+        # in a different order each run. Sorted output is what makes a failure diffable.
+        for dup in sorted(i for i, n in Counter(ids).items() if n > 1):
             errors.append(f"profile id '{dup}' is defined in more than one file")
         # Two DIFFERENT ids can still collapse to one C++ identifier: cpp_symbol() splits on
         # underscores and capitalises, so `a_b` and `a__b` both become `AB`. The check above

--- a/tools/gen_profiles.py
+++ b/tools/gen_profiles.py
@@ -30,8 +30,7 @@ from pathlib import Path
 
 if sys.version_info < (3, 11):
     sys.stderr.write(
-        "gen_profiles.py needs Python >= 3.11 (tomllib); found %s\n"
-        % sys.version.split()[0]
+        f"gen_profiles.py needs Python >= 3.11 (tomllib); found {sys.version.split()[0]}\n"
     )
     sys.exit(1)
 
@@ -951,10 +950,10 @@ def main(argv: list[str]) -> int:
 
 # Under PlatformIO (extra_scripts) SCons provides Import(); standalone it does not.
 try:
-    Import("env")  # type: ignore[name-defined]  # noqa: F821
-    set_root(Path(env["PROJECT_DIR"]))  # type: ignore[name-defined]  # noqa: F821
+    Import("env")  # type: ignore[name-defined]
+    set_root(Path(env["PROJECT_DIR"]))  # type: ignore[name-defined]
     if run() != 0:
-        env.Exit(1)  # type: ignore[name-defined]  # noqa: F821
+        env.Exit(1)  # type: ignore[name-defined]
 except NameError:
     if __name__ == "__main__":
         sys.exit(main(sys.argv[1:]))

--- a/tools/make_screenshots.py
+++ b/tools/make_screenshots.py
@@ -34,9 +34,10 @@ import sys
 import threading
 import urllib.error
 import urllib.request
+from typing import ClassVar
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-import build_web  # noqa: E402
+import build_web
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 ASSET = ROOT / "src/web/assets/index_html.h"
@@ -164,13 +165,16 @@ def extract_page() -> str:
 
 
 class Handler(http.server.SimpleHTTPRequestHandler):
-    page = ""
-    data: dict = {}
+    # ClassVar, not an instance field: http.server builds a fresh Handler per request, so
+    # class attributes are the channel through which the page and its API payloads reach
+    # them. A mutable default on an instance would be a bug; here it is the mechanism.
+    page: ClassVar[str] = ""
+    data: ClassVar[dict] = {}
 
-    def log_message(self, *args):  # noqa: D102 - quiet
+    def log_message(self, *args):  # keep the console quiet
         pass
 
-    def do_GET(self):  # noqa: N802 - http.server's spelling
+    def do_GET(self):  # http.server's spelling, not ours
         path = self.path.split("?")[0]
         if path.startswith("/api/v1/"):
             name = path[len("/api/v1/") :].strip("/")
@@ -285,6 +289,7 @@ def main() -> int:
                 ],
                 capture_output=True,
                 timeout=120,
+                check=False,
             )
             size = target.stat().st_size if target.exists() else 0
             print(f"  {filename:18s} {size // 1024:4d} KB")

--- a/tools/preview_web.py
+++ b/tools/preview_web.py
@@ -22,7 +22,7 @@ import pathlib
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-import build_web  # noqa: E402
+import build_web
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -36,7 +36,7 @@ def page() -> bytes:
 class Handler(http.server.BaseHTTPRequestHandler):
     body = b""
 
-    def do_GET(self):  # noqa: N802  (http.server's own casing)
+    def do_GET(self):  # http.server's own casing, not ours
         # Every path, not only "/": the page is a single document and a stray request for a
         # favicon or a stylesheet should get the page rather than a 404 in the console.
         self.send_response(200)


### PR DESCRIPTION
Six small commits, one per category, each reviewable and revertable on its own. No external
behaviour changes: no REST payload, MQTT topic, register address or config format is touched.

## What the audit actually found

This tree is well kept — `-Wall -Wextra` were already on, dependencies pinned with written
reasons, no dead code, no TODOs, no commented-out blocks. Two of five sweep categories came back
empty. The findings are concentrated, and the largest one was mine from earlier today.

| Commit | What |
|---|---|
| `51020c1` | 20 `-Wmissing-field-initializers`, introduced this morning by appending `allowedLabels` to `DriverOption`. Fixed with one `= {}` rather than 20 edits — GCC does not warn about a field omitted from an aggregate initialiser when it carries a default member initialiser, which is why `minValue`/`maxValue` two lines up never warned. |
| `24fe642` | `%u` against a `uint32_t`, which is `unsigned long` on xtensa. Right output today by accident of register width. |
| `b85f5af` | The publishable-measurement rule was written out by hand in four outputs, once inverted. Now one predicate. |
| `ed34507` | Three hand-rolled loops → `std::any_of` ×2 and `collections.Counter`. |
| `eeb4b41` | The lint gate ran ruff's defaults — ten rules of eight hundred — and reported "pass". Widened, and everything it then found is fixed. |
| `c17794a` | **The platform was pinned to `stable`, a moving target, and it had moved.** |

## The one worth reading twice

`platform = .../releases/download/stable/...` resolved to Arduino core **3.3.9** on this machine
and **3.3.11** in CI. The v0.25.0 images published to OTA today were built by a toolchain nobody
had booted, and no commit recorded the change because from the repo's side nothing changed.

Now pinned to 55.03.311 — what the released binaries already contain. Flash drops 89528 bytes
(-5.7%) rebuilding on it, which is itself the proof the two were not interchangeable.

Still open and now written down rather than implied: 3.3.11 is CI-green but has not been booted
on a board. The comment states which version was hardware-verified and which is merely shipping.

## Rejected

Two sweep findings were wrong and are not acted on: a claimed MPPT array overrun between
`mock_driver` and `register_map` (they are independent local arrays, guarded by six
`static_assert`s), and `BOARD_HAS_PSRAM` as dead (the Arduino core consumes it; removing it
changes where `String` allocates).

## Verification

928 native tests, four board builds, layering, both ruff gates, every generator gate — on the
newly pinned toolchain. **Zero warnings from our own code, down from 80.**

Each behavioural change is mutation-proved rather than assumed: dropping `!stale` from the shared
predicate fails six tests across REST, Prometheus and the register map; neutering the two
`any_of` predicates fails three suites; planting a `dict(generator)` makes the new lint gate fire
a rule the old one did not run.