### PR TITLE
Release 0.25.1

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -151,5 +151,14 @@ jobs:
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body "$BODY"
           else
-            gh issue create --title "$TITLE" --body "$BODY" --label dependencies
+            # Assigned, not merely labelled. An unassigned issue opened by a bot reaches the
+            # maintainer only if their repository watch setting happens to include new issues --
+            # a setting nobody remembers choosing and which this workflow cannot read. Being
+            # assigned notifies regardless, and subsequent comments on that issue notify too,
+            # which is the path every month after the first one takes.
+            #
+            # The point of this job is to be told. An update nobody hears about is the same
+            # outcome as not checking.
+            gh issue create --title "$TITLE" --body "$BODY" --label dependencies \
+              --assignee "${{ github.repository_owner }}"
           fi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -375,7 +375,30 @@ namespace {
 // state.
 #define HELIOGRAPH_VERSION_MAJOR 0
 #define HELIOGRAPH_VERSION_MINOR 25
-#define HELIOGRAPH_VERSION_PATCH 0
+//
+// 0.25.1 changes nothing a bridge does, and changes what builds it.
+//
+// THE TOOLCHAIN IS PINNED TO A VERSION. The platform URL ended in /stable/, which moves. It had
+// already moved: 0.25.0's images were compiled by an Arduino core two patch releases newer than
+// the one this project last booted on a board, and no commit recorded that, because from the
+// repository's side nothing had changed. Firmware meant to run for years unattended should not
+// have its compiler and RTOS replaced underneath a release without a line in the history saying
+// so. Bumping is now an edit somebody reviews. The same image is 89 KB smaller for it, which is
+// the measure of how different the two toolchains were.
+//
+// The monthly dependency check gained a third source, because pinning created a new silence: a
+// version pin nobody watches is a toolchain frozen for years. Neither existing check could see
+// a platform installed from a release URL -- verified by pinning backwards and watching the
+// report still say everything was up to date.
+//
+// EIGHTY COMPILER WARNINGS FROM OUR OWN CODE, NOW ZERO. Twenty were introduced by 0.25.0 itself;
+// the rest were a format string that is wrong on one of the two builds and right by accident on
+// the other. Nothing was suppressed to get there.
+//
+// One rule, one place: whether a reading may be published -- supported, valid, and not stale --
+// was written out by hand in four outputs and inverted in one of them. Anything else is absent,
+// never zero, and that rule is now asked of one predicate.
+#define HELIOGRAPH_VERSION_PATCH 1
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Nothing a bridge does changes. What builds it does.

- The ESP32 toolchain is pinned to a version instead of `/stable/`, a URL that had already moved: 0.25.0 shipped from an Arduino core two patch releases newer than the one last booted on a board, and no commit said so. The same image is **89 KB smaller** on the pinned toolchain — the measure of how different the two were.
- **Eighty compiler warnings from our own code, now zero.** Nothing suppressed to get there.
- Whether a reading may be published — supported, valid, not stale — was written by hand in four outputs and inverted in one. Now one predicate.
- The Python lint gate ran ten of ruff's eight hundred rules while reporting `pass`. Widened, and everything it then found is fixed.
- The monthly dependency check gained a third source: release-URL-pinned platforms, which neither existing step could see — verified by pinning backwards and watching it still report everything up to date. The issue it opens is now **assigned**, so it reaches somebody rather than depending on a watch setting.

Verified on the pinned toolchain: 928 native tests, four board builds, layering, both ruff gates, every generator gate.

Open and stated rather than implied: Arduino core 3.3.11 is CI-green but has not been booted on a board. This release exists so that can happen.