### PR TITLE
Documentation review: what the docs still claimed, and what the code actually does

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ See `docs/adding-a-device.md` for the full workflow.
 
 | Environment | Command | Purpose |
 |---|---|---|
-| `native` | `pio test -e native` | 390+ host tests, no hardware needed |
+| `native` | `pio test -e native` | ~930 host tests, no hardware needed |
 | `waveshare-rs485-can` etc. | `pio run -e waveshare-rs485-can` | Production firmware, one env per board (all drivers) |
 | `mock` | `pio run -e mock` | Full output stack with a simulated inverter |
 
@@ -63,7 +63,7 @@ python3 tools/check_web_js.py         # embedded JS (when touching src/web/)
 ruff check tools/                     # Python tooling lint
 ```
 
-CI runs the same checks plus both firmware builds.
+CI runs the same checks plus a firmware build for each of the four environments.
 
 ## Code style
 
@@ -111,8 +111,11 @@ CI runs the same checks plus both firmware builds.
 | Growatt SPH hybrid, MIC TL-X | Modbus RTU | `src/drivers/modbus_profile/` (profile-driven) |
 | SolaX X1 series | PMU (AA55) over RS485 | `src/drivers/solax_x1/` |
 
-All drivers are **read-only**. Write support requires hardware-verified register maps
-and an explicit write path — neither is enabled today.
+**Do not describe this firmware as read-only.** Two drivers (`modbus_profile`, `sunspec`)
+declare `supportsWrite` and implement a real `execute()`. What holds today is a chain of gates,
+not an absence of capability: no profile ships a `verified` write row, so no profile writes;
+SunSpec's path additionally needs the device to publish model 123; and `security.read_only_mode`
+is **on by default** and refuses the whole path regardless. Describe the gates, not a blanket.
 
 ## Licensing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ To look at the page without a bridge, `python3 tools/preview_web.py` serves it o
 battery, one that never replied. That last one is what the diagnosis card is for, and the only
 way to see it on a desk.
 
-CI runs the same checks, plus both firmware builds.
+CI runs the same checks, plus a firmware build for each of the four environments
+(`waveshare-rs485-can`, `waveshare-relay-1ch`, `waveshare-relay-6ch`, `mock`).
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,26 @@ relay boards (see [Curtailment](#curtailment-turning-the-inverter-down)).
 ### It reads your inverter
 
 Heliograph speaks your inverter's native protocol over RS485, converts everything into one
-common set of measurements, and republishes that:
+common set of measurements, and republishes that.
+
+> **Four words that appear throughout this page.** You do not need to understand them to follow
+> the setup, but they stop being mysterious once someone says them plainly:
+>
+> - **RS485** — a two-wire electrical standard for sending data over a long cable, used by
+>   nearly every inverter's communication port. It is wiring, not software: two data wires and
+>   a ground, and several devices may share one pair.
+> - **Modbus RTU** — the most common *language* spoken over those wires. "RTU" here just means
+>   the serial-cable flavour. Not to be confused with **Modbus TCP**, which is the same language
+>   over your *network*, and is one of the things Heliograph offers to your own tooling. Your
+>   inverter side is RTU; the port-502 side is TCP. They are not the same wires.
+> - **Unit id** — the number that identifies one device on a shared RS485 cable, so that two
+>   inverters on one pair can be told apart. Most ship as 1; some vendors ship something else,
+>   and the table below says so where it matters.
+> - **MPPT** — *maximum power point tracker*: one of the inverter's independent solar inputs.
+>   An inverter with two MPPTs has two strings of panels it optimises separately, which is why
+>   readings come per tracker.
+
+Where it puts the data:
 
 | Integration | How |
 |---|---|
@@ -285,8 +304,28 @@ first, **swapping A and B is the single most common fix** — it cannot damage a
 Open the dashboard and run the wizard on the *Discovery* tab. It tries the supported
 protocols and proposes a driver. It identifies the **protocol**, not the model — so a driver
 that ships several register maps still needs the map chosen, and the wizard's confirm step
-asks for it. If nothing answers, turn the log level up to `trace` under *Settings* and watch
-the *Logs* tab — it shows exactly what is being sent and whether anything comes back.
+asks for it.
+
+The wizard offers two modes. **Quick** tries each driver at its own default address, which is
+what you want for one inverter. **Extended** additionally sweeps addresses 1–8, which is slower
+and is how you check that the addresses you assigned to several inverters actually took.
+
+**If nothing answers**, work down this list — the first two fix most cases:
+
+1. **Swap A and B.** It cannot damage anything, and reversed data wires are the single most
+   common cause of complete silence.
+2. **Check the ground wire is connected.** Without a shared reference the bus can stay silent
+   however the data wires are arranged.
+3. **Unplug the manufacturer's dongle** if one is on that port. Two masters on one bus corrupt
+   each other's messages, and the dongle will not yield.
+4. **Try the other baud rate.** Most inverters ship at 9600; some at 115200. Discovery tries
+   both, but a device configured to something else answers neither.
+5. **Check the unit id.** Most vendors ship 1 — GoodWe ships this family at **247**, and a
+   wrong address looks exactly like a wiring fault. Extended discovery finds it for you.
+6. **Then turn the log level up to `trace`** under *Settings* and watch the *Logs* tab. It
+   shows exactly what is being sent and whether anything comes back, which separates "my wiring
+   is wrong" from "it replied and we could not read it" — a distinction worth having before you
+   open an issue.
 
 <p align="center">
   <img src="docs/images/discovery.png" width="480" alt="The Discovery wizard stepping through interface, mode, probing, candidates, confirm, test poll and save">

--- a/README.md
+++ b/README.md
@@ -120,11 +120,21 @@ picture:
 | SolaX X1 series (X1 Mini G1/G2/G3) | RS485 | **Experimental** — the first attempt on real hardware (an X1-Mini-G1) returned no data at all. Read [docs/solax-x1-protocol.md](docs/solax-x1-protocol.md) before you buy or wire anything |
 | Any inverter implementing **SunSpec** | Modbus RTU over RS485 | **Experimental** — one generic driver for the published standard, so no per-vendor file is needed. Not yet confirmed against any physical device; see [docs/sunspec.md](docs/sunspec.md) for which vendors are worth trying |
 
-What the labels mean:
+What the labels mean, weakest first:
 
-- **Beta** — works, in daily use, still collecting evidence before being called Stable.
 - **Experimental** — the protocol has been implemented from documentation, but nobody has
   confirmed it against that inverter yet. It may simply not work. You would be the first.
+- **Beta** — confirmed against a real inverter, running, still collecting evidence before
+  being called Stable. Nothing sits here today.
+- **Stable** — validated and soak-tested on real hardware over a long enough run to trust it
+  unattended. One driver has reached this.
+
+The same three words apply to the **register map** you pick, separately from the driver that
+reads it. One driver serves every Modbus inverter here, so its label can only ever describe the
+least-proven map in the build — the map's own status is shown next to it when you choose one,
+and in [the coverage matrix](docs/drivers/coverage.md). **Every Modbus map here is
+Experimental**, including those for inverters this project has running: what has been proven
+there is the plumbing, not the register table.
 
 Two more things to check on your own inverter:
 

--- a/docs/adding-a-device.md
+++ b/docs/adding-a-device.md
@@ -183,6 +183,13 @@ exactly like an inverter that does not report it.
 
 ## 4. Testing against the real device
 
+> **You need a build environment for this step, and only for this step.** A profile is compiled
+> into the firmware, so a *new* profile means building an image yourself — there is no released
+> binary containing a map that does not exist yet. If you have never used PlatformIO:
+> `pip install platformio` is the whole installation, and `pio run -e <your board env>` is the
+> whole build. Nothing else on your machine is touched. Reading and writing the TOML needs none
+> of this; it is the testing that does.
+
 1. Build and flash (`pio run -e waveshare-rs485-can`, or the env for your board — the image contains all
    drivers), or OTA-upload the `.bin` if a bridge is already installed.
 2. Select the driver and, if not the default, your profile in the bridge web UI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -633,7 +633,7 @@ Elaborated in `docs/security.md`. Core:
 
 | Topic | MVP |
 |---|---|
-| Global read-only mode | **On** by default; opt-out in *Settings → Security*, which unlocks the relay/DRM outputs (no driver can write to an inverter) |
+| Global read-only mode | **On** by default; opt-out in *Settings → Security*, which unlocks the relay/DRM outputs **and the inverter write path** — two drivers implement one, see docs/security.md |
 | Modbus writing | Off; FC6/16 → exception 0x01 |
 | Raw TCP bridge | Off (not implemented) |
 | REST GET | Unsecured (local network) |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -35,11 +35,20 @@ but for `framework = arduino` it still ships **Arduino core 2.0.17 on ESP-IDF 4.
 Anyone writing `platform = espressif32` silently gets an outdated toolchain without
 core 3.x.
 
-Required in `platformio.ini`:
+Required in `platformio.ini` — **pinned to a version, not to `stable`**:
 
 ```ini
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 ```
+
+> This block used to end in `/stable/`, and that is a trap worth naming rather than quietly
+> editing away. `stable` moves. On 2026-07-31 it was found to have moved without anyone
+> noticing: a developer machine was still on 55.3.39 (Arduino core 3.3.9) while CI had been on
+> 55.03.311 (core 3.3.11) since 2026-07-24 — so release v0.25.0 shipped from a toolchain nobody
+> had booted, and no commit recorded the change because from the repository's side nothing had
+> changed. Anyone following this file verbatim would reintroduce exactly that. The pin is a
+> deliberate edit now; see the comment in `platformio.ini` and the monthly dependency check,
+> which grew a source specifically to watch it.
 
 pioarduino (`55.03.39`, 2026-06-04 = Arduino 3.3.9 / IDF 5.5.4, last push 2026-07-13,
 Apache-2.0) is de facto the maintained route to core 3.x. This is precisely the legacy risk

--- a/docs/drm.md
+++ b/docs/drm.md
@@ -1,8 +1,11 @@
 # DRM curtailment — relays as demand-response contacts
 
-Status: **software complete, not yet validated on relay hardware.** Nothing in this
-document has touched a real inverter DRM port yet; the relay polarity check and the first
-wired test are pending the physical Relay-6CH board.
+Status: **relay hardware validated; the inverter side is not.** Both relay boards exist and
+have been measured — the 6CH's six relays for order, polarity and failsafe-on-power-cut on
+2026-07-23, the 1CH's single relay for switching and LED response on 2026-07-28 (see
+[docs/hardware.md](hardware.md)). What has **not** happened is the part that matters most:
+nothing in this document has been wired to a real inverter's DRM port. Treat the relay side as
+proven and the inverter side as entirely untried.
 
 ## What this is
 

--- a/docs/eversolar-protocol.md
+++ b/docs/eversolar-protocol.md
@@ -1,7 +1,9 @@
 # EverSolar / Zeversolar legacy RS485 protocol
 
-Status: reconstructed from the reference implementation; **since 2026-07-19 partially verified
-against a real TL3000-20** (Phase 3, first contact). Hardware findings are marked as such;
+Status: **Stable** since 2026-07-29 — the only driver in this project at that level. Reconstructed
+from the reference implementation, verified against a real TL3000-20 from 2026-07-19, and promoted
+after eight consecutive unassisted sunrises: the one bug this protocol carried appeared only at the
+night-to-morning transition, so a reboot hid it and no bench test could ever close it. Hardware findings are marked as such;
 two captured frames are stored byte-for-byte in `tools/gen_fixtures.py`, which
 verifies itself against the captures. Where something is unknown, that is stated explicitly — no
 fields have been invented.

--- a/docs/goodwe-et-protocol.md
+++ b/docs/goodwe-et-protocol.md
@@ -113,7 +113,8 @@ The older `sph` profile maps it too, at register 1009, with a comment recording 
 unconfirmed — noted here so this table is not read as saying no other profile has the channel.
 
 **House consumption.** The source computes it from several registers rather than reading one, and
-a profile does no arithmetic. There is also no canonical id for a load channel yet.
+a profile does no arithmetic. `load.power` exists in the vocabulary now, so the id is no longer
+the obstacle — the arithmetic is, and that stays out of a data file.
 
 ## Writing: nothing, deliberately
 

--- a/docs/growatt-sph-protocol.md
+++ b/docs/growatt-sph-protocol.md
@@ -29,7 +29,7 @@ checked against the inverter display — this is the single most likely thing to
 | Quantity | Register(s) | Canonical id | Scale (assumed) | Confidence |
 |---|---|---|---|---|
 | PV total power | 116–117 | `dc.power.total` | ×0.1 W | medium |
-| AC / grid power | 40–41 | `ac.power.total` | ×0.1 W | low (sign/meaning unclear) |
+| AC / grid power | **35–36** | `ac.power.total` | ×0.1 W | address high, sign unverified |
 | Battery power | 1009–1010 | `battery.power` | ×0.1 W | medium — labelled "discharge power"; sign convention TBD |
 | Battery SoC | 1014 | `battery.soc` | ×1 % | high |
 | Battery voltage | 1013 | `battery.voltage` | ×0.1 V | medium |

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -300,9 +300,11 @@ buzzer confirms the wipe; the RS485-CAN has neither, so there the reboot is the 
 ## Open / to be verified on hardware
 
 1. **BOOT factory reset on the RS485-CAN and the 1CH** — see the table above.
-2. **Relay actuation on the Relay-1CH** — the board has been powered and flashed, but its single
-   relay (GPIO47) has not been switched and measured. The 6CH's six were verified on 2026-07-23
-   (order, polarity, failsafe on power-cut).
+2. **Relay polarity on the Relay-1CH, with a meter.** The relay itself was switched on 2026-07-28
+   and the indicator LED followed in both directions, so actuation is confirmed — see the pin
+   table above. What has not been done is putting a multimeter on the contacts to confirm which
+   way NO/NC sit, which is the check that matters before wiring it to a DRM port. The 6CH's six
+   were fully verified on 2026-07-23 (order, polarity, failsafe on power-cut).
 3. **GPIO47 on the RS485-CAN** — no documented function there. The firmware does not touch it;
    the safest state for a pin with no known function is untouched hi-Z. It is the relay pin on
    the 1CH, which is why it appears twice in this project's history.

--- a/docs/modbus-register-map.md
+++ b/docs/modbus-register-map.md
@@ -440,8 +440,6 @@ consumer would treat it as current. Unknown is therefore the more honest answer 
 
 - Whether `energy.today` remains usable as `total_increasing` around midnight (reset to 0)
   depends on the inverter's behavior — to be determined in Phase 9.
-- The eModbus server wiring (`modbus_tcp_server.cpp`) has **not been compiled yet**; only the
-  register map has been tested.
 
 Registers 850-851 are **read-only observation** of the bridge relays (DRM contacts).
 Relay control never goes through Modbus: the unauthenticated Modbus surface only

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -102,19 +102,35 @@ inverter that's off at night doesn't make the bridge offline — that would make
 entities `unavailable` in Home Assistant and ruin the history. The inverter status lives in
 `state` as `inverter_online`.
 
-The `relay/<n>/set` topics (relay boards only) are the single subscription this firmware
-has. Commands pass the RelayController's gates — `security.read_only_mode` off AND
-`relays.enabled` on — and the acknowledged state follows on `relay/<n>/state`, so a
-refused command visibly snaps the Home Assistant switch back. There are **no command
-topics for the inverter.** The active driver has no write capabilities, so the
-bridge subscribes to nothing else. That is not a configuration choice but a consequence of
-`capabilities.write.none()`.
+The bridge subscribes to **three** things:
+
+| Topic | Gated by |
+|---|---|
+| `relay/<n>/set` (relay boards only) | `security.read_only_mode` off **and** `relays.enabled` on |
+| `drm/set` (relay boards only) | the same two gates |
+| `<device>/command/set` | `security.read_only_mode` off, then the driver's own capability check |
+
+Relay commands pass the RelayController's gates, and the acknowledged state follows on
+`relay/<n>/state`, so a refused command visibly snaps the Home Assistant switch back.
+
+**This section used to say the relay topics were the only subscription, and that there were no
+command topics for the inverter because the active driver had no write capabilities.** Both
+stopped being true when the command queue landed: the subscription is unconditional wherever a
+handler is wired, which it always is. What is still true is that no shipped register map has a
+`verified` write row, so a command on that topic ends in `unsupported` rather than a register
+write — and `read_only_mode` refuses the whole path before a driver is reached. See
+[docs/security.md](security.md#what-can-reach-the-inverter) for which drivers can write and under
+what conditions; the honest summary is "gated", not "absent".
+
+The outcome of a submitted command is published on `<device>/command/result`.
 
 ## Publishing strategy
 
-- **Publish-on-change** with deadband, to avoid broker spam: power ≥ 5 W difference,
-  voltage ≥ 0.5 V, energy on every change, status on every change.
-- **Periodic forced refresh** every 60 s (configurable), even without a change.
+- **Publish-on-change** with deadband, to avoid broker spam: power ≥ 5 W, voltage ≥ 0.5 V,
+  current ≥ 0.1 A, frequency ≥ 0.02 Hz, temperature ≥ 0.2 °C; energy and status on every change.
+- **Periodic forced refresh** every 60 s, even without a change. Fixed, not configurable: it is
+  a compile-time constant in `publish_policy.h`, and nothing in the settings or the config file
+  changes it. (This line said "configurable" and there has never been a setting for it.)
 - `identity` and `capabilities` only on change or after (re)connection.
 - JSON document is bounded: `JsonDocument` with explicit capacity checking; exceeding it
   logs an error and does not publish — never a truncated JSON message.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -190,6 +190,7 @@ battery's.
 |---|---|
 | `heliograph_grid_import_power_watts` | W |
 | `heliograph_grid_export_power_watts` | W |
+| `heliograph_load_power_watts` | W, what the house is drawing |
 
 Which of these appear depends on the inverter: a driver only reports what its device actually
 provides, so a single-phase inverter has no three-phase series and an inverter without a

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -372,8 +372,8 @@ drops: 0 dBm would read as a perfect signal.
 
 ## Cardinality
 
-`heliograph_build_info` carries `version`, `driver` and `board` labels. That is the complete
-set — **the inverter's serial number is deliberately not a label**. Serial numbers are
+`heliograph_build_info` carries `device`, `version`, `driver` and `board` labels. That is the
+complete set — **the inverter's serial number is deliberately not a label**. Serial numbers are
 high-cardinality by definition, and putting one in a label would multiply every series by the
 number of devices a scraper has ever seen, which is how a small Prometheus turns into a large
 one. The serial is available over the REST API instead.
@@ -383,6 +383,9 @@ one. The serial is available over the REST API instead.
 An abbreviated real scrape from a production bridge. Note that this one is an RS485-CAN — a
 monitoring-only board — which is exactly why there are **no relay or DRM series in it**: on a
 board without relays those are omitted rather than reported as zeroes.
+
+> The example below predates the per-device `device="…"` label described above, which
+> every device-scoped series carries. Read it for the metric NAMES, not the exact lines.
 
 ```
 # HELP heliograph_build_info Firmware build information

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -17,7 +17,10 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 | GET | `/api/v1/devices/<id>/measurements` | — | All measurements |
 | GET | `/api/v1/devices/<id>/capabilities` | — | Capabilities |
 | GET | `/api/v1/diagnostics` | — | Diagnostics |
+| GET | `/api/v1/logs` | **✔** | The in-memory log ring. Admin-gated because log lines quote configuration |
 | GET | `/api/v1/drivers` | — | Registered drivers + descriptors |
+| GET | `/api/v1/discovery` | — | The last discovery report |
+| GET | `/api/v1/wifi/scan` | **✔** | Networks in range, for the settings page |
 | GET | `/api/v1/config` | — | Config **without secrets** |
 | PATCH | `/api/v1/config` | **✔** | Change config |
 | GET | `/api/v1/config/backup` | **✔** | Download the whole configuration as a file (`?secrets=true` to include passwords) |
@@ -29,8 +32,14 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 | POST | `/api/v1/actions/poll` | **✔** | Force an immediate poll |
 | POST | `/api/v1/actions/reboot` | **✔** | Reboot |
 | POST | `/api/v1/actions/clear-coredump` | **✔** | Discard a stored crash dump (404 when there is none) |
+| POST | `/api/v1/actions/factory-reset` | **✔** | Erase the stored configuration and return to first-boot setup |
+| POST | `/api/v1/devices/<id>/commands` | **✔** | Submit a setpoint for the write queue — see [Commands](#commands) |
+| GET | `/api/v1/devices/<id>/commands/<request_id>` | — | What happened to a submitted command |
+| POST | `/api/v1/relays/<n>` | **✔** | Switch one relay — relay boards only, see [docs/drm.md](drm.md) |
+| POST | `/api/v1/drm/set` | **✔** | Set the DRM curtailment mode — see [docs/drm.md](drm.md) |
 | POST | `/api/v1/ota` | **✔** | Firmware upload (`?board=` and `?sha256=` optional; both refuse a mismatch) |
 | GET | `/api/v1/events` | — | Server-Sent Events (live updates) |
+| POST | `/api/v1/provision` | — | First-boot setup: WiFi + admin password. Open only while no password exists yet — see [Auth](#auth) |
 | GET | `/metrics` | — | Prometheus |
 
 Each driver in `/api/v1/drivers` declares its own options, and the web UI renders them
@@ -70,8 +79,23 @@ save, including ones touching nothing driver-related.
 must be able to show the available drivers and their support level without hardcoding
 them in the frontend.
 
-There are **no control endpoints** (`/actions/set-power-limit` etc.). Those only appear
-once a driver has write capabilities.
+## Commands
+
+`POST /api/v1/devices/<id>/commands` submits one setpoint. It **accepts for a queue** rather than
+performing anything: the RS485 task owns the bus and runs the transaction on its next cycle, so
+the reply is `202` with a `request_id`, and `GET /api/v1/devices/<id>/commands/<request_id>` says
+what became of it.
+
+**Nothing currently ends in a device being written to**, and the endpoint says so rather than
+pretending. Every shipping driver answers `Unsupported`, and both halves return
+`404 no_command_path` while no write path is wired at all. The layers below are real —
+[write-path.md](device-profiles/write-path.md) describes what a profile must declare before a
+register is ever written, and `security.read_only_mode` refuses the whole path regardless.
+
+This section previously read "there are **no control endpoints**". That stopped being true when
+the queue and its entry points landed; the endpoints exist, they are admin-gated, and they
+decline for reasons a caller can act on. Which is a different thing from not existing, and worth
+knowing if you are building against this API.
 
 ## `GET /api/v1/status`
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -196,7 +196,7 @@ Uniform, for every error:
 | 404 | Unknown device or path |
 | 409 | Discovery already in progress; RS485 bus busy |
 | 413 | Body > 4 KB (8 KB on `/config/restore`, which carries a whole configuration) |
-| 429 | Rate limit (1 req/s on `/actions/*`) |
+| 429 | Rate limit — 1 req/s, shared across **every** write-ish route: `/actions/*`, `POST /devices/<id>/commands`, `POST /relays/<n>` and `POST /drm/set`. One limiter, not one per path |
 | 503 | No valid data yet (cold start) |
 
 Never an HTTP 200 with an error message in the body.
@@ -649,6 +649,9 @@ If SSE goes away, the web interface polls `/api/v1/status` every 5 s — SSE is 
 optimization, not a dependency.
 
 ## Prometheus
+
+> The example below predates the per-device `device="…"` label that every series now
+> carries; see [prometheus.md](prometheus.md) for the current shape.
 
 ```
 # HELP heliograph_inverter_ac_power_watts Current AC output power

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,7 +7,7 @@ the same LAN", not "someone holding the PCB in their hands".
 
 | Topic | Status |
 |---|---|
-| Global read-only mode | On by default; a deliberate opt-out in *Settings → Security*. While on, every inverter command and every relay move is refused. Turning it off unlocks the relay/DRM contacts — no driver in this build can write to an inverter, so nothing reaches the inverter either way |
+| Global read-only mode | On by default; a deliberate opt-out in *Settings → Security*. While on, every inverter command and every relay move is refused. **This is the protection that actually holds** — see [What can reach the inverter](#what-can-reach-the-inverter) below, because it is not true that no driver is capable of writing |
 | Modbus writes | Off; FC6/FC16 → exception 0x01. `write_enabled=true` is rejected by config validation |
 | Raw TCP bridge | Not implemented |
 | REST GET | Unsecured (local network) |
@@ -20,6 +20,28 @@ the same LAN", not "someone holding the PCB in their hands".
 | Request size | 4096 bytes, rejected with 413 |
 | String lengths | Bounded in `validate()`; SSID 32 and PSK 64 are the 802.11/WPA2 limits |
 | Hardcoded credentials | None. Verified by scanning the firmware image for strings |
+
+## What can reach the inverter
+
+This section exists because the sentence it replaces was wrong, and wrong in the direction that
+matters here: it said no driver in this build can write to an inverter. Two of the four can.
+
+| Driver | Can it write? |
+|---|---|
+| `eversolar_legacy` | No. `supportsWrite = false`, and the protocol defines no writes at all |
+| `solax_x1` | No. `supportsWrite = false` |
+| `modbus_profile` | **Declares it and implements it** — `execute()` writes one holding register over FC06 and verifies the device's echo. But every `[[write]]` row in every shipped profile is `verified = false`, and the driver refuses an unverified row, so **no profile writes today** |
+| `sunspec` | **Declares it and implements it, and its gate is a device property rather than a review flag.** `execute()` writes the power-limit registers and the connect/disconnect register. It requires that the inverter published SunSpec model 123 and that the block was read. Attach a SunSpec inverter that implements model 123, turn read-only mode off, send the command, and it will write |
+
+**So what actually protects the inverter with the shipped configuration is
+`security.read_only_mode`, which is `true` by default and refuses every command before a driver
+is reached.** Not an absence of capability. If you are relying on this bridge being unable to
+act on your inverter — for a rented installation, a warranty condition, or a site where you are
+not the only one with LAN access — rely on that flag, keep it on, and note that it is reachable
+by anyone who has the admin password.
+
+The relay/DRM outputs are governed by the same flag plus their own `relays.enabled`, and are
+covered in [docs/drm.md](drm.md).
 
 ## Known limitations — explicit
 
@@ -179,7 +201,7 @@ admin password strong and the network trusted.
 
 | Can | Cannot |
 |---|---|
-| Read all measurements (REST, Modbus, Prometheus) | Control the inverter — no driver can write |
+| Read all measurements (REST, Modbus, Prometheus) | Control the inverter — refused while read-only mode is on, which is the default |
 | Read the configuration **without secrets** | Read passwords via the API |
 | DoS the device with traffic | Disrupt the RS485 polling (separate core, separate task) |
 | — | Change settings, OTA, or reboot without the admin password |

--- a/docs/solis-rhi-protocol.md
+++ b/docs/solis-rhi-protocol.md
@@ -99,11 +99,13 @@ difference, so neither reading is mapped and `grid.import_power`/`grid.export_po
 The cumulative import/export *energy* registers (33169/33173) do agree — but our canonical grid
 channels are instantaneous power.
 
-### House load — blocked on the vocabulary, not the register
+### House load — mapped since `load.power` was added
 
-Both sources carry house load (33147) and backup load (33148) and agree on both. There is no
-canonical id for a load channel yet, so mapping them needs a
-[vocabulary addition](device-profiles/canonical-measurements.md) first.
+Both sources carry house load (33147) and backup load (33148) and agree on both. House load is
+**mapped** as `load.power`, which joined the
+[vocabulary](device-profiles/canonical-measurements.md) on 2026-07-30; this section said it was
+blocked on that id until the id existed. Backup load stays unmapped — it is a different quantity
+(what the backup port carries, not what the house draws) and has no canonical id.
 
 ### Strings 3 and 4
 

--- a/docs/sungrow-sh-protocol.md
+++ b/docs/sungrow-sh-protocol.md
@@ -147,9 +147,9 @@ read the register the manufacturer points you at.
 
 ## Not mapped
 
-- **Load power (13008) and export power (13010).** Both sources agree on both. There is still no
-  canonical id for a house-load channel, so this is blocked on the
-  [vocabulary](device-profiles/canonical-measurements.md), not on the register. Export power is
+- **Export power (13010).** Both sources agree. (Load power was in this list until `load.power`
+  joined the [vocabulary](device-profiles/canonical-measurements.md); PDU 13007 is mapped now and
+  appears in the table above.) Export power is
   signed and bidirectional; our grid channels are two unsigned rails, so splitting it needs
   arithmetic a profile cannot do.
 - **Imported/exported energy (13036/13037, 13045/13046).** Agreed, but our `grid.*` channels are

--- a/platformio.ini
+++ b/platformio.ini
@@ -138,10 +138,16 @@ lib_deps =
 ; to 55.03.39 would have made the NEXT release differ from the last one in the other direction,
 ; with no more evidence behind it.
 ;
-; VERIFIED: 55.3.39 (core 3.3.9 / IDF 5.5.4) built clean and ran on hardware, 2026-07-16.
-; 55.03.311 (core 3.3.11 / IDF 5.5.5) is CI-green on all four board environments and is what
-; v0.25.0 shipped, but has NOT been booted on a board by this project. The next bench session
-; is what makes "verified" true again for the version actually in the field.
+; VERIFIED ON HARDWARE: 55.03.311 (core 3.3.11 / IDF 5.5.5) boots and runs on the RS485-CAN,
+; 2026-07-31 — v0.25.1 flashed over OTA onto the production bridge. First 76 minutes: 448 polls
+; against a live EverSolar with one failure, poll duration ewma 102 ms and max 108 ms, no
+; coredump, no MQTT publish failures, 8.38 MB PSRAM free (so qio_opi is right for this module).
+; RS485 timing is the thing a toolchain change could plausibly have disturbed, and it did not.
+;
+; What that does NOT yet show: a full day, a sunrise, or a long uptime. The previous release ran
+; 15.3 hours before this one replaced it. Treat 3.3.11 as booted and behaving, not as soaked.
+;
+; Earlier: 55.3.39 (core 3.3.9 / IDF 5.5.4) built clean and ran on hardware, 2026-07-16.
 ; ---------------------------------------------------------------------------------------
 [esp32common]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip


### PR DESCRIPTION
Ten commits, one per theme. All prose — no code, no behaviour change. Every finding was verified against the implementation before a word was edited; several agent-reported findings were rejected as wrong and are listed at the bottom.

## The one to read first

`docs/security.md` told a reader twice, and `architecture.md` once, that **no driver can write to an inverter**. Two of the four can.

| Driver | Reality |
|---|---|
| `modbus_profile` | writes one holding register over FC06, but refuses any `[[write]]` row that is not `verified` — and no shipped profile sets it. A review flag, and it holds. |
| `sunspec` | writes the power-limit and connect/disconnect registers. Its gate is that the **inverter** published SunSpec model 123 — a device property, not a flag anyone here clears. |

So what protects an inverter in the shipped configuration is `security.read_only_mode`, `true` by default and enforced before a driver is reached — **not an absence of capability**. A security document saying "cannot" where the truth is "will not unless you turn it off" invites someone to rely on the wrong thing: a rented installation, a warranty condition, a site where they are not the only one with the admin password.

`docs/mqtt.md` carried the same denial in the same words ("no command topics for the inverter"), and `rest-api.md` a third version ("there are no control endpoints"). All three are corrected, and each says that it used to claim otherwise — because people who read those pages last month believe them.

## The rest

- **Two protocol docs described a state their own profile left yesterday.** Solis and Sungrow said house load was "blocked on the vocabulary"; both profiles map `load.power`. Same root cause as the missing Prometheus row: the id was added and wired everywhere, and the prose explaining why it could not be was left behind.
- **The SPH doc pointed AC power at registers 40–41** after the profile moved to 35–36 (40–41 is VA, not watts).
- **`hardware.md` contradicted itself** about whether the Relay-1CH had been measured. Resolved toward the measurement, with the genuinely open part sharpened: relay actuates and LED follows, but nobody has put a meter on the contacts to confirm NO/NC — the check that matters before a DRM port.
- **`decisions.md` still prescribed the `stable` platform URL.** Following it verbatim reintroduces exactly the drift fixed in #159.
- **Counts:** CI builds four environments, not "both"; the tree has 928 tests, not "390+".
- **For non-experts:** RS485, Modbus RTU vs TCP, unit id and MPPT are now explained where first used — none ever was, and MPPT appeared nowhere in the repo spelled out. Discovery has a failure checklist in the step where people get stuck (it existed, in a contributor doc they never open). `adding-a-device.md` now says you need a build environment and that `pip install platformio` is the whole of it.

## Rejected

Not everything reported survived checking. A claimed MPPT array overrun between two translation units was false (independent local arrays, six `static_assert`s). `BOARD_HAS_PSRAM` as dead code was false and dangerous (the Arduino core consumes it). And my own auth-extraction heuristic got two existing rows wrong in opposite directions before I read each handler individually — no Auth value that was already documented has been changed.

## Verified clean

119 internal links, every documented `pio` env and `tools/` path, the getting-started numbers (BOOT 5 s, 8 devices, sweep 1–8), and six of twelve protocol documents consistent with their profile register-for-register — Deye, Huawei, GoodWe, MIC/MIN, SunSpec, rs485-bus.