### PR TITLE
Cache the compiled native tree between CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,33 @@ jobs:
             ~/.cache/pip
           key: pio-native-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
 
+      # The COMPILED tree, which is a different thing from the cache above: that one holds the
+      # packages, this one holds the objects built from them. The native env compiles 65 src
+      # objects and then links them into a separate binary per test suite, so the src half is
+      # built once and paid for on every run. Locally the same suite takes ~40 s cold and ~24 s
+      # warm; this is an attempt to give CI the warm number.
+      #
+      # ~15 MB, measured -- worth stating next to the toolchain cache's ~1.7 GB, because the
+      # repo budget is 10 GB and cache-warm.yml exists partly because five oversized entries
+      # were evicting the small useful ones. This is not one of those.
+      #
+      # KEYED PER COMMIT with a prefix fallback, which is the shape that makes it work at all: a
+      # key that matched exactly would only ever hit on a re-run of the same commit, and a key
+      # that ignored the commit would never be refreshed. The restore-key picks up the newest
+      # tree built from the same platformio.ini, and SCons decides what is stale from there.
+      #
+      # platformio.ini is in the key because it carries the BUILD FLAGS. SCons tracks source
+      # dependencies, not the command line it was invoked with, so a changed -D would otherwise
+      # link objects compiled under the old one -- the one way this cache could turn a red run
+      # green. Everything else that matters is content-hashed by SCons itself.
+      - name: Cache the native build tree
+        uses: actions/cache@v6
+        with:
+          path: .pio/build/native
+          key: pio-build-native-${{ runner.os }}-${{ hashFiles('platformio.ini') }}-${{ github.sha }}
+          restore-keys: |
+            pio-build-native-${{ runner.os }}-${{ hashFiles('platformio.ini') }}-
+
       - name: Install PlatformIO
         run: pip install platformio
 

--- a/src/diagnostics/bus_tap.cpp
+++ b/src/diagnostics/bus_tap.cpp
@@ -9,8 +9,8 @@ namespace heliograph::diag {
 
 const char* busDirectionName(BusDirection direction) {
     switch (direction) {
-        case BusDirection::Tx: return "rx";
-        case BusDirection::Rx: return "tx";
+        case BusDirection::Tx: return "tx";
+        case BusDirection::Rx: return "rx";
     }
     return "unknown";
 }

--- a/src/diagnostics/bus_tap.cpp
+++ b/src/diagnostics/bus_tap.cpp
@@ -9,8 +9,8 @@ namespace heliograph::diag {
 
 const char* busDirectionName(BusDirection direction) {
     switch (direction) {
-        case BusDirection::Tx: return "tx";
-        case BusDirection::Rx: return "rx";
+        case BusDirection::Tx: return "rx";
+        case BusDirection::Rx: return "tx";
     }
     return "unknown";
 }


### PR DESCRIPTION
Lever A from the test review — the one the evidence pointed at after #170 turned out to be noise on CI.

## The hypothesis

The native env compiles **65 src objects** and links them into a separate binary per test suite. The src half is built once and paid for on every run.

| | |
|---|---|
| local, cold | ~40 s |
| local, warm | ~24 s |
| CI | 68 s, cold every time |

This gives CI the warm tree to start from.

## Measured before writing it

**~15 MB.** Worth stating next to the toolchain cache's ~1.7 GB: the repo budget is 10 GB, and `cache-warm.yml` exists partly because five oversized entries had been evicting the small useful ones. This is not one of those.

## The key shape, and the one real risk

Keyed per commit with a prefix fallback. That is the only shape that works — an exact key hits only on a re-run of the same commit, and a key without the commit never refreshes.

`platformio.ini` is in the key **because it carries the build flags**, and that is the one way this cache could turn a red run green: SCons content-hashes sources but does not track the command line it was invoked with, so a changed `-D` would otherwise link objects compiled under the old one. Everything else is SCons's own problem and it is good at it.

## ⚠️ Not yet measured on CI

The number that matters comes from comparing runs after this lands. **#170 was closed for exactly this reason** — a local speedup that did not survive contact with the runner — so this PR does not claim a CI win until it has one.

Two things to establish before this is mergeable, and I will post both here:

1. **Does it actually save time?** Cold run vs warm run vs the 68 s baseline, several samples, because runner variance on this repo is wide enough to swallow a small effect.
2. **Can it hide a regression?** A build cache that lets a broken commit pass is worse than a slow CI. I will push a deliberately broken test onto the warm cache and confirm CI goes red, then revert it.