### PR TITLE
The platform version was written in a form that matches no release tag

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,13 +33,18 @@ The hard rule: **brand-specific knowledge exists exclusively in `src/drivers/<dr
 No output module knows the word "EverSolar", except in one place: the string in
 `DeviceIdentity::manufacturer`, which comes from the driver and is passed through as data.
 
-This is mechanically enforceable and is checked by `tools/check_layering.sh`:
+This is mechanically enforceable, and `tools/check_layering.sh` is what enforces it — rules 1
+and 2:
 
 ```
 1. Brand names do not appear outside src/drivers/  — not even in comments
 2. The host-testable core does not include any Arduino/ESP-IDF headers
-3. The fixtures are in sync with their generator
 ```
+
+The script has since grown past those two, one rule per class of mistake that reached the tree
+unnoticed. **Run it for the list**; it prints every rule by name. This page deliberately does not
+repeat them, because a copy of a list is a copy that goes stale — this block itself stopped at
+three while the script was at nine.
 
 **This check must be run in full.** Its last line is `RESULT: PASS` or
 `RESULT: FAIL`. Earlier versions ended with the "OK" of the final sub-check, so that

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -43,7 +43,7 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 
 > This block used to end in `/stable/`, and that is a trap worth naming rather than quietly
 > editing away. `stable` moves. On 2026-07-31 it was found to have moved without anyone
-> noticing: a developer machine was still on 55.3.39 (Arduino core 3.3.9) while CI had been on
+> noticing: a developer machine was still on 55.03.39 (Arduino core 3.3.9) while CI had been on
 > 55.03.311 (core 3.3.11) since 2026-07-24 — so release v0.25.0 shipped from a toolchain nobody
 > had booted, and no commit recorded the change because from the repository's side nothing had
 > changed. Anyone following this file verbatim would reintroduce exactly that. The pin is a
@@ -129,7 +129,7 @@ ESP32 environments compile and link cleanly.
 
 | What | Outcome |
 |---|---|
-| pioarduino | `espressif32@55.3.39` → Arduino core **3.3.9** on **ESP-IDF 5.5.4** ✔ as researched |
+| pioarduino | `espressif32@55.03.39` → Arduino core **3.3.9** on **ESP-IDF 5.5.4** ✔ as researched |
 | Toolchain | `xtensa-esp-elf@14.2.0` |
 | Board/PSRAM | `esp32-s3-devkitc-1` + `qio_opi` + `BOARD_HAS_PSRAM` ✔ |
 | Firmware image | `Flash size: 16MB`, `Chip ID: 9 (ESP32-S3)` ✔ |

--- a/platformio.ini
+++ b/platformio.ini
@@ -190,7 +190,8 @@ lib_deps =
 ; VERSION FORMAT: the middle component is zero-padded -- 55.03.39, 55.03.311. Both the release tag
 ; and the `version` field in the platform's own platform.json use that form, so it is what the URL
 ; needs and what `pio pkg list` prints. Earlier notes here dropped the zero, which matches no tag
-; and no package version; anyone pasting that into the URL above gets a 404.
+; and no package version; anyone pasting that into the URL above gets a 404. check_layering.sh
+; rule 10 fails the build on the unpadded form, here and in the docs.
 ; ---------------------------------------------------------------------------------------
 [esp32common]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -124,7 +124,7 @@ lib_deps =
 ; the header in src/boards/); everything else is shared through [esp32common].
 ;
 ; PINNED TO A VERSION, NOT TO `stable`. That URL is a moving target, and on 2026-07-31 it was
-; found to have moved: this machine still had 55.3.39 (Arduino core 3.3.9, IDF 5.5.4) from the
+; found to have moved: this machine still had 55.03.39 (Arduino core 3.3.9, IDF 5.5.4) from the
 ; note below, while CI had picked up 55.03.311 (core 3.3.11, IDF 5.5.5) and had been building
 ; every release from it since 2026-07-24. The v0.25.0 images that went out to OTA were compiled
 ; by a toolchain nobody had booted on hardware, and nothing in the repo said so.
@@ -171,7 +171,7 @@ lib_deps =
 ; measured.
 ;
 ; VERDICT: the toolchain question is answered for this board. Two days, two nights, two unassisted
-; sunrises, timing that has not moved. That is strictly more evidence than 55.3.39 ever had -- its
+; sunrises, timing that has not moved. That is strictly more evidence than 55.03.39 ever had -- its
 ; own line below says "built clean and ran on hardware", one day, and it was called verified. It
 ; would be inconsistent to hold the replacement to a higher bar than the thing it replaced.
 ;
@@ -185,7 +185,12 @@ lib_deps =
 ; no PSRAM, against this board's qio_opi with 8 MB), and memory configuration is exactly where a
 ; compiler and RTOS change can interact. Waiting longer will never close that; flashing one will.
 ;
-; Earlier: 55.3.39 (core 3.3.9 / IDF 5.5.4) built clean and ran on hardware, 2026-07-16.
+; Earlier: 55.03.39 (core 3.3.9 / IDF 5.5.4) built clean and ran on hardware, 2026-07-16.
+;
+; VERSION FORMAT: the middle component is zero-padded -- 55.03.39, 55.03.311. Both the release tag
+; and the `version` field in the platform's own platform.json use that form, so it is what the URL
+; needs and what `pio pkg list` prints. Earlier notes here dropped the zero, which matches no tag
+; and no package version; anyone pasting that into the URL above gets a 404.
 ; ---------------------------------------------------------------------------------------
 [esp32common]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -179,11 +179,17 @@ lib_deps =
 ; the night-to-morning transition, so only sunrises could close it; it was met on 2026-07-29,
 ; before this pin existed. Do not import that number here -- different question, different risk.)
 ;
-; WHAT IS STILL OPEN IS NOT TIME, IT IS BOARDS. 3.3.11 has run on the RS485-CAN only. CI compiles
-; all four environments, but nobody has booted it on the Relay-1CH or the Relay-6CH. The 6CH is
-; the one to check: it is a different module with a different memory configuration (qio_qspi, N8,
-; no PSRAM, against this board's qio_opi with 8 MB), and memory configuration is exactly where a
-; compiler and RTOS change can interact. Waiting longer will never close that; flashing one will.
+; WHAT IS STILL OPEN IS NOT TIME, IT IS COVERAGE. 3.3.11 has run on the RS485-CAN only, driving
+; one inverter through one driver (eversolar_legacy). CI compiles all four environments, but
+; nobody has booted it on the Relay-1CH or the Relay-6CH. The 6CH is the one to check: it is a
+; different module with a different memory configuration (qio_qspi, N8, no PSRAM, against this
+; board's qio_opi with 8 MB), and memory configuration is exactly where a compiler and RTOS change
+; can interact.
+;
+; The driver gap is the smaller of the two: every driver runs on the same rs485Task and the same
+; transport, so a timing regression would have surfaced on this path. But "verified" above means
+; this board and this driver, not every board and every protocol. Waiting longer closes neither
+; gap; flashing a board closes one of them.
 ;
 ; Earlier: 55.03.39 (core 3.3.9 / IDF 5.5.4) built clean and ran on hardware, 2026-07-16.
 ;

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 #
-# Enforces the two architectural invariants from docs/architecture.md that are cheap to
-# check mechanically. Run in CI and before every phase hand-off.
+# Enforces the invariants that are cheap to check mechanically. It started as the two layering
+# rules from docs/architecture.md and has grown one rule per class of mistake that reached the
+# tree unnoticed -- each numbered check below carries the story of the one that caused it.
+# Run in CI and before every phase hand-off.
 set -uo pipefail
 
 cd "$(dirname "$0")/.."

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -274,6 +274,31 @@ else
     status=1
 fi
 
+echo "==> 10. The ESP32 platform version is written the way the release tag is written"
+# pioarduino zero-pads the middle component: 55.03.39, 55.03.311. That is the release tag, and
+# it is also the `version` in the platform's own platform.json, so it is what the download URL
+# needs and what `pio pkg list` prints. Drop the zero and you get a string that matches nothing:
+# no tag, no package, a 404 for anyone who pastes it into the URL.
+#
+# It happened. Four occurrences across platformio.ini and docs/decisions.md sat in the tree
+# through a full review round, mixed in with correctly written ones in the same paragraph --
+# which is why a human diff does not catch this and a grep does.
+#
+# Deliberately matches the SHAPE (55.<one digit>.<digit>) and not a list of known-bad versions, so
+# the next release is covered without editing this rule.
+#
+# The leading guard is not decoration. Without it the pattern matches the tail of every IPv4
+# netmask in the tree -- 255.0.0.0 contains "55.0." -- and the first run of this rule failed on
+# five lines of ipv4.h and its tests. A digit or a dot in front means it is part of a longer
+# number, not a platform version.
+if padding=$(git grep -nE '(^|[^0-9.])55\.[0-9]\.[0-9]' -- ':!:.pio' 2>/dev/null) && [ -n "$padding" ]; then
+    echo "FAIL: platform version is missing the zero padding pioarduino's tags use:"
+    echo "$padding"
+    status=1
+else
+    echo "OK"
+fi
+
 echo
 if [ $status -eq 0 ]; then
     echo "RESULT: PASS"


### PR DESCRIPTION
Follow-up to #165, which was already merged when Copilot reviewed it. Two comments, one right and one not.

## The version string was wrong, in four places

Copilot flagged that `55.3.39` and `55.03.311` are written inconsistently in the same note. It is not a style inconsistency — one of them matches nothing.

pioarduino zero-pads the middle component. Verified two ways rather than assumed:

- the release list has `55.03.39` and `55.03.311`; there is no `55.3.39` tag
- the installed `platform.json` for both versions declares the same zero-padded string in its `version` field, so it is also what `pio pkg list` prints

So the unpadded form matches no tag, no package version, and 404s if pasted into the download URL. Four occurrences, in `platformio.ini` and `docs/decisions.md` — including two inside the toolchain note itself, five lines from the correctly written pin.

## And a gate, because a human diff will not catch this again

These survived a full review round precisely because they sat next to correct ones. `check_layering.sh` rule 10 now matches the *shape* — `55.<one digit>.<digit>` — so the next release is covered without editing the rule.

Two things worth knowing about it:

- the guard against a preceding digit is load-bearing. Without it the pattern matches the tail of every IPv4 netmask in the tree (`255.0.0.0` contains `55.0.`) and the first run failed on five lines of `ipv4.h` and its tests.
- proved in the failing direction too: reintroducing `espressif32@55.3.39` in `docs/decisions.md` makes the rule report that line and the script exit non-zero.

The note itself had to be rephrased so it no longer quotes the bad string as its own example — the same trap the pip-pin monitor fell into, where the automation reported its own documentation.

## The verdict now states its driver scope

Copilot's second point: the verdict is broader than the evidence, because the soak exercised one driver and one attached inverter. Fair on the driver dimension — the open-items paragraph named only boards, leaving that unstated rather than stated-and-bounded. It now says the soak was two days of `eversolar_legacy`, and why that is the smaller gap: `Rs485Transport` is the only transport compiled into the firmware (`TransportType::Tcp` is declared and unimplemented) and every driver polls from `rs485Task`, so a timing regression had one place to show.

## What I did not change

Copilot also asked to remove the inverter brand name from the note, as device-specific detail that will mislead if the production inverter changes. Declined: this is a soak record, and a soak record that does not say what it ran against cannot be checked by anyone later. Naming the attached hardware is what makes the measurement evidence rather than assertion. The layering rule that keeps brand names out of the codebase applies to `src/`, not to a dated record of a hardware test.

## Verification

Comment and documentation changes only — no compiled code is touched.

- `check_layering.sh`: PASS, all 10 rules
- `pio test -e native`: 928 test cases, 928 succeeded
- `gen_profiles.py --check`, `check_web_js.py`, `check_dashboard_layout.py`, `check_measurement_ids.py`: all OK
- `ruff check` + `ruff format --check`: clean
- `pio project config` still resolves the pin to `55.03.311`, so the ini edits did not disturb parsing