### PR TITLE
The 8-word tail is not only zeros and 0xFFFF

### DIFF
--- a/docs/eversolar-protocol.md
+++ b/docs/eversolar-protocol.md
@@ -253,10 +253,38 @@ Two explanations, and we don't yet know which one is correct:
 #### What the TL3000-20 actually sends — hypothesis refuted (2026-07-19)
 
 The real 1-string TL3000-20 sends **44 bytes**: the 14 single-string words followed by an
-8-word tail of zeros and `0xFFFF`, meaning unknown. Not 28. The values in the first 14
+8-word tail, meaning unknown. Not 28. The values in the first 14
 words have been verified against reality (38.6°C, 346.4 V × 2.0 A DC ≈ 655 W AC,
 50.03 Hz, 35,445.9 kWh lifetime — mutually consistent and physically plausible; frame stored
 as `kRespNormalInfoCaptured` in the fixtures).
+
+##### The tail, read off the wire (2026-08-03)
+
+This paragraph used to describe that tail as "zeros and `0xFFFF`". It is not only those two
+values. Three consecutive replies, captured on the production bridge, carry the same eight words
+byte for byte:
+
+```
+word   14   15   16   17   18   19   20   21
+     0000 0000 FFFF 0000 0000 0000 FF00 0000
+```
+
+Word 20 is `FF00` — neither zero nor `0xFFFF`, and stable across all three frames, so it is a
+constant rather than noise. Still unknown, and still not decoded: nothing here reads past word
+13. What changed is only that the description now matches the bytes.
+
+How this was found is the point worth recording. The 2026-07-19 entry above needed a USB-RS485
+tap and a laptop at the inverter — which is why the tail got a one-line summary and no
+transcript. This came from the bridge itself: a **driver capture** (`mode=driver`, 30 s) records
+the driver's own request/response pairs while polling continues, so checking this document
+against the wire no longer needs any hardware beyond the bridge that is already there. Three
+request/reply pairs, six frames, all six with a valid AA55 checksum, decoded by hand and
+cross-checked against the same bridge's published measurements — 333.9 V × 5.2 A DC against
+1671 W AC is 96.3% efficiency, which is what a string inverter does.
+
+That feature exists because the older PASSIVE capture cannot do this: it takes the bus away from
+the driver for the whole window, so pointing it at a working inverter records nothing at all.
+See [adding-a-device.md § 6.5](adding-a-device.md#65-recording-a-driver-we-already-have).
 
 That resolves the question about the config option in the reference: `eversolar.pl` indexes
 words and ignores everything after them, so the payload length was never relevant to the


### PR DESCRIPTION
The first thing the driver capture has taught us about a protocol.

## The correction

`docs/eversolar-protocol.md` described the TL3000-20's payload tail as *"an 8-word tail of zeros and `0xFFFF`"*. Word 20 is `FF00`, which is neither.

Three consecutive replies, captured on the production bridge, carry the same eight words byte for byte:

```
word   14   15   16   17   18   19   20   21
     0000 0000 FFFF 0000 0000 0000 FF00 0000
```

Identical across all three, so it is a constant and not noise. **Still unknown, still not decoded** — nothing in the driver reads past word 13. Only the description changed.

## The lineage, which is the part worth recording

The section this sits under is `#### What the TL3000-20 actually sends — hypothesis refuted (2026-07-19)`. That entry established 44 bytes against a documented 28, and it needed **a USB-RS485 tap and a laptop at the inverter** — which is why the tail got one summarising line and no transcript. Nobody was going to stand in the meter cupboard to characterise eight words nothing reads.

This one came off the bridge itself. A driver capture, 30 s, while polling continued:

| | |
|---|---|
| records | 6 (3 sent, 3 received) |
| AA55 valid | 6 |
| Modbus CRC valid | 0 |
| response time | 32, 35, 32 ms |
| poll interval | ~10.2 s |

Every field matched the documented frame layout: source `01 00` and destination `00 10` swapping on the reply, `11 02` → `11 82`, lengths exactly `11 + N`, checksums holding.

And the payload decoded by hand cross-checks against the same bridge's published measurements — with the differences being *time*, not error: power fell (1671 → 1583 W) while the accumulating counters rose (1.58 → 1.62 kWh today) over the minutes between capture and read. Internally the frame is coherent as physics: 333.9 V × 5.2 A DC against 1671 W AC is **96.3% efficiency**, and 238.8 V × 6.9 A AC ≈ the same 1671 W.

## Why this is possible now

The older **passive** capture cannot do this: it takes the bus away from the driver for the whole window, so pointing it at a working inverter records nothing at all — confirmed on hardware, `frames: 0, bytes: 0`. The driver capture shipped in 0.26.x for exactly this job, and this is it doing it.

No code change. Documentation only.