### PR TITLE
A capture that records the driver's own conversation (#62)

### DIFF
--- a/docs/adding-a-device.md
+++ b/docs/adding-a-device.md
@@ -329,7 +329,8 @@ Each record carries a **direction** and the rule that ended it:
 | gap on a **←** | the device's response time — what a driver's read timeout has to cover |
 | `turn` | the conversation turned around. Exact at any baud rate |
 | `silence` | the same t3.5 idle gap the passive mode uses throughout |
-| `split` | the record hit its byte limit — **a cut the protocol did not make**, so these bytes and the next row's may belong together |
+| `split` | the record hit its byte limit — **a cut the protocol did not make**, so these bytes and the next row's may belong together. The recording carries on |
+| `full` | the recording ran out of room here. Also not a protocol boundary, and unlike `split` **nothing after it was recorded**, however much of the window was left |
 | `end` | the window closed with this record still open |
 
 Only `turn` and `silence` mean "these bytes are one frame". Because the direction boundary is

--- a/docs/adding-a-device.md
+++ b/docs/adding-a-device.md
@@ -244,7 +244,22 @@ worked for the EverSolar driver:
    only show on real hardware over days (our sunrise-recovery saga is the cautionary
    tale), so plan for a soak-test phase.
 
-## 6. Capturing an unknown device
+## 6. Capturing the bus
+
+There are **two** recordings, and picking the wrong one wastes an afternoon. The question is
+whether this build already has a driver for the device:
+
+| | No driver yet | A driver we ship |
+|---|---|---|
+| Use | **passive** — the rest of this section | **driver mode** — [below](#65-recording-a-driver-we-already-have) |
+| Where | the discovery wizard, "Record the raw bus" | Health → "Record the driver's own conversation" |
+| The bridge | stays silent and listens | keeps polling, and that traffic is the recording |
+
+Point the passive recording at an inverter that already works and it captures **nothing**: the
+driver that would produce the traffic is the very thing it pauses. That is not a bug in it, and
+it is why the second mode exists.
+
+### 6.1 Recording a device nothing can identify
 
 When the discovery wizard finishes and names nothing, it offers **"Record the raw bus"**.
 That is this feature, and it needs no working driver — which is the point, because the
@@ -285,6 +300,56 @@ A text file you can attach to an issue directly:
        0       0    8  modbus    01 03 00 00 00 0A C5 CD
       41      33   25  modbus    01 03 14 00 00 09 C4 ... 
 ```
+
+## 6.5 Recording a driver we already have
+
+**Health → "Record the driver's own conversation."** Nothing is interrupted: the bridge polls
+exactly as it always does, and that traffic *is* the recording. No line settings to choose —
+there is a working driver, so the bridge knows the line, and the API refuses the parameters
+rather than recording at something other than what you asked for.
+
+Three jobs this does that the passive recording cannot:
+
+- **Check a shipped driver against its protocol document**, on real hardware, without a
+  USB-RS485 tap and a laptop in the meter cupboard.
+- **Turn "works for me / not for me" into bytes.** A reporter with no tap can still attach the
+  actual exchange.
+- **Tell "nobody is talking" apart from "the device is not answering."** Requests with no
+  replies is a diagnosis; a passive capture cannot reach it, because there the bridge is the
+  silent one and both look like an empty report.
+
+### Reading it
+
+Each record carries a **direction** and the rule that ended it:
+
+| Column | Meaning |
+|---|---|
+| **→** | the bridge asking |
+| **←** | the device answering |
+| gap on a **←** | the device's response time — what a driver's read timeout has to cover |
+| `turn` | the conversation turned around. Exact at any baud rate |
+| `silence` | the same t3.5 idle gap the passive mode uses throughout |
+| `split` | the record hit its byte limit — **a cut the protocol did not make**, so these bytes and the next row's may belong together |
+| `end` | the window closed with this record still open |
+
+Only `turn` and `silence` mean "these bytes are one frame". Because the direction boundary is
+exact, this mode does not carry the passive mode's approximation above 19200 baud.
+
+The text file names its own mode, so the two cannot be confused in an issue:
+
+```
+# Heliograph driver capture (the bridge kept polling throughout)
+# line: 9600 baud, none parity, 8 data bits, 1 stop bits
+# 14 records, 182 bytes, 7 sent, 7 received, 14 valid Modbus CRC, 0 valid AA55
+#
+# dir  time_ms  gap_ms  len  checksum  cut_by            bytes
+->        12      12    8  modbus    direction_change  01 03 00 00 00 0A C5 CD
+<-        54      42   25  modbus    idle_gap          01 03 14 00 00 09 C4 ...
+```
+
+Discovery is refused while this runs, and it has to be: a probe sweep re-registers every
+inverter and walks eight addresses, so the recording would show something no driver ever does,
+under a heading claiming to be the driver's own conversation.
 
 **Write down what the device is and what was talking to it while this ran.** That context
 is the one part nobody can recover from the bytes, and it is the difference between a

--- a/docs/eversolar-protocol.md
+++ b/docs/eversolar-protocol.md
@@ -8,6 +8,11 @@ two captured frames are stored byte-for-byte in `tools/gen_fixtures.py`, which
 verifies itself against the captures. Where something is unknown, that is stated explicitly — no
 fields have been invented.
 
+**Checking this document against a running bridge** no longer needs a USB-RS485 tap and a laptop
+at the inverter. Health → *"Record the driver's own conversation"* records the requests and
+replies as they happen, with a direction on each; hold them next to the frame layouts below. See
+[adding-a-device.md § 6.5](adding-a-device.md#65-recording-a-driver-we-already-have).
+
 ## Origin and license
 
 | | |

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -435,14 +435,14 @@ exists.
 
 ### `POST /api/v1/actions/capture`
 
-Contributor-facing; [docs/adding-a-device.md](adding-a-device.md#6-capturing-an-unknown-device)
+Contributor-facing; [docs/adding-a-device.md](adding-a-device.md#6-capturing-the-bus)
 is the guide, this is the wire contract.
 
 | Parameter | Default | Range | Modes |
 |---|---|---|---|
 | `mode` | `passive` | `passive`, `driver` | both |
 | `seconds` | 30 | 1–300 | both |
-| `frames` | 64 | 1–256 | both |
+| `frames` | 64 | 1–256 (`passive`), **1–128** (`driver`) | both |
 | `baud` | 9600 | 300–921600 | `passive` only |
 | `parity` | `none` | `none`, `even`, `odd` | `passive` only |
 | `data_bits` | 8 | 5–8 | `passive` only |
@@ -452,6 +452,11 @@ The four line parameters are **rejected with 400** in `mode=driver` rather than 
 a working driver, so the line is a fact about the bridge; accepting a baud rate and then
 recording at a different one would put a number in the report the capture never ran at.
 
+`frames` is capped lower in `mode=driver` — 128 rather than 256 — and refused rather than
+clamped. Each record there carries a direction and a cut reason, and above roughly 160 records
+the report no longer fits the response bound: the capture would complete, spend real bus time,
+and then only ever answer 500. Measured worst case at the ceiling is 56 KB of a 64 KB bound.
+
 `mode` is optional and defaults to `passive`, so every existing caller keeps its meaning.
 
 202 on acceptance; **409** when a capture or a discovery run is already using the bus. The guard
@@ -459,12 +464,15 @@ is symmetric — `/actions/discover` refuses while a capture is pending or runni
 be: rs485Task checks discovery first, so a discovery accepted alongside a pending capture would
 jump the queue and the capture would then record the tail of the probe run.
 
-The capture runs on the task that owns the bus, **instead of** that cycle's poll — the same
-handover discovery uses. That is the concurrency answer: there is no iteration in which the bus
-is being listened to and polled, so the two cannot interleave. The bridge transmits nothing for
-the whole window.
+### `GET /api/v1/capture`
 
-`GET /api/v1/capture` returns the report, poll it for progress:
+The **passive** report. In that mode the capture runs on the task that owns the bus, **instead
+of** that cycle's poll — the same handover discovery uses. That is the concurrency answer: there
+is no iteration in which the bus is being listened to and polled, so the two cannot interleave,
+and the bridge transmits nothing for the whole window. None of that is true of `mode=driver`,
+which arms a recorder and lets the poll continue; see its own section below.
+
+Poll it for progress:
 
 ```json
 {
@@ -531,7 +539,8 @@ intermittently in service.
 |---|---|
 | `direction_change` | the conversation turned around — exact at any baud rate |
 | `idle_gap` | silence, same rule the passive mode uses throughout |
-| `byte_cap` | the record hit its byte bound and was split — **a cut the protocol did not make**, so the halves may belong together |
+| `byte_cap` | the record hit its byte bound and was split — **a cut the protocol did not make**, so the halves may belong together. Recording continues |
+| `capture_full` | the capture's total byte budget ran out here. Also not a protocol boundary, and unlike `byte_cap` **nothing further was recorded**, however much of the window was left |
 | `window_end` | the window closed with this record still open |
 
 Only `direction_change` and `idle_gap` mean "these bytes are one frame". Because the direction

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -27,8 +27,9 @@ Versioning is in the path: `/api/v1/`. Breaking changes → `/api/v2/`.
 | POST | `/api/v1/config/restore` | **✔** | Apply a backup file (`?dry_run=true` to preview only) |
 | POST | `/api/v1/actions/undo-restore` | **✔** | Swap back to the configuration from before the last restore |
 | POST | `/api/v1/actions/discover` | **✔** | Start discovery |
-| POST | `/api/v1/actions/capture` | **✔** | Record raw RS485 traffic (`?seconds=&baud=&parity=&frames=`) |
-| GET | `/api/v1/capture` | — | The last capture, with per-frame hex and checksum verdicts |
+| POST | `/api/v1/actions/capture` | **✔** | Record the bus (`?mode=passive\|driver&seconds=&frames=`, plus line settings in `passive`) |
+| GET | `/api/v1/capture` | — | The last passive capture, with per-frame hex and checksum verdicts |
+| GET | `/api/v1/capture/driver` | — | The last driver capture: the same, plus a direction per frame |
 | POST | `/api/v1/actions/poll` | **✔** | Force an immediate poll |
 | POST | `/api/v1/actions/reboot` | **✔** | Reboot |
 | POST | `/api/v1/actions/clear-coredump` | **✔** | Discard a stored crash dump (404 when there is none) |
@@ -414,20 +415,44 @@ a field on this object would have been a knob that changed nothing.
 
 While the override is off these fields are stored but not validated — they configure nothing.
 
-## Capturing an unknown device
+## Capturing the bus
 
-`POST /api/v1/actions/capture` records raw RS485 traffic without needing a driver that
-understands it. Contributor-facing; [docs/adding-a-device.md](adding-a-device.md#6-capturing-an-unknown-device)
+Two modes, and which one you want depends on a single question: **does this build already have a
+driver for the device?**
+
+| | `mode=passive` (default) | `mode=driver` |
+|---|---|---|
+| For | a device nothing here can identify | a driver we ship, checked against its protocol document |
+| The bridge | says nothing for the whole window | polls exactly as normal |
+| Polling | stops | continues — that traffic *is* the recording |
+| Line settings | you supply them; a wrong guess shows as bytes with no valid checksums | taken from the driver, and refused if you send them |
+| Frames cut on | silence (Modbus t3.5) | direction change, then silence |
+| Report | `GET /api/v1/capture` | `GET /api/v1/capture/driver` |
+
+Point `passive` at an inverter that already works and it records **nothing** — the driver that
+would produce the traffic is the thing it pauses. That is not a bug in it; it is why `driver`
+exists.
+
+### `POST /api/v1/actions/capture`
+
+Contributor-facing; [docs/adding-a-device.md](adding-a-device.md#6-capturing-an-unknown-device)
 is the guide, this is the wire contract.
 
-| Parameter | Default | Range |
-|---|---|---|
-| `seconds` | 30 | 1–300 |
-| `frames` | 64 | 1–256 |
-| `baud` | 9600 | 300–921600 |
-| `parity` | `none` | `none`, `even`, `odd` |
-| `data_bits` | 8 | 5–8 |
-| `stop_bits` | 1 | 1–2 |
+| Parameter | Default | Range | Modes |
+|---|---|---|---|
+| `mode` | `passive` | `passive`, `driver` | both |
+| `seconds` | 30 | 1–300 | both |
+| `frames` | 64 | 1–256 | both |
+| `baud` | 9600 | 300–921600 | `passive` only |
+| `parity` | `none` | `none`, `even`, `odd` | `passive` only |
+| `data_bits` | 8 | 5–8 | `passive` only |
+| `stop_bits` | 1 | 1–2 | `passive` only |
+
+The four line parameters are **rejected with 400** in `mode=driver` rather than ignored. There is
+a working driver, so the line is a fact about the bridge; accepting a baud rate and then
+recording at a different one would put a number in the report the capture never ran at.
+
+`mode` is optional and defaults to `passive`, so every existing caller keeps its meaning.
 
 202 on acceptance; **409** when a capture or a discovery run is already using the bus. The guard
 is symmetric — `/actions/discover` refuses while a capture is pending or running too. It has to
@@ -467,6 +492,59 @@ Frames are cut on `idle_gap_ms` of silence, derived from the baud rate (Modbus t
 floored at 2 ms. Above 19200 the true gap is finer than the read loop can resolve, so adjacent
 frames may merge into one record — the byte stream stays complete and ordered, only the cut
 points are approximate. Stated here rather than left to be discovered from confusing output.
+
+### `GET /api/v1/capture/driver`
+
+The driver-mode report. A separate document, not the same one with extra fields:
+
+```json
+{
+  "status": "done",
+  "line": { "baud_rate": 9600, "parity": "none", "data_bits": 8, "stop_bits": 1,
+            "idle_gap_ms": 4 },
+  "requested_seconds": 30, "max_frames": 64, "elapsed_ms": 30004,
+  "summary": { "frames": 14, "bytes": 182, "sent": 7, "received": 7,
+               "modbus_crc_ok": 14, "aa55_frames_ok": 0, "truncated": false },
+  "frames": [
+    { "direction": "tx", "offset_ms": 12, "gap_before_ms": 12, "length": 8,
+      "modbus_crc_ok": true, "aa55_ok": false, "cut_by": "direction_change",
+      "hex": "01 03 00 00 00 0A C5 CD" },
+    { "direction": "rx", "offset_ms": 54, "gap_before_ms": 42, "length": 25,
+      "modbus_crc_ok": true, "aa55_ok": false, "cut_by": "idle_gap",
+      "hex": "01 03 14 ..." }
+  ]
+}
+```
+
+**`summary.sent` against `summary.received` is the pair to read first.** Requests with no
+replies means the bridge is talking and the device is not answering — a diagnosis the passive
+mode cannot reach, because there the bridge is the silent one and a dead bus looks identical to
+a quiet one.
+
+`gap_before_ms` on an `rx` frame is the device's **response time**. That is what a driver's read
+timeout has to cover, and the number to look at when an inverter answers reliably by hand and
+intermittently in service.
+
+`cut_by` says which rule ended each record:
+
+| Value | Meaning |
+|---|---|
+| `direction_change` | the conversation turned around — exact at any baud rate |
+| `idle_gap` | silence, same rule the passive mode uses throughout |
+| `byte_cap` | the record hit its byte bound and was split — **a cut the protocol did not make**, so the halves may belong together |
+| `window_end` | the window closed with this record still open |
+
+Only `direction_change` and `idle_gap` mean "these bytes are one frame". Because the direction
+boundary is exact, this mode does **not** carry the passive mode's approximation above 19200
+baud.
+
+While a driver capture runs, the report carries `status` and `elapsed_ms` but **no frames** — the
+bus task is still appending to them. Poll until `status` is `done`.
+
+Traffic that arrives after the window closes is not recorded. Unlike the passive mode, this one
+cannot stop the traffic when its deadline passes; it can only be unhooked on the bus task's next
+visit, so the recorder itself refuses late bytes rather than quietly swallowing the poll that
+straddles the deadline.
 
 The report is bounded at 64 KB and the capture stops when full rather than dropping the oldest:
 for a handshake the interesting part is at the beginning, and a ring buffer would reliably

--- a/platformio.ini
+++ b/platformio.ini
@@ -86,6 +86,7 @@ build_src_filter =
     +<app/device_plan.cpp>
     +<app/discovery_runner.cpp>
     +<app/capture_runner.cpp>
+    +<app/driver_capture_runner.cpp>
     +<drivers/eversolar_legacy/>
     +<drivers/modbus_profile/>
     +<drivers/solax_x1/>

--- a/src/app/driver_capture_runner.cpp
+++ b/src/app/driver_capture_runner.cpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+
+#include "driver_capture_runner.h"
+
+#include <utility>
+
+namespace heliograph {
+
+const char* driverCaptureStatusName(DriverCaptureStatus status) {
+    switch (status) {
+        case DriverCaptureStatus::Idle:      return "idle";
+        case DriverCaptureStatus::Requested: return "requested";
+        case DriverCaptureStatus::Running:   return "running";
+        case DriverCaptureStatus::Done:      return "done";
+    }
+    return "unknown";
+}
+
+DriverCaptureRunner::DriverCaptureRunner(ClockFn clock) : clock_(std::move(clock)) {}
+
+bool DriverCaptureRunner::busy() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return report_.status == DriverCaptureStatus::Requested ||
+           report_.status == DriverCaptureStatus::Running;
+}
+
+bool DriverCaptureRunner::request(const diag::TapConfig& config, const SerialProfile& profile) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (report_.status == DriverCaptureStatus::Requested ||
+        report_.status == DriverCaptureStatus::Running) {
+        return false;
+    }
+    // Discarded rather than appended to, same rule as the passive capture: two runs in one
+    // report would mean the counts describe two different stretches of time.
+    report_             = DriverCaptureReport{};
+    report_.status      = DriverCaptureStatus::Requested;
+    report_.config      = config;
+    report_.profile     = profile;
+    report_.requestedMs = clock_ ? clock_() : 0;
+    return true;
+}
+
+DriverCaptureService DriverCaptureRunner::service(Transport& transport) {
+    DriverCaptureStatus status = DriverCaptureStatus::Idle;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        status = report_.status;
+    }
+
+    if (status == DriverCaptureStatus::Requested) {
+        diag::TapConfig config;
+        SerialProfile   profile;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            config  = report_.config;
+            profile = report_.profile;
+        }
+        // Allocated on arming and released when collected, rather than held for the life of the
+        // bridge: this is up to 12 KB, and the one board with no PSRAM has to fit it alongside
+        // the JSON copy of it.
+        tap_ = std::make_unique<diag::BusTap>(config, profile);
+        tap_->begin(transport.nowMs());
+        transport.setTap(tap_.get());
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            report_.status    = DriverCaptureStatus::Running;
+            report_.startedMs = clock_ ? clock_() : 0;
+        }
+        return DriverCaptureService::Armed;
+    }
+
+    if (status != DriverCaptureStatus::Running) {
+        return DriverCaptureService::Idle;
+    }
+    if (tap_ == nullptr) {
+        // Cannot happen through this class's own transitions, and is handled rather than
+        // asserted because the alternative is a Running capture nobody can ever end.
+        std::lock_guard<std::mutex> lock(mutex_);
+        report_.status     = DriverCaptureStatus::Done;
+        report_.finishedMs = clock_ ? clock_() : 0;
+        return DriverCaptureService::Collected;
+    }
+    if (!tap_->done(transport.nowMs())) {
+        return DriverCaptureService::Recording;
+    }
+
+    // Unhook FIRST. Everything after this point is reading a recorder nothing is feeding any
+    // more, which is what lets the frames be copied out without a lock on the byte path.
+    transport.setTap(nullptr);
+    tap_->finish(transport.nowMs());
+    collect(clock_ ? clock_() : 0);
+    return DriverCaptureService::Collected;
+}
+
+void DriverCaptureRunner::collect(uint64_t nowMs) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    report_.frames       = tap_->frames();
+    report_.totalBytes   = tap_->totalBytes();
+    report_.txFrames     = tap_->txFrames();
+    report_.rxFrames     = tap_->rxFrames();
+    report_.modbusFrames = tap_->modbusFrames();
+    report_.pmuFrames    = tap_->pmuFrames();
+    report_.truncated    = tap_->truncated();
+    report_.idleGapMs    = tap_->idleGapMs();
+    report_.status       = DriverCaptureStatus::Done;
+    report_.finishedMs   = nowMs;
+    tap_.reset();
+}
+
+DriverCaptureReport DriverCaptureRunner::report() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return report_;
+}
+
+}  // namespace heliograph

--- a/src/app/driver_capture_runner.h
+++ b/src/app/driver_capture_runner.h
@@ -129,4 +129,19 @@ private:
 /// bounds how long a recorder sits in the RS485 path and how much of the report can accumulate.
 inline constexpr uint32_t kMaxDriverCaptureSeconds = 300;
 
+/// Ceiling on the number of records, and LOWER than the passive capture's 256 on purpose.
+///
+/// Not a memory limit on the tap -- it is what keeps a finished capture fetchable. Each record
+/// in this report carries two fields the passive one does not (`direction`, `cut_by`), which is
+/// roughly 48 extra bytes of JSON per record, and the response is bounded at
+/// kMaxCaptureResponseBytes. Measured against the true worst case (six-digit timestamps, the
+/// longest cut_by name, the full 12 KB of bytes): 128 records render to 56.0 KB, 160 to 60.3 KB,
+/// and 200 does not fit at all.
+///
+/// Letting a client ask for 256 would mean a capture that completes, spends real bus time, and
+/// can then only ever answer 500 -- the report exists on the device and no request can retrieve
+/// it. Refusing up front, with a reason, is the honest version. 128 records is 64 exchanges,
+/// which is many poll cycles for the job this does.
+inline constexpr long kMaxDriverCaptureFrames = 128;
+
 }  // namespace heliograph

--- a/src/app/driver_capture_runner.h
+++ b/src/app/driver_capture_runner.h
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+//
+// Runs a capture that does NOT stop the bridge polling.
+//
+// The opposite mechanics to CaptureRunner, from the same starting point. That one takes an
+// iteration of rs485Task away from polling and spends the whole window inside it, because for an
+// unidentified device the bridge's own traffic would be noise in the recording. Here the
+// bridge's own traffic IS the recording, so taking the bus away would record nothing -- which is
+// exactly what happened on hardware and is what issue #62 is about.
+//
+// So this runner never occupies an iteration. It ARMS: hangs a BusTap on the transport and
+// returns immediately. Polling continues, the tap fills from inside the driver's own
+// transactions, and a later visit unhooks it when the window has closed. Two lines in
+// rs485Task, no `continue`, no bus lock, and no line reconfiguration -- so the whole
+// lineReconfigured / restoreDriverLine() failure class that the passive mode has to handle does
+// not exist here.
+//
+// WHICH TASK DOES WHAT, because the split is the only thing keeping this safe without a lock on
+// the byte path:
+//
+//   - request() runs on the web task. It only sets a pending state.
+//   - service() runs on rs485Task. It is the ONLY thing that touches the tap or the transport's
+//     tap pointer, which is what the transport's lifetime rule requires.
+//   - report() runs on the web task, under the mutex, and returns frames only once the capture
+//     is Done. A page polling for progress gets status and elapsed time while it runs; handing
+//     out a half-written frame list would mean copying a vector the bus task is appending to.
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "device/clock.h"
+#include "diagnostics/bus_tap.h"
+#include "transport/transport.h"
+
+namespace heliograph {
+
+enum class DriverCaptureStatus : uint8_t {
+    Idle,
+    /// Requested, not yet picked up by rs485Task.
+    Requested,
+    /// Armed: the tap is on the transport and the bridge is polling normally.
+    Running,
+    Done,
+};
+
+const char* driverCaptureStatusName(DriverCaptureStatus status);
+
+/// What one visit from the bus task actually did.
+enum class DriverCaptureService : uint8_t {
+    /// Nothing pending, nothing running.
+    Idle,
+    /// A pending request was armed on this visit. The tap is now on the transport.
+    Armed,
+    /// Armed on an earlier visit and still inside its window.
+    Recording,
+    /// The window closed on this visit: the tap is off and the report is complete.
+    Collected,
+};
+
+struct DriverCaptureReport {
+    DriverCaptureStatus            status = DriverCaptureStatus::Idle;
+    diag::TapConfig                config;
+    /// The driver's own line, echoed back. Not a guess the operator supplied -- there is a
+    /// working driver, so the line is known -- but it still belongs in the report: the idle gap
+    /// derives from it, and a reader a day later cannot check the framing without it.
+    SerialProfile                  profile;
+    std::vector<diag::TappedFrame> frames;
+    uint32_t totalBytes   = 0;
+    uint32_t txFrames     = 0;
+    uint32_t rxFrames     = 0;
+    uint32_t modbusFrames = 0;
+    uint32_t pmuFrames    = 0;
+    bool     truncated    = false;
+    uint32_t idleGapMs    = 0;
+    uint64_t requestedMs  = 0;
+    uint64_t startedMs    = 0;
+    uint64_t finishedMs   = 0;
+};
+
+class DriverCaptureRunner {
+public:
+    explicit DriverCaptureRunner(ClockFn clock);
+
+    /// Called from the web task. False when one is already pending or running; the REST layer
+    /// turns that into 409.
+    bool request(const diag::TapConfig& config, const SerialProfile& profile);
+
+    /// Called from rs485Task, once per iteration, before anything else it does.
+    ///
+    /// Arms a pending request and unhooks a finished one. Returns immediately in every case --
+    /// this must NEVER cause the caller to skip its poll, because the poll is what it is
+    /// recording.
+    ///
+    /// The return says which transition happened rather than merely whether something is
+    /// running, so the caller can log the two interesting ones exactly once each. A bool would
+    /// leave "armed" and "still recording" indistinguishable, and the caller would have to
+    /// reconstruct the difference from the report -- which is how a once-per-capture log line
+    /// becomes a once-per-iteration one.
+    DriverCaptureService service(Transport& transport);
+
+    // No abandon()/cancel(). Nothing that would take the bus for itself can start while this is
+    // armed -- discovery and the passive capture are both refused at request time -- so an
+    // unhook-early path would have no caller, and an unused escape hatch is worse than none:
+    // it invites a future caller to reach for it instead of asking why the guard exists.
+
+    DriverCaptureReport report() const;
+    bool                busy() const;
+
+private:
+    void collect(uint64_t nowMs);
+
+    ClockFn                        clock_;
+    mutable std::mutex             mutex_;
+    DriverCaptureReport            report_;
+    /// Touched only by service()/abandon(), i.e. only by the bus task. Deliberately outside the
+    /// mutex: putting the tap behind the same lock the web task takes would drag that lock into
+    /// the per-byte path for no benefit, since no other task may look at it.
+    std::unique_ptr<diag::BusTap>  tap_;
+};
+
+/// Ceiling on a requested window.
+///
+/// The same number as the passive capture, for a different reason. There it bounds how long one
+/// authenticated request can stop the inverter being polled; nothing is stopped here, so this
+/// bounds how long a recorder sits in the RS485 path and how much of the report can accumulate.
+inline constexpr uint32_t kMaxDriverCaptureSeconds = 300;
+
+}  // namespace heliograph

--- a/src/diagnostics/bus_tap.cpp
+++ b/src/diagnostics/bus_tap.cpp
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+
+#include "bus_tap.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace heliograph::diag {
+
+const char* busDirectionName(BusDirection direction) {
+    switch (direction) {
+        case BusDirection::Tx: return "tx";
+        case BusDirection::Rx: return "rx";
+    }
+    return "unknown";
+}
+
+const char* cutReasonName(CutReason reason) {
+    switch (reason) {
+        case CutReason::DirectionChange: return "direction_change";
+        case CutReason::IdleGap:         return "idle_gap";
+        case CutReason::ByteCap:         return "byte_cap";
+        case CutReason::WindowEnd:       return "window_end";
+    }
+    return "unknown";
+}
+
+BusTap::BusTap(const TapConfig& config, const SerialProfile& profile)
+    : config_(config),
+      gapMs_(config.idleGapMs != 0 ? config.idleGapMs : idleGapMsFor(profile)) {
+    frames_.reserve(config_.maxFrames);
+}
+
+void BusTap::begin(uint64_t nowMs) {
+    startMs_    = nowMs;
+    lastByteMs_ = nowMs;
+}
+
+void BusTap::recordTx(const uint8_t* data, size_t len, uint64_t nowMs) {
+    feed(BusDirection::Tx, data, len, nowMs);
+}
+
+void BusTap::recordRx(const uint8_t* data, size_t len, uint64_t nowMs) {
+    feed(BusDirection::Rx, data, len, nowMs);
+}
+
+void BusTap::feed(BusDirection direction, const uint8_t* data, size_t len, uint64_t nowMs) {
+    if (len == 0 || data == nullptr) {
+        // A read that timed out. It carries no direction -- nothing went on the wire -- so it
+        // may only close an open record on silence, never on a direction change. Treating an
+        // empty read as "the conversation turned around" would cut a reply in half every time
+        // the driver's read loop came back empty mid-transaction.
+        if (openHasBytes_ && nowMs - lastByteMs_ >= gapMs_) {
+            closeFrame(CutReason::IdleGap);
+            // Not advanced on the silent path: the next real byte's gapBeforeMs has to measure
+            // from the last BYTE, not from the last time anyone looked.
+        }
+        return;
+    }
+
+    if (openHasBytes_) {
+        // Direction is checked FIRST, and the order is the point. When a device answers after a
+        // long pause both rules fire, and only one of them is the real boundary: the turn-around
+        // is exact, the gap is a threshold that happens to have been crossed. Reporting IdleGap
+        // there would understate what is known about the cut.
+        if (open_.direction != direction) {
+            closeFrame(CutReason::DirectionChange);
+        } else if (nowMs - lastByteMs_ >= gapMs_) {
+            closeFrame(CutReason::IdleGap);
+        }
+    }
+
+    if (frames_.size() >= config_.maxFrames || totalBytes_ >= config_.maxTotalBytes) {
+        truncated_ = true;
+        return;
+    }
+    if (!openHasBytes_) {
+        open_             = TappedFrame{};
+        open_.direction   = direction;
+        open_.offsetMs    = static_cast<uint32_t>(nowMs - startMs_);
+        open_.gapBeforeMs = static_cast<uint32_t>(nowMs - lastByteMs_);
+        openHasBytes_     = true;
+    }
+    for (size_t i = 0; i < len; ++i) {
+        if (totalBytes_ >= config_.maxTotalBytes) {
+            truncated_ = true;
+            break;
+        }
+        if (open_.bytes.size() >= config_.maxFrameBytes) {
+            closeFrame(CutReason::ByteCap);
+            if (frames_.size() >= config_.maxFrames) {
+                truncated_ = true;
+                return;
+            }
+            open_           = TappedFrame{};
+            open_.direction = direction;
+            open_.offsetMs  = static_cast<uint32_t>(nowMs - startMs_);
+            // Zero, and honestly so: no time passed at a cut the protocol did not make.
+            open_.gapBeforeMs = 0;
+            openHasBytes_     = true;
+        }
+        open_.bytes.push_back(data[i]);
+        ++totalBytes_;
+    }
+    lastByteMs_ = nowMs;
+}
+
+void BusTap::finish(uint64_t nowMs) {
+    (void)nowMs;
+    if (openHasBytes_) {
+        closeFrame(CutReason::WindowEnd);
+    }
+}
+
+void BusTap::closeFrame(CutReason reason) {
+    if (!openHasBytes_) {
+        return;
+    }
+    // Computed once, here, rather than on every read of the report: a page polling for progress
+    // fetches the report repeatedly, and a CRC over every record each time is work with a fixed
+    // answer. Shared with FrameCapture so the two recorders cannot disagree about a frame.
+    open_.modbusCrcValid = modbusCrcHolds(open_.bytes);
+    open_.pmuFrameValid  = pmuFrameHolds(open_.bytes);
+    open_.cutBy          = reason;
+    frames_.push_back(std::move(open_));
+    open_         = TappedFrame{};
+    openHasBytes_ = false;
+}
+
+bool BusTap::done(uint64_t nowMs) const {
+    return truncated_ || frames_.size() >= config_.maxFrames ||
+           totalBytes_ >= config_.maxTotalBytes || (nowMs - startMs_) >= config_.durationMs;
+}
+
+uint32_t BusTap::txFrames() const {
+    return static_cast<uint32_t>(std::count_if(frames_.begin(), frames_.end(), [](const TappedFrame& f) {
+        return f.direction == BusDirection::Tx;
+    }));
+}
+
+uint32_t BusTap::rxFrames() const {
+    return static_cast<uint32_t>(std::count_if(frames_.begin(), frames_.end(), [](const TappedFrame& f) {
+        return f.direction == BusDirection::Rx;
+    }));
+}
+
+uint32_t BusTap::modbusFrames() const {
+    return static_cast<uint32_t>(std::count_if(
+        frames_.begin(), frames_.end(), [](const TappedFrame& f) { return f.modbusCrcValid; }));
+}
+
+uint32_t BusTap::pmuFrames() const {
+    return static_cast<uint32_t>(std::count_if(
+        frames_.begin(), frames_.end(), [](const TappedFrame& f) { return f.pmuFrameValid; }));
+}
+
+}  // namespace heliograph::diag

--- a/src/diagnostics/bus_tap.cpp
+++ b/src/diagnostics/bus_tap.cpp
@@ -90,11 +90,8 @@ void BusTap::feed(BusDirection direction, const uint8_t* data, size_t len, uint6
         open_.gapBeforeMs = static_cast<uint32_t>(nowMs - lastByteMs_);
         openHasBytes_     = true;
     }
-    bool ranOutOfRoom = false;
     for (size_t i = 0; i < len; ++i) {
         if (totalBytes_ >= config_.maxTotalBytes) {
-            truncated_   = true;
-            ranOutOfRoom = true;
             break;
         }
         if (open_.bytes.size() >= config_.maxFrameBytes) {
@@ -115,12 +112,18 @@ void BusTap::feed(BusDirection direction, const uint8_t* data, size_t len, uint6
     }
     lastByteMs_ = nowMs;
 
-    // Closed HERE rather than left open for finish() to deal with. Left open, the record
-    // survives to the end of the window and finish() labels it WindowEnd -- which is a false
+    // Asked AFTER the loop, on the state, rather than flagged inside it -- and that distinction
+    // IS the bug this replaced. A flag set only on the loop's early exit misses the write whose
+    // last byte lands exactly on the budget: that loop ends normally, so the record stayed open,
+    // finish() later called it WindowEnd, and truncated() said false while nothing further could
+    // ever be recorded. Every subsequent feed() is refused by the cap check above, so "the
+    // budget is gone" is the whole condition, however the loop happened to leave.
+    //
+    // Closed here rather than left for finish() for the same reason: WindowEnd is a false
     // account when the budget ran out with most of the window still to go, and cut_by exists
-    // precisely so a reader does not have to guess at that. Every later feed() is refused by
-    // the cap check above, so nothing would have been added to it anyway.
-    if (ranOutOfRoom) {
+    // precisely so a reader does not have to guess at that.
+    if (totalBytes_ >= config_.maxTotalBytes) {
+        truncated_ = true;
         closeFrame(CutReason::CaptureFull);
     }
 }

--- a/src/diagnostics/bus_tap.cpp
+++ b/src/diagnostics/bus_tap.cpp
@@ -45,6 +45,14 @@ void BusTap::recordRx(const uint8_t* data, size_t len, uint64_t nowMs) {
 }
 
 void BusTap::feed(BusDirection direction, const uint8_t* data, size_t len, uint64_t nowMs) {
+    // The window is a window. Unlike the passive capture -- which sits in a loop it controls and
+    // simply stops looping -- this one is fed by whatever the driver happens to be doing, and
+    // the runner can only unhook it on its next visit to the bus task. Without this guard a
+    // 30 s capture would quietly keep recording through the poll that straddles the deadline.
+    // finish() still closes whatever was open, as WindowEnd.
+    if (nowMs - startMs_ >= config_.durationMs) {
+        return;
+    }
     if (len == 0 || data == nullptr) {
         // A read that timed out. It carries no direction -- nothing went on the wire -- so it
         // may only close an open record on silence, never on a direction change. Treating an

--- a/src/diagnostics/bus_tap.cpp
+++ b/src/diagnostics/bus_tap.cpp
@@ -20,6 +20,7 @@ const char* cutReasonName(CutReason reason) {
         case CutReason::DirectionChange: return "direction_change";
         case CutReason::IdleGap:         return "idle_gap";
         case CutReason::ByteCap:         return "byte_cap";
+        case CutReason::CaptureFull:     return "capture_full";
         case CutReason::WindowEnd:       return "window_end";
     }
     return "unknown";
@@ -89,9 +90,11 @@ void BusTap::feed(BusDirection direction, const uint8_t* data, size_t len, uint6
         open_.gapBeforeMs = static_cast<uint32_t>(nowMs - lastByteMs_);
         openHasBytes_     = true;
     }
+    bool ranOutOfRoom = false;
     for (size_t i = 0; i < len; ++i) {
         if (totalBytes_ >= config_.maxTotalBytes) {
-            truncated_ = true;
+            truncated_   = true;
+            ranOutOfRoom = true;
             break;
         }
         if (open_.bytes.size() >= config_.maxFrameBytes) {
@@ -111,6 +114,15 @@ void BusTap::feed(BusDirection direction, const uint8_t* data, size_t len, uint6
         ++totalBytes_;
     }
     lastByteMs_ = nowMs;
+
+    // Closed HERE rather than left open for finish() to deal with. Left open, the record
+    // survives to the end of the window and finish() labels it WindowEnd -- which is a false
+    // account when the budget ran out with most of the window still to go, and cut_by exists
+    // precisely so a reader does not have to guess at that. Every later feed() is refused by
+    // the cap check above, so nothing would have been added to it anyway.
+    if (ranOutOfRoom) {
+        closeFrame(CutReason::CaptureFull);
+    }
 }
 
 void BusTap::finish(uint64_t nowMs) {

--- a/src/diagnostics/bus_tap.h
+++ b/src/diagnostics/bus_tap.h
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+//
+// Records the conversation a working driver is already having, as it happens.
+//
+// The sibling of FrameCapture, and the answer to the one thing FrameCapture structurally cannot
+// do. That one is PASSIVE: the bus owner runs it instead of a poll, so the bridge is silent for
+// the whole window. Point it at an inverter this build can already talk to and it records
+// nothing at all -- confirmed on hardware, 30 s against a live inverter with a working driver,
+// zero frames. The driver that would produce the traffic is the thing being paused.
+//
+// So this one does not pause anything. It sits on the transport and watches the driver's own
+// requests and replies go past. Polling continues throughout; that traffic IS the recording.
+//
+// WHAT MAKES THIS POSSIBLE, and it is worth stating because it decided the whole design: every
+// driver reaches the bus through Transport, and both protocol layers hand a COMPLETE request to
+// a single write() call (see pmu_transaction.cpp and modbus_client.cpp). So the transport knows
+// which direction each byte went without any driver being asked, and a record can follow the
+// transaction instead of guessing at silence.
+//
+// That second part matters. FrameCapture cuts records on the Modbus t3.5 idle gap, which is
+// honest at 9600 and 19200 and approximate above that, because at 38400 the real gap is finer
+// than any reader can resolve. Here the primary boundary is the direction turning around, which
+// is exact at any baud rate. The idle gap is still used -- a device that answers twice, or a
+// driver that reads a reply in pieces, needs it -- but it is no longer the only thing holding
+// the framing up, and every record says which rule cut it.
+//
+// Deliberately protocol-blind, exactly like its sibling: bytes, direction and timing, plus the
+// two checksum verdicts (shared with FrameCapture, one source of truth). Interpreting them stays
+// with the per-protocol decoders in tools/ and the protocol documents in docs/.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "frame_capture.h"
+#include "transport/serial_profile.h"
+
+namespace heliograph::diag {
+
+/// Which way the bytes went, from the bridge's point of view.
+enum class BusDirection : uint8_t {
+    /// The bridge wrote them. A driver's request.
+    Tx,
+    /// The bridge read them. A device's reply, or anything else on the bus.
+    Rx,
+};
+
+const char* busDirectionName(BusDirection direction);
+
+/// Why a record ended. Reported per record rather than inferred, because the reader cannot
+/// otherwise tell a boundary the protocol made from one this recorder imposed -- and only the
+/// first kind means "these bytes are one frame".
+enum class CutReason : uint8_t {
+    /// The conversation turned around. Exact at any baud rate; the boundary a driver's own
+    /// transaction structure gives you for free.
+    DirectionChange,
+    /// Silence at least as long as the t3.5 gap. The same rule the passive capture leans on.
+    IdleGap,
+    /// Neither -- the record hit its byte bound and was split. A cut the protocol did not make,
+    /// so the bytes on either side may well belong together.
+    ByteCap,
+    /// The window ended with this record still open.
+    WindowEnd,
+};
+
+const char* cutReasonName(CutReason reason);
+
+/// One run of bytes in one direction.
+struct TappedFrame {
+    BusDirection         direction = BusDirection::Tx;
+    /// Milliseconds since the tap was armed, at the first byte of this record.
+    uint32_t             offsetMs = 0;
+    /// Silence before this record. Across a direction change this is the device's response time,
+    /// which is protocol evidence in its own right: an inverter that answers in 20 ms behaves
+    /// differently from one that takes 200, and a driver's read timeout has to cover the slower.
+    uint32_t             gapBeforeMs = 0;
+    std::vector<uint8_t> bytes;
+    bool                 modbusCrcValid = false;
+    bool                 pmuFrameValid  = false;
+    CutReason            cutBy = CutReason::WindowEnd;
+};
+
+struct TapConfig {
+    /// How long to watch. Unlike the passive capture this does not stop the inverter being
+    /// polled, so the bound is about the size of the report rather than about downtime.
+    uint32_t durationMs    = 30000;
+    size_t   maxFrames     = 64;
+    size_t   maxFrameBytes = 256;
+    /// The bound that actually caps the response, for the same reason it does on CaptureConfig:
+    /// maxFrames * maxFrameBytes is a product of two independently chosen limits and therefore a
+    /// bound on nothing. 12 KB of bytes is ~36 KB of hex, which the Relay-6CH -- the one board
+    /// with no PSRAM to fall back on -- can hold alongside a copy.
+    size_t   maxTotalBytes = 12288;
+    /// Silence that ends a record when the direction has not changed. Zero means "derive it from
+    /// the line", which is what the runner passes; an explicit value exists for tests.
+    uint32_t idleGapMs     = 0;
+};
+
+/// Accumulates tapped bytes into records.
+///
+/// Pure, like FrameCapture: no UART, no clock of its own, every time value passed in. It is also
+/// NOT internally locked, and that is deliberate -- only the task that owns the bus ever feeds
+/// it, so putting a mutex on the per-byte path would be paying for contention that cannot
+/// happen. The runner that owns one is what guards the report handed to the web task.
+class BusTap {
+public:
+    BusTap(const TapConfig& config, const SerialProfile& profile);
+
+    /// Marks the start of the window. Every offsetMs is measured from here.
+    void begin(uint64_t nowMs);
+
+    /// Bytes the bridge just wrote.
+    void recordTx(const uint8_t* data, size_t len, uint64_t nowMs);
+
+    /// Bytes the bridge just read. `len == 0` is a normal and necessary call: a read that timed
+    /// out still advances time, and without it the silence that ends the last record before a
+    /// quiet stretch would never be observed.
+    void recordRx(const uint8_t* data, size_t len, uint64_t nowMs);
+
+    /// Closes the open record, if any, as WindowEnd. Call once when the window ends.
+    void finish(uint64_t nowMs);
+
+    /// True when the window has elapsed or a bound is reached.
+    bool done(uint64_t nowMs) const;
+
+    /// True when it stopped because it filled up rather than because time ran out. Full means
+    /// STOPPED, not "oldest dropped" -- for a handshake the interesting part is at the
+    /// beginning, and a ring buffer would reliably throw away exactly that.
+    bool truncated() const { return truncated_; }
+
+    const std::vector<TappedFrame>& frames() const { return frames_; }
+    uint32_t totalBytes() const { return totalBytes_; }
+    uint32_t idleGapMs() const { return gapMs_; }
+
+    /// Records in each direction. A recording with requests and no replies is the single most
+    /// informative shape this can produce -- it says the bridge is talking and the device is not
+    /// answering, which no passive capture can distinguish from a dead bus.
+    uint32_t txFrames() const;
+    uint32_t rxFrames() const;
+    uint32_t modbusFrames() const;
+    uint32_t pmuFrames() const;
+
+private:
+    void feed(BusDirection direction, const uint8_t* data, size_t len, uint64_t nowMs);
+    void closeFrame(CutReason reason);
+
+    TapConfig                config_;
+    uint32_t                 gapMs_      = 0;
+    uint64_t                 startMs_    = 0;
+    uint64_t                 lastByteMs_ = 0;
+    uint32_t                 totalBytes_ = 0;
+    bool                     truncated_  = false;
+    TappedFrame              open_;
+    bool                     openHasBytes_ = false;
+    std::vector<TappedFrame> frames_;
+};
+
+}  // namespace heliograph::diag

--- a/src/diagnostics/bus_tap.h
+++ b/src/diagnostics/bus_tap.h
@@ -59,8 +59,15 @@ enum class CutReason : uint8_t {
     /// Silence at least as long as the t3.5 gap. The same rule the passive capture leans on.
     IdleGap,
     /// Neither -- the record hit its byte bound and was split. A cut the protocol did not make,
-    /// so the bytes on either side may well belong together.
+    /// so the bytes on either side may well belong together. Recording continues after it.
     ByteCap,
+    /// The capture's total byte budget ran out here. Also a cut the protocol did not make, and
+    /// kept separate from ByteCap because the consequence differs: after ByteCap the recording
+    /// carries on, after this one NOTHING further is recorded, however much of the window is
+    /// left. Reported per record because "the window closed on it" and "it ran out of room"
+    /// mean very different things about the traffic that followed, and the report-level
+    /// `truncated` flag cannot say which record it happened to.
+    CaptureFull,
     /// The window ended with this record still open.
     WindowEnd,
 };

--- a/src/diagnostics/frame_capture.cpp
+++ b/src/diagnostics/frame_capture.cpp
@@ -16,6 +16,8 @@ uint32_t bitsPerCharacter(const SerialProfile& profile) {
            profile.stopBits;
 }
 
+}  // namespace
+
 bool modbusCrcHolds(const std::vector<uint8_t>& bytes) {
     // Four is the shortest thing that can carry one: unit, function and two CRC bytes. Below
     // that there is nothing to check rather than a check that fails.
@@ -34,8 +36,6 @@ bool pmuFrameHolds(const std::vector<uint8_t>& bytes) {
     pmu::Frame frame;
     return pmu::parseFrame(bytes.data(), bytes.size(), frame) == pmu::ParseResult::Ok;
 }
-
-}  // namespace
 
 uint32_t idleGapMsFor(const SerialProfile& profile) {
     if (profile.baudRate == 0) {

--- a/src/diagnostics/frame_capture.h
+++ b/src/diagnostics/frame_capture.h
@@ -78,6 +78,18 @@ struct CaptureConfig {
 /// resolution it actually has, and the framing note above says what that costs.
 uint32_t idleGapMsFor(const SerialProfile& profile);
 
+/// The two checksum verdicts, shared by every recorder in this directory.
+///
+/// Public rather than file-local because BusTap needs exactly the same judgement on exactly the
+/// same kind of byte run, and two recorders disagreeing about whether a frame checks out would
+/// be worse than either answer: the counts are the number an operator reads first, and they have
+/// to mean the same thing in both reports.
+///
+/// Neither one decodes. They answer "do the bytes hold together as this family's frame", which
+/// is how you find out whether the line settings were right -- not what the frame says.
+bool modbusCrcHolds(const std::vector<uint8_t>& bytes);
+bool pmuFrameHolds(const std::vector<uint8_t>& bytes);
+
 /// Accumulates bytes into records. Pure: no UART, no clock of its own, every time value passed
 /// in. The reading loop lives in CaptureRunner, on the task that owns the bus.
 class FrameCapture {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "app/capture_runner.h"
+#include "app/driver_capture_runner.h"
 #include "app/device_plan.h"
 #include "app/discovery_runner.h"
 #include "boards/board.h"
@@ -558,6 +559,11 @@ DiscoveryRunner g_discovery{g_registry, nowMs};
 /// Owns passive bus captures, on the same terms and for the same reason.
 CaptureRunner g_capture{nowMs};
 
+/// Owns driver captures. Same request-from-the-web, act-on-the-bus-task split, opposite
+/// mechanics: this one never takes an iteration away from polling, because the polling is what
+/// it records.
+DriverCaptureRunner g_driverCapture{nowMs};
+
 /// The configured driver, or the highest-priority one compiled in. No manufacturer name here.
 std::string selectedDriverId() {
     if (!g_config.driver.id.empty() && g_registry.contains(g_config.driver.id)) {
@@ -575,6 +581,28 @@ std::string selectedDriverId() {
 /// running discovery from the web UI on a healthy bridge silently reset the line and the
 /// inverter went quiet until the next power cycle -- the same failure the override exists to
 /// prevent, on the one path that reconfigures the line at runtime (review, 2026-07-25).
+/// The line the bus is actually running at.
+///
+/// Two sources and no third: the stored override when it is on, otherwise the profile the
+/// driver's begin() put on the UART -- the first of its recommended profiles, which is exactly
+/// what applySerialOverride() below declines to replace. A driver capture reports this because
+/// the idle gap derives from it, and because nobody can check the framing against a protocol
+/// document a day later without knowing what the line was.
+///
+/// Caller holds g_configMutex.
+SerialProfile effectiveSerialProfile() {
+    if (g_config.serial.enabled) {
+        return g_config.serial.profile;
+    }
+    if (g_driver != nullptr && !g_driver->descriptor().recommendedSerialProfiles.empty()) {
+        return g_driver->descriptor().recommendedSerialProfiles.front();
+    }
+    // No driver, or one that declares no profile. Falls back to SerialProfile's own default
+    // rather than guessing; with no driver there is no conversation to record anyway, so this
+    // is a value for the report to carry, not one anybody acts on.
+    return SerialProfile{};
+}
+
 void applySerialOverride() {
     if (!g_config.serial.enabled) {
         // Logged even when nothing is overridden. Most bridges follow their driver, and without
@@ -1076,21 +1104,41 @@ void startRestApi() {
     // capture would then record the tail of the probe run -- exactly what the guard on the
     // other side exists to prevent. Guarding one direction only left that hole open.
     ctx.requestDiscovery = [](bool extended) {
-        if (g_capture.busy()) {
+        // A driver capture is refused here too, and for a reason the other two do not have. It
+        // does not want the bus -- it would happily keep recording through a probe sweep. That
+        // is the problem: a sweep re-registers every inverter and walks eight addresses, so the
+        // recording would be of something no driver ever does, filed under a report that claims
+        // to show the driver's own conversation.
+        if (g_capture.busy() || g_driverCapture.busy()) {
             return false;
         }
         return g_discovery.request(extended);
     };
     ctx.discoveryReport     = [] { return g_discovery.report(); };
     // Refused while discovery is pending or running as well as while another capture is: both
-    // want exclusive use of the same bus.
+    // want exclusive use of the same bus. A driver capture blocks it too -- this one takes the
+    // bus away from the driver, which is precisely the traffic the other is recording.
     ctx.requestCapture = [](const diag::CaptureConfig& config, const SerialProfile& profile) {
-        if (g_discovery.busy()) {
+        if (g_discovery.busy() || g_driverCapture.busy()) {
             return false;
         }
         return g_capture.request(config, profile);
     };
     ctx.captureReport = [] { return g_capture.report(); };
+    // The mirror of the two above. Nothing else may be holding or about to hold the bus: a
+    // recording of a probe sweep or of a passive window (in which the bridge says nothing at
+    // all) is not what this report claims to contain.
+    ctx.requestDriverCapture = [](const diag::TapConfig& config) {
+        if (g_discovery.busy() || g_capture.busy()) {
+            return false;
+        }
+        // The line is not the operator's to choose here -- there is a working driver and it is
+        // already talking. Read from the bridge rather than taken from the request, so the
+        // report cannot end up describing a line the capture did not run at.
+        std::lock_guard<std::mutex> lock(g_configMutex);
+        return g_driverCapture.request(config, effectiveSerialProfile());
+    };
+    ctx.driverCaptureReport = [] { return g_driverCapture.report(); };
     ctx.requestFactoryReset = [] { return g_store.factoryReset(); };
     // The undo behind a configuration restore. Straight through to the store, which owns both
     // the stash and the swap; the REST layer only decides when.
@@ -1245,6 +1293,33 @@ void rs485Task(void* /*arg*/) {
         // on xtensa); the scan only walks the unused region -- microseconds.
         g_diagnostics.recordRs485StackFree(
             static_cast<uint32_t>(uxTaskGetStackHighWaterMark(nullptr)));
+        // The driver capture, and note that it does NOT `continue`. Every other branch in this
+        // loop takes the iteration away from polling because it needs the bus to itself; this
+        // one arms a recorder and gets out of the way, because the poll further down is the
+        // thing it exists to record. Taking the iteration would reproduce exactly the bug that
+        // issue #62 is about -- a capture that records nothing because it paused the driver
+        // whose traffic it wanted.
+        //
+        // It is also first, so that a capture armed this iteration covers the poll in the same
+        // iteration rather than starting one cycle late.
+        switch (g_driverCapture.service(g_transport)) {
+            case DriverCaptureService::Armed:
+                log::info("driver capture: recording the bus for %u s",
+                          static_cast<unsigned>(g_driverCapture.report().config.durationMs / 1000));
+                break;
+            case DriverCaptureService::Collected: {
+                const auto report = g_driverCapture.report();
+                log::info("driver capture: %u frames (%u sent, %u received), %u bytes",
+                          static_cast<unsigned>(report.frames.size()),
+                          static_cast<unsigned>(report.txFrames),
+                          static_cast<unsigned>(report.rxFrames),
+                          static_cast<unsigned>(report.totalBytes));
+                break;
+            }
+            case DriverCaptureService::Idle:
+            case DriverCaptureService::Recording:
+                break;
+        }
         // Discovery first, and instead of polling this cycle: probing re-registers every
         // inverter on the bus, so the two must never interleave. This task owns the bus, which
         // is why the web handler only ever *requests* a run.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -375,31 +375,36 @@ namespace {
 // implement. A wrong map can report a wrong number; it cannot put a device into an untested
 // state.
 #define HELIOGRAPH_VERSION_MAJOR 0
-#define HELIOGRAPH_VERSION_MINOR 25
+#define HELIOGRAPH_VERSION_MINOR 26
 //
-// 0.25.1 changes nothing a bridge does, and changes what builds it.
+// 0.26.0 can record a conversation it is having, not just one it is overhearing.
 //
-// THE TOOLCHAIN IS PINNED TO A VERSION. The platform URL ended in /stable/, which moves. It had
-// already moved: 0.25.0's images were compiled by an Arduino core two patch releases newer than
-// the one this project last booted on a board, and no commit recorded that, because from the
-// repository's side nothing had changed. Firmware meant to run for years unattended should not
-// have its compiler and RTOS replaced underneath a release without a line in the history saying
-// so. Bumping is now an edit somebody reviews. The same image is 89 KB smaller for it, which is
-// the measure of how different the two toolchains were.
+// The raw bus capture has always been PASSIVE by design: the bus task runs it instead of a poll,
+// so the bridge is silent for the whole window. Right for an unidentified device, where our own
+// traffic would present two conversations as one stream -- and structurally unable to record a
+// protocol we already speak, because the driver that would produce that traffic is the thing it
+// pauses. Thirty seconds against a live inverter with a working driver: zero frames, zero bytes.
 //
-// The monthly dependency check gained a third source, because pinning created a new silence: a
-// version pin nobody watches is a toolchain frozen for years. Neither existing check could see
-// a platform installed from a release URL -- verified by pinning backwards and watching the
-// report still say everything was up to date.
+// mode=driver arms a recorder instead of taking the bus. Polling continues; that traffic IS the
+// recording. One observation made it possible: every driver reaches the bus through Transport,
+// and both protocol layers hand a complete request to a single write(), so the transport knows
+// which direction each byte went without any driver being asked. No driver changed, and every
+// driver added later is covered the day it arrives.
 //
-// EIGHTY COMPILER WARNINGS FROM OUR OWN CODE, NOW ZERO. Twenty were introduced by 0.25.0 itself;
-// the rest were a format string that is wrong on one of the two builds and right by accident on
-// the other. Nothing was suppressed to get there.
+// That also makes the framing exact. The passive mode cuts on the t3.5 idle gap, which is honest
+// at 9600 and 19200 and approximate above, because at 38400 the real gap is finer than any
+// reader resolves. Here the primary boundary is the direction turning around, which holds at any
+// baud rate -- and every record says which rule cut it, because a boundary the protocol made and
+// one the recorder imposed are otherwise indistinguishable.
 //
-// One rule, one place: whether a reading may be published -- supported, valid, and not stale --
-// was written out by hand in four outputs and inverted in one of them. Anything else is absent,
-// never zero, and that rule is now asked of one predicate.
-#define HELIOGRAPH_VERSION_PATCH 1
+// What it buys, beyond bytes: a shipped driver can be checked against its protocol document on
+// real hardware without a USB-RS485 tap at the inverter, and "requests with no replies" becomes
+// a diagnosis the passive mode structurally cannot reach -- there the bridge is the silent one,
+// so a dead bus and an unanswering device produce the same empty report.
+//
+// Cost in the RS485 hot path when nothing is recording: one inline null check. It never takes
+// the bus lock and never touches the line.
+#define HELIOGRAPH_VERSION_PATCH 0
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -1090,6 +1090,58 @@ bool RestApi::begin() {
             return std::strtol(request->getParam(name)->value().c_str(), nullptr, 10);
         };
 
+        // Which conversation to record. Default `passive` so every existing caller keeps its
+        // meaning: this endpoint has always recorded a bus the bridge was silent on.
+        const bool driverMode =
+            request->hasParam("mode") && request->getParam("mode")->value() == "driver";
+        if (request->hasParam("mode") && !driverMode &&
+            request->getParam("mode")->value() != "passive") {
+            sendError(request, {400, "invalid_parameter", "mode must be passive or driver"});
+            return;
+        }
+
+        if (driverMode) {
+            if (context_.requestDriverCapture == nullptr) {
+                sendError(request, {404, "no_capture", "this build cannot capture"});
+                return;
+            }
+            // Refused, not ignored. There is a working driver here, so the line is a fact about
+            // the bridge -- accepting a baud rate and then recording at a different one would
+            // put a number in the report that the capture never ran at, which is worse than
+            // any error message.
+            for (const char* param : {"baud", "parity", "data_bits", "stop_bits"}) {
+                if (request->hasParam(param)) {
+                    sendError(request, {400, "invalid_parameter",
+                                        std::string("mode=driver records the line the driver is "
+                                                    "already using; remove '") +
+                                            param + "'"});
+                    return;
+                }
+            }
+            diag::TapConfig tap;
+            const long      seconds = number("seconds", 30);
+            if (seconds < 1 || seconds > static_cast<long>(kMaxDriverCaptureSeconds)) {
+                sendError(request, {400, "invalid_parameter",
+                                    "seconds must be between 1 and " +
+                                        std::to_string(kMaxDriverCaptureSeconds)});
+                return;
+            }
+            tap.durationMs   = static_cast<uint32_t>(seconds) * 1000u;
+            const long frames = number("frames", 64);
+            if (frames < 1 || frames > 256) {
+                sendError(request, {400, "invalid_parameter", "frames must be between 1 and 256"});
+                return;
+            }
+            tap.maxFrames = static_cast<size_t>(frames);
+            if (!context_.requestDriverCapture(tap)) {
+                sendError(request, {409, "bus_busy",
+                                    "a capture or discovery run is already using the bus"});
+                return;
+            }
+            request->send(202, kJson, "{\"status\":\"accepted\"}");
+            return;
+        }
+
         diag::CaptureConfig config;
         const long seconds = number("seconds", 30);
         if (seconds < 1 || seconds > static_cast<long>(kMaxCaptureSeconds)) {
@@ -1152,6 +1204,26 @@ bool RestApi::begin() {
         }
         std::string body;
         if (!buildCapturePayload(context_.captureReport(), context_.clock(), body)) {
+            sendError(request, {500, "payload_too_large", "the capture exceeded its bound"});
+            return;
+        }
+        request->send(200, kJson, body.c_str());
+    });
+
+    // Its own route rather than a mode on the one above, because the two reports are not the
+    // same document: every frame here carries a direction and the rule that ended it, and the
+    // summary counts requests against replies. One route would have to decide which of two
+    // independent last-reports to hand back, and a consumer would have to branch on a mode field
+    // anyway -- with half the fields absent, which reads as missing data rather than as a
+    // different kind of report.
+    g_server->on("/api/v1/capture/driver", HTTP_GET, [this](AsyncWebServerRequest* request) {
+        context_.diagnostics->recordRestRequest();
+        if (context_.driverCaptureReport == nullptr) {
+            sendError(request, {404, "no_capture", "this build cannot capture"});
+            return;
+        }
+        std::string body;
+        if (!buildDriverCapturePayload(context_.driverCaptureReport(), context_.clock(), body)) {
             sendError(request, {500, "payload_too_large", "the capture exceeded its bound"});
             return;
         }

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -1073,9 +1073,10 @@ bool RestApi::begin() {
         request->send(202, kJson, "{\"status\":\"accepted\"}");
     });
 
-    // Raw bus capture, for a device discovery could not name. Every parameter travels in the
-    // query: they are four numbers and an enum, and a JSON body would need the whole
-    // collectBody dance for that.
+    // Bus capture, in either of its two modes: `passive` for a device discovery could not name,
+    // `driver` for one we already talk to. Every parameter travels in the query: they are a
+    // handful of numbers and two enums, and a JSON body would need the whole collectBody dance
+    // for that.
     g_server->on("/api/v1/actions/capture", HTTP_POST,
                  [this, authorised, rateLimited](AsyncWebServerRequest* request) {
         if (!authorised(request) || rateLimited(request)) {
@@ -1126,10 +1127,17 @@ bool RestApi::begin() {
                                         std::to_string(kMaxDriverCaptureSeconds)});
                 return;
             }
-            tap.durationMs   = static_cast<uint32_t>(seconds) * 1000u;
+            tap.durationMs    = static_cast<uint32_t>(seconds) * 1000u;
             const long frames = number("frames", 64);
-            if (frames < 1 || frames > 256) {
-                sendError(request, {400, "invalid_parameter", "frames must be between 1 and 256"});
+            // Lower than the passive mode's 256, and refused rather than silently clamped: this
+            // report carries a direction and a cut reason per record, and above ~160 records it
+            // no longer fits the response bound. A capture that completes and can only ever
+            // answer 500 has spent real bus time for a report nobody can fetch.
+            if (frames < 1 || frames > kMaxDriverCaptureFrames) {
+                sendError(request, {400, "invalid_parameter",
+                                    "frames must be between 1 and " +
+                                        std::to_string(kMaxDriverCaptureFrames) +
+                                        " in mode=driver"});
                 return;
             }
             tap.maxFrames = static_cast<size_t>(frames);

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -36,6 +36,7 @@ class AsyncWebServerRequest;
 #include "diagnostics/diagnostics.h"
 #include "app/capture_runner.h"
 #include "app/discovery_runner.h"
+#include "app/driver_capture_runner.h"
 #include "drivers/driver_registry.h"
 #include "rest_payloads.h"
 #include "state/state_store.h"
@@ -85,6 +86,13 @@ struct RestContext {
     std::function<bool(const diag::CaptureConfig&, const SerialProfile&)> requestCapture;
     /// The current capture report, for the wizard to poll and then download.
     std::function<CaptureReport()> captureReport;
+    /// Start a capture of the driver's own conversation. No SerialProfile argument, and that is
+    /// the point: there is a working driver, so the line is a fact about the bridge rather than
+    /// a guess the operator supplies. Returns false when anything else is using the bus.
+    std::function<bool(const diag::TapConfig&)> requestDriverCapture;
+    /// The current driver-capture report. Carries frames only once it is done -- while it runs,
+    /// the bus task is still appending to them.
+    std::function<DriverCaptureReport()> driverCaptureReport;
     /// Wipes stored configuration including credentials, then reboots into the setup portal.
     /// The same wipe the BOOT-hold performs, reached over the network instead of the button --
     /// which is what a user without physical access has when a config locks them out.

--- a/src/outputs/rest/rest_payloads.cpp
+++ b/src/outputs/rest/rest_payloads.cpp
@@ -17,6 +17,25 @@ using json_util::finish;
 using json_util::writeDeviceStatus;
 using json_util::writeMeasurement;
 
+/// Uppercase, space-separated: the form every protocol document and every decoder example in
+/// docs/ uses, so a captured frame can be held next to one and compared by eye.
+///
+/// Shared by both capture reports. They differ in almost everything else, but a frame rendered
+/// two ways would defeat the one thing this format is for.
+std::string hexBytes(const std::vector<uint8_t>& bytes) {
+    static const char kDigits[] = "0123456789ABCDEF";
+    std::string       hex;
+    hex.reserve(bytes.size() * 3);
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        if (i != 0) {
+            hex.push_back(' ');
+        }
+        hex.push_back(kDigits[bytes[i] >> 4]);
+        hex.push_back(kDigits[bytes[i] & 0x0F]);
+    }
+    return hex;
+}
+
 }  // namespace
 
 bool buildErrorPayload(const ApiError& error, const std::string& requestId, std::string& out) {
@@ -657,17 +676,58 @@ bool buildCapturePayload(const CaptureReport& report, uint64_t nowMs, std::strin
         e["length"]         = f.bytes.size();
         e["modbus_crc_ok"]  = f.modbusCrcValid;
         e["aa55_ok"]        = f.pmuFrameValid;
-        // Uppercase, space-separated: the form every protocol document and every decoder
-        // example in docs/ uses, so a captured frame can be compared against one by eye.
-        std::string hex;
-        hex.reserve(f.bytes.size() * 3);
-        for (size_t i = 0; i < f.bytes.size(); ++i) {
-            static const char kDigits[] = "0123456789ABCDEF";
-            if (i != 0) hex.push_back(' ');
-            hex.push_back(kDigits[f.bytes[i] >> 4]);
-            hex.push_back(kDigits[f.bytes[i] & 0x0F]);
-        }
-        e["hex"] = hex;
+        e["hex"] = hexBytes(f.bytes);
+    }
+    return finish(doc, out, maxBytes);
+}
+
+bool buildDriverCapturePayload(const DriverCaptureReport& report, uint64_t nowMs, std::string& out,
+                               size_t maxBytes) {
+    JsonDocument doc;
+    doc["status"] = driverCaptureStatusName(report.status);
+
+    // The line the DRIVER is running at, not one the operator guessed. Echoed for the same
+    // reason it is in the passive report: the idle gap derives from it, and nobody can check
+    // this framing against a protocol document a day later without it.
+    JsonObject line     = doc["line"].to<JsonObject>();
+    line["baud_rate"]   = report.profile.baudRate;
+    line["parity"]      = parityName(report.profile.parity);
+    line["data_bits"]   = report.profile.dataBits;
+    line["stop_bits"]   = report.profile.stopBits;
+    line["idle_gap_ms"] = report.idleGapMs;
+
+    doc["requested_seconds"] = report.config.durationMs / 1000;
+    doc["max_frames"]        = report.config.maxFrames;
+    if (report.startedMs != 0) {
+        const uint64_t end = report.finishedMs != 0 ? report.finishedMs : nowMs;
+        doc["elapsed_ms"]  = end - report.startedMs;
+    }
+
+    JsonObject summary        = doc["summary"].to<JsonObject>();
+    summary["frames"]         = report.frames.size();
+    summary["bytes"]          = report.totalBytes;
+    // The pair that makes this report worth having. Requests with no replies is a diagnosis a
+    // passive capture cannot reach -- there the bridge is the silent one, so "nobody is talking"
+    // and "the device is not answering" look identical.
+    summary["sent"]           = report.txFrames;
+    summary["received"]       = report.rxFrames;
+    summary["modbus_crc_ok"]  = report.modbusFrames;
+    summary["aa55_frames_ok"] = report.pmuFrames;
+    summary["truncated"]      = report.truncated;
+
+    JsonArray frames = doc["frames"].to<JsonArray>();
+    for (const auto& f : report.frames) {
+        JsonObject e       = frames.add<JsonObject>();
+        e["direction"]     = diag::busDirectionName(f.direction);
+        e["offset_ms"]     = f.offsetMs;
+        e["gap_before_ms"] = f.gapBeforeMs;
+        e["length"]        = f.bytes.size();
+        e["modbus_crc_ok"] = f.modbusCrcValid;
+        e["aa55_ok"]       = f.pmuFrameValid;
+        // Which rule ended this record. Without it a reader cannot tell a boundary the protocol
+        // made from one the recorder imposed, and only the first kind means "one frame".
+        e["cut_by"]        = diag::cutReasonName(f.cutBy);
+        e["hex"]           = hexBytes(f.bytes);
     }
     return finish(doc, out, maxBytes);
 }

--- a/src/outputs/rest/rest_payloads.h
+++ b/src/outputs/rest/rest_payloads.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "app/capture_runner.h"
+#include "app/driver_capture_runner.h"
 #include "config/config_backup.h"
 #include "device/bridge_info.h"
 #include "device/device_state.h"
@@ -195,6 +196,19 @@ bool buildLogsPayload(const std::vector<std::string>& lines, uint32_t totalLines
 inline constexpr size_t kMaxCaptureResponseBytes = 65536;
 bool buildCapturePayload(const CaptureReport& report, uint64_t nowMs, std::string& out,
                          size_t maxBytes = kMaxCaptureResponseBytes);
+
+/// A capture of the driver's own conversation.
+///
+/// A separate builder rather than a mode flag on the one above, because the two reports differ
+/// in what a reader has to know about them: every frame here carries a direction and the rule
+/// that ended it, and the summary counts requests against replies. Folding both into one shape
+/// would mean half the fields being absent depending on which mode produced it -- a consumer
+/// would have to branch anyway, and the absent half would look like missing data rather than
+/// like a different kind of report.
+///
+/// Same byte bound, same reason.
+bool buildDriverCapturePayload(const DriverCaptureReport& report, uint64_t nowMs,
+                               std::string& out, size_t maxBytes = kMaxCaptureResponseBytes);
 /// What a restore would do, before it does it.
 ///
 /// The preview is computed against the MERGED result, not against the file, so it tells the

--- a/src/transport/rs485_transport.cpp
+++ b/src/transport/rs485_transport.cpp
@@ -88,6 +88,9 @@ size_t Rs485Transport::write(const uint8_t* data, size_t len) {
     // reads what actually goes onto the bus, without the transport learning any protocol. The
     // bus carries no secrets.
     log::traceHex("RS485 TX", data, n);
+    // `n`, not `len`: a short write means the tail never reached the wire, and recording it
+    // would describe a frame the device never saw.
+    tapTx(data, n);
     return n;
 }
 
@@ -119,6 +122,12 @@ size_t Rs485Transport::read(uint8_t* buf, size_t len, uint32_t timeoutMs) {
     // the bounded in-memory ring the REST log serves, where it evicted all surrounding
     // context (2026-07-20). The driver traces the assembled buffer once per transaction,
     // together with the outcome, which is the level a reader actually reasons at.
+    //
+    // The recorder is fed regardless, INCLUDING when got == 0. That is the opposite decision to
+    // the tracing above and for the opposite reason: a timed-out read is exactly how a recorder
+    // learns that time passed, and it reassembles the pieces itself instead of emitting one
+    // entry per read.
+    tapRx(buf, got);
     return got;
 }
 

--- a/src/transport/transport.cpp
+++ b/src/transport/transport.cpp
@@ -2,7 +2,15 @@
 
 #include "transport.h"
 
+#include "diagnostics/bus_tap.h"
+
 namespace heliograph {
+
+// The timestamp comes from the transport's own clock rather than from the caller: it is the one
+// clock the recorder and the bus agree on, and a driver has no reason to be passing time values
+// into a facility it does not know exists.
+void Transport::tapTxImpl(const uint8_t* data, size_t len) { tap_->recordTx(data, len, nowMs()); }
+void Transport::tapRxImpl(const uint8_t* data, size_t len) { tap_->recordRx(data, len, nowMs()); }
 
 const char* parityName(SerialParity parity) {
     switch (parity) {

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -54,8 +54,14 @@ public:
     /// never hold the bus lock indefinitely. See the receive loops in the drivers.
     virtual uint64_t nowMs() const = 0;
 
-    /// Exclusive access to the bus. Exactly one component may talk at a time; the raw TCP
-    /// bridge and discovery both go through this rather than touching the UART directly.
+    /// Exclusive access to the bus. Exactly one component may talk at a time: a driver's
+    /// transaction, a discovery probe, or a passive capture -- all through here, never touching
+    /// the UART directly.
+    ///
+    /// (This used to name a "raw TCP bridge" as one of the users. There has never been one in
+    /// this tree; the Modbus TCP server reads the cached register map and never sees a
+    /// Transport. Found by review, 2026-08-02, three lines above a facility that was being
+    /// extended on the strength of who takes this lock.)
     virtual bool lock(uint32_t timeoutMs) = 0;
     virtual void unlock() = 0;
 

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -15,6 +15,10 @@
 
 namespace heliograph {
 
+namespace diag {
+class BusTap;
+}
+
 enum class TransportType : uint8_t { Rs485, Rs232, Can, Tcp, Mock };
 
 struct TransportStats {
@@ -56,6 +60,53 @@ public:
     virtual void unlock() = 0;
 
     virtual const TransportStats& stats() const = 0;
+
+    /// Installs a recorder that sees every byte, with the direction it went. `nullptr` removes
+    /// it, which is the normal state.
+    ///
+    /// Concrete and non-virtual on purpose. A pure virtual would oblige every implementation to
+    /// grow a member it has no opinion about; this way an implementation opts in by calling the
+    /// two helpers below in its read/write, and one that never does is simply never tapped.
+    ///
+    /// THE TAP NEVER TAKES THE BUS LOCK. It runs inside a transaction whose caller already holds
+    /// it -- taking it again would deadlock, and taking it separately would defeat the whole
+    /// point, which is to watch traffic that is happening anyway rather than to stop it.
+    ///
+    /// Ownership stays with the caller, and so does the lifetime rule: whoever installs a tap
+    /// must remove it before the object dies, and must only install from the task that owns the
+    /// bus. There is no locking here because there is nothing to lock against -- one task reads
+    /// and writes, and the pointer changes only between its own transactions.
+    void setTap(diag::BusTap* tap) { tap_ = tap; }
+    bool tapped() const { return tap_ != nullptr; }
+
+protected:
+    /// Called by implementations from write()/read(). Pass what actually went on the wire, not
+    /// what was asked for -- a short write means the tail never left, and a recording that
+    /// showed it would be describing a frame the device never saw.
+    ///
+    /// The null check is inline and the work is not: when nothing is recording, which is almost
+    /// always, the cost in the RS485 hot path is one compare against a member already in cache.
+    void tapTx(const uint8_t* data, size_t len) {
+        if (tap_ != nullptr) {
+            tapTxImpl(data, len);
+        }
+    }
+    /// `len == 0` is a normal call and must not be skipped: a read that timed out is how the
+    /// recorder learns that time passed, and without it the last record before a quiet stretch
+    /// would never be closed.
+    void tapRx(const uint8_t* data, size_t len) {
+        if (tap_ != nullptr) {
+            tapRxImpl(data, len);
+        }
+    }
+
+private:
+    // Out of line so transport.h does not have to include the recorder's header, and so the
+    // inline part above stays a single branch.
+    void tapTxImpl(const uint8_t* data, size_t len);
+    void tapRxImpl(const uint8_t* data, size_t len);
+
+    diag::BusTap* tap_ = nullptr;
 };
 
 /// RAII helper for Transport::lock/unlock.

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -2007,13 +2007,14 @@ function renderDriverCapture(d){
         <td class="n dim">${esc(f.gap_before_ms)} ms</td>
         <td class="n">${esc(f.length)}</td>
         <td>${f.modbus_crc_ok?'<span style="color:var(--ok)">Modbus</span>':f.aa55_ok?'<span style="color:var(--ok)">AA55</span>':'<span class="dim">—</span>'}</td>
-        <td class="dim">${esc(f.cut_by==='byte_cap'?'split':f.cut_by==='direction_change'?'turn':f.cut_by==='idle_gap'?'silence':'end')}</td>
+        <td class="dim">${esc(f.cut_by==='byte_cap'?'split':f.cut_by==='capture_full'?'full':f.cut_by==='direction_change'?'turn':f.cut_by==='idle_gap'?'silence':'end')}</td>
         <td><code style="word-break:break-all">${esc(f.hex)}</code></td></tr>`).join('')}
     </tbody></table>
     <div class="hint"><b>→</b> is the bridge asking, <b>←</b> is the device answering. The gap on a
       reply is how long that device took — which is what a driver's read timeout has to cover.
       <b>split</b> in the last column means the record hit its byte limit, so those bytes and the
-      next row's may belong to one frame.</div>
+      next row's may belong to one frame; <b>full</b> means the recording ran out of room there
+      and nothing after it was kept.</div>
     <div class="acts"><button onclick="downloadDriverCapture()">Download as a text file</button></div>`;
 }
 function downloadDriverCapture(){

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -1061,8 +1061,13 @@ function paintHealth(){
     <div class="between"><b>Counters</b><button class="alt pill" onclick="copyCounters(this)">Copy as text</button></div>
     <div class="hint">Named the way a person would ask for them; the raw field name is still on <code>/api/v1/diagnostics</code>, unchanged.</div>
     <div class="groups" id="h_counters" style="margin-top:14px"></div>
-  </div>`;
+  </div>
+  ${driverCaptureHtml()}`;
   $('#health').innerHTML=h;
+  // Rendered again after the card exists, so a repaint of this tab does not throw away a
+  // recording somebody is still reading. The other capture loses its table on a repaint; this
+  // one keeps the last report in a variable precisely so it does not have to.
+  if(driverCapture)renderDriverCapture(driverCapture);
   renderLogs();
 }
 let logLines=[], logMeta='', logStop=false;
@@ -1937,6 +1942,93 @@ function downloadCapture(){
     ...(d.frames||[]).map(f=>String(f.offset_ms).padStart(8)+'  '+String(f.gap_before_ms).padStart(6)+'  '+
       String(f.length).padStart(3)+'  '+(f.modbus_crc_ok?'modbus  ':f.aa55_ok?'aa55    ':'-       ')+'  '+f.hex)];
   saveBlob(new Blob([lines.join('\n')+'\n'],{type:'text/plain'}),'heliograph-capture-'+d.line.baud_rate+'.txt');
+}
+// ---------------- driver capture: recording the conversation we already have ----------------
+// Lives on Health, not in the troubleshooting flow. That flow only appears when discovery names
+// nothing, which is exactly the bridge this cannot help -- there is no driver talking to record.
+let dcapTimer=null, driverCapture=null;
+function driverCaptureHtml(){
+  return `<div class="card" style="margin-top:12px">
+    <div class="between"><b>Record the driver's own conversation</b>
+      <button class="alt pill" onclick="startDriverCapture()">Start recording</button></div>
+    <div class="hint"><b>Polling continues</b> — that traffic is the recording. Nothing is
+      interrupted and the inverter keeps reporting throughout. Use this to check what the bridge
+      actually puts on the wire against the protocol document, or to attach real bytes to a bug
+      report when you have no RS485 tap at the inverter.</div>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:10px">
+      <label for="dcap_secs" style="margin:0">Record for</label>
+      <input id="dcap_secs" class="tiny" type="number" value="30" min="1" max="300" style="width:80px">
+      <span class="hint" style="margin:0">seconds — a poll cycle or two is usually enough</span>
+    </div>
+    <div id="dcap_msg" class="msg hide"></div><div id="dcap_out"></div></div>`;
+}
+async function startDriverCapture(){
+  // No line settings: there is a working driver, so the bridge knows the line and the API
+  // refuses the parameters rather than recording at something other than what you asked for.
+  const q='?mode=driver&seconds='+(Number(val('dcap_secs'))||30);
+  say('#dcap_msg','','Starting…');$('#dcap_out').innerHTML='';driverCapture=null;
+  const r=await authFetch('/api/v1/actions/capture'+q,{method:'POST'});
+  if(!r.ok&&r.status!==202){
+    const d=await r.json().catch(()=>({}));
+    say('#dcap_msg','err',esc((d.error&&d.error.message)||httpWhy(r)));return;
+  }
+  say('#dcap_msg','','Recording while the bridge polls…');
+  if(dcapTimer)clearInterval(dcapTimer);
+  dcapTimer=setInterval(pollDriverCapture,1000);
+}
+async function pollDriverCapture(){
+  if(!$('#dcap_msg')){clearInterval(dcapTimer);dcapTimer=null;return}
+  let d;try{d=await getJson('/api/v1/capture/driver')}catch(e){return}
+  if(d.status==='requested'||d.status==='running'){
+    // No byte count while it runs: the frames belong to the bus task until it is done, so the
+    // report genuinely has nothing to show yet. Claiming "0 bytes so far" would read as a
+    // silent bus rather than as a report that is not finished.
+    say('#dcap_msg','','Recording… '+Math.round((d.elapsed_ms||0)/1000)+' of '+(d.requested_seconds||0)+' s.');
+    return;
+  }
+  clearInterval(dcapTimer);dcapTimer=null;
+  if(d.status==='idle')return;
+  renderDriverCapture(d);
+}
+function renderDriverCapture(d){
+  driverCapture=d;
+  const s=d.summary||{}, sent=s.sent||0, got=s.received||0;
+  // The verdict first, and it is a different verdict from the passive mode's. There the question
+  // was "is the line speed right"; here the line is known, so the question is whether anything
+  // answered.
+  if(!sent)say('#dcap_msg','err','The bridge sent nothing at all during the recording. Either no device is configured, or the poll interval is longer than the window — try a longer recording.');
+  else if(!got)say('#dcap_msg','err',esc(sent)+' requests went out and nothing came back. The bridge is talking and the device is not answering: check the address, the wiring, and whether the inverter is awake.');
+  else say('#dcap_msg','ok',esc(sent)+' requests, '+esc(got)+' replies, '+esc(s.bytes)+' bytes at '+esc(d.line.baud_rate)+' baud.');
+  $('#dcap_out').innerHTML=`
+    ${s.truncated?'<div class="msg err" style="display:block">Stopped early — a limit was reached. The beginning is kept.</div>':''}
+    <table><thead><tr><th>Time</th><th></th><th>Gap</th><th>Len</th><th>Checksum</th><th>Cut by</th><th>Bytes</th></tr></thead><tbody>
+      ${(d.frames||[]).map(f=>`<tr><td class="n">${esc(f.offset_ms)} ms</td>
+        <td>${f.direction==='tx'?'<b>→</b>':'<span style="color:var(--ok)">←</span>'}</td>
+        <td class="n dim">${esc(f.gap_before_ms)} ms</td>
+        <td class="n">${esc(f.length)}</td>
+        <td>${f.modbus_crc_ok?'<span style="color:var(--ok)">Modbus</span>':f.aa55_ok?'<span style="color:var(--ok)">AA55</span>':'<span class="dim">—</span>'}</td>
+        <td class="dim">${esc(f.cut_by==='byte_cap'?'split':f.cut_by==='direction_change'?'turn':f.cut_by==='idle_gap'?'silence':'end')}</td>
+        <td><code style="word-break:break-all">${esc(f.hex)}</code></td></tr>`).join('')}
+    </tbody></table>
+    <div class="hint"><b>→</b> is the bridge asking, <b>←</b> is the device answering. The gap on a
+      reply is how long that device took — which is what a driver's read timeout has to cover.
+      <b>split</b> in the last column means the record hit its byte limit, so those bytes and the
+      next row's may belong to one frame.</div>
+    <div class="acts"><button onclick="downloadDriverCapture()">Download as a text file</button></div>`;
+}
+function downloadDriverCapture(){
+  const d=driverCapture;if(!d)return;
+  const s=d.summary||{};
+  const lines=['# Heliograph driver capture (the bridge kept polling throughout)',
+    '# line: '+d.line.baud_rate+' baud, '+d.line.parity+' parity, '+d.line.data_bits+' data bits, '+d.line.stop_bits+' stop bits',
+    '# '+s.frames+' records, '+s.bytes+' bytes, '+(s.sent||0)+' sent, '+(s.received||0)+' received, '+
+      (s.modbus_crc_ok||0)+' valid Modbus CRC, '+(s.aa55_frames_ok||0)+' valid AA55'+
+      (s.truncated?' (stopped at a limit)':''),
+    '#','# dir  time_ms  gap_ms  len  checksum  cut_by            bytes',
+    ...(d.frames||[]).map(f=>(f.direction==='tx'?'-> ':'<- ')+String(f.offset_ms).padStart(8)+'  '+
+      String(f.gap_before_ms).padStart(6)+'  '+String(f.length).padStart(3)+'  '+
+      (f.modbus_crc_ok?'modbus  ':f.aa55_ok?'aa55    ':'-       ')+'  '+String(f.cut_by).padEnd(16)+'  '+f.hex)];
+  saveBlob(new Blob([lines.join('\n')+'\n'],{type:'text/plain'}),'heliograph-driver-capture.txt');
 }
 function saveBlob(blob,name){
   const url=URL.createObjectURL(blob);

--- a/test/support/mock_transport.h
+++ b/test/support/mock_transport.h
@@ -118,6 +118,10 @@ public:
     }
 
     uint64_t nowMs() const override { return clockMs_; }
+    /// Moves the simulated clock forward without any I/O. For tests about what happens when time
+    /// passes BETWEEN transactions -- a capture window closing, say -- which msPerRead cannot
+    /// express because it only advances while somebody is reading.
+    void advanceClock(uint64_t ms) { clockMs_ += ms; }
     /// Milliseconds the simulated clock advances per read(). 0 (default) = time stands still.
     uint32_t msPerRead = 0;
     /// When set, every read() returns one noise byte and never a valid frame or silence.

--- a/test/support/mock_transport.h
+++ b/test/support/mock_transport.h
@@ -44,7 +44,22 @@ public:
         ++flushCalls;
     }
 
+    // The tap is fed here rather than inside the bodies below, which have several return points
+    // each. Same contract the real transport honours: what actually moved, and a zero-length
+    // read still reported so the recorder learns that time passed.
     size_t write(const uint8_t* data, size_t len) override {
+        const size_t n = writeImpl(data, len);
+        tapTx(data, n);
+        return n;
+    }
+
+    size_t read(uint8_t* buf, size_t len, uint32_t timeoutMs) override {
+        const size_t n = readImpl(buf, len, timeoutMs);
+        tapRx(buf, n);
+        return n;
+    }
+
+    size_t writeImpl(const uint8_t* data, size_t len) {
         writes.emplace_back(data, data + len);
         if (writeFails) {
             return 0;
@@ -67,7 +82,7 @@ public:
         return len;
     }
 
-    size_t read(uint8_t* buf, size_t len, uint32_t timeoutMs) override {
+    size_t readImpl(uint8_t* buf, size_t len, uint32_t timeoutMs) {
         (void)timeoutMs;
         // A read advances the simulated clock so tests can drive an overall transaction
         // deadline: `msPerRead` models bytes that trickle in just under each read's own

--- a/test/test_capture/test_main.cpp
+++ b/test/test_capture/test_main.cpp
@@ -10,6 +10,7 @@
 #include "app/capture_runner.h"
 #include "diagnostics/bus_tap.h"
 #include "diagnostics/frame_capture.h"
+#include "protocols/modbus/modbus_client.h"
 #include "protocols/modbus/modbus_rtu.h"
 #include "protocols/pmu/pmu_protocol.h"
 #include "support/mock_transport.h"
@@ -654,6 +655,130 @@ static void test_the_checksum_verdicts_agree_with_the_passive_capture() {
     TEST_ASSERT_EQUAL_UINT32(capture.modbusFrames(), tap.modbusFrames());
 }
 
+// ---------------------------------------------------------------------------------------
+// The tap on a transport, driven by a REAL transaction rather than by hand-fed bytes. This is
+// the claim the feature rests on: a driver that knows nothing about recording produces a
+// legible request/reply pair, because the transport is the one place every driver passes
+// through.
+// ---------------------------------------------------------------------------------------
+
+/// A well-formed reply to modbusFrame(): two input registers, CRC and all.
+static std::vector<uint8_t> modbusReply(uint8_t unit, uint16_t a, uint16_t b) {
+    std::vector<uint8_t> f{unit, 0x03, 0x04,
+                           static_cast<uint8_t>(a >> 8), static_cast<uint8_t>(a & 0xFF),
+                           static_cast<uint8_t>(b >> 8), static_cast<uint8_t>(b & 0xFF)};
+    const uint16_t crc = modbus::crc16(f.data(), f.size());
+    f.push_back(static_cast<uint8_t>(crc & 0xFF));
+    f.push_back(static_cast<uint8_t>(crc >> 8));
+    return f;
+}
+
+static void test_a_real_transaction_is_recorded_as_a_request_and_a_reply() {
+    MockTransport transport;
+    transport.setResponder([](const std::vector<uint8_t>& request, std::vector<uint8_t>& reply) {
+        reply = modbusReply(request[0], 0x1234, 0x5678);
+        return true;
+    });
+
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(transport.nowMs());
+    transport.setTap(&tap);
+
+    uint16_t   regs[2] = {0, 0};
+    const auto outcome = modbus::readRegisters(transport, 3, modbus::kReadHoldingRegisters, 0, 2,
+                                               regs, 2);
+    transport.setTap(nullptr);
+    tap.finish(transport.nowMs());
+
+    // The transaction itself still worked -- the tap changed nothing about it.
+    TEST_ASSERT_EQUAL(modbus::ReadStatus::Ok, outcome.status);
+    TEST_ASSERT_EQUAL_UINT16(0x1234, regs[0]);
+
+    // And it was recorded, in two directions, without the driver or the protocol layer knowing.
+    TEST_ASSERT_EQUAL_UINT32(1, tap.txFrames());
+    TEST_ASSERT_EQUAL_UINT32(1, tap.rxFrames());
+    TEST_ASSERT_EQUAL(BusDirection::Tx, tap.frames()[0].direction);
+    TEST_ASSERT_EQUAL(CutReason::DirectionChange, tap.frames()[0].cutBy);
+    // Both halves check out as Modbus, which is the verdict that tells an operator the line
+    // settings were right rather than that the device was silent.
+    TEST_ASSERT_TRUE(tap.frames()[0].modbusCrcValid);
+    TEST_ASSERT_TRUE(tap.frames()[1].modbusCrcValid);
+    TEST_ASSERT_EQUAL_UINT32(2, tap.modbusFrames());
+}
+
+/// A reply arriving a few bytes per read -- which is what really happens on a UART -- must come
+/// back as one record, not as one record per read.
+static void test_a_reply_delivered_in_chunks_is_still_one_record() {
+    MockTransport transport;
+    transport.chunkSize = 2;
+    // Time has to actually pass between the chunks, or this proves nothing: with a standing
+    // clock the idle gap can never fire and the test would pass against broken gap logic. One
+    // millisecond per read, against a 4 ms gap -- close enough to be a real question.
+    transport.msPerRead = 1;
+    transport.setResponder([](const std::vector<uint8_t>& request, std::vector<uint8_t>& reply) {
+        reply = modbusReply(request[0], 1, 2);
+        return true;
+    });
+
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(transport.nowMs());
+    transport.setTap(&tap);
+
+    uint16_t regs[2] = {0, 0};
+    modbus::readRegisters(transport, 3, modbus::kReadHoldingRegisters, 0, 2, regs, 2);
+    transport.setTap(nullptr);
+    tap.finish(transport.nowMs());
+
+    TEST_ASSERT_EQUAL_UINT32(1, tap.rxFrames());
+    TEST_ASSERT_EQUAL_size_t(9, tap.frames()[1].bytes.size());
+    TEST_ASSERT_TRUE(tap.frames()[1].modbusCrcValid);
+}
+
+/// Removing the tap has to actually stop the recording. Otherwise a finished capture would keep
+/// growing against a report nobody is reading, on a bridge that polls every few seconds.
+static void test_removing_the_tap_stops_the_recording() {
+    MockTransport transport;
+    transport.setResponder([](const std::vector<uint8_t>& request, std::vector<uint8_t>& reply) {
+        reply = modbusReply(request[0], 1, 2);
+        return true;
+    });
+
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(transport.nowMs());
+    transport.setTap(&tap);
+    uint16_t regs[2] = {0, 0};
+    modbus::readRegisters(transport, 3, modbus::kReadHoldingRegisters, 0, 2, regs, 2);
+    transport.setTap(nullptr);
+    tap.finish(transport.nowMs());
+
+    const size_t recorded = tap.frames().size();
+    TEST_ASSERT_TRUE(recorded > 0);
+    TEST_ASSERT_FALSE(transport.tapped());
+
+    modbus::readRegisters(transport, 3, modbus::kReadHoldingRegisters, 0, 2, regs, 2);
+    TEST_ASSERT_EQUAL_size_t(recorded, tap.frames().size());
+}
+
+/// The bridge talking to nothing. A passive capture cannot tell this apart from a dead bus,
+/// because in that mode the bridge is the silent one; here it is the whole diagnosis.
+static void test_a_device_that_never_answers_leaves_requests_only() {
+    MockTransport transport;  // no responder: every read times out
+
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(transport.nowMs());
+    transport.setTap(&tap);
+
+    uint16_t   regs[2] = {0, 0};
+    const auto outcome = modbus::readRegisters(transport, 3, modbus::kReadHoldingRegisters, 0, 2,
+                                               regs, 2, {50, 10});
+    transport.setTap(nullptr);
+    tap.finish(transport.nowMs());
+
+    TEST_ASSERT_EQUAL(modbus::ReadStatus::Timeout, outcome.status);
+    TEST_ASSERT_EQUAL_UINT32(1, tap.txFrames());
+    TEST_ASSERT_EQUAL_UINT32(0, tap.rxFrames());
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_idle_gap_follows_the_baud_rate);
@@ -692,5 +817,9 @@ int main() {
     RUN_TEST(test_the_byte_ceiling_stops_the_tap);
     RUN_TEST(test_requests_with_no_replies_are_visible_as_such);
     RUN_TEST(test_the_checksum_verdicts_agree_with_the_passive_capture);
+    RUN_TEST(test_a_real_transaction_is_recorded_as_a_request_and_a_reply);
+    RUN_TEST(test_a_reply_delivered_in_chunks_is_still_one_record);
+    RUN_TEST(test_removing_the_tap_stops_the_recording);
+    RUN_TEST(test_a_device_that_never_answers_leaves_requests_only);
     return UNITY_END();
 }

--- a/test/test_capture/test_main.cpp
+++ b/test/test_capture/test_main.cpp
@@ -635,6 +635,29 @@ static void test_running_out_of_room_is_not_reported_as_the_window_ending() {
     TEST_ASSERT_EQUAL_size_t(1, tap.frames().size());
     TEST_ASSERT_EQUAL(CutReason::CaptureFull, tap.frames()[0].cutBy);
     TEST_ASSERT_EQUAL_size_t(10, tap.frames()[0].bytes.size());
+    TEST_ASSERT_TRUE(tap.truncated());
+}
+
+/// The boundary the first version of that fix missed: a write whose LAST byte lands exactly on
+/// the budget. The loop then ends normally instead of breaking out, so a flag set only on the
+/// early-exit path never fires -- the record stayed open, finish() called it WindowEnd, and
+/// truncated() said false while nothing further could ever be recorded. Found by review,
+/// 2026-08-02, on the fix for the case one byte past this one.
+static void test_a_budget_filled_exactly_is_still_a_full_capture() {
+    TapConfig config     = tapConfig();
+    config.maxTotalBytes = 8;
+    config.durationMs    = 1000;
+    BusTap tap(config, profileAt(9600));
+    tap.begin(0);
+
+    tx(tap, {1, 2, 3, 4}, 10);
+    tx(tap, {5, 6, 7, 8}, 12);  // exactly fills it; not one byte over
+    tap.finish(1000);
+
+    TEST_ASSERT_EQUAL_size_t(1, tap.frames().size());
+    TEST_ASSERT_EQUAL(CutReason::CaptureFull, tap.frames()[0].cutBy);
+    TEST_ASSERT_TRUE(tap.truncated());
+    TEST_ASSERT_TRUE(tap.done(20));
 }
 
 /// A recording with requests and no replies is the most informative shape this can produce: it
@@ -997,6 +1020,7 @@ int main() {
     RUN_TEST(test_a_record_split_on_its_byte_bound_says_so);
     RUN_TEST(test_the_byte_ceiling_stops_the_tap);
     RUN_TEST(test_running_out_of_room_is_not_reported_as_the_window_ending);
+    RUN_TEST(test_a_budget_filled_exactly_is_still_a_full_capture);
     RUN_TEST(test_requests_with_no_replies_are_visible_as_such);
     RUN_TEST(test_the_checksum_verdicts_agree_with_the_passive_capture);
     RUN_TEST(test_a_real_transaction_is_recorded_as_a_request_and_a_reply);

--- a/test/test_capture/test_main.cpp
+++ b/test/test_capture/test_main.cpp
@@ -593,7 +593,9 @@ static void test_a_record_split_on_its_byte_bound_says_so() {
     TEST_ASSERT_EQUAL(CutReason::WindowEnd, tap.frames()[1].cutBy);
 }
 
-/// The bounds are the passive capture's bounds, for the same no-PSRAM reason.
+/// The bounds are the passive capture's bounds, for the same no-PSRAM reason. "Stops" means
+/// stops: the assertions check that nothing more is recorded afterwards, not merely that a
+/// counter reached its ceiling.
 static void test_the_byte_ceiling_stops_the_tap() {
     TapConfig config     = tapConfig();
     config.maxTotalBytes = 6;
@@ -602,11 +604,37 @@ static void test_the_byte_ceiling_stops_the_tap() {
 
     rx(tap, {1, 2, 3, 4}, 0);
     rx(tap, {5, 6, 7, 8}, 50);
-    tap.finish(51);
+    const size_t afterTheCap = tap.frames().size();
+    // Two more attempts, one in each direction, well inside the window.
+    rx(tap, {9, 10}, 100);
+    tx(tap, {11, 12}, 150);
+    tap.finish(200);
 
     TEST_ASSERT_EQUAL_UINT32(6, tap.totalBytes());
     TEST_ASSERT_TRUE(tap.truncated());
     TEST_ASSERT_TRUE(tap.done(1));
+    TEST_ASSERT_EQUAL_size_t(afterTheCap, tap.frames().size());
+}
+
+/// A record that stopped growing because the capture ran out of room must say so. Leaving it
+/// open until finish() would label it WindowEnd -- a false account when the budget ran out with
+/// most of the window still to go, and the report-level `truncated` flag cannot say WHICH
+/// record it happened to. Found by review, 2026-08-02.
+static void test_running_out_of_room_is_not_reported_as_the_window_ending() {
+    TapConfig config     = tapConfig();
+    config.maxTotalBytes = 10;
+    config.durationMs    = 1000;
+    BusTap tap(config, profileAt(9600));
+    tap.begin(0);
+
+    tx(tap, {1, 2, 3, 4, 5, 6, 7, 8}, 10);
+    // The budget runs out inside this write, with 980 ms of window still to go.
+    tx(tap, {9, 10, 11, 12}, 12);
+    tap.finish(1000);
+
+    TEST_ASSERT_EQUAL_size_t(1, tap.frames().size());
+    TEST_ASSERT_EQUAL(CutReason::CaptureFull, tap.frames()[0].cutBy);
+    TEST_ASSERT_EQUAL_size_t(10, tap.frames()[0].bytes.size());
 }
 
 /// A recording with requests and no replies is the most informative shape this can produce: it
@@ -968,6 +996,7 @@ int main() {
     RUN_TEST(test_silence_still_cuts_when_the_direction_does_not_change);
     RUN_TEST(test_a_record_split_on_its_byte_bound_says_so);
     RUN_TEST(test_the_byte_ceiling_stops_the_tap);
+    RUN_TEST(test_running_out_of_room_is_not_reported_as_the_window_ending);
     RUN_TEST(test_requests_with_no_replies_are_visible_as_such);
     RUN_TEST(test_the_checksum_verdicts_agree_with_the_passive_capture);
     RUN_TEST(test_a_real_transaction_is_recorded_as_a_request_and_a_reply);

--- a/test/test_capture/test_main.cpp
+++ b/test/test_capture/test_main.cpp
@@ -8,14 +8,19 @@
 #include <vector>
 
 #include "app/capture_runner.h"
+#include "diagnostics/bus_tap.h"
 #include "diagnostics/frame_capture.h"
 #include "protocols/modbus/modbus_rtu.h"
 #include "protocols/pmu/pmu_protocol.h"
 #include "support/mock_transport.h"
 
 using namespace heliograph;
+using heliograph::diag::BusDirection;
+using heliograph::diag::BusTap;
 using heliograph::diag::CaptureConfig;
+using heliograph::diag::CutReason;
 using heliograph::diag::FrameCapture;
+using heliograph::diag::TapConfig;
 using heliograph::test::MockTransport;
 
 void setUp() {}
@@ -433,6 +438,222 @@ static void test_a_new_capture_discards_the_previous_result() {
     TEST_ASSERT_EQUAL_UINT32(0, runner.report().totalBytes);
 }
 
+// ---------------------------------------------------------------------------------------
+// BusTap: the same recording problem with one extra fact available -- which way the bytes
+// went. Everything below is about what that fact buys and where it does not apply.
+// ---------------------------------------------------------------------------------------
+
+static TapConfig tapConfig() {
+    TapConfig c;
+    c.idleGapMs = 4;
+    return c;
+}
+
+static void tx(BusTap& t, const std::vector<uint8_t>& bytes, uint64_t at) {
+    t.recordTx(bytes.data(), bytes.size(), at);
+}
+
+static void rx(BusTap& t, const std::vector<uint8_t>& bytes, uint64_t at) {
+    t.recordRx(bytes.data(), bytes.size(), at);
+}
+
+/// The whole point of the feature: a request and its reply come out as two records, labelled,
+/// with no silence needed between them to tell them apart.
+static void test_a_request_and_its_reply_are_two_labelled_records() {
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+
+    tx(tap, modbusFrame(1), 0);
+    // One millisecond later -- far inside the 4 ms idle gap, so silence could not have cut this.
+    rx(tap, modbusFrame(1), 1);
+    tap.finish(2);
+
+    TEST_ASSERT_EQUAL_size_t(2, tap.frames().size());
+    TEST_ASSERT_EQUAL(BusDirection::Tx, tap.frames()[0].direction);
+    TEST_ASSERT_EQUAL(BusDirection::Rx, tap.frames()[1].direction);
+    TEST_ASSERT_EQUAL(CutReason::DirectionChange, tap.frames()[0].cutBy);
+    TEST_ASSERT_EQUAL_UINT32(1, tap.txFrames());
+    TEST_ASSERT_EQUAL_UINT32(1, tap.rxFrames());
+}
+
+/// A driver's read loop returns short reads. Those are one reply, not three.
+static void test_a_reply_read_in_pieces_is_one_record() {
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+
+    rx(tap, {0xAA, 0x55}, 0);
+    rx(tap, {0x01, 0x02}, 1);
+    rx(tap, {0x03}, 2);
+    tap.finish(3);
+
+    TEST_ASSERT_EQUAL_size_t(1, tap.frames().size());
+    TEST_ASSERT_EQUAL_size_t(5, tap.frames()[0].bytes.size());
+}
+
+/// The read that came back empty is how time advances, and it must not be mistaken for the
+/// conversation turning around: a driver polls its read in a loop and gets nothing on most
+/// iterations, so treating an empty read as a direction change would cut every reply to pieces.
+static void test_a_read_that_timed_out_does_not_cut_a_reply() {
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+
+    rx(tap, {0xAA, 0x55}, 0);
+    tap.recordRx(nullptr, 0, 1);  // the read loop, coming back empty
+    tap.recordRx(nullptr, 0, 2);
+    rx(tap, {0x01}, 3);
+    tap.finish(4);
+
+    TEST_ASSERT_EQUAL_size_t(1, tap.frames().size());
+    TEST_ASSERT_EQUAL_size_t(3, tap.frames()[0].bytes.size());
+}
+
+/// The case that actually exercises the rule, and the one a mutation found missing: the empty
+/// read comes straight after a REQUEST, so its nominal direction differs from the open record's.
+/// If an empty read were allowed to count as a turn-around, every request would be closed by the
+/// driver's first fruitless read rather than by the reply -- with the wrong reason on it, and
+/// with the reply's gapBeforeMs measured from the wrong point. Nothing went on the wire, so
+/// nothing turned around.
+static void test_an_empty_read_after_a_request_does_not_close_it() {
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+
+    tx(tap, modbusFrame(1), 0);
+    tap.recordRx(nullptr, 0, 1);  // the driver starts reading; nothing has arrived yet
+    rx(tap, modbusFrame(1), 2);
+    tap.finish(3);
+
+    TEST_ASSERT_EQUAL_size_t(2, tap.frames().size());
+    TEST_ASSERT_EQUAL(CutReason::DirectionChange, tap.frames()[0].cutBy);
+    TEST_ASSERT_EQUAL_UINT32(2, tap.frames()[1].gapBeforeMs);
+}
+
+/// ...but an empty read may still close a record once the silence is long enough. Without this
+/// the last record before a quiet stretch would stay open until the window ended.
+static void test_a_long_enough_silence_closes_a_record_on_empty_reads() {
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+
+    rx(tap, {0xAA, 0x55}, 0);
+    tap.recordRx(nullptr, 0, 10);  // past the 4 ms gap
+
+    TEST_ASSERT_EQUAL_size_t(1, tap.frames().size());
+    TEST_ASSERT_EQUAL(CutReason::IdleGap, tap.frames()[0].cutBy);
+}
+
+/// When a device answers after a long pause both rules apply. Only one of them is exact, and
+/// that is the one the record has to name -- the turn-around is a fact, the gap is a threshold
+/// that happens to have been crossed.
+static void test_a_turnaround_after_a_pause_is_reported_as_a_turnaround() {
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+
+    tx(tap, modbusFrame(1), 0);
+    rx(tap, modbusFrame(1), 200);  // fifty times the idle gap
+    tap.finish(201);
+
+    TEST_ASSERT_EQUAL_size_t(2, tap.frames().size());
+    TEST_ASSERT_EQUAL(CutReason::DirectionChange, tap.frames()[0].cutBy);
+    // And the pause is kept, because it is the device's response time -- the number that says
+    // whether a driver's read timeout is generous enough for this inverter.
+    TEST_ASSERT_EQUAL_UINT32(200, tap.frames()[1].gapBeforeMs);
+}
+
+/// Two replies in a row, with real silence between them: no direction change to lean on, so the
+/// idle gap is still doing the work it does in the passive capture.
+static void test_silence_still_cuts_when_the_direction_does_not_change() {
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+
+    rx(tap, modbusFrame(1), 0);
+    rx(tap, modbusFrame(2), 50);
+    tap.finish(51);
+
+    TEST_ASSERT_EQUAL_size_t(2, tap.frames().size());
+    TEST_ASSERT_EQUAL(CutReason::IdleGap, tap.frames()[0].cutBy);
+    TEST_ASSERT_EQUAL(BusDirection::Rx, tap.frames()[1].direction);
+}
+
+/// A cut the protocol did not make is labelled as such, so nobody reads the two halves as two
+/// frames. The gap reads zero because no time passed -- that is the honest value, not a missing
+/// one.
+static void test_a_record_split_on_its_byte_bound_says_so() {
+    TapConfig config   = tapConfig();
+    config.maxFrameBytes = 4;
+    BusTap tap(config, profileAt(9600));
+    tap.begin(0);
+
+    rx(tap, {1, 2, 3, 4, 5, 6}, 0);
+    tap.finish(1);
+
+    TEST_ASSERT_EQUAL_size_t(2, tap.frames().size());
+    TEST_ASSERT_EQUAL(CutReason::ByteCap, tap.frames()[0].cutBy);
+    TEST_ASSERT_EQUAL_UINT32(0, tap.frames()[1].gapBeforeMs);
+    TEST_ASSERT_EQUAL(CutReason::WindowEnd, tap.frames()[1].cutBy);
+}
+
+/// The bounds are the passive capture's bounds, for the same no-PSRAM reason.
+static void test_the_byte_ceiling_stops_the_tap() {
+    TapConfig config     = tapConfig();
+    config.maxTotalBytes = 6;
+    BusTap tap(config, profileAt(9600));
+    tap.begin(0);
+
+    rx(tap, {1, 2, 3, 4}, 0);
+    rx(tap, {5, 6, 7, 8}, 50);
+    tap.finish(51);
+
+    TEST_ASSERT_EQUAL_UINT32(6, tap.totalBytes());
+    TEST_ASSERT_TRUE(tap.truncated());
+    TEST_ASSERT_TRUE(tap.done(1));
+}
+
+/// A recording with requests and no replies is the most informative shape this can produce: it
+/// separates "the bridge is talking and nothing answers" from "the bus is dead", which a passive
+/// capture cannot do because in that mode the bridge is the silent one.
+static void test_requests_with_no_replies_are_visible_as_such() {
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+
+    tx(tap, modbusFrame(1), 0);
+    tx(tap, modbusFrame(1), 1000);
+    tx(tap, modbusFrame(1), 2000);
+    tap.finish(2001);
+
+    TEST_ASSERT_EQUAL_UINT32(3, tap.txFrames());
+    TEST_ASSERT_EQUAL_UINT32(0, tap.rxFrames());
+}
+
+/// Both recorders must judge the same bytes the same way. They share one helper precisely so
+/// that the count an operator reads first cannot mean two different things depending on which
+/// mode produced the report.
+static void test_the_checksum_verdicts_agree_with_the_passive_capture() {
+    const std::vector<uint8_t> good = modbusFrame(7);
+    std::vector<uint8_t>       bad  = good;
+    bad.back() ^= 0xFF;
+
+    CaptureConfig captureConfig;
+    captureConfig.idleGapMs = 4;
+    FrameCapture capture(captureConfig, profileAt(9600));
+    capture.begin(0);
+    feed(capture, good, 0);
+    feed(capture, bad, 50);
+    capture.finish(51);
+
+    BusTap tap(tapConfig(), profileAt(9600));
+    tap.begin(0);
+    rx(tap, good, 0);
+    rx(tap, bad, 50);
+    tap.finish(51);
+
+    TEST_ASSERT_EQUAL_size_t(2, capture.frames().size());
+    TEST_ASSERT_EQUAL_size_t(2, tap.frames().size());
+    TEST_ASSERT_EQUAL(capture.frames()[0].modbusCrcValid, tap.frames()[0].modbusCrcValid);
+    TEST_ASSERT_EQUAL(capture.frames()[1].modbusCrcValid, tap.frames()[1].modbusCrcValid);
+    TEST_ASSERT_TRUE(tap.frames()[0].modbusCrcValid);
+    TEST_ASSERT_FALSE(tap.frames()[1].modbusCrcValid);
+    TEST_ASSERT_EQUAL_UINT32(capture.modbusFrames(), tap.modbusFrames());
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_idle_gap_follows_the_baud_rate);
@@ -460,5 +681,16 @@ int main() {
     RUN_TEST(test_line_settings_that_will_not_apply_fail_rather_than_record_nothing);
     RUN_TEST(test_the_tick_callback_fires_throughout_the_window);
     RUN_TEST(test_a_new_capture_discards_the_previous_result);
+    RUN_TEST(test_a_request_and_its_reply_are_two_labelled_records);
+    RUN_TEST(test_a_reply_read_in_pieces_is_one_record);
+    RUN_TEST(test_a_read_that_timed_out_does_not_cut_a_reply);
+    RUN_TEST(test_an_empty_read_after_a_request_does_not_close_it);
+    RUN_TEST(test_a_long_enough_silence_closes_a_record_on_empty_reads);
+    RUN_TEST(test_a_turnaround_after_a_pause_is_reported_as_a_turnaround);
+    RUN_TEST(test_silence_still_cuts_when_the_direction_does_not_change);
+    RUN_TEST(test_a_record_split_on_its_byte_bound_says_so);
+    RUN_TEST(test_the_byte_ceiling_stops_the_tap);
+    RUN_TEST(test_requests_with_no_replies_are_visible_as_such);
+    RUN_TEST(test_the_checksum_verdicts_agree_with_the_passive_capture);
     return UNITY_END();
 }

--- a/test/test_capture/test_main.cpp
+++ b/test/test_capture/test_main.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "app/capture_runner.h"
+#include "app/driver_capture_runner.h"
 #include "diagnostics/bus_tap.h"
 #include "diagnostics/frame_capture.h"
 #include "protocols/modbus/modbus_client.h"
@@ -779,6 +780,158 @@ static void test_a_device_that_never_answers_leaves_requests_only() {
     TEST_ASSERT_EQUAL_UINT32(0, tap.rxFrames());
 }
 
+// ---------------------------------------------------------------------------------------
+// DriverCaptureRunner: the arm/collect handover. The passive runner's tests are about what it
+// does with an iteration of the bus task; these are about it NOT taking one.
+// ---------------------------------------------------------------------------------------
+
+static uint64_t testClock() { return g_clock; }
+
+static diag::TapConfig windowOf(uint32_t ms) {
+    diag::TapConfig c;
+    c.durationMs = ms;
+    c.idleGapMs  = 4;
+    return c;
+}
+
+static void runTransaction(MockTransport& transport) {
+    uint16_t regs[2] = {0, 0};
+    modbus::readRegisters(transport, 3, modbus::kReadHoldingRegisters, 0, 2, regs, 2);
+}
+
+static void answerNormally(MockTransport& transport) {
+    transport.setResponder([](const std::vector<uint8_t>& request, std::vector<uint8_t>& reply) {
+        reply = modbusReply(request[0], 1, 2);
+        return true;
+    });
+}
+
+static void test_nothing_is_armed_until_something_is_requested() {
+    MockTransport       transport;
+    DriverCaptureRunner runner(testClock);
+
+    TEST_ASSERT_EQUAL(DriverCaptureService::Idle, runner.service(transport));
+    TEST_ASSERT_FALSE(transport.tapped());
+    TEST_ASSERT_EQUAL(DriverCaptureStatus::Idle, runner.report().status);
+}
+
+/// The claim the whole design rests on, tested rather than asserted in a comment: arming does
+/// not take the bus. If it did, the driver could not poll, and there would be nothing to record
+/// -- which is the bug this feature exists to fix.
+static void test_arming_never_takes_the_bus() {
+    MockTransport       transport;
+    DriverCaptureRunner runner(testClock);
+    answerNormally(transport);
+
+    TEST_ASSERT_TRUE(runner.request(windowOf(1000), profileAt(9600)));
+    TEST_ASSERT_EQUAL(DriverCaptureService::Armed, runner.service(transport));
+
+    TEST_ASSERT_TRUE(transport.tapped());
+    TEST_ASSERT_EQUAL_UINT32(0, transport.lockCalls);
+    TEST_ASSERT_FALSE(transport.locked);
+    // And it does not touch the line either, so there is nothing to put back afterwards.
+    TEST_ASSERT_EQUAL_UINT32(0, transport.configureCalls);
+}
+
+/// The end-to-end shape: arm, let the bridge poll as it normally would, collect.
+static void test_a_poll_during_the_window_lands_in_the_report() {
+    MockTransport       transport;
+    DriverCaptureRunner runner(testClock);
+    answerNormally(transport);
+
+    runner.request(windowOf(1000), profileAt(9600));
+    runner.service(transport);
+    runTransaction(transport);
+
+    // Still inside the window: the bus task keeps visiting, and keeps polling.
+    TEST_ASSERT_EQUAL(DriverCaptureService::Recording, runner.service(transport));
+
+    transport.advanceClock(1000);
+    TEST_ASSERT_EQUAL(DriverCaptureService::Collected, runner.service(transport));
+
+    const auto report = runner.report();
+    TEST_ASSERT_EQUAL(DriverCaptureStatus::Done, report.status);
+    TEST_ASSERT_EQUAL_UINT32(1, report.txFrames);
+    TEST_ASSERT_EQUAL_UINT32(1, report.rxFrames);
+    TEST_ASSERT_EQUAL_UINT32(2, report.modbusFrames);
+    // Unhooked, so the next poll costs nothing and cannot grow a report nobody is reading.
+    TEST_ASSERT_FALSE(transport.tapped());
+}
+
+/// While it runs, the frame list belongs to the bus task. Handing out a copy mid-flight would
+/// mean reading a vector another task is appending to; the page gets status and timing instead.
+static void test_the_report_carries_no_frames_until_it_is_done() {
+    MockTransport       transport;
+    DriverCaptureRunner runner(testClock);
+    answerNormally(transport);
+
+    runner.request(windowOf(1000), profileAt(9600));
+    runner.service(transport);
+    runTransaction(transport);
+
+    const auto during = runner.report();
+    TEST_ASSERT_EQUAL(DriverCaptureStatus::Running, during.status);
+    TEST_ASSERT_EQUAL_size_t(0, during.frames.size());
+    // The counts stay at zero too, for the same reason: they are read off the tap when it is
+    // collected, not accumulated into the report as it goes.
+    TEST_ASSERT_EQUAL_UINT32(0, during.totalBytes);
+
+    transport.advanceClock(1000);
+    runner.service(transport);
+    TEST_ASSERT_TRUE(runner.report().frames.size() > 0);
+}
+
+/// The window is a window. This runner cannot stop the traffic when the deadline passes -- it
+/// only gets to unhook on its next visit to the bus task -- so the recorder itself has to
+/// refuse bytes that arrive after the window closed. Without that a 30 s capture would quietly
+/// include the poll that straddles the deadline.
+static void test_traffic_after_the_window_is_not_recorded() {
+    MockTransport       transport;
+    DriverCaptureRunner runner(testClock);
+    answerNormally(transport);
+
+    runner.request(windowOf(100), profileAt(9600));
+    runner.service(transport);
+    runTransaction(transport);
+
+    transport.advanceClock(500);  // the window has closed, but nobody has visited yet
+    runTransaction(transport);    // ...and the bridge polls again
+
+    runner.service(transport);
+    const auto report = runner.report();
+    TEST_ASSERT_EQUAL(DriverCaptureStatus::Done, report.status);
+    TEST_ASSERT_EQUAL_UINT32(1, report.txFrames);
+    TEST_ASSERT_EQUAL_UINT32(1, report.rxFrames);
+}
+
+static void test_a_second_request_is_refused_while_one_is_running() {
+    MockTransport       transport;
+    DriverCaptureRunner runner(testClock);
+
+    TEST_ASSERT_TRUE(runner.request(windowOf(1000), profileAt(9600)));
+    TEST_ASSERT_FALSE(runner.request(windowOf(1000), profileAt(9600)));
+    runner.service(transport);
+    TEST_ASSERT_FALSE(runner.request(windowOf(1000), profileAt(9600)));
+    TEST_ASSERT_TRUE(runner.busy());
+}
+
+static void test_a_new_request_discards_the_previous_report() {
+    MockTransport       transport;
+    DriverCaptureRunner runner(testClock);
+    answerNormally(transport);
+
+    runner.request(windowOf(100), profileAt(9600));
+    runner.service(transport);
+    runTransaction(transport);
+    transport.advanceClock(200);
+    runner.service(transport);
+    TEST_ASSERT_TRUE(runner.report().frames.size() > 0);
+
+    TEST_ASSERT_TRUE(runner.request(windowOf(100), profileAt(9600)));
+    TEST_ASSERT_EQUAL_size_t(0, runner.report().frames.size());
+    TEST_ASSERT_EQUAL_UINT32(0, runner.report().totalBytes);
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_idle_gap_follows_the_baud_rate);
@@ -821,5 +974,12 @@ int main() {
     RUN_TEST(test_a_reply_delivered_in_chunks_is_still_one_record);
     RUN_TEST(test_removing_the_tap_stops_the_recording);
     RUN_TEST(test_a_device_that_never_answers_leaves_requests_only);
+    RUN_TEST(test_nothing_is_armed_until_something_is_requested);
+    RUN_TEST(test_arming_never_takes_the_bus);
+    RUN_TEST(test_a_poll_during_the_window_lands_in_the_report);
+    RUN_TEST(test_the_report_carries_no_frames_until_it_is_done);
+    RUN_TEST(test_traffic_after_the_window_is_not_recorded);
+    RUN_TEST(test_a_second_request_is_refused_while_one_is_running);
+    RUN_TEST(test_a_new_request_discards_the_previous_report);
     return UNITY_END();
 }

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -1520,6 +1520,86 @@ static void test_capture_payload_echoes_the_line_it_listened_at() {
     TEST_ASSERT_FALSE(doc["summary"]["truncated"].as<bool>());
 }
 
+static DriverCaptureReport driverCaptureWithAnExchange() {
+    DriverCaptureReport report;
+    report.status            = DriverCaptureStatus::Done;
+    report.profile.baudRate  = 9600;
+    report.config.durationMs = 30000;
+    report.config.maxFrames  = 64;
+    report.idleGapMs         = 4;
+    report.startedMs         = 1000;
+    report.finishedMs        = 31000;
+    report.totalBytes        = 13;
+    report.txFrames          = 1;
+    report.rxFrames          = 1;
+    report.modbusFrames      = 2;
+
+    diag::TappedFrame request;
+    request.direction      = diag::BusDirection::Tx;
+    request.offsetMs       = 5;
+    request.bytes          = {0x03, 0x03, 0x00, 0x00};
+    request.modbusCrcValid = true;
+    request.cutBy          = diag::CutReason::DirectionChange;
+    report.frames.push_back(request);
+
+    diag::TappedFrame reply;
+    reply.direction      = diag::BusDirection::Rx;
+    reply.offsetMs       = 47;
+    reply.gapBeforeMs    = 42;
+    reply.bytes          = {0x03, 0x03, 0x02, 0x00, 0x7B};
+    reply.modbusCrcValid = true;
+    reply.cutBy          = diag::CutReason::WindowEnd;
+    report.frames.push_back(reply);
+    return report;
+}
+
+/// Direction is the entire reason this report exists, so it is per frame and spelled out rather
+/// than implied by ordering -- an exchange that lost a reply would otherwise renumber silently.
+static void test_driver_capture_payload_labels_each_frame_with_its_direction() {
+    std::string body;
+    TEST_ASSERT_TRUE(
+        rest::buildDriverCapturePayload(driverCaptureWithAnExchange(), 31000, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_EQUAL_STRING("tx", doc["frames"][0]["direction"]);
+    TEST_ASSERT_EQUAL_STRING("rx", doc["frames"][1]["direction"]);
+    TEST_ASSERT_EQUAL_STRING("03 03 00 00", doc["frames"][0]["hex"]);
+    // The device's response time, which is what a driver's read timeout has to cover.
+    TEST_ASSERT_EQUAL_INT(42, doc["frames"][1]["gap_before_ms"].as<int>());
+}
+
+/// Which rule ended a record. A reader cannot otherwise tell a boundary the protocol made from
+/// one the recorder imposed, and only the first kind means "these bytes are one frame".
+static void test_driver_capture_payload_says_what_ended_each_record() {
+    std::string body;
+    TEST_ASSERT_TRUE(
+        rest::buildDriverCapturePayload(driverCaptureWithAnExchange(), 31000, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_EQUAL_STRING("direction_change", doc["frames"][0]["cut_by"]);
+    TEST_ASSERT_EQUAL_STRING("window_end", doc["frames"][1]["cut_by"]);
+}
+
+/// Requests against replies. This is the diagnosis a passive capture structurally cannot make --
+/// there the bridge is the silent one, so "nothing is talking" and "the device is not answering"
+/// produce the same empty report.
+static void test_driver_capture_payload_counts_requests_against_replies() {
+    std::string body;
+    TEST_ASSERT_TRUE(
+        rest::buildDriverCapturePayload(driverCaptureWithAnExchange(), 31000, body));
+    JsonDocument doc;
+    TEST_ASSERT_TRUE(deserializeJson(doc, body) == DeserializationError::Ok);
+    TEST_ASSERT_EQUAL_STRING("done", doc["status"]);
+    TEST_ASSERT_EQUAL_INT(1, doc["summary"]["sent"].as<int>());
+    TEST_ASSERT_EQUAL_INT(1, doc["summary"]["received"].as<int>());
+    TEST_ASSERT_EQUAL_INT(2, doc["summary"]["modbus_crc_ok"].as<int>());
+    // The line is reported even though the operator did not choose it: the idle gap derives
+    // from it, and the framing cannot be checked against a document without it.
+    TEST_ASSERT_EQUAL_INT(9600, doc["line"]["baud_rate"].as<int>());
+    TEST_ASSERT_EQUAL_INT(4, doc["line"]["idle_gap_ms"].as<int>());
+    TEST_ASSERT_EQUAL_INT(30000, doc["elapsed_ms"].as<int>());
+}
+
 /// A failure has to carry its reason. "failed" alone leaves the operator unable to tell a busy
 /// bus from line settings the UART refused.
 static void test_a_failed_capture_carries_its_reason() {
@@ -2847,6 +2927,9 @@ int main(int, char**) {
     RUN_TEST(test_status_payload_reports_clock_sync_state);
     RUN_TEST(test_capture_payload_renders_hex_the_way_the_docs_do);
     RUN_TEST(test_capture_payload_echoes_the_line_it_listened_at);
+    RUN_TEST(test_driver_capture_payload_labels_each_frame_with_its_direction);
+    RUN_TEST(test_driver_capture_payload_says_what_ended_each_record);
+    RUN_TEST(test_driver_capture_payload_counts_requests_against_replies);
     RUN_TEST(test_a_failed_capture_carries_its_reason);
     RUN_TEST(test_a_capture_filled_to_its_byte_ceiling_fits_in_the_response);
     RUN_TEST(test_restore_preview_carries_the_file_and_the_changes);

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -2,6 +2,7 @@
 // REST payloads, configuration redaction/validation and Prometheus output.
 
 #include <unity.h>
+#include <cstdio>
 
 #include <cstring>
 

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -246,6 +246,31 @@ tracked_dirs = {str(pathlib.PurePosixPath(t).parent) for t in tracked}
 root = pathlib.Path(".").resolve()
 bad = []
 
+
+def slug(heading: str) -> str:
+    """GitHub's heading anchor: lowercase, punctuation dropped, EACH space to a hyphen.
+
+    "## 6.5 Recording a driver" -> "65-recording-a-driver": the dot vanishes rather than
+    becoming a hyphen, which is exactly the kind of detail nobody gets right by hand.
+
+    One space per hyphen, not one per RUN of spaces. "Recovery - hold BOOT" with an em dash
+    leaves two spaces once the dash is dropped, and therefore two hyphens. Collapsing them was
+    the first version of this function, and it reported a correct link in README.md as broken --
+    a check that cries wolf gets switched off, so the slug rule has to be exact.
+    """
+    s = heading.strip().lstrip("#").strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s)
+    return re.sub(r"\s", "-", s)
+
+
+def anchors_in(path: pathlib.Path) -> set:
+    return {
+        slug(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.startswith("#")
+    }
+
+
 for doc in sorted(pathlib.Path(".").rglob("*.md")):
     if ".git" in doc.parts or ".pio" in doc.parts:
         continue
@@ -260,9 +285,19 @@ for doc in sorted(pathlib.Path(".").rglob("*.md")):
             rel = str((doc.parent / target).resolve().relative_to(root))
         except ValueError:
             continue  # outside the repo; not ours to judge
-        if rel in tracked or rel in tracked_dirs:
+        line_no = text[: m.start()].count(chr(10)) + 1
+        if rel not in tracked and rel not in tracked_dirs:
+            bad.append(f"{doc}:{line_no} -> {target}")
             continue
-        bad.append(f"{doc}:{text[: m.start()].count(chr(10)) + 1} -> {target}")
+        # The ANCHOR, not just the file. A link to a real document at a heading that no longer
+        # exists lands the reader at the top of it with no sign anything is wrong -- which is
+        # worse than a 404, because it looks like it worked. This rule was written checking only
+        # the path, and a renamed heading in the very same commit slipped straight through it
+        # (found by review, 2026-08-02).
+        anchor = (m.group(3) or "")[1:]
+        if anchor and rel.endswith(".md") and rel in tracked:
+            if anchor not in anchors_in(root / rel):
+                bad.append(f"{doc}:{line_no} -> {target} (no such heading)")
 
 if bad:
     print("\n".join(bad))

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -264,11 +264,30 @@ def slug(heading: str) -> str:
 
 
 def anchors_in(path: pathlib.Path) -> set:
-    return {
-        slug(line)
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if line.startswith("#")
-    }
+    """Heading slugs, skipping fenced code blocks.
+
+    A hash inside a fenced block is a shell comment, not a heading. This project's own docs are
+    full of them -- the capture examples start with "# Heliograph driver capture ..." -- and
+    counting those as anchors makes the check fail OPEN: a link to a heading that no longer
+    exists could match one of these phantoms and be waved through. A checker with false
+    negatives is worse than none, because it is trusted. There were 13 such phantoms across two
+    documents when this was added.
+
+    The fence marker is built rather than written out. A literal backtick run inside this
+    heredoc breaks the SHELL parser -- the heredoc sits in a $(...) substitution, where bash
+    still tracks backticks as legacy command substitution even though the delimiter is quoted.
+    It cost a run of this script to find out.
+    """
+    fence = chr(96) * 3
+    found = set()
+    fenced = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.lstrip().startswith(fence):
+            fenced = not fenced
+            continue
+        if not fenced and line.startswith("#"):
+            found.add(slug(line))
+    return found
 
 
 for doc in sorted(pathlib.Path(".").rglob("*.md")):


### PR DESCRIPTION
Closes #62.

## The problem, in one measurement

The raw bus capture is **passive by design**: `rs485Task` runs it *instead of* a poll, so the bridge is silent for the whole window. That is right for an unidentified device. It also means it cannot record a protocol we already speak — the driver that would produce that traffic is the thing it pauses. Thirty seconds against a live inverter with a working driver: `frames: 0, bytes: 0`.

## The observation that decided the design

The issue left two questions open. One observation answers both:

- both protocol layers hand a **complete request to a single `write()` call** ([pmu_transaction.cpp:27](src/protocols/pmu/pmu_transaction.cpp:27), [modbus_client.cpp:37](src/protocols/modbus/modbus_client.cpp:37))
- every driver reaches the bus through `Transport`, and `Rs485Transport` is the only transport compiled into the firmware

So **direction is knowable at the transport** — no driver is asked, no driver changed, and every driver added later is covered the day it arrives. And the record boundary can follow the transaction instead of guessing at silence.

That lifts the passive mode's documented ceiling. It cuts on the t3.5 idle gap, honest at 9600 and 19200 and approximate above, because at 38400 the real gap is finer than any reader resolves. Here the primary boundary is the direction turning around, exact at any baud rate. The gap still cuts when the direction does not change, and **every record says which rule made it** — a boundary the protocol made and one the recorder imposed are otherwise indistinguishable, and only the first kind means "these bytes are one frame".

## It arms; it does not take the bus

The branch in `rs485Task` deliberately does **not** `continue`. Every other branch there takes the iteration away from polling because it needs the bus; taking it here would reproduce exactly the bug this fixes.

Three failure classes the passive mode has to handle do not exist: no bus lock, no line reconfiguration, and therefore no `lineReconfigured` / `restoreDriverLine()` dance. The line is read off the bridge rather than supplied — there is a working driver, so it is a fact.

Cost in the RS485 hot path when nothing is recording: **one inline null check**.

## API — additive

`mode` defaults to `passive`, so every existing caller keeps its meaning and `GET /api/v1/capture` is byte-for-byte what it was.

**Deviation from the plan, stated rather than done quietly.** The plan had one GET returning either report with a `mode` field. Two independent runners keep two independent last-reports, so one route would need new state to decide which to return, and a consumer would branch on `mode` anyway — with half the fields absent, which reads as missing data rather than as a different kind of report. So `GET /api/v1/capture/driver` is its own route.

The four line parameters are **rejected with 400** in `mode=driver`, not ignored: accepting a baud rate and recording at a different one would put a number in the report the capture never ran at.

## What it can tell you that the passive mode cannot

- **`sent` against `received`.** Requests with no replies means the bridge is talking and the device is not answering. The passive mode cannot reach that diagnosis — there the bridge is the silent one, so a dead bus and an unanswering device produce the same empty report.
- **The gap on a reply is the device's response time** — the number a driver's read timeout has to cover, and the one to look at when an inverter answers by hand and intermittently in service.
- **A shipped driver can be checked against its protocol document** on real hardware, with no USB-RS485 tap and laptop at the inverter.

## UI

The existing capture card lives under `if(!c.length)` — it only appears when discovery names nothing, which is exactly the bridge this mode cannot help. The driver capture goes on **Health**, reachable whenever the bridge is working.

Verified in a browser against `tools/preview_web.py`, not assumed from a passing syntax check: the card renders, a four-frame report comes out as `→` / `←` with `turn` / `silence` / `split`, and both failure verdicts read as intended.

## Things I changed my mind about while building

- **Wrote an `abandon()` and deleted it.** Nothing that would take the bus can start while this is armed, so it had no caller. An unused escape hatch invites a future caller to reach for it instead of asking why the guard exists.
- **`service()` returns the transition, not a bool.** A bool leaves "armed" and "still recording" indistinguishable, which is how a once-per-capture log line becomes one per iteration.
- **Discovery is refused during a driver capture**, for a reason the other two do not share: it would not conflict at all — it would happily record straight through a probe sweep — and the report would then show something no driver ever does.

## Verification

- **953 native tests**, 26 new. Six mutations, each aimed at one decision: reversing the direction/gap check order, letting an empty read count as a turn-around, removing the direction cut, removing the window guard, taking a `TransportLock` in `service()`, swapping the tx/rx labels. All caught.
- One mutation found a **missing test rather than a bug**: an empty read counting as a turn-around only misbehaves when it follows a *request*, which no test covered — and every driver's read loop does exactly that on its first fruitless read.
- One assertion of mine asserted nothing (`0 == 0` under a standing clock) and was replaced.
- `check_layering.sh` all ten rules — rule 1 caught two brand names in my own header comment.
- `check_web_js.py`, `check_dashboard_layout.py`, `check_measurement_ids.py`, `ruff`: clean.
- Firmware builds with no warnings from our own sources. RAM 22.5%, flash 22.9%.

## Not verified

**Nothing here has run on hardware yet.** Per the agreed gate: merge on host tests and CI, then OTA to the production bridge and compare poll duration against the known baseline — ewma 103 ms, max 111 ms, min 97 ms. A recorder in the hot path that moves those measurably is a finding, not a detail. The real acceptance test is a driver capture against the live inverter, held next to `docs/eversolar-protocol.md`.