### PR TITLE
The reading guide linked to a file that is not in the repository

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,6 @@ them as guidance — a "next step" in one of them may have happened months ago.
 |---|---|
 | [audit-2026-07-29.md](audit-2026-07-29.md) | Resource and efficiency audit: tasks, memory, timing, build variants. |
 | [esp32s3-hardware-audit.md](esp32s3-hardware-audit.md) | Hardware audit against v0.13.2, 2026-07-26. |
-| [implementation-plan.md](implementation-plan.md) | The phase log the project was built from. Dutch. |
 | [solar-assistant-source.md](solar-assistant-source.md) | Notes on a comparable product's MQTT structure. |
 
 ---

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -227,6 +227,53 @@ else
     echo "OK"
 fi
 
+echo "==> 9. Every documentation link points at something the public can actually open"
+# A link check that only asks "does this file exist" passes on the author's machine and fails
+# for everyone else: an ignored file is present locally and absent from the clone. That is
+# exactly how docs/README.md shipped a link to docs/implementation-plan.md, which .gitignore
+# keeps out of the repo on purpose (it is a personal tracker). Ask git, not the filesystem.
+#
+# Directories are checked by whether they CONTAIN a tracked file -- git tracks files, not
+# directories, so `git ls-files <dir>` returning anything means the link resolves on GitHub.
+# The first version of this check reported .vscode/ as broken for that reason.
+if link_report=$(python3 - <<'PYEOF'
+import pathlib, re, subprocess, sys
+
+tracked = set(subprocess.run(["git", "ls-files"], capture_output=True, text=True).stdout.split())
+tracked_dirs = {str(pathlib.PurePosixPath(t).parent) for t in tracked}
+root = pathlib.Path(".").resolve()
+bad = []
+
+for doc in sorted(pathlib.Path(".").rglob("*.md")):
+    if ".git" in doc.parts or ".pio" in doc.parts:
+        continue
+    if str(doc) not in tracked:
+        continue  # only published documents can mislead a reader
+    text = doc.read_text(encoding="utf-8")
+    for m in re.finditer(r"\[([^\]]*)\]\(([^)#]+)(#[^)]*)?\)", text):
+        target = m.group(2)
+        if target.startswith(("http://", "https://", "mailto:")):
+            continue
+        try:
+            rel = str((doc.parent / target).resolve().relative_to(root))
+        except ValueError:
+            continue  # outside the repo; not ours to judge
+        if rel in tracked or rel in tracked_dirs:
+            continue
+        bad.append(f"{doc}:{text[: m.start()].count(chr(10)) + 1} -> {target}")
+
+if bad:
+    print("\n".join(bad))
+    sys.exit(1)
+PYEOF
+    ); then
+    echo "OK"
+else
+    echo "FAIL: documentation links to files that are not in the repository:"
+    echo "$link_report"
+    status=1
+fi
+
 echo
 if [ $status -eq 0 ]; then
     echo "RESULT: PASS"


### PR DESCRIPTION
`docs/README.md` listed `docs/implementation-plan.md` among the historical records and linked to it. That file is gitignored on purpose — *"Internal phase tracker (personal planning, test evidence)"* — so it is on one machine and in nobody's clone. The page whose whole job is telling readers where to go handed every visitor a 404.

**The verification that missed it was mine.** I checked whether the target *existed*; on the machine that wrote the guide, it does. A published link must be checked against what git publishes, and the two differ by exactly the set of files someone deliberately kept private.

The row is removed rather than the file published — keeping it out predates this and is not mine to reverse.

**Layering rule 9** now asks git instead of the disk, across every tracked `.md`. Directories pass when they contain a tracked file, since git tracks files and not directories: the first version of this check called `.vscode/` broken when `.vscode/extensions.json` is tracked and the link resolves fine.

Mutation-proved both ways — restoring the link fails the gate, and so does a link to a file that exists nowhere. 159 links across the tree pass.