### PR TITLE
Cleanup: one latent overflow, three unread things, two duplicated fixtures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,6 @@ struct SerialProfile {
     uint8_t       dataBits          = 8;
     uint8_t       stopBits          = 1;
     uint32_t      responseTimeoutMs = 1000;
-    uint8_t       retries           = 3;
 };
 
 class Transport {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,7 +243,7 @@ EverSolar:
   .manufacturer = "Ever-Solar",
   .protocol = "EverSolar PMU RS485",
   .supportedTransports = { TransportType::Rs485, TransportType::Mock },
-  .recommendedSerialProfiles = { { 9600, SerialParity::None, 8, 1, 1000, 3 } },  // only one known
+  .recommendedSerialProfiles = { { 9600, SerialParity::None, 8, 1, 1000 } },  // only one known
   .supportLevel = DriverSupportLevel::Experimental,   // → Beta after Phase 3, Stable after Phase 9
   .probePriority = 10,
   .supportsAutoDetection = true,

--- a/docs/eversolar-protocol.md
+++ b/docs/eversolar-protocol.md
@@ -470,8 +470,17 @@ The reference does `sleep 1` after each request and then blindly reads 256 bytes
 (`:430-446`). That is crude but proves that the inverter responds well within a second.
 
 Our transport layer does it properly: read until the frame is complete (length follows from
-byte 8), with a response timeout of **1000 ms** and **3** retries. These values are set in the
-driver's `SerialProfile` and are configurable.
+byte 8), with a response timeout of **1000 ms** and a **3000 ms** ceiling on the whole
+transaction, so a device that trickles bytes forever still ends. Both are compile-time constants
+in `src/protocols/pmu/pmu_transaction.h` (`kResponseTimeoutMs`, `kTransactionDeadlineMs`), shared
+with the other PMU-family driver.
+
+**There are no retries at this layer.** An earlier version of this paragraph said "3 retries,
+set in the driver's `SerialProfile` and configurable", which was wrong in all three parts: no
+retry loop exists in the poll path, the `SerialProfile::retries` field it named was never read by
+anything (it has since been removed), and nothing ever exposed it as a setting. A failed
+transaction is counted and the next poll comes round on its own schedule; recovery is per-poll,
+not per-transaction.
 
 ## Several inverters on one bus
 

--- a/src/config/configuration.h
+++ b/src/config/configuration.h
@@ -203,9 +203,13 @@ struct SecuritySettings {
 /// begin(), which means at boot AND after a discovery run -- missing the second one silently
 /// undid the override on a running bridge.
 ///
-/// responseTimeoutMs and retries within `profile` are carried but unused: read deadlines are
-/// per-driver compile-time constants, and Rs485Transport::read() takes its timeout from the
-/// caller. Exposing them would have been a control that changes nothing.
+/// responseTimeoutMs within `profile` is carried but does not govern anything: it reaches
+/// uart_.setTimeout() in Rs485Transport::configure(), and that setting only bounds readBytes(),
+/// which read() calls exclusively when the bytes are already available. Read deadlines are
+/// per-driver compile-time constants and read() takes its timeout from the caller. Exposing it
+/// would have been a control that changes nothing. (A sibling `retries` field was carried the
+/// same way with nothing reading it at all, and was removed rather than left to look like a
+/// setting.)
 struct SerialOverride {
     bool          enabled = false;
     SerialProfile profile{};

--- a/src/drivers/eversolar_legacy/descriptor.cpp
+++ b/src/drivers/eversolar_legacy/descriptor.cpp
@@ -18,7 +18,7 @@ const DriverDescriptor& descriptor() {
         x.supportedTransports = {TransportType::Rs485, TransportType::Mock};
         // 9600 8N1 is hardcoded in the reference implementation and is the only profile
         // known to work. Offering more would be guessing on a live bus.
-        x.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3}};
+        x.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000}};
         // Beta from 2026-07-19: Phase 3 exit criteria met against a real TL3000-20 -- stable
         // reads over hours, values matching eversolar-monitor within the documented tolerance
         // (energy.total exactly +HI*0.1 kWh, hours/status/impedance/serial exact), and both

--- a/src/drivers/modbus_profile/descriptor.cpp
+++ b/src/drivers/modbus_profile/descriptor.cpp
@@ -80,8 +80,8 @@ const DriverDescriptor& descriptor() {
         // specifies; 115200 stays because some units genuinely ship that way, and guessing wrong
         // on a live bus just looks like silence.
         x.recommendedSerialProfiles = {
-            SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3},
-            SerialProfile{115200, SerialParity::None, 8, 1, 1000, 3},
+            SerialProfile{9600, SerialParity::None, 8, 1, 1000},
+            SerialProfile{115200, SerialParity::None, 8, 1, 1000},
         };
         // Experimental as a driver-level floor: every profile is transcribed from documentation
         // or community maps, and none has yet been confirmed against the device it describes.

--- a/src/drivers/modbus_profile/modbus_profile_driver.cpp
+++ b/src/drivers/modbus_profile/modbus_profile_driver.cpp
@@ -30,10 +30,16 @@ void traceBlock(uint8_t unitId, RegSpace space, uint16_t start, uint16_t count,
     const char* spaceName = space == RegSpace::Input ? "in" : "hold";
     constexpr uint16_t perLine = 8;
     for (uint16_t i = 0; i < count; i += perLine) {
-        char line[128];
-        int  pos = snprintf(line, sizeof(line), "MODBUS unit %u %s %u:",
-                            static_cast<unsigned>(unitId), spaceName,
-                            static_cast<unsigned>(start + i));
+        // Zero-initialised because a failed snprintf leaves the array's contents indeterminate.
+        // It never writes past the size it was given, so a pre-zeroed buffer stays NUL-terminated
+        // whatever happens below, and the trace call at the end always has a string to print.
+        char line[128] = {};
+        int  pos       = snprintf(line, sizeof(line), "MODBUS unit %u %s %u:",
+                                  static_cast<unsigned>(unitId), spaceName,
+                                  static_cast<unsigned>(start + i));
+        if (pos < 0) {
+            continue;  // encoding error: there is nothing trustworthy to say about this block
+        }
         for (uint16_t j = 0; j < perLine && i + j < count; ++j) {
             // snprintf returns what it WOULD have written, not what it did, so `pos` can run
             // past the buffer -- and then `sizeof(line) - pos` underflows to a huge size_t and
@@ -41,11 +47,16 @@ void traceBlock(uint8_t unitId, RegSpace space, uint16_t start, uint16_t count,
             // buffer makes that subtraction unconditionally safe. Unreachable at today's
             // constants (a ~27-char prefix plus eight 5-char registers against 128), which is
             // exactly why it is worth a line: nothing else here would notice a wider format.
-            if (pos < 0 || static_cast<size_t>(pos) >= sizeof(line)) {
+            if (static_cast<size_t>(pos) >= sizeof(line)) {
                 break;
             }
-            pos += snprintf(line + pos, sizeof(line) - static_cast<size_t>(pos), " %04X",
-                            values[i + j]);
+            const int written =
+                snprintf(line + pos, sizeof(line) - static_cast<size_t>(pos), " %04X",
+                         values[i + j]);
+            if (written < 0) {
+                break;  // keep pos non-negative; print the registers that did format
+            }
+            pos += written;
         }
         log::trace("%s", line);
     }

--- a/src/drivers/modbus_profile/modbus_profile_driver.cpp
+++ b/src/drivers/modbus_profile/modbus_profile_driver.cpp
@@ -35,7 +35,17 @@ void traceBlock(uint8_t unitId, RegSpace space, uint16_t start, uint16_t count,
                             static_cast<unsigned>(unitId), spaceName,
                             static_cast<unsigned>(start + i));
         for (uint16_t j = 0; j < perLine && i + j < count; ++j) {
-            pos += snprintf(line + pos, sizeof(line) - pos, " %04X", values[i + j]);
+            // snprintf returns what it WOULD have written, not what it did, so `pos` can run
+            // past the buffer -- and then `sizeof(line) - pos` underflows to a huge size_t and
+            // becomes the next call's buffer size. Stopping while pos is still inside the
+            // buffer makes that subtraction unconditionally safe. Unreachable at today's
+            // constants (a ~27-char prefix plus eight 5-char registers against 128), which is
+            // exactly why it is worth a line: nothing else here would notice a wider format.
+            if (pos < 0 || static_cast<size_t>(pos) >= sizeof(line)) {
+                break;
+            }
+            pos += snprintf(line + pos, sizeof(line) - static_cast<size_t>(pos), " %04X",
+                            values[i + j]);
         }
         log::trace("%s", line);
     }

--- a/src/drivers/solax_x1/descriptor.cpp
+++ b/src/drivers/solax_x1/descriptor.cpp
@@ -20,7 +20,7 @@ const DriverDescriptor& descriptor() {
             "hardware.";
         x.supportedTransports = {TransportType::Rs485, TransportType::Mock};
         // One documented line speed for the whole family.
-        x.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3}};
+        x.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000}};
         x.supportLevel              = DriverSupportLevel::Experimental;
         // Below the sibling PMU driver (10): the two speak the same framing, so both may
         // answer a probe of the same physical device. The margin rule in discovery then

--- a/src/drivers/sunspec/descriptor.cpp
+++ b/src/drivers/sunspec/descriptor.cpp
@@ -24,8 +24,8 @@ const DriverDescriptor& descriptor() {
         x.supportedTransports = {TransportType::Rs485, TransportType::Mock};
         // SunSpec does not mandate a line speed; 9600 and 19200 are both common, so both are
         // offered and discovery tries them in order.
-        x.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3},
-                                       SerialProfile{19200, SerialParity::None, 8, 1, 1000, 3}};
+        x.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000},
+                                       SerialProfile{19200, SerialParity::None, 8, 1, 1000}};
         x.supportLevel              = DriverSupportLevel::Experimental;
         // Above the vendor Modbus driver: the "SunS" marker is a far stronger fingerprint than
         // any register-shape heuristic, so when a device answers it, it is not a guess.

--- a/src/network/provisioning_policy.cpp
+++ b/src/network/provisioning_policy.cpp
@@ -43,7 +43,7 @@ uint32_t retryDelayMs(const ProvisioningPolicy& policy, uint32_t attempt) {
     return delay > policy.maxRetryMs ? policy.maxRetryMs : static_cast<uint32_t>(delay);
 }
 
-std::string setupApSsid(const uint8_t mac[6]) {
+std::string setupApSsid(const MacAddress& mac) {
     char buf[32];
     std::snprintf(buf, sizeof(buf), "Heliograph-Setup-%02X%02X", mac[4], mac[5]);
     return std::string(buf);

--- a/src/network/provisioning_policy.h
+++ b/src/network/provisioning_policy.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <string>
 
@@ -56,9 +57,16 @@ ProvisioningState decideState(const ProvisioningPolicy& policy, bool hasCredenti
 /// Back-off delay for attempt N (1-based). Doubles, capped at maxRetryMs.
 uint32_t retryDelayMs(const ProvisioningPolicy& policy, uint32_t attempt);
 
+/// The factory MAC, as a type that carries its own length.
+///
+/// `uint8_t mac[6]` in a parameter list is documentation, not a check: it decays to a plain
+/// pointer, so a caller passing a shorter buffer compiles silently and the reads run past its
+/// end. std::array keeps the six in the type, where the compiler can see it.
+using MacAddress = std::array<uint8_t, 6>;
+
 /// SSID for the setup access point, e.g. "Heliograph-Setup-A1B2".
 ///
 /// Derived from the MAC so two bridges being provisioned in one room stay distinguishable.
-std::string setupApSsid(const uint8_t mac[6]);
+std::string setupApSsid(const MacAddress& mac);
 
 }  // namespace heliograph

--- a/src/network/rtc_pcf85063.cpp
+++ b/src/network/rtc_pcf85063.cpp
@@ -56,8 +56,8 @@ bool readUtc(time_t& out) {
     if (!g_present) {
         return false;
     }
-    uint8_t r[7];
-    if (!readRegs(kRegSeconds, r, sizeof(r))) {
+    Registers r{};
+    if (!readRegs(kRegSeconds, r.data(), r.size())) {
         return false;
     }
     // Everything past the I2C read is pure and lives in rtc_time.cpp, where it is host-tested:
@@ -70,7 +70,7 @@ bool writeUtc(time_t t) {
     if (!g_present || t <= 0) {
         return false;
     }
-    uint8_t r[7];
+    Registers r{};
     encodeRegisters(t, r);  // weekday included; see rtc_time.cpp
 
     Wire.beginTransmission(board::kRtcI2cAddress);

--- a/src/network/rtc_time.cpp
+++ b/src/network/rtc_time.cpp
@@ -45,7 +45,7 @@ void civilFromDays(int64_t z, int& y, int& m, int& d) {
     y = static_cast<int>(yoe + era * 400) + (m <= 2);
 }
 
-bool decodeRegisters(const uint8_t regs[7], time_t& out) {
+bool decodeRegisters(const Registers& regs, time_t& out) {
     if ((regs[0] & kOsFlag) != 0) {
         return false;  // oscillator stopped since the last write: time is untrustworthy
     }
@@ -80,7 +80,7 @@ bool decodeRegisters(const uint8_t regs[7], time_t& out) {
     return true;
 }
 
-void encodeRegisters(time_t utc, uint8_t regs[7]) {
+void encodeRegisters(time_t utc, Registers& regs) {
     const int64_t days = static_cast<int64_t>(utc) / 86400;
     int32_t       rem  = static_cast<int32_t>(static_cast<int64_t>(utc) - days * 86400);
     const int     hour = rem / 3600;

--- a/src/network/rtc_time.h
+++ b/src/network/rtc_time.h
@@ -9,10 +9,19 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <ctime>
 
 namespace heliograph::rtc {
+
+/// The chip's seven time registers, in chip order from Seconds: sec, min, hour, day, weekday,
+/// month, year-2000. All BCD.
+///
+/// A named type rather than `uint8_t regs[7]` in each signature, because that form decays to a
+/// pointer: the seven is a comment the compiler does not read, and decode and encode could drift
+/// apart on it without anything failing to build. Here the length is checked at every call.
+using Registers = std::array<uint8_t, 7>;
 
 /// The RTC counts a two-digit year from 2000, so 2000-2099 is everything it can express. The
 /// lower bound is deliberately "before this firmware existed", and it deliberately matches
@@ -40,9 +49,9 @@ void    civilFromDays(int64_t z, int& y, int& m, int& d);
 ///   - The year had no bound, and 0xFF decodes to 165 -> the year 2165. Because
 ///     TimeManager::synced() only guards the low side, that reads as "the clock is set", and on
 ///     a bridge that never reaches NTP it stays that way forever.
-bool decodeRegisters(const uint8_t regs[7], time_t& out);
+bool decodeRegisters(const Registers& regs, time_t& out);
 
 /// The inverse, for the write-back after an NTP sync. Fills seven registers starting at Seconds.
-void encodeRegisters(time_t utc, uint8_t regs[7]);
+void encodeRegisters(time_t utc, Registers& regs);
 
 }  // namespace heliograph::rtc

--- a/src/network/wifi_manager.cpp
+++ b/src/network/wifi_manager.cpp
@@ -25,11 +25,9 @@ namespace {
 /// MQTT topic root and the Home Assistant device identifier -- all of which must be stable
 /// from the first line of setup() and unique per board. esp_read_mac() reads efuse directly
 /// and works before WiFi exists.
-void readFactoryMac(uint8_t mac[6]) {
-    if (esp_read_mac(mac, ESP_MAC_WIFI_STA) != ESP_OK) {
-        for (int i = 0; i < 6; ++i) {
-            mac[i] = 0;
-        }
+void readFactoryMac(MacAddress& mac) {
+    if (esp_read_mac(mac.data(), ESP_MAC_WIFI_STA) != ESP_OK) {
+        mac.fill(0);
     }
 }
 
@@ -37,7 +35,7 @@ void readFactoryMac(uint8_t mac[6]) {
 
 std::string WifiManager::bridgeId() const {
     static const std::string id = [] {
-        uint8_t mac[6] = {};
+        MacAddress mac{};
         readFactoryMac(mac);
         char buf[32];
         snprintf(buf, sizeof(buf), "heliograph-%02x%02x%02x", mac[3], mac[4], mac[5]);
@@ -61,7 +59,7 @@ void WifiManager::startPortal() {
     if (portalActive_) {
         return;
     }
-    uint8_t mac[6] = {};
+    MacAddress mac{};
     readFactoryMac(mac);
     apSsid_ = setupApSsid(mac);
 

--- a/src/ota/ota_manager.cpp
+++ b/src/ota/ota_manager.cpp
@@ -24,9 +24,9 @@ const char* otaResultName(OtaResult result) {
 }
 
 OtaResult OtaManager::finishHash() {
-    uint8_t digest[32];
+    Digest digest{};
     hasher_.finish(digest);
-    writtenSha256_ = toHex(digest, sizeof(digest));
+    writtenSha256_ = toHex(digest.data(), digest.size());
     if (expectedSha_.empty()) {
         return OtaResult::Ok;  // nothing was promised; a hand-picked file has nothing to check
     }

--- a/src/ota/sha256.cpp
+++ b/src/ota/sha256.cpp
@@ -120,7 +120,7 @@ void Sha256::update(const uint8_t* data, size_t len) {
     }
 }
 
-void Sha256::finish(uint8_t out[32]) {
+void Sha256::finish(Digest& out) {
     // Padding: a 1 bit, zeroes, then the 64-bit big-endian length. When the length will not fit
     // in the current block, one more block is emitted -- the case a naive implementation gets
     // wrong for messages of 56..63 bytes mod 64, which is why the tests include one.
@@ -161,12 +161,12 @@ std::string toHex(const uint8_t* data, size_t len) {
 }
 
 std::string Sha256::finishHex() {
-    uint8_t digest[32];
+    Digest digest{};
     finish(digest);
-    return toHex(digest, sizeof(digest));
+    return toHex(digest.data(), digest.size());
 }
 
-bool hexDigestEquals(const std::string& expectedHex, const uint8_t digest[32]) {
+bool hexDigestEquals(const std::string& expectedHex, const Digest& digest) {
     if (expectedHex.size() != 64) {
         return false;
     }

--- a/src/ota/sha256.h
+++ b/src/ota/sha256.h
@@ -20,11 +20,21 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string>
 
 namespace heliograph::ota {
+
+/// A SHA-256 digest: exactly 32 bytes, and the type says so.
+///
+/// `uint8_t out[32]` in a parameter list decays to a pointer, which makes the 32 a comment. That
+/// matters more here than almost anywhere else in this firmware: finish() and hexDigestEquals()
+/// sit on either side of the check that decides whether an update is accepted, and if they ever
+/// disagreed about the length, the disagreement would be a buffer overrun on one side and a
+/// silently short comparison on the other -- neither of which the build would notice.
+using Digest = std::array<uint8_t, 32>;
 
 /// Feed it the image as it arrives; ask for the digest at the end.
 class Sha256 {
@@ -35,7 +45,7 @@ public:
     void update(const uint8_t* data, size_t len);
 
     /// Writes the 32-byte digest. The object must not be updated afterwards without reset().
-    void finish(uint8_t out[32]);
+    void finish(Digest& out);
 
     /// Lowercase hex, the form every tool prints and the form latest.json carries.
     std::string finishHex();
@@ -60,6 +70,6 @@ std::string toHex(const uint8_t* data, size_t len);
 /// expectation is a refusal rather than a comparison that happens to fail. Constant-time is
 /// deliberately NOT attempted: this compares a public checksum, not a secret, and pretending
 /// otherwise would be security theatre.
-bool hexDigestEquals(const std::string& expectedHex, const uint8_t digest[32]);
+bool hexDigestEquals(const std::string& expectedHex, const Digest& digest);
 
 }  // namespace heliograph::ota

--- a/src/transport/serial_profile.h
+++ b/src/transport/serial_profile.h
@@ -18,7 +18,6 @@ struct SerialProfile {
     uint8_t      dataBits          = 8;
     uint8_t      stopBits          = 1;
     uint32_t     responseTimeoutMs = 1000;
-    uint8_t      retries           = 3;
 
     friend bool operator==(const SerialProfile& a, const SerialProfile& b) {
         return a.baudRate == b.baudRate && a.parity == b.parity && a.dataBits == b.dataBits &&

--- a/test/support/eversolar_rig.h
+++ b/test/support/eversolar_rig.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+//
+// The real EverSolar driver against the simulated inverter, plus the BridgeInfo that goes with
+// it -- the fixture the MQTT and REST suites both poll to get a populated DeviceState.
+//
+// These forty-six lines were byte-for-byte identical in test_mqtt and test_rest, including five
+// literal bridge values (id, RSSI, uptime, heap, firmware version). Those literals are what made
+// it worth extracting rather than tolerating: the two suites assert on the SAME payload builders
+// reading the SAME BridgeInfo, so the day one copy's uptime or version drifted, one suite would
+// have started describing a bridge the other did not, with nothing to say which was right.
+//
+// The fake clock lives here too, because Rig::poll() feeds it to DeviceContext. It keeps the
+// name `g_now` deliberately: the two suites reference it about ninety times between them, and
+// renaming those to gain a shared declaration would have been churn rather than cleanup. Pull it
+// in with `using heliograph::test::g_now;` and every existing call site still reads the same.
+
+#pragma once
+
+#include <cstdint>
+
+#include "device/device_context.h"
+#include "device/device_state.h"
+#include "diagnostics/diagnostics.h"
+#include "drivers/eversolar_legacy/eversolar_driver.h"
+#include "state/state_store.h"
+#include "support/fake_eversolar_device.h"
+#include "support/mock_transport.h"
+
+namespace heliograph::test {
+
+/// Settable "now", in milliseconds. Each suite's setUp() chooses the starting value.
+inline uint64_t g_now = 0;
+inline uint64_t clockFn() { return g_now; }
+
+inline BridgeInfo makeBridge() {
+    BridgeInfo b;
+    b.bridgeId        = "heliograph-a1b2c3";
+    b.bridgeOnline    = true;
+    b.wifiConnected   = true;
+    b.wifiRssiDbm     = -57;
+    b.uptimeSeconds   = 86400;
+    b.freeHeapBytes   = 180000;
+    b.firmwareVersion = "0.1.0";
+    return b;
+}
+
+/// The real EverSolar driver against the simulated inverter.
+struct Rig {
+    MockTransport              transport;
+    FakeEversolarDevice        device;
+    eversolar::EversolarDriver driver{transport};
+    StateStore                 store;
+    Diagnostics                diagnostics;
+
+    Rig() {
+        device.installOn(transport);
+        driver.begin(transport);
+    }
+    DeviceState poll() {
+        DeviceContext ctx(driver, store, diagnostics, clockFn);
+        ctx.pollOnce();
+        return *store.snapshot();
+    }
+};
+
+}  // namespace heliograph::test

--- a/test/support/eversolar_rig.h
+++ b/test/support/eversolar_rig.h
@@ -3,11 +3,12 @@
 // The real EverSolar driver against the simulated inverter, plus the BridgeInfo that goes with
 // it -- the fixture the MQTT and REST suites both poll to get a populated DeviceState.
 //
-// These forty-six lines were byte-for-byte identical in test_mqtt and test_rest, including five
-// literal bridge values (id, RSSI, uptime, heap, firmware version). Those literals are what made
-// it worth extracting rather than tolerating: the two suites assert on the SAME payload builders
-// reading the SAME BridgeInfo, so the day one copy's uptime or version drifted, one suite would
-// have started describing a bridge the other did not, with nothing to say which was right.
+// Thirty-five lines were byte-for-byte identical in test_mqtt and test_rest -- the whole fixture
+// block bar one doc comment that only test_mqtt carried -- including five literal bridge values
+// (id, RSSI, uptime, heap, firmware version). Those literals are what made it worth extracting
+// rather than tolerating: the two suites assert on the SAME payload builders reading the SAME
+// BridgeInfo, so the day one copy's uptime or version drifted, one suite would have started
+// describing a bridge the other did not, with nothing to say which was right.
 //
 // The fake clock lives here too, because Rig::poll() feeds it to DeviceContext. It keeps the
 // name `g_now` deliberately: the two suites reference it about ninety times between them, and

--- a/test/support/mock_transport.h
+++ b/test/support/mock_transport.h
@@ -170,12 +170,6 @@ public:
         rx_.insert(rx_.end(), bytes.begin(), bytes.end());
     }
 
-    void clearScript() {
-        replies_.clear();
-        rx_.clear();
-        writes.clear();
-    }
-
     size_t pendingReplies() const { return replies_.size(); }
     const SerialProfile& profile() const { return profile_; }
 

--- a/test/support/modbus_frame.h
+++ b/test/support/modbus_frame.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+//
+// Modbus RTU's trailing checksum, appended the one way the wire accepts it: LOW byte first.
+//
+// This lived inline as the same three lines in sixteen places -- every hand-built request in
+// test_capture, every scripted reply in test_modbus_profile and test_modbus, and the fake
+// SunSpec device. A byte order written out sixteen times is sixteen chances to write it
+// backwards once, and a test that builds its frame backwards and then asserts against a decoder
+// that reads it backwards passes. Both halves have to agree with the bus, not merely with each
+// other, so the order belongs in one place.
+//
+// Only for frames assembled in a std::vector. test_modbus/rtu.cpp keeps its own arithmetic: it
+// is the suite that tests crc16 itself, and a helper built on the thing under test would assert
+// nothing.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "protocols/modbus/modbus_rtu.h"
+
+// heliograph::test, not a global `test`: that is where mock_transport.h and the fake devices
+// already live, and a second top-level namespace with the same name is ambiguous the moment a
+// suite says `using namespace heliograph;` -- which most of them do.
+namespace heliograph::test {
+
+inline void appendModbusCrc(std::vector<uint8_t>& frame) {
+    const uint16_t crc = modbus::crc16(frame.data(), frame.size());
+    frame.push_back(static_cast<uint8_t>(crc & 0xFF));
+    frame.push_back(static_cast<uint8_t>(crc >> 8));
+}
+
+}  // namespace heliograph::test

--- a/test/test_capture/test_main.cpp
+++ b/test/test_capture/test_main.cpp
@@ -15,6 +15,7 @@
 #include "protocols/modbus/modbus_rtu.h"
 #include "protocols/pmu/pmu_protocol.h"
 #include "support/mock_transport.h"
+#include "support/modbus_frame.h"
 
 using namespace heliograph;
 using heliograph::diag::BusDirection;
@@ -37,9 +38,7 @@ static SerialProfile profileAt(uint32_t baud) {
 /// A well-formed Modbus RTU read request, CRC and all.
 static std::vector<uint8_t> modbusFrame(uint8_t unit) {
     std::vector<uint8_t> f{unit, 0x03, 0x00, 0x00, 0x00, 0x02};
-    const uint16_t       crc = modbus::crc16(f.data(), f.size());
-    f.push_back(static_cast<uint8_t>(crc & 0xFF));
-    f.push_back(static_cast<uint8_t>(crc >> 8));
+    test::appendModbusCrc(f);
     return f;
 }
 
@@ -719,9 +718,7 @@ static std::vector<uint8_t> modbusReply(uint8_t unit, uint16_t a, uint16_t b) {
     std::vector<uint8_t> f{unit, 0x03, 0x04,
                            static_cast<uint8_t>(a >> 8), static_cast<uint8_t>(a & 0xFF),
                            static_cast<uint8_t>(b >> 8), static_cast<uint8_t>(b & 0xFF)};
-    const uint16_t crc = modbus::crc16(f.data(), f.size());
-    f.push_back(static_cast<uint8_t>(crc & 0xFF));
-    f.push_back(static_cast<uint8_t>(crc >> 8));
+    test::appendModbusCrc(f);
     return f;
 }
 

--- a/test/test_discovery/test_main.cpp
+++ b/test/test_discovery/test_main.cpp
@@ -99,7 +99,7 @@ static DriverDescriptor desc(const std::string& id, int priority, bool autoDetec
     d.id                    = id;
     d.displayName           = id;
     d.supportedTransports   = {TransportType::Mock};
-    d.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3}};
+    d.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000}};
     d.probePriority         = priority;
     d.supportsAutoDetection = autoDetect;
     return d;
@@ -414,8 +414,8 @@ static void test_the_remaining_profiles_are_not_swept_once_one_answers() {
     AddressBus     bus;
     bus.occupied            = {"3"};
     DriverDescriptor d      = addressedDesc("two_speed", "1");
-    d.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3},
-                                   SerialProfile{115200, SerialParity::None, 8, 1, 1000, 3}};
+    d.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000},
+                                   SerialProfile{115200, SerialParity::None, 8, 1, 1000}};
     addAddressedDriver(reg, d, &bus);
 
     DiscoveryEngine e(reg, t);
@@ -700,8 +700,8 @@ static void test_a_device_on_the_second_profile_is_still_found() {
     s.bus                = &t;
 
     auto d = desc("two_rates", 10);
-    d.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000, 3},
-                                   SerialProfile{115200, SerialParity::None, 8, 1, 1000, 3}};
+    d.recommendedSerialProfiles = {SerialProfile{9600, SerialParity::None, 8, 1, 1000},
+                                   SerialProfile{115200, SerialParity::None, 8, 1, 1000}};
     addDriver(reg, d, &s);
 
     DiscoveryEngine e(reg, t);

--- a/test/test_modbus/client.cpp
+++ b/test/test_modbus/client.cpp
@@ -12,6 +12,7 @@
 
 #include "protocols/modbus/modbus_client.h"
 #include "support/mock_transport.h"
+#include "support/modbus_frame.h"
 
 using namespace heliograph;
 using namespace heliograph::modbus;
@@ -30,17 +31,13 @@ std::vector<uint8_t> goodReply(uint8_t unit, uint8_t fn, const std::vector<uint1
         f.push_back(static_cast<uint8_t>(v >> 8));
         f.push_back(static_cast<uint8_t>(v & 0xFF));
     }
-    const uint16_t crc = crc16(f.data(), f.size());
-    f.push_back(static_cast<uint8_t>(crc & 0xFF));
-    f.push_back(static_cast<uint8_t>(crc >> 8));
+    test::appendModbusCrc(f);
     return f;
 }
 
 std::vector<uint8_t> exceptionReply(uint8_t unit, uint8_t fn, uint8_t code) {
     std::vector<uint8_t> f{unit, static_cast<uint8_t>(fn | 0x80), code};
-    const uint16_t       crc = crc16(f.data(), f.size());
-    f.push_back(static_cast<uint8_t>(crc & 0xFF));
-    f.push_back(static_cast<uint8_t>(crc >> 8));
+    test::appendModbusCrc(f);
     return f;
 }
 

--- a/test/test_modbus_profile/test_main.cpp
+++ b/test/test_modbus_profile/test_main.cpp
@@ -623,7 +623,7 @@ static void test_a_profile_declared_serial_overrides_the_descriptor_default() {
         nullptr, 0,
         /*supportsRtu=*/true, /*supportsTcp=*/false, /*tcpPort=*/0,
         /*hasSerial=*/true,
-        SerialProfile{115200, SerialParity::None, 8, 1, 1000, 3},
+        SerialProfile{115200, SerialParity::None, 8, 1, 1000},
     };
     MockTransport  transport;
     ProfileOptions options;

--- a/test/test_modbus_profile/test_main.cpp
+++ b/test/test_modbus_profile/test_main.cpp
@@ -16,6 +16,7 @@
 #include "drivers/modbus_profile/profile_tables.h"
 #include "protocols/modbus/modbus_rtu.h"
 #include "support/mock_transport.h"
+#include "support/modbus_frame.h"
 
 using namespace heliograph;
 using namespace heliograph::profile;
@@ -280,9 +281,7 @@ static heliograph::test::Responder sphResponder() {
             reply.push_back(static_cast<uint8_t>((v >> 8) & 0xFF));
             reply.push_back(static_cast<uint8_t>(v & 0xFF));
         }
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        test::appendModbusCrc(reply);
         return true;
     };
 }
@@ -316,9 +315,7 @@ static heliograph::test::Responder alwaysException() {
         reply.push_back(req[0]);
         reply.push_back(static_cast<uint8_t>(req[1] | modbus::kExceptionFlag));
         reply.push_back(0x02);  // illegal data address
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        test::appendModbusCrc(reply);
         return true;
     };
 }
@@ -361,9 +358,7 @@ static void test_one_refused_block_does_not_sink_the_poll() {
                 reply.push_back(static_cast<uint8_t>(v & 0xFF));
             }
         }
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        test::appendModbusCrc(reply);
         return true;
     });
     ModbusProfileDriver driver(transport);
@@ -387,9 +382,7 @@ static void test_a_refused_block_outranks_a_timeout_in_the_outcome() {
         reply.push_back(req[0]);
         reply.push_back(static_cast<uint8_t>(req[1] | modbus::kExceptionFlag));
         reply.push_back(0x02);
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        test::appendModbusCrc(reply);
         return true;
     });
     ModbusProfileDriver driver(transport);
@@ -483,9 +476,7 @@ static void test_a_silent_probe_block_moves_no_bus_counter() {
         for (uint16_t i = 0; i < count * 2; ++i) {
             reply.push_back(0x00);
         }
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        test::appendModbusCrc(reply);
         return true;
     });
     ModbusProfileDriver driver(transport);
@@ -517,9 +508,7 @@ static void test_a_silent_mapped_block_is_still_counted() {
         for (uint16_t i = 0; i < count * 2; ++i) {
             reply.push_back(0x00);
         }
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        test::appendModbusCrc(reply);
         return true;
     });
     ModbusProfileDriver driver(transport);
@@ -558,9 +547,7 @@ static void test_an_intact_reply_from_another_unit_is_not_a_checksum_error() {
         reply.push_back(2);
         reply.push_back(0x00);
         reply.push_back(0x2A);
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+        test::appendModbusCrc(reply);
         return true;
     });
     ModbusProfileDriver driver(transport);
@@ -844,9 +831,7 @@ void echoWrites(MockTransport& t) {
             return false;
         }
         reply.assign(req.begin(), req.begin() + 6);
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>(crc >> 8));
+        test::appendModbusCrc(reply);
         return true;
     });
 }
@@ -1881,9 +1866,7 @@ static void test_a_device_that_refuses_is_rejected_not_reported_as_a_fault() {
             return false;
         }
         reply = {req[0], static_cast<uint8_t>(req[1] | 0x80), 0x02};  // illegal data address
-        const uint16_t crc = modbus::crc16(reply.data(), reply.size());
-        reply.push_back(static_cast<uint8_t>(crc & 0xFF));
-        reply.push_back(static_cast<uint8_t>(crc >> 8));
+        test::appendModbusCrc(reply);
         return true;
     });
     DeviceProfile profile = profileWith(kTestWrites, 1);

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -21,51 +21,22 @@
 #include "outputs/mqtt/mqtt_topics.h"
 #include "outputs/mqtt/publish_policy.h"
 #include "state/state_store.h"
+#include "support/eversolar_rig.h"
 #include "support/fake_eversolar_device.h"
 #include "support/mock_transport.h"
 
 using namespace heliograph;
 using namespace heliograph::mqtt;
 namespace fx = heliograph::fixtures;
+using test::clockFn;
 using test::FakeEversolarDevice;
+using test::g_now;
+using test::makeBridge;
 using test::MockTransport;
-
-static uint64_t g_now = 0;
-static uint64_t clockFn() { return g_now; }
+using test::Rig;
 
 void setUp() { g_now = 100000; }
 void tearDown() {}
-
-static BridgeInfo makeBridge() {
-    BridgeInfo b;
-    b.bridgeId        = "heliograph-a1b2c3";
-    b.bridgeOnline    = true;
-    b.wifiConnected   = true;
-    b.wifiRssiDbm     = -57;
-    b.uptimeSeconds   = 86400;
-    b.freeHeapBytes   = 180000;
-    b.firmwareVersion = "0.1.0";
-    return b;
-}
-
-/// The real EverSolar driver against the simulated inverter.
-struct Rig {
-    MockTransport              transport;
-    FakeEversolarDevice        device;
-    eversolar::EversolarDriver driver{transport};
-    StateStore                 store;
-    Diagnostics                diagnostics;
-
-    Rig() {
-        device.installOn(transport);
-        driver.begin(transport);
-    }
-    DeviceState poll() {
-        DeviceContext ctx(driver, store, diagnostics, clockFn);
-        ctx.pollOnce();
-        return *store.snapshot();
-    }
-};
 
 static JsonDocument parse(const std::string& json) {
     JsonDocument doc;

--- a/test/test_provisioning/test_main.cpp
+++ b/test/test_provisioning/test_main.cpp
@@ -985,8 +985,8 @@ static void test_retry_backoff_is_bounded() {
 }
 
 static void test_setup_ssid_is_stable_and_distinguishable() {
-    const uint8_t a[6] = {0x24, 0x6F, 0x28, 0x11, 0xA1, 0xB2};
-    const uint8_t b[6] = {0x24, 0x6F, 0x28, 0x11, 0xC3, 0xD4};
+    const MacAddress a{0x24, 0x6F, 0x28, 0x11, 0xA1, 0xB2};
+    const MacAddress b{0x24, 0x6F, 0x28, 0x11, 0xC3, 0xD4};
     TEST_ASSERT_EQUAL_STRING("Heliograph-Setup-A1B2", setupApSsid(a).c_str());
     // Two bridges being provisioned in one room must not present the same SSID.
     TEST_ASSERT_EQUAL_STRING("Heliograph-Setup-C3D4", setupApSsid(b).c_str());

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -26,51 +26,23 @@
 #include "outputs/rest/capture_request.h"
 #include "outputs/rest/rest_payloads.h"
 #include "state/state_store.h"
-#include "support/fake_eversolar_device.h"
-#include "fixtures/eversolar_frames.h"
-#include "support/mock_transport.h"
 #include "support/configured_device.h"
+#include "support/eversolar_rig.h"
+#include "support/fake_eversolar_device.h"
+#include "support/mock_transport.h"
+#include "fixtures/eversolar_frames.h"
 
 using namespace heliograph;
+using test::clockFn;
 using test::FakeEversolarDevice;
+using test::g_now;
+using test::makeBridge;
 using test::MockTransport;
+using test::Rig;
 namespace fx = heliograph::fixtures;
-
-static uint64_t g_now = 0;
-static uint64_t clockFn() { return g_now; }
 
 void setUp() { g_now = 100000; }
 void tearDown() {}
-
-static BridgeInfo makeBridge() {
-    BridgeInfo b;
-    b.bridgeId        = "heliograph-a1b2c3";
-    b.bridgeOnline    = true;
-    b.wifiConnected   = true;
-    b.wifiRssiDbm     = -57;
-    b.uptimeSeconds   = 86400;
-    b.freeHeapBytes   = 180000;
-    b.firmwareVersion = "0.1.0";
-    return b;
-}
-
-struct Rig {
-    MockTransport              transport;
-    FakeEversolarDevice        device;
-    eversolar::EversolarDriver driver{transport};
-    StateStore                 store;
-    Diagnostics                diagnostics;
-
-    Rig() {
-        device.installOn(transport);
-        driver.begin(transport);
-    }
-    DeviceState poll() {
-        DeviceContext ctx(driver, store, diagnostics, clockFn);
-        ctx.pollOnce();
-        return *store.snapshot();
-    }
-};
 
 static JsonDocument parse(const std::string& json) {
     JsonDocument doc;

--- a/test/test_rest/test_main.cpp
+++ b/test/test_rest/test_main.cpp
@@ -2,20 +2,16 @@
 // REST payloads, configuration redaction/validation and Prometheus output.
 
 #include <unity.h>
-#include <cstdio>
-
-#include <cstring>
-
-#include "diagnostics/breadcrumbs.h"
 
 #include <cmath>
+#include <cstdio>
 #include <cstring>
+#include <string>
 
 #include <ArduinoJson.h>
 
-#include <string>
-
 #include "config/configuration.h"
+#include "diagnostics/breadcrumbs.h"
 #include "diagnostics/coredump.h"
 #include "diagnostics/logger.h"
 #include "outputs/modbus_tcp/modbus_tcp_server.h"

--- a/test/test_rtc_time/test_main.cpp
+++ b/test/test_rtc_time/test_main.cpp
@@ -16,7 +16,7 @@ void tearDown() {}
 namespace {
 
 /// Registers in chip order: sec, min, hour, day, weekday, month, year-2000. All BCD.
-void regs(uint8_t out[7], uint8_t s, uint8_t mi, uint8_t h, uint8_t d, uint8_t mo, uint8_t y) {
+void regs(Registers& out, uint8_t s, uint8_t mi, uint8_t h, uint8_t d, uint8_t mo, uint8_t y) {
     out[0] = s;
     out[1] = mi;
     out[2] = h;
@@ -29,7 +29,7 @@ void regs(uint8_t out[7], uint8_t s, uint8_t mi, uint8_t h, uint8_t d, uint8_t m
 }  // namespace
 
 static void test_a_normal_time_decodes() {
-    uint8_t r[7];
+    Registers r{};
     regs(r, 0x30, 0x45, 0x12, 0x25, 0x07, 0x26);  // 2026-07-25 12:45:30 UTC
     time_t t = 0;
     TEST_ASSERT_TRUE(decodeRegisters(r, t));
@@ -38,7 +38,7 @@ static void test_a_normal_time_decodes() {
 }
 
 static void test_a_round_trip_survives() {
-    uint8_t r[7];
+    Registers r{};
     const time_t original = 1784983530;
     encodeRegisters(original, r);
     time_t back = 0;
@@ -47,7 +47,7 @@ static void test_a_round_trip_survives() {
 }
 
 static void test_the_oscillator_stopped_flag_refuses_the_read() {
-    uint8_t r[7];
+    Registers r{};
     regs(r, 0x30 | 0x80, 0x45, 0x12, 0x25, 0x07, 0x26);  // OS bit set
     time_t t = 0;
     TEST_ASSERT_FALSE(decodeRegisters(r, t));
@@ -57,7 +57,7 @@ static void test_the_oscillator_stopped_flag_refuses_the_read() {
 // TimeManager::synced() only guards the low side, so that reads as "the clock is set". It then
 // stamps every log line, every payload, and gets written back into the chip on the next sync.
 static void test_a_garbled_year_is_refused_rather_than_becoming_2165() {
-    uint8_t r[7];
+    Registers r{};
     regs(r, 0x30, 0x45, 0x12, 0x25, 0x07, 0xFF);
     time_t t = 0;
     TEST_ASSERT_FALSE(decodeRegisters(r, t));
@@ -65,7 +65,7 @@ static void test_a_garbled_year_is_refused_rather_than_becoming_2165() {
 
 // ...and a merely legal-but-implausible year, which is not garbled BCD at all.
 static void test_a_year_outside_the_plausible_range_is_refused() {
-    uint8_t r[7];
+    Registers r{};
     regs(r, 0x30, 0x45, 0x12, 0x25, 0x07, 0x99);  // 2099 is the chip's ceiling: accepted
     time_t t = 0;
     TEST_ASSERT_TRUE(decodeRegisters(r, t));
@@ -79,7 +79,7 @@ static void test_a_year_outside_the_plausible_range_is_refused() {
 // A byte that is not valid BCD can still decode to something in range. 0x1A -> 20 is a
 // perfectly plausible minute, so the range checks alone would wave it through.
 static void test_a_non_bcd_byte_is_refused_even_when_it_decodes_in_range() {
-    uint8_t r[7];
+    Registers r{};
     regs(r, 0x30, 0x1A, 0x12, 0x25, 0x07, 0x26);  // minutes = 0x1A
     time_t t = 0;
     TEST_ASSERT_FALSE(decodeRegisters(r, t));
@@ -89,7 +89,7 @@ static void test_a_non_bcd_byte_is_refused_even_when_it_decodes_in_range() {
 }
 
 static void test_out_of_range_fields_are_refused() {
-    uint8_t r[7];
+    Registers r{};
     time_t  t = 0;
     regs(r, 0x60, 0x45, 0x12, 0x25, 0x07, 0x26);  // 60 seconds
     TEST_ASSERT_FALSE(decodeRegisters(r, t));
@@ -106,7 +106,7 @@ static void test_out_of_range_fields_are_refused() {
 // February 31st passes every field-range check and silently becomes March 3rd. A plausible
 // date that is not the one on the chip is exactly what this file exists to refuse.
 static void test_a_date_that_does_not_exist_is_refused() {
-    uint8_t r[7];
+    Registers r{};
     time_t  t = 0;
     regs(r, 0x00, 0x00, 0x12, 0x31, 0x02, 0x26);  // 31 February
     TEST_ASSERT_FALSE(decodeRegisters(r, t));
@@ -123,7 +123,7 @@ static void test_a_date_that_does_not_exist_is_refused() {
 // was the one piece of arithmetic no test could see, in the file split out precisely to stop
 // that -- and deleting the caller's line as redundant would have stored every write as Sunday.
 static void test_the_weekday_register_is_filled() {
-    uint8_t r[7];
+    Registers r{};
     encodeRegisters(1784983530, r);  // 2026-07-25 was a Saturday
     TEST_ASSERT_EQUAL_UINT8(6, r[4]);
     encodeRegisters(1835395200, r);  // 2028-02-29 was a Tuesday
@@ -131,7 +131,7 @@ static void test_the_weekday_register_is_filled() {
 }
 
 static void test_a_leap_day_is_handled() {
-    uint8_t r[7];
+    Registers r{};
     regs(r, 0x00, 0x00, 0x00, 0x29, 0x02, 0x28);  // 2028-02-29T00:00:00Z
     time_t t = 0;
     TEST_ASSERT_TRUE(decodeRegisters(r, t));

--- a/test/test_sha256/test_main.cpp
+++ b/test/test_sha256/test_main.cpp
@@ -14,6 +14,7 @@
 
 #include "ota/sha256.h"
 
+using heliograph::ota::Digest;
 using heliograph::ota::hexDigestEquals;
 using heliograph::ota::Sha256;
 
@@ -140,7 +141,7 @@ static void test_hex_renders_every_byte_as_two_lowercase_characters() {
 static void test_a_matching_hex_digest_compares_equal() {
     Sha256 h;
     h.update(reinterpret_cast<const uint8_t*>("abc"), 3);
-    uint8_t digest[32];
+    Digest  digest{};
     h.finish(digest);
     TEST_ASSERT_TRUE(hexDigestEquals(
         "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", digest));
@@ -154,7 +155,7 @@ static void test_a_matching_hex_digest_compares_equal() {
 static void test_a_malformed_expectation_is_refused() {
     Sha256 h;
     h.update(reinterpret_cast<const uint8_t*>("abc"), 3);
-    uint8_t digest[32];
+    Digest  digest{};
     h.finish(digest);
 
     TEST_ASSERT_FALSE(hexDigestEquals("", digest));
@@ -170,7 +171,7 @@ static void test_a_malformed_expectation_is_refused() {
 static void test_one_wrong_bit_is_refused() {
     Sha256 h;
     h.update(reinterpret_cast<const uint8_t*>("abc"), 3);
-    uint8_t digest[32];
+    Digest  digest{};
     h.finish(digest);
     // Last nibble changed: the case that matters, because a comparison that stopped early
     // would accept it.

--- a/tools/gen_profiles.py
+++ b/tools/gen_profiles.py
@@ -822,7 +822,7 @@ def generate(
             w("     /*hasSerial=*/true,")
             w(
                 f"     SerialProfile{{{s['baud']}, SerialParity::{PARITIES[s['parity']]}, "
-                f"8, {s['stop_bits']}, 1000, 3}},"
+                f"8, {s['stop_bits']}, 1000}},"
             )
         else:
             w("     /*hasSerial=*/false, SerialProfile{},")


### PR DESCRIPTION
An audit-first cleanup pass. The audit is the larger half of the result: most of what was
looked for was not there, and that is reported below rather than quietly omitted.

## Baseline before any change

| Gate | Result |
|---|---|
| Clean build, `waveshare-rs485-can` | 0 warnings in `src/` (4 in eModbus) |
| `pio check` (cppcheck) | 0 high, 0 medium |
| `ruff check` + `format --check` | clean |
| Native tests | 27 suites, 964 cases, green |
| All six `tools/check_*` gates | pass |
| Dependency pins | all 7 at the latest upstream release |
| `#if 0`, commented-out code, dead feature flags | none |

## What changed

**1. `traceBlock()` no longer trusts unwritten margin** — `pos += snprintf(line + pos, sizeof(line) - pos, ...)`
accumulates what `snprintf` *would* have written. Past `sizeof(line)`, the `size_t` subtraction
underflows and becomes the next call's buffer size. Unreachable at today's constants (~27-char
prefix plus 40 for eight registers, against 128) — but both numbers in that margin are field
widths, and nothing in the code stated the bound.

The same pattern exists once more, in `logger.cpp`'s `traceHex()`. That one is left alone
deliberately: its buffer is `3 * kMaxBytes + 1` for a loop writing exactly three characters at
most `kMaxBytes` times, so the bound is exact by construction rather than by margin.

**2. Three things nothing reads** — `SerialProfile::retries` (nineteen positional initialisers,
always `3`, zero readers, not in the config store, not in any REST payload, not in `operator==`);
`MockTransport::clearScript()`; a duplicate `#include <cstring>` two lines from its twin.

Worth recording: the audit called `retries` "never written". That was wrong — a grep for the name
misses positional aggregate initialisers. It was write-only, not untouched. Removing it deletes
**nineteen** copies of a literal with one value: twelve hand-written, which the compiler refused
the moment the field went away, and seven generated, which never errored because
`gen_profiles.py` runs pre-build and its template was corrected in the same pass.

(An earlier version of this paragraph said seventeen, and credited the compiler with all of them.
Both were wrong — see commit `af85641`, which corrects three counts this branch got wrong about
itself.)

**3. Two duplicated test fixtures get one home each** — `test_mqtt` and `test_rest` carried
**thirty-five** byte-for-byte identical lines (the whole fixture block bar one doc comment only
`test_mqtt` had) including five literal bridge values; the Modbus CRC append was inline in
thirteen places in two spellings.

Both extractions are mutation-proved, not assumed: changing `uptimeSeconds` in the shared bridge
turns both suites red, and making the CRC helper emit the high byte twice fails 21 cases across
three suites.

## What was deliberately not done

- **The fake clock in eight suites.** Consolidating a two-line idiom would churn 144 references to
  save five lines, and each test binary is independent so the copies cannot drift into each other.
- **`unique_ptr` for `new`/`delete` in `wifi_manager` and `rest_api`** — program-lifetime objects
  never destructed, symmetric guarded pairs, and the `void*` is a deliberate compile firewall.
- **`std::stoi` → `from_chars`** in `mqtt_output.cpp` — the input is validated to 1–2 digits three
  lines earlier.
- **Merging `hexBytes()` and `traceHex()`** — the audit claimed a shared `kDigits` table. There
  isn't one; `traceHex` uses `snprintf`. Rejected on inspection.
- **cppcheck's 247 `unusedFunction` reports** — structural false positives: it analyses only the
  native subset, so every ESP32-only caller is invisible to it.

## Open for a decision

`uint8_t mac[6]`, `regs[7]`, `out[32]` in signatures are documentation, not checks — they decay to
`uint8_t*`. `std::array` would make the size compile-checkable, but it is churn in the OTA, crypto
and RTC paths for code that is correct today, and it removes no lines. Not done; say the word.

The three deprecation warnings are eModbus calling `AsyncClient::close(bool)`, which AsyncTCP 3.5.0
deprecated. Not fixable without patching a dependency. Related: eModbus is the only pin whose tag
is over a year old (v1.7.4.stable, June 2025) while its repo is active — the situation
`platformio.ini` already documents.

## Verification

Every commit was verified separately. After the last: 964/964 native cases, all `tools/check_*`
gates, `ruff`, and a clean `waveshare-rs485-can` build with no warnings in `src/`.

No external behaviour or API changed. `retries` never reached a payload or the config store.

