### PR TITLE
Render the sixteen layout scenarios concurrently

### DIFF
--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -31,6 +31,7 @@ import re
 import subprocess
 import sys
 import tempfile
+from typing import NamedTuple
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import build_web
@@ -651,7 +652,22 @@ const tick=setInterval(async()=>{
 
 
 # Ceiling on concurrent browsers. See the note at the call site.
-kMaxRenderWorkers = 4
+MAX_RENDER_WORKERS = 4
+
+
+class Scenario(NamedTuple):
+    """One thing to render and the name it answers to.
+
+    Named rather than a bare tuple because the fields are three strings and an int in an order
+    nobody can infer -- and the renderer is now called through a mapping function, where a
+    positional mix-up would silently render the wrong page at the wrong width under the right
+    label. The failure would read as a real layout bug.
+    """
+
+    label: str
+    page: str
+    width: int
+    tag: str
 
 
 def build_page(stripped: str, stub: str, battery: str, extra_js: str) -> str:
@@ -727,10 +743,10 @@ def main() -> int:
     # `jobs` keeps the ORDER the scenarios were written in, and the report loop walks it, so the
     # output is identical to the serial version. A layout failure has to be findable by reading
     # down the list; interleaving it by completion time would trade the whole saving for that.
-    jobs: list[tuple[str, str, int, str]] = []  # (label, page, width, tag)
+    jobs: list[Scenario] = []
 
     def plan(label: str, page: str, width: int, tag: str) -> None:
-        jobs.append((label, page, width, tag))
+        jobs.append(Scenario(label, page, width, tag))
 
     with tempfile.TemporaryDirectory(prefix="heliograph-layout-") as scratch:
         page = build_page(stripped, stub, "{soc:68,power:-1240}", ASSERT_JS)
@@ -807,17 +823,20 @@ def main() -> int:
         # two-core CI runner sixteen at once would swap rather than render, and a layout check
         # that fails on memory pressure is worse than a slow one -- it fails on the machine
         # rather than on the page. Four is the point where the process churn stops dominating.
-        workers = min(kMaxRenderWorkers, len(jobs), (os.cpu_count() or 1) * 2)
+        workers = min(MAX_RENDER_WORKERS, len(jobs), (os.cpu_count() or 1) * 2)
+
+        def verdict_for(scenario: Scenario) -> str:
+            return render(chrome, scenario.page, scenario.width, scratch, scenario.tag)[
+                0
+            ]
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
-            verdicts = list(
-                pool.map(
-                    lambda job: render(chrome, job[1], job[2], scratch, job[3])[0], jobs
-                )
-            )
+            # pool.map yields in the order it was given, not the order things finished.
+            verdicts = list(pool.map(verdict_for, jobs))
 
     status = 0
-    for (label, _, _, _), verdict in zip(jobs, verdicts, strict=True):
-        status |= report(label, verdict)
+    for scenario, verdict in zip(jobs, verdicts, strict=True):
+        status |= report(scenario.label, verdict)
     return status
 
 

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -24,6 +24,8 @@
 # a runner image that stops shipping Chrome shows up as a red check rather than as a layout
 # check that quietly stopped rendering anything.
 
+import concurrent.futures
+import os
 import pathlib
 import re
 import subprocess
@@ -648,6 +650,10 @@ const tick=setInterval(async()=>{
 """
 
 
+# Ceiling on concurrent browsers. See the note at the call site.
+kMaxRenderWorkers = 4
+
+
 def build_page(stripped: str, stub: str, battery: str, extra_js: str) -> str:
     """The served page with the stub attached, and the assertions after it.
 
@@ -672,6 +678,11 @@ def render(
             "--headless",
             "--disable-gpu",
             "--no-sandbox",
+            # NO --user-data-dir here, and that is a measured decision rather than an omission.
+            # These renders run concurrently, so a shared profile directory looked like the
+            # obvious hazard -- but pointing each one at its own directory made Chrome hang until
+            # the 120 s timeout, every time. Headless already gives each process a throwaway
+            # profile; naming one asks for a real profile to be initialised instead.
             f"--window-size={width},900",
             "--virtual-time-budget=6000",
             "--dump-dom",
@@ -708,12 +719,23 @@ def main() -> int:
         print("dashboard layout: FAIL (no Chrome/Chromium on PATH to render with)")
         return 1
 
-    status = 0
+    # Every scenario is built first and rendered afterwards, because they are independent: a
+    # separate process, a separate page file, no shared state. Rendering them one at a time was
+    # sixteen Chrome starts in series, and the process churn -- not the rendering -- was most of
+    # the wall time (9.6 s of system time against 14.5 s of user time on a 34 s run).
+    #
+    # `jobs` keeps the ORDER the scenarios were written in, and the report loop walks it, so the
+    # output is identical to the serial version. A layout failure has to be findable by reading
+    # down the list; interleaving it by completion time would trade the whole saving for that.
+    jobs: list[tuple[str, str, int, str]] = []  # (label, page, width, tag)
+
+    def plan(label: str, page: str, width: int, tag: str) -> None:
+        jobs.append((label, page, width, tag))
+
     with tempfile.TemporaryDirectory(prefix="heliograph-layout-") as scratch:
         page = build_page(stripped, stub, "{soc:68,power:-1240}", ASSERT_JS)
         for width in WIDTHS:
-            verdict, _ = render(chrome, page, width, scratch, str(width))
-            status |= report(f"dashboard layout @{width}px", verdict)
+            plan(f"dashboard layout @{width}px", page, width, str(width))
 
         for label, soc, power, wanted, unwanted in BATTERY_CASES:
             # The DOM itself is the subject here, so the assertions read it as text rather than
@@ -732,44 +754,70 @@ def main() -> int:
                 "    document.title=fail.length?'LAYOUT-FAIL '+fail.join(' || '):'LAYOUT-OK';}\n"
                 "},25);})();"
             )
-            page = build_page(stripped, stub, f"{{soc:{soc},power:{power}}}", js)
-            verdict, _ = render(chrome, page, 1000, scratch, label)
-            status |= report(f"battery {label}", verdict)
+            plan(
+                f"battery {label}",
+                build_page(stripped, stub, f"{{soc:{soc},power:{power}}}", js),
+                1000,
+                label,
+            )
 
         # The tab that takes input rather than only showing it.
-        page = build_page(stripped, stub, "{soc:68,power:-1240}", INVERTERS_JS)
-        verdict, _ = render(chrome, page, 1000, scratch, "inverters")
-        status |= report("inverters tab interaction", verdict)
+        plan(
+            "inverters tab interaction",
+            build_page(stripped, stub, "{soc:68,power:-1240}", INVERTERS_JS),
+            1000,
+            "inverters",
+        )
 
         # And the state every owner passes through exactly once, on a different stub: a bridge
         # that has just been provisioned and has never been told what it is wired to.
         fresh = (ROOT / "tools" / "fresh_bridge.js").read_text(encoding="utf-8")
         page = build_web.inject_before_script(stripped, fresh)
         page = page.replace("</body>", f"<script>{FRESH_BRIDGE_JS}</script></body>", 1)
-        verdict, _ = render(chrome, page, 1000, scratch, "fresh")
-        status |= report("first run, nothing configured", verdict)
+        plan("first run, nothing configured", page, 1000, "fresh")
 
         # The mirror image, and the reason the config alone is not the question: driver.id is
         # equally empty here, but the inverter it auto-picked is answering.
         auto = (ROOT / "tools" / "autopick_bridge.js").read_text(encoding="utf-8")
         page = build_web.inject_before_script(stripped, auto)
         page = page.replace("</body>", f"<script>{AUTOPICK_JS}</script></body>", 1)
-        verdict, _ = render(chrome, page, 1000, scratch, "autopick")
-        status |= report("auto-picked driver, answering", verdict)
+        plan("auto-picked driver, answering", page, 1000, "autopick")
 
         # Data keeps moving; the page around it does not get rebuilt.
-        page = build_page(stripped, stub, "{soc:68,power:-1240}", BRIDGE_JS)
-        verdict, _ = render(chrome, page, 1000, scratch, "bridge")
-        status |= report("bridge tab keeps what you typed", verdict)
+        plan(
+            "bridge tab keeps what you typed",
+            build_page(stripped, stub, "{soc:68,power:-1240}", BRIDGE_JS),
+            1000,
+            "bridge",
+        )
+        plan(
+            "health keeps your place in the log",
+            build_page(stripped, stub, "{soc:68,power:-1240}", HEALTH_JS),
+            1000,
+            "health",
+        )
+        plan(
+            "integrations still reports what changed",
+            build_page(stripped, stub, "{soc:68,power:-1240}", INTEGRATIONS_JS),
+            1000,
+            "int",
+        )
 
-        page = build_page(stripped, stub, "{soc:68,power:-1240}", HEALTH_JS)
-        verdict, _ = render(chrome, page, 1000, scratch, "health")
-        status |= report("health keeps your place in the log", verdict)
+        # Bounded, and not by "how many can we start". Each worker is a whole browser; on a
+        # two-core CI runner sixteen at once would swap rather than render, and a layout check
+        # that fails on memory pressure is worse than a slow one -- it fails on the machine
+        # rather than on the page. Four is the point where the process churn stops dominating.
+        workers = min(kMaxRenderWorkers, len(jobs), (os.cpu_count() or 1) * 2)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            verdicts = list(
+                pool.map(
+                    lambda job: render(chrome, job[1], job[2], scratch, job[3])[0], jobs
+                )
+            )
 
-        page = build_page(stripped, stub, "{soc:68,power:-1240}", INTEGRATIONS_JS)
-        verdict, _ = render(chrome, page, 1000, scratch, "int")
-        status |= report("integrations still reports what changed", verdict)
-
+    status = 0
+    for (label, _, _, _), verdict in zip(jobs, verdicts, strict=True):
+        status |= report(label, verdict)
     return status
 
 


### PR DESCRIPTION
Point C from the test review. Independent of #169 — touches only `tools/check_dashboard_layout.py`.

## ⚠️ The CI benefit I opened this PR for does not exist

I measured it after opening. **On CI the effect is not distinguishable from noise.**

| | layout step |
|---|---|
| without this change | 7, 8, 16, 16, 18 s |
| with this change | 11, 14, 15, 15 s |

The two fastest runs of the whole set are on the *unchanged* code. Runner variance is larger than any effect this has. My original body said "expect less than 2×" — the honest answer is closer to zero, and the spread swamps it either way.

## What it does deliver

**Local: 34.1 s → 17.1 s**, reproducible across three runs. That is the check developers pay for on every pre-push verification, and it is one of the slower local gates.

Where the time went, and why halving was possible: the check starts a whole browser per scenario and there are **sixteen** — five widths, five battery states, six tab scenarios. (I said eight in the review; that was the count of `render()` call sites, not of iterations.) Serially, 9.6 s of it was *system* time against 14.5 s of user time. Most of the cost was starting and reaping processes, not rendering pages.

## The trade to weigh

A previously linear, boring check now has concurrency in it. That is a real cost against a benefit that is now local-only. Reasonable to reject on those terms — the measurement is above so the call can be made on the numbers rather than on the pitch.

## What changed

Scenarios are planned first and rendered afterwards through a bounded pool. The report loop walks the plan **in the order the scenarios were written**, so output is identical to the serial version: a layout failure has to be findable by reading down the list.

## Two things measured rather than assumed

- **`--user-data-dir` per render made it worse.** Added first, reasoning that concurrent Chromes would contend on a shared profile. Every render then hung until the 120 s timeout — headless already hands each process a throwaway profile, and naming one asks for a real profile to be initialised. Gone, with a comment, because it is exactly the "fix" someone reaches for on seeing concurrency here.
- **Worker ceiling is 4**, not "as many as there are jobs". Each worker is a browser; on a two-core runner sixteen at once would swap rather than render, and a check that fails on memory pressure fails on the machine rather than on the page.

## A faster check that no longer fails is worth nothing

Mutation-proved against the real UI, and re-proved after the review refactor:

| mutation | result |
|---|---|
| `min-width:1400px` on `.fleetrow` | all five width scenarios FAIL |
| battery direction arrow removed | exactly the two battery cases that assert it FAIL |

Labels stay attached to the right scenarios — the one thing parallel execution, and later the tuple-to-NamedTuple refactor, could plausibly have broken. Stability: three consecutive local runs, 16/16 green each time.

## Still open from the test review

Lever A, caching `.pio/build/native` in CI (~40 s of the 68 s test step), is untouched — and on this evidence it is the one worth doing for CI time.