### PR TITLE
Two days on Arduino core 3.3.11: verified on this board, and what is still open

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -144,8 +144,18 @@ lib_deps =
 ; coredump, no MQTT publish failures, 8.38 MB PSRAM free (so qio_opi is right for this module).
 ; RS485 timing is the thing a toolchain change could plausibly have disturbed, and it did not.
 ;
-; What that does NOT yet show: a full day, a sunrise, or a long uptime. The previous release ran
-; 15.3 hours before this one replaced it. Treat 3.3.11 as booted and behaving, not as soaked.
+; RE-CHECKED 2026-08-01 at 30.8 h uptime: boot_count still 4 (no reboot since the OTA), no
+; coredump. Cumulative since that boot: 8028 polls / 485 failures (953 of them RS485 timeouts) --
+; the failure share rose from day one's 0.22% to ~5.7%, but that is the inverter going dark
+; overnight and not answering Modbus, not a regression; by day consecutive_poll_failures is back
+; to 0 and it polls successfully every few seconds. Poll duration ewma 103 ms / max 111 ms (was
+; 102 / 108) -- essentially flat. free_heap_bytes rose to 148080 (was 132896) and psram_free_bytes
+; is unchanged at 8378140, so no leak trend yet. The EverSolar also came back online after the
+; night on its own and resumed publishing real ac.power.total / energy.today, so the driver's
+; sunrise-recovery path is unaffected by this toolchain too.
+;
+; What that still does NOT show: this is one night and one sunrise, not a soak across weeks or
+; seasons. Treat 3.3.11 as booted, behaving, and surviving a day -- not as fully soaked.
 ;
 ; Earlier: 55.3.39 (core 3.3.9 / IDF 5.5.4) built clean and ran on hardware, 2026-07-16.
 ; ---------------------------------------------------------------------------------------

--- a/platformio.ini
+++ b/platformio.ini
@@ -144,15 +144,31 @@ lib_deps =
 ; coredump, no MQTT publish failures, 8.38 MB PSRAM free (so qio_opi is right for this module).
 ; RS485 timing is the thing a toolchain change could plausibly have disturbed, and it did not.
 ;
-; RE-CHECKED 2026-08-01 at 30.8 h uptime: boot_count still 4 (no reboot since the OTA), no
-; coredump. Cumulative since that boot: 8028 polls / 485 failures (953 of them RS485 timeouts) --
-; the failure share rose from day one's 0.22% to ~5.7%, but that is the inverter going dark
-; overnight and not answering Modbus, not a regression; by day consecutive_poll_failures is back
-; to 0 and it polls successfully every few seconds. Poll duration ewma 103 ms / max 111 ms (was
-; 102 / 108) -- essentially flat. free_heap_bytes rose to 148080 (was 132896) and psram_free_bytes
-; is unchanged at 8378140, so no leak trend yet. The EverSolar also came back online after the
-; night on its own and resumed publishing real ac.power.total / energy.today, so the driver's
-; sunrise-recovery path is unaffected by this toolchain too.
+; RE-CHECKED 2026-08-01 at 30.8 h and again 2026-08-02 at 46.6 h: boot_count still 4 -- no reboot
+; since the OTA -- and no coredump either time. Poll duration ewma 103 ms, max 111 ms, min 97 ms
+; (day one: 102 / 108); free heap 148324 and PSRAM free unchanged at 8378140, so no leak trend.
+; The EverSolar came back on its own after each night and resumed publishing real
+; ac.power.total / energy.today, so the driver's sunrise-recovery path is unaffected by this
+; toolchain. RS485 timing is the thing a compiler change could have disturbed, and across two
+; days it has not moved.
+;
+; ON THE FAILURE COUNT, because the raw numbers mislead. At 46.6 h: 10775 successful polls, 967
+; failed, 1898 rs485_timeout_total, and zero checksum errors and zero invalid frames.
+;
+; The timeouts are NOT a subset of the failed polls -- 1898 is nearly twice 967, and they count
+; different things. poll_failure_total counts POLLS; rs485_timeout_total accumulates the driver's
+; own bus-error counter (device_context.cpp records the delta of driver_.busErrors().timeouts),
+; which counts individual RS485 TRANSACTIONS, and one poll costs more than one. The ratio held at
+; both samples (953/485 and 1898/967, both ~1.96). An earlier version of this note read "967
+; failures (1898 of them timeouts)", which cannot be true of a subset.
+;
+; The cumulative failure share climbs with every night -- 0.22% after the first 76 daylight
+; minutes, 5.7% at 30.8 h, 8.2% at 46.6 h -- because the inverter is dark and does not answer.
+; That is the expected shape, not a regression: checksum errors and invalid frames are both still
+; zero, consecutive_poll_failures is 0 by day, and it polls successfully every few seconds. What
+; this does NOT establish is that the overnight pattern is exactly the expected one; the bridge
+; exposes cumulative counters, not a per-hour breakdown, so that remains inferred rather than
+; measured.
 ;
 ; What that still does NOT show: this is one night and one sunrise, not a soak across weeks or
 ; seasons. Treat 3.3.11 as booted, behaving, and surviving a day -- not as fully soaked.

--- a/platformio.ini
+++ b/platformio.ini
@@ -170,8 +170,20 @@ lib_deps =
 ; exposes cumulative counters, not a per-hour breakdown, so that remains inferred rather than
 ; measured.
 ;
-; What that still does NOT show: this is one night and one sunrise, not a soak across weeks or
-; seasons. Treat 3.3.11 as booted, behaving, and surviving a day -- not as fully soaked.
+; VERDICT: the toolchain question is answered for this board. Two days, two nights, two unassisted
+; sunrises, timing that has not moved. That is strictly more evidence than 55.3.39 ever had -- its
+; own line below says "built clean and ran on hardware", one day, and it was called verified. It
+; would be inconsistent to hold the replacement to a higher bar than the thing it replaced.
+;
+; (The eight-sunrise gate belongs to the EVERSOLAR DRIVER, not to a toolchain. That bug lived at
+; the night-to-morning transition, so only sunrises could close it; it was met on 2026-07-29,
+; before this pin existed. Do not import that number here -- different question, different risk.)
+;
+; WHAT IS STILL OPEN IS NOT TIME, IT IS BOARDS. 3.3.11 has run on the RS485-CAN only. CI compiles
+; all four environments, but nobody has booted it on the Relay-1CH or the Relay-6CH. The 6CH is
+; the one to check: it is a different module with a different memory configuration (qio_qspi, N8,
+; no PSRAM, against this board's qio_opi with 8 MB), and memory configuration is exactly where a
+; compiler and RTOS change can interact. Waiting longer will never close that; flashing one will.
 ;
 ; Earlier: 55.3.39 (core 3.3.9 / IDF 5.5.4) built clean and ran on hardware, 2026-07-16.
 ; ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Documentation only — one file, `platformio.ini`. Three commits: the scheduled day-one check, a correction to its arithmetic, and the verdict.

## The measurement

Read from the production bridge, not reported by feel. Baseline is the 76 minutes recorded when v0.25.1 was flashed.

| | 76 min | 30.8 h | 46.6 h |
|---|---|---|---|
| `boot_count` | 4 | 4 | **4** — no reboot at any point |
| coredump | none | none | none |
| poll duration ewma / max | 102 / 108 ms | 103 / 111 ms | **103 / 111 ms** |
| free heap | 132896 | 148080 | 148324 — up, no leak |
| PSRAM free | 8378140 | 8378140 | unchanged |
| checksum errors / invalid frames | — | — | **0 / 0** |

RS485 timing is the one thing a compiler and RTOS change could plausibly have disturbed. Across two days it has not moved.

## A correction

The scheduled run wrote *"485 failures (953 of them RS485 timeouts)"*. 953 cannot be a subset of 485, and the same shape appears today: 967 failed polls against 1898 timeouts.

They count different things. `poll_failure_total` counts **polls**; `rs485_timeout_total` accumulates the driver's own bus-error counter (`device_context.cpp` records the delta of `driver_.busErrors().timeouts`) and counts individual **RS485 transactions**, of which one poll costs more than one. The ratio is ~1.96 at both samples — which is why the numbers looked plausible written the wrong way round.

## The verdict, and why it changed

The note hedged this as *"not fully soaked"*. The version it replaces, 55.3.39, is recorded in the same file as *"built clean and ran on hardware"* after one day — and was called **VERIFIED**. Holding the replacement to a stricter bar than the thing it replaced is inconsistency, not caution.

It had also borrowed a number that belongs elsewhere: the **eight-sunrise gate is the EverSolar driver's**, for a bug that lived at the night-to-morning transition, met on 2026-07-29 before this pin existed. A toolchain is a different question. The file now says so, so the figure does not get imported again.

## What is still open — and it is not time

**3.3.11 has run on the RS485-CAN and nowhere else.** CI compiles all four environments; neither relay board has booted it. The **Relay-6CH** is the one to check: a different module with a different memory configuration (`qio_qspi`, N8, no PSRAM, against `qio_opi` with 8 MB here), and memory configuration is exactly where a compiler and RTOS change can interact.

Waiting longer will never close that. Flashing one will.