### PR TITLE
Make the capture endpoint's rules testable, then test them

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -101,6 +101,7 @@ build_src_filter =
     +<outputs/mqtt/publish_policy.cpp>
     +<outputs/mqtt/mqtt_output.cpp>
     +<outputs/rest/rest_payloads.cpp>
+    +<outputs/rest/capture_request.cpp>
     +<outputs/prometheus/prometheus_metrics.cpp>
     +<config/configuration.cpp>
     +<config/configuration_store.cpp>

--- a/src/outputs/rest/capture_request.cpp
+++ b/src/outputs/rest/capture_request.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+
+#include "capture_request.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace heliograph::rest {
+namespace {
+
+/// A numeric parameter, or its default when absent.
+///
+/// strtol with no errno check, deliberately and unchanged from the handler this came out of:
+/// every unparseable form it accepts ("", "abc", "-5") yields a value that the range check
+/// below rejects anyway, so adding a second error path would produce a different message for
+/// the same outcome. "30abc" reads as 30, which is the one lenient case and has been the
+/// endpoint's behaviour since it existed.
+long number(const QueryParam& param, const char* name, long fallback) {
+    const char* raw = param(name);
+    return raw == nullptr ? fallback : std::strtol(raw, nullptr, 10);
+}
+
+ApiError invalid(std::string message) {
+    return ApiError{400, "invalid_parameter", std::move(message)};
+}
+
+}  // namespace
+
+std::optional<ApiError> parseCaptureRequest(const QueryParam& param, CaptureRequest& out) {
+    out = CaptureRequest{};
+
+    // Which conversation to record. Absent means passive, so every caller written before the
+    // second mode existed keeps its meaning.
+    const char* mode = param("mode");
+    if (mode != nullptr) {
+        if (std::strcmp(mode, "driver") == 0) {
+            out.driverMode = true;
+        } else if (std::strcmp(mode, "passive") != 0) {
+            return invalid("mode must be passive or driver");
+        }
+    }
+
+    if (out.driverMode) {
+        // Refused, not ignored. There is a working driver, so the line is a fact about the
+        // bridge; accepting a baud rate and then recording at a different one would put a
+        // number in the report that the capture never ran at.
+        for (const char* name : {"baud", "parity", "data_bits", "stop_bits"}) {
+            if (param(name) != nullptr) {
+                return invalid(std::string("mode=driver records the line the driver is already "
+                                           "using; remove '") +
+                               name + "'");
+            }
+        }
+        const long seconds = number(param, "seconds", 30);
+        if (seconds < 1 || seconds > static_cast<long>(kMaxDriverCaptureSeconds)) {
+            return invalid("seconds must be between 1 and " +
+                           std::to_string(kMaxDriverCaptureSeconds));
+        }
+        out.tap.durationMs = static_cast<uint32_t>(seconds) * 1000u;
+
+        const long frames = number(param, "frames", 64);
+        // Lower than the passive mode's ceiling, and refused rather than clamped: this report
+        // carries a direction and a cut reason per record, and past ~160 records it no longer
+        // fits the response bound. A capture that completes and can only answer 500 has spent
+        // real bus time for a report nobody can fetch.
+        if (frames < 1 || frames > kMaxDriverCaptureFrames) {
+            return invalid("frames must be between 1 and " +
+                           std::to_string(kMaxDriverCaptureFrames) + " in mode=driver");
+        }
+        out.tap.maxFrames = static_cast<size_t>(frames);
+        return std::nullopt;
+    }
+
+    const long seconds = number(param, "seconds", 30);
+    if (seconds < 1 || seconds > static_cast<long>(kMaxCaptureSeconds)) {
+        // Bounded because a passive capture holds the bus for its whole window: this is also the
+        // longest one authenticated request can stop the inverter being polled.
+        return invalid("seconds must be between 1 and " + std::to_string(kMaxCaptureSeconds));
+    }
+    out.config.durationMs = static_cast<uint32_t>(seconds) * 1000u;
+
+    const long frames = number(param, "frames", 64);
+    if (frames < 1 || frames > kMaxPassiveCaptureFrames) {
+        return invalid("frames must be between 1 and " + std::to_string(kMaxPassiveCaptureFrames));
+    }
+    out.config.maxFrames = static_cast<size_t>(frames);
+
+    // The line to listen at. There is no driver to ask -- that is the whole situation this mode
+    // exists for -- so the operator supplies it, and a wrong guess shows up in the report as
+    // bytes with no valid checksums rather than as silence.
+    const long baud = number(param, "baud", 9600);
+    if (baud < kMinBaudRate || baud > kMaxBaudRate) {
+        return invalid("baud must be between " + std::to_string(kMinBaudRate) + " and " +
+                       std::to_string(kMaxBaudRate));
+    }
+    out.profile.baudRate = static_cast<uint32_t>(baud);
+
+    if (const char* parity = param("parity")) {
+        SerialParity parsed{};
+        if (!parseParity(parity, parsed)) {
+            return invalid("parity must be none, even or odd");
+        }
+        out.profile.parity = parsed;
+    }
+
+    const long dataBits = number(param, "data_bits", 8);
+    const long stopBits = number(param, "stop_bits", 1);
+    if (dataBits < 5 || dataBits > 8 || stopBits < 1 || stopBits > 2) {
+        return invalid("data_bits must be 5-8 and stop_bits 1 or 2");
+    }
+    out.profile.dataBits = static_cast<uint8_t>(dataBits);
+    out.profile.stopBits = static_cast<uint8_t>(stopBits);
+    return std::nullopt;
+}
+
+}  // namespace heliograph::rest

--- a/src/outputs/rest/capture_request.cpp
+++ b/src/outputs/rest/capture_request.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <utility>  // std::move in invalid(); reaching it transitively is luck, not a contract
 
 namespace heliograph::rest {
 namespace {

--- a/src/outputs/rest/capture_request.h
+++ b/src/outputs/rest/capture_request.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+//
+// What a POST /api/v1/actions/capture query asks for, and whether it is allowed to ask it.
+//
+// Split out of the route handler for one reason: rest_api.cpp is 97% inside `#if defined(ESP32)`,
+// so on the host build it compiles to a stub. Every bound, every refusal and every default in
+// that endpoint was therefore unreachable by any test -- not untested by oversight, untestable
+// by construction. The validation is pure, it has more branches than anything else in the file,
+// and it is exactly the layer where a wrong 400 or a missing bound gets in.
+//
+// The web server does not appear here at all. The caller passes a lookup, so the rules can be
+// exercised with a std::map on the host and with AsyncWebServerRequest on the device -- one
+// implementation, two callers, no second copy of the bounds to drift.
+
+#pragma once
+
+#include <functional>
+#include <optional>
+
+#include "app/driver_capture_runner.h"
+#include "diagnostics/bus_tap.h"
+#include "diagnostics/frame_capture.h"
+#include "rest_payloads.h"
+#include "transport/serial_profile.h"
+
+namespace heliograph::rest {
+
+/// A checked request. Exactly one of the two halves is meaningful, per `driverMode`.
+struct CaptureRequest {
+    bool                driverMode = false;
+    diag::CaptureConfig config;   ///< passive mode
+    SerialProfile       profile;  ///< passive mode
+    diag::TapConfig     tap;      ///< driver mode
+};
+
+/// Reads one query parameter. Returns nullptr when it is absent -- which is different from
+/// present-and-empty, and the difference matters: `?parity=` is a value the operator typed and
+/// gets validated, while an absent parity keeps the default.
+using QueryParam = std::function<const char*(const char* name)>;
+
+/// Validates, and fills `out` when it passes. Returns the error to send otherwise.
+///
+/// Knows nothing about whether the build can capture or whether the bus is free -- those are
+/// facts about the running bridge, not about the request, and they stay with the handler that
+/// can see them.
+std::optional<ApiError> parseCaptureRequest(const QueryParam& param, CaptureRequest& out);
+
+/// Bounds for the passive mode, here rather than as literals in the handler so a test asserts
+/// the same numbers the endpoint enforces.
+inline constexpr long kMaxPassiveCaptureFrames = 256;
+inline constexpr long kMinBaudRate             = 300;
+inline constexpr long kMaxBaudRate             = 921600;
+
+}  // namespace heliograph::rest

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -4,6 +4,8 @@
 
 #include "rest_api.h"
 
+#include "capture_request.h"
+
 #if defined(ESP32)
 
 #include <ESPAsyncWebServer.h>
@@ -1082,66 +1084,37 @@ bool RestApi::begin() {
         if (!authorised(request) || rateLimited(request)) {
             return;
         }
-        if (context_.requestCapture == nullptr) {
+        // Every bound and every refusal lives in parseCaptureRequest, which is compiled on the
+        // host and has tests. This file is inside `#if defined(ESP32)`, so anything written
+        // inline here can only ever be verified by reading it.
+        //
+        // `value()` returns a reference owned by the request, so the pointer stays good for the
+        // whole call.
+        const rest::QueryParam param = [request](const char* name) -> const char* {
+            return request->hasParam(name) ? request->getParam(name)->value().c_str() : nullptr;
+        };
+        rest::CaptureRequest parsed;
+        if (const auto error = rest::parseCaptureRequest(param, parsed)) {
+            sendError(request, *error);
+            return;
+        }
+
+        // The capability check comes AFTER validation now, and asks about the mode that was
+        // actually requested. It used to be one unconditional check of requestCapture ahead of
+        // everything -- which answered "this build cannot capture" to a driver-mode request on a
+        // hypothetical build that had the driver hook and not the passive one. Unreachable
+        // today, since main wires both at the same place, but it was checking the wrong
+        // capability. The cost of the reorder is that a malformed request to a build with no
+        // capture support now gets 400 rather than 404, which describes it at least as well.
+        const bool available = parsed.driverMode ? context_.requestDriverCapture != nullptr
+                                                 : context_.requestCapture != nullptr;
+        if (!available) {
             sendError(request, {404, "no_capture", "this build cannot capture"});
             return;
         }
-        const auto number = [request](const char* name, long fallback) -> long {
-            if (!request->hasParam(name)) return fallback;
-            return std::strtol(request->getParam(name)->value().c_str(), nullptr, 10);
-        };
 
-        // Which conversation to record. Default `passive` so every existing caller keeps its
-        // meaning: this endpoint has always recorded a bus the bridge was silent on.
-        const bool driverMode =
-            request->hasParam("mode") && request->getParam("mode")->value() == "driver";
-        if (request->hasParam("mode") && !driverMode &&
-            request->getParam("mode")->value() != "passive") {
-            sendError(request, {400, "invalid_parameter", "mode must be passive or driver"});
-            return;
-        }
-
-        if (driverMode) {
-            if (context_.requestDriverCapture == nullptr) {
-                sendError(request, {404, "no_capture", "this build cannot capture"});
-                return;
-            }
-            // Refused, not ignored. There is a working driver here, so the line is a fact about
-            // the bridge -- accepting a baud rate and then recording at a different one would
-            // put a number in the report that the capture never ran at, which is worse than
-            // any error message.
-            for (const char* param : {"baud", "parity", "data_bits", "stop_bits"}) {
-                if (request->hasParam(param)) {
-                    sendError(request, {400, "invalid_parameter",
-                                        std::string("mode=driver records the line the driver is "
-                                                    "already using; remove '") +
-                                            param + "'"});
-                    return;
-                }
-            }
-            diag::TapConfig tap;
-            const long      seconds = number("seconds", 30);
-            if (seconds < 1 || seconds > static_cast<long>(kMaxDriverCaptureSeconds)) {
-                sendError(request, {400, "invalid_parameter",
-                                    "seconds must be between 1 and " +
-                                        std::to_string(kMaxDriverCaptureSeconds)});
-                return;
-            }
-            tap.durationMs    = static_cast<uint32_t>(seconds) * 1000u;
-            const long frames = number("frames", 64);
-            // Lower than the passive mode's 256, and refused rather than silently clamped: this
-            // report carries a direction and a cut reason per record, and above ~160 records it
-            // no longer fits the response bound. A capture that completes and can only ever
-            // answer 500 has spent real bus time for a report nobody can fetch.
-            if (frames < 1 || frames > kMaxDriverCaptureFrames) {
-                sendError(request, {400, "invalid_parameter",
-                                    "frames must be between 1 and " +
-                                        std::to_string(kMaxDriverCaptureFrames) +
-                                        " in mode=driver"});
-                return;
-            }
-            tap.maxFrames = static_cast<size_t>(frames);
-            if (!context_.requestDriverCapture(tap)) {
+        if (parsed.driverMode) {
+            if (!context_.requestDriverCapture(parsed.tap)) {
                 sendError(request, {409, "bus_busy",
                                     "a capture or discovery run is already using the bus"});
                 return;
@@ -1150,53 +1123,7 @@ bool RestApi::begin() {
             return;
         }
 
-        diag::CaptureConfig config;
-        const long seconds = number("seconds", 30);
-        if (seconds < 1 || seconds > static_cast<long>(kMaxCaptureSeconds)) {
-            // Bounded because a capture holds the bus for its whole window: this is also the
-            // longest one authenticated request can stop the inverter being polled.
-            sendError(request, {400, "invalid_parameter",
-                                "seconds must be between 1 and " +
-                                    std::to_string(kMaxCaptureSeconds)});
-            return;
-        }
-        config.durationMs = static_cast<uint32_t>(seconds) * 1000u;
-        const long frames = number("frames", 64);
-        if (frames < 1 || frames > 256) {
-            sendError(request, {400, "invalid_parameter", "frames must be between 1 and 256"});
-            return;
-        }
-        config.maxFrames = static_cast<size_t>(frames);
-
-        // The line to listen at. There is no driver to ask -- that is the whole situation this
-        // endpoint exists for -- so the operator supplies it, and a wrong guess shows up in the
-        // report as bytes with no valid checksums rather than as silence.
-        SerialProfile profile;
-        const long    baud = number("baud", 9600);
-        if (baud < 300 || baud > 921600) {
-            sendError(request, {400, "invalid_parameter", "baud must be between 300 and 921600"});
-            return;
-        }
-        profile.baudRate = static_cast<uint32_t>(baud);
-        if (request->hasParam("parity")) {
-            SerialParity parity{};
-            if (!parseParity(request->getParam("parity")->value().c_str(), parity)) {
-                sendError(request, {400, "invalid_parameter", "parity must be none, even or odd"});
-                return;
-            }
-            profile.parity = parity;
-        }
-        const long dataBits = number("data_bits", 8);
-        const long stopBits = number("stop_bits", 1);
-        if (dataBits < 5 || dataBits > 8 || stopBits < 1 || stopBits > 2) {
-            sendError(request, {400, "invalid_parameter",
-                                "data_bits must be 5-8 and stop_bits 1 or 2"});
-            return;
-        }
-        profile.dataBits = static_cast<uint8_t>(dataBits);
-        profile.stopBits = static_cast<uint8_t>(stopBits);
-
-        if (!context_.requestCapture(config, profile)) {
+        if (!context_.requestCapture(parsed.config, parsed.profile)) {
             sendError(request, {409, "bus_busy",
                                 "a capture or discovery run is already using the bus"});
             return;

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -24,6 +24,10 @@
 #include "drivers/eversolar_legacy/eversolar_driver.h"
 #include "drivers/mock/mock_driver.h"
 #include "outputs/prometheus/prometheus_metrics.h"
+#include <map>
+#include <optional>
+
+#include "outputs/rest/capture_request.h"
 #include "outputs/rest/rest_payloads.h"
 #include "state/state_store.h"
 #include "support/fake_eversolar_device.h"
@@ -1601,6 +1605,157 @@ static void test_driver_capture_payload_counts_requests_against_replies() {
     TEST_ASSERT_EQUAL_INT(30000, doc["elapsed_ms"].as<int>());
 }
 
+// ---------------------------------------------------------------------------------------
+// The capture endpoint's query rules.
+//
+// These had no tests at all until now, and not by oversight: rest_api.cpp is almost entirely
+// inside `#if defined(ESP32)`, so on this build it is a stub and every bound in that handler
+// was unreachable. The rules moved into parseCaptureRequest so they can be asked questions.
+// ---------------------------------------------------------------------------------------
+
+/// A query, as the handler sees it: present-with-a-value, or absent.
+using Query = std::map<std::string, std::string>;
+
+static rest::QueryParam queryOf(const Query& q) {
+    return [&q](const char* name) -> const char* {
+        const auto it = q.find(name);
+        return it == q.end() ? nullptr : it->second.c_str();
+    };
+}
+
+static std::optional<rest::ApiError> parseQuery(const Query& q, rest::CaptureRequest& out) {
+    return rest::parseCaptureRequest(queryOf(q), out);
+}
+
+/// No parameters at all is a valid request, and the defaults are part of the contract: this is
+/// what the "Start recording" button sends before anyone touches a field.
+static void test_an_empty_capture_query_is_the_documented_default() {
+    rest::CaptureRequest r;
+    TEST_ASSERT_FALSE(parseQuery({}, r).has_value());
+    TEST_ASSERT_FALSE(r.driverMode);
+    TEST_ASSERT_EQUAL_UINT32(30000, r.config.durationMs);
+    TEST_ASSERT_EQUAL_size_t(64, r.config.maxFrames);
+    TEST_ASSERT_EQUAL_UINT32(9600, r.profile.baudRate);
+    TEST_ASSERT_EQUAL_UINT8(8, r.profile.dataBits);
+    TEST_ASSERT_EQUAL_UINT8(1, r.profile.stopBits);
+}
+
+/// Absent mode means passive, which is what keeps every caller written before the second mode
+/// existed meaning what it meant.
+static void test_mode_defaults_to_passive_and_only_two_values_are_accepted() {
+    rest::CaptureRequest r;
+    TEST_ASSERT_FALSE(parseQuery({{"mode", "passive"}}, r).has_value());
+    TEST_ASSERT_FALSE(r.driverMode);
+    TEST_ASSERT_FALSE(parseQuery({{"mode", "driver"}}, r).has_value());
+    TEST_ASSERT_TRUE(r.driverMode);
+
+    // Case-sensitive, and an empty value is a value the operator typed rather than an absence.
+    for (const char* bad : {"DRIVER", "", "both", "active"}) {
+        const auto error = parseQuery({{"mode", bad}}, r);
+        TEST_ASSERT_TRUE(error.has_value());
+        TEST_ASSERT_EQUAL_INT(400, error->httpStatus);
+        TEST_ASSERT_EQUAL_STRING("invalid_parameter", error->code.c_str());
+    }
+}
+
+/// The rule that matters most in driver mode: the line is a fact about the bridge, so a supplied
+/// line setting is REFUSED rather than ignored. Accepting a baud rate and recording at another
+/// would put a number in the report the capture never ran at.
+static void test_driver_mode_refuses_every_line_parameter_by_name() {
+    for (const char* name : {"baud", "parity", "data_bits", "stop_bits"}) {
+        rest::CaptureRequest r;
+        const auto error = parseQuery({{"mode", "driver"}, {name, "9600"}}, r);
+        TEST_ASSERT_TRUE(error.has_value());
+        TEST_ASSERT_EQUAL_INT(400, error->httpStatus);
+        // The message names the offending parameter, so the caller knows which one to drop
+        // rather than being told to remove "a line setting".
+        TEST_ASSERT_TRUE(error->message.find(name) != std::string::npos);
+    }
+}
+
+/// ...and the same parameters are perfectly legal in passive mode, where there is no driver to
+/// ask. A guard that refused them everywhere would have broken the mode it was added beside.
+static void test_the_same_line_parameters_are_accepted_in_passive_mode() {
+    rest::CaptureRequest r;
+    const Query q{{"baud", "19200"}, {"parity", "even"}, {"data_bits", "7"}, {"stop_bits", "2"}};
+    TEST_ASSERT_FALSE(parseQuery(q, r).has_value());
+    TEST_ASSERT_EQUAL_UINT32(19200, r.profile.baudRate);
+    TEST_ASSERT_EQUAL(SerialParity::Even, r.profile.parity);
+    TEST_ASSERT_EQUAL_UINT8(7, r.profile.dataBits);
+    TEST_ASSERT_EQUAL_UINT8(2, r.profile.stopBits);
+}
+
+/// Both modes bound the window, and the boundary values themselves are the interesting part:
+/// off-by-one here is the difference between a legal request and a 400.
+static void test_the_window_bounds_hold_at_their_edges() {
+    rest::CaptureRequest r;
+    for (const char* mode : {"passive", "driver"}) {
+        TEST_ASSERT_FALSE(parseQuery({{"mode", mode}, {"seconds", "1"}}, r).has_value());
+        TEST_ASSERT_EQUAL_UINT32(1000, mode[0] == 'd' ? r.tap.durationMs : r.config.durationMs);
+        TEST_ASSERT_FALSE(parseQuery({{"mode", mode}, {"seconds", "300"}}, r).has_value());
+        TEST_ASSERT_TRUE(parseQuery({{"mode", mode}, {"seconds", "0"}}, r).has_value());
+        TEST_ASSERT_TRUE(parseQuery({{"mode", mode}, {"seconds", "301"}}, r).has_value());
+        TEST_ASSERT_TRUE(parseQuery({{"mode", mode}, {"seconds", "-1"}}, r).has_value());
+    }
+}
+
+/// The frame ceilings DIFFER by mode, and that asymmetry is load-bearing: the driver report
+/// carries two extra fields per record and stops fitting the response bound past ~160.
+static void test_driver_mode_has_a_lower_frame_ceiling_than_passive() {
+    rest::CaptureRequest r;
+    TEST_ASSERT_FALSE(parseQuery({{"frames", "256"}}, r).has_value());
+    TEST_ASSERT_EQUAL_size_t(256, r.config.maxFrames);
+    TEST_ASSERT_TRUE(parseQuery({{"frames", "257"}}, r).has_value());
+
+    TEST_ASSERT_FALSE(parseQuery({{"mode", "driver"}, {"frames", "128"}}, r).has_value());
+    TEST_ASSERT_EQUAL_size_t(128, r.tap.maxFrames);
+    const auto error = parseQuery({{"mode", "driver"}, {"frames", "129"}}, r);
+    TEST_ASSERT_TRUE(error.has_value());
+    // Says which mode's limit was hit, because 129 is legal in the other one.
+    TEST_ASSERT_TRUE(error->message.find("driver") != std::string::npos);
+}
+
+static void test_the_line_bounds_are_enforced() {
+    rest::CaptureRequest r;
+    TEST_ASSERT_FALSE(parseQuery({{"baud", "300"}}, r).has_value());
+    TEST_ASSERT_FALSE(parseQuery({{"baud", "921600"}}, r).has_value());
+    TEST_ASSERT_TRUE(parseQuery({{"baud", "299"}}, r).has_value());
+    TEST_ASSERT_TRUE(parseQuery({{"baud", "921601"}}, r).has_value());
+    TEST_ASSERT_TRUE(parseQuery({{"parity", "mark"}}, r).has_value());
+    TEST_ASSERT_TRUE(parseQuery({{"data_bits", "4"}}, r).has_value());
+    TEST_ASSERT_TRUE(parseQuery({{"data_bits", "9"}}, r).has_value());
+    TEST_ASSERT_TRUE(parseQuery({{"stop_bits", "0"}}, r).has_value());
+    TEST_ASSERT_TRUE(parseQuery({{"stop_bits", "3"}}, r).has_value());
+}
+
+/// Unparseable numbers land on 0 and are then caught by the range check rather than by a parse
+/// error. Recorded as the behaviour it is: the caller gets a 400 either way, and the endpoint
+/// has read numbers this way since it existed.
+static void test_a_number_that_is_not_a_number_is_refused_by_its_range() {
+    rest::CaptureRequest r;
+    for (const char* junk : {"abc", "", "  "}) {
+        const auto error = parseQuery({{"seconds", junk}}, r);
+        TEST_ASSERT_TRUE(error.has_value());
+        TEST_ASSERT_EQUAL_INT(400, error->httpStatus);
+    }
+    // The one lenient case, stated rather than discovered: a trailing tail is ignored.
+    TEST_ASSERT_FALSE(parseQuery({{"seconds", "30abc"}}, r).has_value());
+    TEST_ASSERT_EQUAL_UINT32(30000, r.config.durationMs);
+}
+
+/// A rejected request must not leave half-filled settings behind for a caller that ignores the
+/// error -- and a second parse must not inherit anything from the first.
+static void test_a_refused_request_leaves_nothing_behind() {
+    rest::CaptureRequest r;
+    TEST_ASSERT_FALSE(parseQuery({{"mode", "driver"}, {"frames", "99"}}, r).has_value());
+    TEST_ASSERT_TRUE(r.driverMode);
+
+    // The second parse resets everything: no leftover driverMode, and no leftover 99.
+    TEST_ASSERT_TRUE(parseQuery({{"baud", "1"}}, r).has_value());
+    TEST_ASSERT_FALSE(r.driverMode);
+    TEST_ASSERT_NOT_EQUAL(99u, r.tap.maxFrames);
+}
+
 /// A failure has to carry its reason. "failed" alone leaves the operator unable to tell a busy
 /// bus from line settings the UART refused.
 static void test_a_failed_capture_carries_its_reason() {
@@ -2931,6 +3086,15 @@ int main(int, char**) {
     RUN_TEST(test_driver_capture_payload_labels_each_frame_with_its_direction);
     RUN_TEST(test_driver_capture_payload_says_what_ended_each_record);
     RUN_TEST(test_driver_capture_payload_counts_requests_against_replies);
+    RUN_TEST(test_an_empty_capture_query_is_the_documented_default);
+    RUN_TEST(test_mode_defaults_to_passive_and_only_two_values_are_accepted);
+    RUN_TEST(test_driver_mode_refuses_every_line_parameter_by_name);
+    RUN_TEST(test_the_same_line_parameters_are_accepted_in_passive_mode);
+    RUN_TEST(test_the_window_bounds_hold_at_their_edges);
+    RUN_TEST(test_driver_mode_has_a_lower_frame_ceiling_than_passive);
+    RUN_TEST(test_the_line_bounds_are_enforced);
+    RUN_TEST(test_a_number_that_is_not_a_number_is_refused_by_its_range);
+    RUN_TEST(test_a_refused_request_leaves_nothing_behind);
     RUN_TEST(test_a_failed_capture_carries_its_reason);
     RUN_TEST(test_a_capture_filled_to_its_byte_ceiling_fits_in_the_response);
     RUN_TEST(test_restore_preview_carries_the_file_and_the_changes);


### PR DESCRIPTION
Follow-up to #167, on the coverage gap the test review turned up.

## The gap was not "nobody wrote tests"

`src/outputs/rest/rest_api.cpp` is 1497 lines, of which **1459 sit inside `#if defined(ESP32)`**. The host build compiles the stub underneath. So every bound, default and refusal in that handler was unreachable by any test *by construction* — including the `mode=driver` validation added in #167 earlier the same day.

## What changed

`parseCaptureRequest` is that logic, lifted out whole into a host-compilable unit. It takes a lookup rather than an `AsyncWebServerRequest`, so one implementation answers a `std::map` on the host and the real request on the device — no second copy of the bounds to drift.

Proved rather than asserted: `nm` on the firmware's `rest_api.cpp.o` shows an undefined reference to `parseCaptureRequest`, so the handler links the very function the tests exercise.

## Nine tests, on rules that were invisible

- the defaults an untouched form sends (30 s, 64 frames, 9600 8N1)
- `mode` is case-sensitive, and an empty value is a value the operator typed rather than an absence
- each of the four line parameters refused **by name** in driver mode, and accepted in passive — a guard that refused them everywhere would have broken the mode it was added beside
- the window bounds at their exact edges, in both modes
- the two *different* frame ceilings, and that the message says which mode's limit was hit
- the line bounds
- what an unparseable number does

## One thing recorded rather than changed

`strtol` with no errno check lands `"abc"` on 0, which the range check then refuses — the caller gets a 400 either way. `"30abc"` reads as 30, the one lenient case, and that has been this endpoint's behaviour since it existed. A test stating it is worth more than tightening it and finding out who relied on it.

## One deliberate behaviour change

The capability check used to be a single unconditional test of `requestCapture` **ahead of all parsing**, so a driver-mode request on a build with the driver hook and not the passive one would answer "this build cannot capture". It now runs after validation and asks about the mode actually requested.

Unreachable today — `main.cpp` wires both hooks at the same place — but it was checking the wrong capability. The cost is that a malformed request to a build with no capture support gets 400 rather than 404, which describes it at least as well.

## Verification

- 964 native tests (was 955), all green
- three mutations, one per rule: allowing the line parameters through, restoring the 256 frame ceiling, and widening the window bound each trip their own test
- `check_layering.sh` all ten rules; `check_web_js.py`, `check_dashboard_layout.py`, `check_measurement_ids.py`, `ruff` clean
- firmware builds with no warnings from our own sources; RAM 22.5%, flash 22.9%

## Not addressed here

The other two levers from the test review are untouched and still open: caching `.pio/build/native` in CI (~40 s of the 68 s test step) and the layout check launching Chrome eight times (~8 s of its 15 s).