### PR TITLE
Announce the diagnostics Home Assistant never knew existed

### DIFF
--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -540,7 +540,13 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
         bool optional;
     };
     static const Spec kSpecs[] = {
-        {"wifi_rssi", "WiFi Signal", "wifi_rssi_dbm", "signal_strength", "measurement", "dBm", false},
+        // optional, and it always should have been: json_util.h nulls wifi_rssi_dbm whenever the
+        // bridge is not associated, because 0 dBm would read as an excellent signal. It shipped
+        // unguarded for as long as this entity has existed. Narrow window -- the payload only
+        // travels while MQTT is up, which needs WiFi -- but the rule this file now applies is
+        // "nullable means guarded", and applying it to five fields while leaving the sixth is
+        // how the next reader concludes the rule is decorative.
+        {"wifi_rssi", "WiFi Signal", "wifi_rssi_dbm", "signal_strength", "measurement", "dBm", true},
         {"uptime", "Uptime", "uptime_seconds", "duration", "total_increasing", "s", false},
         {"free_heap", "Free Heap", "free_heap_bytes", "data_size", "measurement", "B", false},
         {"poll_success", "Polls Succeeded", "poll_success_total", nullptr, "total_increasing", nullptr, false},
@@ -549,9 +555,12 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
         {"rs485_timeouts", "RS485 Timeouts", "rs485_timeout_total", nullptr, "total_increasing", nullptr, false},
 
         // --- added 2026-08-03 -------------------------------------------------------------
-        // The payload has carried thirty-eight fields for a while; seven of them were
-        // announced, so the rest were on the bus and invisible in Home Assistant. These ten
-        // are the ones worth their own recorder stream -- each answers a question that is
+        // The payload has carried between thirty-five and forty-two fields for a while --
+        // measured, not counted by eye: two groups are conditional, the poll_duration quintet
+        // (absent until a poll succeeds) and ntp_server/ntp_server_source (absent until the
+        // clock syncs, via an early return in addClockFields). Seven were announced, so the
+        // rest were on the bus and invisible in Home Assistant. These ten are the ones worth
+        // their own recorder stream -- each answers a question that is
         // asked over time and therefore wants a graph. Everything else rides along as
         // attributes on the "Diagnostics" entity below, which costs one stream instead of
         // twenty.
@@ -643,8 +652,8 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
 
     // Everything else in the payload, as ATTRIBUTES on one entity rather than as entities.
     //
-    // The payload carries thirty-eight fields. Announcing each as its own sensor would give
-    // Home Assistant thirty-eight recorder streams per bridge, each writing every
+    // The payload carries up to forty-two fields. Announcing each as its own sensor would give
+    // Home Assistant that many recorder streams per bridge, each writing every
     // diagnosticsIntervalMs (60 s by default) -- around fifty-five thousand rows a day, per
     // bridge, for numbers that are read when something is wrong and ignored the rest of the
     // time. json_attributes_topic puts the whole document on ONE entity: templatable, visible

--- a/src/outputs/mqtt/home_assistant_discovery.cpp
+++ b/src/outputs/mqtt/home_assistant_discovery.cpp
@@ -526,15 +526,55 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
         const char* deviceClass;
         const char* stateClass;
         const char* unit;
+        /// The field can be absent or null in a valid payload, so the template has to guard.
+        ///
+        /// Two different reasons, one fix. poll_duration_* is OMITTED until a poll has
+        /// succeeded (json_util.h emits nothing rather than a zero: the mock driver polls in
+        /// 0 ms, so zero is a real measurement and cannot double as "no data"). The stack and
+        /// PSRAM fields are present but NULL until sampled, or on a board with no PSRAM.
+        ///
+        /// Both reach Jinja the same way: an unguarded `{{ value_json.x }}` renders the string
+        /// "None" for a null and errors on an absent key, and Home Assistant would take "None"
+        /// as the state of a numeric sensor. Rendering EMPTY instead tells it to skip the
+        /// update and leave the entity unknown, which is what "not measured yet" means.
+        bool optional;
     };
     static const Spec kSpecs[] = {
-        {"wifi_rssi", "WiFi Signal", "wifi_rssi_dbm", "signal_strength", "measurement", "dBm"},
-        {"uptime", "Uptime", "uptime_seconds", "duration", "total_increasing", "s"},
-        {"free_heap", "Free Heap", "free_heap_bytes", "data_size", "measurement", "B"},
-        {"poll_success", "Polls Succeeded", "poll_success_total", nullptr, "total_increasing", nullptr},
-        {"poll_failure", "Polls Failed", "poll_failure_total", nullptr, "total_increasing", nullptr},
-        {"checksum_errors", "Checksum Errors", "checksum_error_total", nullptr, "total_increasing", nullptr},
-        {"rs485_timeouts", "RS485 Timeouts", "rs485_timeout_total", nullptr, "total_increasing", nullptr},
+        {"wifi_rssi", "WiFi Signal", "wifi_rssi_dbm", "signal_strength", "measurement", "dBm", false},
+        {"uptime", "Uptime", "uptime_seconds", "duration", "total_increasing", "s", false},
+        {"free_heap", "Free Heap", "free_heap_bytes", "data_size", "measurement", "B", false},
+        {"poll_success", "Polls Succeeded", "poll_success_total", nullptr, "total_increasing", nullptr, false},
+        {"poll_failure", "Polls Failed", "poll_failure_total", nullptr, "total_increasing", nullptr, false},
+        {"checksum_errors", "Checksum Errors", "checksum_error_total", nullptr, "total_increasing", nullptr, false},
+        {"rs485_timeouts", "RS485 Timeouts", "rs485_timeout_total", nullptr, "total_increasing", nullptr, false},
+
+        // --- added 2026-08-03 -------------------------------------------------------------
+        // The payload has carried thirty-eight fields for a while; seven of them were
+        // announced, so the rest were on the bus and invisible in Home Assistant. These ten
+        // are the ones worth their own recorder stream -- each answers a question that is
+        // asked over time and therefore wants a graph. Everything else rides along as
+        // attributes on the "Diagnostics" entity below, which costs one stream instead of
+        // twenty.
+        //
+        // Poll duration is the pair that caught the toolchain question: ewma moves within a
+        // minute of a load change, max keeps the worst case a moving average would hide.
+        {"poll_duration_ewma", "Poll Duration (average)", "poll_duration_ewma_ms", "duration", "measurement", "ms", true},
+        {"poll_duration_max", "Poll Duration (max)", "poll_duration_max_ms", "duration", "measurement", "ms", true},
+        // Stack headroom only ever falls. A bridge that reboots overnight without a coredump
+        // is usually this, and without a graph there is nothing to look at afterwards.
+        {"rs485_stack_free", "RS485 Task Stack Free", "rs485_stack_free_bytes", "data_size", "measurement", "B", true},
+        {"loop_stack_free", "Loop Task Stack Free", "loop_stack_free_bytes", "data_size", "measurement", "B", true},
+        {"psram_free", "PSRAM Free", "psram_free_bytes", "data_size", "measurement", "B", true},
+        // The quiet failure paths. A publish refused by a wedged client used to be
+        // indistinguishable from a delivered one; a reconnect counter that climbs while
+        // everything looks connected is the same shape of problem.
+        {"mqtt_publish_failures", "MQTT Publishes Refused", "mqtt_publish_failure_total", nullptr, "total_increasing", nullptr, false},
+        {"mqtt_reconnects", "MQTT Reconnects", "mqtt_reconnect_total", nullptr, "total_increasing", nullptr, false},
+        {"wifi_reconnects", "WiFi Reconnects", "wifi_reconnect_total", nullptr, "total_increasing", nullptr, false},
+        {"invalid_frames", "Invalid Frames", "invalid_frame_total", nullptr, "total_increasing", nullptr, false},
+        // Measurement, NOT total_increasing: this one resets to zero on every success, and a
+        // total_increasing sensor that drops is treated by Home Assistant as a counter reset.
+        {"consecutive_poll_failures", "Consecutive Poll Failures", "consecutive_poll_failures", nullptr, "measurement", nullptr, false},
     };
 
     std::vector<DiscoveryEntity> entities;
@@ -545,7 +585,11 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
         e["object_id"]      = bridge.bridgeId + "_" + spec.slug;
         e["name"]           = spec.name;
         e["state_topic"]    = topics.diagnostics();
-        e["value_template"] = std::string("{{ value_json.") + spec.jsonKey + " }}";
+        e["value_template"] =
+            spec.optional
+                ? std::string("{% if value_json.") + spec.jsonKey + " is defined and value_json." +
+                      spec.jsonKey + " is not none %}{{ value_json." + spec.jsonKey + " }}{% endif %}"
+                : std::string("{{ value_json.") + spec.jsonKey + " }}";
         e["availability_topic"] = topics.availability();
         e["entity_category"]    = "diagnostic";
         if (spec.deviceClass) {
@@ -563,6 +607,70 @@ std::vector<DiscoveryEntity> buildBridgeDiagnosticEntities(const BridgeInfo&  br
         entity.uniqueId = e["unique_id"].as<std::string>();
         entity.configTopic =
             discoveryPrefix + "/sensor/" + bridge.bridgeId + "/" + spec.slug + "/config";
+        if (serialise(doc, entity.payload)) {
+            entities.push_back(std::move(entity));
+        }
+    }
+
+    // A stored coredump is a STATE, not a measurement: it survives the reboot that produced it
+    // and stays true until it is cleared. device_class "problem" puts it in Home Assistant's
+    // own problem handling rather than leaving it as a number nobody has an automation for.
+    {
+        JsonDocument doc;
+        JsonObject   e     = doc.to<JsonObject>();
+        e["unique_id"]     = bridge.bridgeId + "_coredump";
+        e["object_id"]     = bridge.bridgeId + "_coredump";
+        e["name"]          = "Coredump Stored";
+        e["state_topic"]   = topics.diagnostics();
+        // coredump_present is a JSON bool; Jinja renders those as True/False, which is neither
+        // payload_on nor payload_off. Mapped explicitly rather than relying on the spelling.
+        e["value_template"]     = "{{ 'ON' if value_json.coredump_present else 'OFF' }}";
+        e["payload_on"]         = "ON";
+        e["payload_off"]        = "OFF";
+        e["device_class"]       = "problem";
+        e["availability_topic"] = topics.availability();
+        e["entity_category"]    = "diagnostic";
+        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true, bridge.bridgeId);
+
+        DiscoveryEntity entity;
+        entity.uniqueId    = e["unique_id"].as<std::string>();
+        entity.configTopic =
+            discoveryPrefix + "/binary_sensor/" + bridge.bridgeId + "/coredump/config";
+        if (serialise(doc, entity.payload)) {
+            entities.push_back(std::move(entity));
+        }
+    }
+
+    // Everything else in the payload, as ATTRIBUTES on one entity rather than as entities.
+    //
+    // The payload carries thirty-eight fields. Announcing each as its own sensor would give
+    // Home Assistant thirty-eight recorder streams per bridge, each writing every
+    // diagnosticsIntervalMs (60 s by default) -- around fifty-five thousand rows a day, per
+    // bridge, for numbers that are read when something is wrong and ignored the rest of the
+    // time. json_attributes_topic puts the whole document on ONE entity: templatable, visible
+    // in the UI, and one stream to exclude from the recorder if even that is too much.
+    //
+    // The state is the firmware version, which makes the entity itself worth having and
+    // changes only on an update -- so the row that gets written is mostly attribute churn on a
+    // stable state, not a new value every minute.
+    {
+        JsonDocument doc;
+        JsonObject   e             = doc.to<JsonObject>();
+        e["unique_id"]             = bridge.bridgeId + "_diagnostics";
+        e["object_id"]             = bridge.bridgeId + "_diagnostics";
+        e["name"]                  = "Diagnostics";
+        e["state_topic"]           = topics.diagnostics();
+        e["value_template"]        = "{{ value_json.firmware_version }}";
+        e["json_attributes_topic"] = topics.diagnostics();
+        e["availability_topic"]    = topics.availability();
+        e["entity_category"]       = "diagnostic";
+        e["icon"]                  = "mdi:stethoscope";
+        addDeviceBlock(e, bridge, DeviceIdentity{}, /*isBridgeEntity=*/true, bridge.bridgeId);
+
+        DiscoveryEntity entity;
+        entity.uniqueId    = e["unique_id"].as<std::string>();
+        entity.configTopic =
+            discoveryPrefix + "/sensor/" + bridge.bridgeId + "/diagnostics/config";
         if (serialise(doc, entity.payload)) {
             entities.push_back(std::move(entity));
         }

--- a/test/test_modbus_profile/test_main.cpp
+++ b/test/test_modbus_profile/test_main.cpp
@@ -2008,7 +2008,7 @@ static void test_a_full_line_fits_the_buffer_the_driver_gives_it() {
     TEST_ASSERT_EQUAL_size_t(8, n);
     TEST_ASSERT_EQUAL_STRING(
         "MODBUS unit 255 hold 65535: FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF", line);
-    TEST_ASSERT_TRUE_MESSAGE(strlen(line) < sizeof(line) - 1, "the widest line must not fill the buffer");
+    TEST_ASSERT_TRUE_MESSAGE(std::strlen(line) < sizeof(line) - 1, "the widest line must not fill the buffer");
 }
 
 static void test_a_buffer_that_runs_out_cuts_back_to_a_whole_register() {
@@ -2021,7 +2021,7 @@ static void test_a_buffer_that_runs_out_cuts_back_to_a_whole_register() {
     // does not.
     TEST_ASSERT_EQUAL_size_t(1, n);
     TEST_ASSERT_EQUAL_STRING("MODBUS unit 1 in 40000: 0001", line);
-    TEST_ASSERT_TRUE_MESSAGE(strlen(line) < sizeof(line), "must stay inside the buffer");
+    TEST_ASSERT_TRUE_MESSAGE(std::strlen(line) < sizeof(line), "must stay inside the buffer");
 }
 
 static void test_a_buffer_too_small_for_the_prefix_still_yields_a_string() {
@@ -2033,7 +2033,7 @@ static void test_a_buffer_too_small_for_the_prefix_still_yields_a_string() {
     const size_t   n = formatRegisterLine(line, sizeof(line), 1, RegSpace::Input, 40000, regs, 1);
     TEST_ASSERT_EQUAL_size_t(0, n);
     TEST_ASSERT_EQUAL_STRING("MODBUS un", line);
-    TEST_ASSERT_TRUE_MESSAGE(strlen(line) < sizeof(line), "must stay inside the buffer");
+    TEST_ASSERT_TRUE_MESSAGE(std::strlen(line) < sizeof(line), "must stay inside the buffer");
 }
 
 static void test_a_zero_sized_buffer_is_refused_without_writing() {

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -6,6 +6,7 @@
 #include <ArduinoJson.h>
 
 #include <algorithm>
+#include <cctype>
 #include <map>
 #include <string>
 #include <vector>
@@ -878,7 +879,8 @@ static std::vector<std::string> announcedJsonKeys(const std::vector<DiscoveryEnt
             while ((i = t.find("value_json.", i)) != std::string::npos) {
                 i += 11;
                 size_t j = i;
-                while (j < t.size() && (isalnum(static_cast<unsigned char>(t[j])) || t[j] == '_')) {
+                while (j < t.size() &&
+                       (std::isalnum(static_cast<unsigned char>(t[j])) || t[j] == '_')) {
                     ++j;
                 }
                 keys.push_back(t.substr(i, j - i));

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -855,6 +855,151 @@ static void test_bridge_diagnostic_entities() {
     TEST_ASSERT_EQUAL_STRING("Waveshare ESP32-S3-RS485-CAN", doc["device"]["model"]);
 }
 
+// --- bridge diagnostics reaching Home Assistant ----------------------------------------------
+//
+// The payload has carried thirty-eight fields since well before these entities existed. Seven
+// were announced, so the rest sat on the retained diagnostics topic and were invisible in Home
+// Assistant -- readable with an MQTT client, absent from the place anyone actually looks.
+
+/// Every `value_json.<key>` a discovery entity refers to, from its value_template.
+static std::vector<std::string> announcedJsonKeys(const std::vector<DiscoveryEntity>& entities) {
+    std::vector<std::string> keys;
+    for (const auto& e : entities) {
+        if (e.payload.empty()) {
+            continue;
+        }
+        auto doc = parse(e.payload);
+        for (const char* field : {"value_template", "json_attributes_template"}) {
+            if (!doc[field].is<const char*>()) {
+                continue;
+            }
+            const std::string t = doc[field].as<std::string>();
+            size_t            i = 0;
+            while ((i = t.find("value_json.", i)) != std::string::npos) {
+                i += 11;
+                size_t j = i;
+                while (j < t.size() && (isalnum(static_cast<unsigned char>(t[j])) || t[j] == '_')) {
+                    ++j;
+                }
+                keys.push_back(t.substr(i, j - i));
+                i = j;
+            }
+        }
+    }
+    std::sort(keys.begin(), keys.end());
+    keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
+    return keys;
+}
+
+static void test_every_announced_field_exists_in_the_diagnostics_payload() {
+    // The invariant that would have caught the original gap from the other side: an entity may
+    // only point at a key the payload actually emits. Rename a field in json_util.h without
+    // touching discovery and Home Assistant gets a sensor that is forever unknown, with nothing
+    // failing anywhere.
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
+
+    DiagnosticsSnapshot d;
+    d.pollDurationCount = 1;  // the poll_duration_* keys are absent until a poll has succeeded
+    std::string payload;
+    TEST_ASSERT_TRUE(buildDiagnosticsPayload(d, bridge, payload));
+    auto doc = parse(payload);
+
+    for (const auto& key : announcedJsonKeys(entities)) {
+        // Present is what matters, not non-null: psram_free_bytes is a legitimate null on a
+        // board without PSRAM, and the entity's own guard handles that. An ABSENT key is the
+        // failure -- it means discovery is pointing at a field the payload no longer emits.
+        TEST_ASSERT_TRUE_MESSAGE(doc.containsKey(key), key.c_str());
+    }
+}
+
+static void test_the_debugging_metrics_are_announced_not_only_published() {
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
+
+    // The ones added because they answer a question asked over time.
+    for (const char* slug : {"poll_duration_ewma", "poll_duration_max", "rs485_stack_free",
+                             "loop_stack_free", "psram_free", "mqtt_publish_failures",
+                             "mqtt_reconnects", "wifi_reconnects", "invalid_frames",
+                             "consecutive_poll_failures"}) {
+        const std::string id = std::string("heliograph-a1b2c3_") + slug;
+        TEST_ASSERT_NOT_NULL_MESSAGE(findEntity(entities, id), slug);
+    }
+}
+
+static void test_a_field_that_can_be_missing_renders_empty_rather_than_none() {
+    // poll_duration_* is omitted until a poll has succeeded; the stack and PSRAM fields are
+    // null until sampled. An unguarded template renders the string "None", which Home Assistant
+    // would store as the state of a numeric sensor.
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
+
+    for (const char* slug : {"poll_duration_ewma", "rs485_stack_free", "psram_free"}) {
+        const auto* e = findEntity(entities, std::string("heliograph-a1b2c3_") + slug);
+        TEST_ASSERT_NOT_NULL_MESSAGE(e, slug);
+        const std::string tmpl = parse(e->payload)["value_template"].as<std::string>();
+        TEST_ASSERT_TRUE_MESSAGE(tmpl.find("is defined") != std::string::npos, slug);
+        TEST_ASSERT_TRUE_MESSAGE(tmpl.find("is not none") != std::string::npos, slug);
+    }
+    // A field that is always present must NOT carry the guard -- it would be noise suggesting
+    // the value is optional when it is not.
+    const auto* always = findEntity(entities, "heliograph-a1b2c3_mqtt_reconnects");
+    TEST_ASSERT_NOT_NULL(always);
+    TEST_ASSERT_EQUAL_STRING("{{ value_json.mqtt_reconnect_total }}",
+                             parse(always->payload)["value_template"]);
+}
+
+static void test_consecutive_failures_is_a_measurement_not_a_rising_total() {
+    // It resets to zero on every success. Announced as total_increasing, Home Assistant reads
+    // each reset as a counter rollover and the statistics become nonsense.
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
+    const auto* e = findEntity(entities, "heliograph-a1b2c3_consecutive_poll_failures");
+    TEST_ASSERT_NOT_NULL(e);
+    TEST_ASSERT_EQUAL_STRING("measurement", parse(e->payload)["state_class"]);
+}
+
+static void test_a_stored_coredump_is_a_problem_not_a_number() {
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
+    const auto* e = findEntity(entities, "heliograph-a1b2c3_coredump");
+    TEST_ASSERT_NOT_NULL(e);
+    auto doc = parse(e->payload);
+    TEST_ASSERT_EQUAL_STRING("problem", doc["device_class"]);
+    TEST_ASSERT_EQUAL_STRING("ON", doc["payload_on"]);
+    TEST_ASSERT_EQUAL_STRING("OFF", doc["payload_off"]);
+    // A JSON bool renders as True/False in Jinja, which matches neither payload. The template
+    // has to map it.
+    const std::string tmpl = doc["value_template"].as<std::string>();
+    TEST_ASSERT_TRUE(tmpl.find("'ON'") != std::string::npos);
+    TEST_ASSERT_TRUE(tmpl.find("'OFF'") != std::string::npos);
+    TEST_ASSERT_TRUE_MESSAGE(e->configTopic.find("/binary_sensor/") != std::string::npos,
+                             "a state belongs on a binary_sensor, not a sensor");
+}
+
+static void test_the_rest_of_the_payload_rides_along_as_attributes() {
+    // One entity carrying the whole document, instead of an entity per field. Thirty-eight
+    // recorder streams per bridge at a 60 s interval is around fifty-five thousand rows a day
+    // for numbers that are read when something is wrong and ignored the rest of the time.
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
+    const auto* e = findEntity(entities, "heliograph-a1b2c3_diagnostics");
+    TEST_ASSERT_NOT_NULL(e);
+    auto doc = parse(e->payload);
+    TEST_ASSERT_EQUAL_STRING("heliograph/heliograph-a1b2c3/diagnostics",
+                             doc["json_attributes_topic"]);
+    TEST_ASSERT_EQUAL_STRING("diagnostic", doc["entity_category"]);
+    // The state is the firmware version: worth having on its own, and it changes on an update
+    // rather than every minute.
+    TEST_ASSERT_EQUAL_STRING("{{ value_json.firmware_version }}", doc["value_template"]);
+}
+
 static void test_relay_entities_follow_count_and_enabled() {
     auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
@@ -1396,6 +1541,12 @@ int main(int, char**) {
     RUN_TEST(test_discovery_signature_changes_when_writable_flips_with_unchanged_bounds);
     RUN_TEST(test_the_mock_hybrid_gets_battery_and_phase_entities_for_free);
     RUN_TEST(test_bridge_diagnostic_entities);
+    RUN_TEST(test_every_announced_field_exists_in_the_diagnostics_payload);
+    RUN_TEST(test_the_debugging_metrics_are_announced_not_only_published);
+    RUN_TEST(test_a_field_that_can_be_missing_renders_empty_rather_than_none);
+    RUN_TEST(test_consecutive_failures_is_a_measurement_not_a_rising_total);
+    RUN_TEST(test_a_stored_coredump_is_a_problem_not_a_number);
+    RUN_TEST(test_the_rest_of_the_payload_rides_along_as_attributes);
     RUN_TEST(test_relay_entities_follow_count_and_enabled);
     RUN_TEST(test_drm_select_and_role_names_follow_the_roles);
     RUN_TEST(test_sanitize_id);

--- a/test/test_mqtt/test_main.cpp
+++ b/test/test_mqtt/test_main.cpp
@@ -930,26 +930,128 @@ static void test_the_debugging_metrics_are_announced_not_only_published() {
 }
 
 static void test_a_field_that_can_be_missing_renders_empty_rather_than_none() {
-    // poll_duration_* is omitted until a poll has succeeded; the stack and PSRAM fields are
-    // null until sampled. An unguarded template renders the string "None", which Home Assistant
-    // would store as the state of a numeric sensor.
+    // Asserts the EXACT template, not that it contains "is defined" somewhere.
+    //
+    // The first version of this test checked for those substrings, which made it a spelling
+    // check: a template with a dropped {% endif %}, or one that guards on field A and then
+    // renders field B, contains them just as happily and would have passed. Pinning the whole
+    // string also closes the key-swap hole -- the payload-invariant test below proves every
+    // referenced key EXISTS, not that this entity points at the right one, so two specs could
+    // trade json keys and both tests would stay green.
+    //
+    // What no test here can do is RENDER it. There is no Jinja engine in this suite, so the
+    // claim that an empty result makes Home Assistant skip the update rests on Home Assistant's
+    // documentation, not on anything executed here. That is a real limit of this test and the
+    // reason the template is pinned character for character instead.
     const auto bridge = makeBridge();
     const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
     const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
 
-    for (const char* slug : {"poll_duration_ewma", "rs485_stack_free", "psram_free"}) {
-        const auto* e = findEntity(entities, std::string("heliograph-a1b2c3_") + slug);
-        TEST_ASSERT_NOT_NULL_MESSAGE(e, slug);
-        const std::string tmpl = parse(e->payload)["value_template"].as<std::string>();
-        TEST_ASSERT_TRUE_MESSAGE(tmpl.find("is defined") != std::string::npos, slug);
-        TEST_ASSERT_TRUE_MESSAGE(tmpl.find("is not none") != std::string::npos, slug);
+    struct Expected {
+        const char* slug;
+        const char* key;
+    };
+    // Every field json_util.h can emit as null or omit entirely, and therefore every field whose
+    // entity must carry the guard.
+    static const Expected kGuarded[] = {
+        {"poll_duration_ewma", "poll_duration_ewma_ms"},
+        {"poll_duration_max", "poll_duration_max_ms"},
+        {"rs485_stack_free", "rs485_stack_free_bytes"},
+        {"loop_stack_free", "loop_stack_free_bytes"},
+        {"psram_free", "psram_free_bytes"},
+        {"wifi_rssi", "wifi_rssi_dbm"},
+    };
+    for (const auto& g : kGuarded) {
+        const auto* e = findEntity(entities, std::string("heliograph-a1b2c3_") + g.slug);
+        TEST_ASSERT_NOT_NULL_MESSAGE(e, g.slug);
+        const std::string want = std::string("{% if value_json.") + g.key +
+                                 " is defined and value_json." + g.key +
+                                 " is not none %}{{ value_json." + g.key + " }}{% endif %}";
+        TEST_ASSERT_EQUAL_STRING_MESSAGE(want.c_str(),
+                                         parse(e->payload)["value_template"].as<std::string>().c_str(),
+                                         g.slug);
     }
-    // A field that is always present must NOT carry the guard -- it would be noise suggesting
-    // the value is optional when it is not.
+
+    // A field that is always present must NOT carry the guard -- it would suggest the value is
+    // optional when it is not.
     const auto* always = findEntity(entities, "heliograph-a1b2c3_mqtt_reconnects");
     TEST_ASSERT_NOT_NULL(always);
     TEST_ASSERT_EQUAL_STRING("{{ value_json.mqtt_reconnect_total }}",
                              parse(always->payload)["value_template"]);
+}
+
+static void test_every_new_sensor_declares_the_unit_it_reports() {
+    // Existence is not correctness. Without this, a sensor could be announced with the wrong
+    // device_class or unit -- Home Assistant would accept it, draw a graph, and label the axis
+    // wrongly -- and every other test here would stay green.
+    const auto bridge = makeBridge();
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
+
+    struct Expected {
+        const char* slug;
+        const char* jsonKey;       // the payload field this entity must read
+        const char* deviceClass;   // nullptr = must be absent
+        const char* stateClass;
+        const char* unit;          // nullptr = must be absent
+    };
+    static const Expected kExpected[] = {
+        {"poll_duration_ewma", "poll_duration_ewma_ms", "duration", "measurement", "ms"},
+        {"poll_duration_max", "poll_duration_max_ms", "duration", "measurement", "ms"},
+        {"rs485_stack_free", "rs485_stack_free_bytes", "data_size", "measurement", "B"},
+        {"loop_stack_free", "loop_stack_free_bytes", "data_size", "measurement", "B"},
+        {"psram_free", "psram_free_bytes", "data_size", "measurement", "B"},
+        {"mqtt_publish_failures", "mqtt_publish_failure_total", nullptr, "total_increasing", nullptr},
+        {"mqtt_reconnects", "mqtt_reconnect_total", nullptr, "total_increasing", nullptr},
+        {"wifi_reconnects", "wifi_reconnect_total", nullptr, "total_increasing", nullptr},
+        {"invalid_frames", "invalid_frame_total", nullptr, "total_increasing", nullptr},
+        {"consecutive_poll_failures", "consecutive_poll_failures", nullptr, "measurement", nullptr},
+    };
+    for (const auto& x : kExpected) {
+        const auto* e = findEntity(entities, std::string("heliograph-a1b2c3_") + x.slug);
+        TEST_ASSERT_NOT_NULL_MESSAGE(e, x.slug);
+        auto doc = parse(e->payload);
+        // The entity must read the field it is named after. Without this, two specs could trade
+        // json keys and every other test here would stay green: the payload-invariant test only
+        // proves each referenced key EXISTS, not that this entity points at the right one.
+        const std::string tmpl = doc["value_template"].as<std::string>();
+        TEST_ASSERT_TRUE_MESSAGE(tmpl.find(std::string("value_json.") + x.jsonKey) != std::string::npos,
+                                 x.slug);
+        TEST_ASSERT_EQUAL_STRING_MESSAGE(x.stateClass, doc["state_class"], x.slug);
+        if (x.deviceClass) {
+            TEST_ASSERT_EQUAL_STRING_MESSAGE(x.deviceClass, doc["device_class"], x.slug);
+        } else {
+            TEST_ASSERT_FALSE_MESSAGE(doc["device_class"].is<const char*>(), x.slug);
+        }
+        if (x.unit) {
+            TEST_ASSERT_EQUAL_STRING_MESSAGE(x.unit, doc["unit_of_measurement"], x.slug);
+        } else {
+            TEST_ASSERT_FALSE_MESSAGE(doc["unit_of_measurement"].is<const char*>(), x.slug);
+        }
+        TEST_ASSERT_EQUAL_STRING_MESSAGE("diagnostic", doc["entity_category"], x.slug);
+    }
+}
+
+static void test_a_disconnected_bridge_does_not_report_a_signal_strength() {
+    // wifi_rssi_dbm is null while unassociated -- 0 dBm would read as an excellent signal. The
+    // entity shipped unguarded for as long as it has existed; this pins both halves, the
+    // producer's null and the consumer's guard, so they cannot drift apart again.
+    auto bridge = makeBridge();
+    bridge.wifiConnected = false;
+    DiagnosticsSnapshot d;
+    std::string payload;
+    TEST_ASSERT_TRUE(buildDiagnosticsPayload(d, bridge, payload));
+    auto doc = parse(payload);
+    TEST_ASSERT_TRUE_MESSAGE(doc.containsKey("wifi_rssi_dbm"), "the key must stay, as null");
+    TEST_ASSERT_TRUE_MESSAGE(doc["wifi_rssi_dbm"].isNull(), "0 dBm would look like a great signal");
+
+    const MqttTopics topics(kDefaultBaseTopic, bridge.bridgeId);
+    const auto entities = buildBridgeDiagnosticEntities(bridge, topics, kDefaultDiscoveryPrefix);
+    const auto* e = findEntity(entities, "heliograph-a1b2c3_wifi_rssi");
+    TEST_ASSERT_NOT_NULL(e);
+    TEST_ASSERT_TRUE_MESSAGE(
+        parse(e->payload)["value_template"].as<std::string>().find("is not none") != std::string::npos,
+        "a nullable field needs the guard, or Home Assistant stores the string \"None\"");
 }
 
 static void test_consecutive_failures_is_a_measurement_not_a_rising_total() {
@@ -1544,6 +1646,8 @@ int main(int, char**) {
     RUN_TEST(test_every_announced_field_exists_in_the_diagnostics_payload);
     RUN_TEST(test_the_debugging_metrics_are_announced_not_only_published);
     RUN_TEST(test_a_field_that_can_be_missing_renders_empty_rather_than_none);
+    RUN_TEST(test_every_new_sensor_declares_the_unit_it_reports);
+    RUN_TEST(test_a_disconnected_bridge_does_not_report_a_signal_strength);
     RUN_TEST(test_consecutive_failures_is_a_measurement_not_a_rising_total);
     RUN_TEST(test_a_stored_coredump_is_a_problem_not_a_number);
     RUN_TEST(test_the_rest_of_the_payload_rides_along_as_attributes);


### PR DESCRIPTION
Reported from the far end: *"we added a lot of metrics for debugging and I don't see them in
Home Assistant."*

## The diagnosis

The data was never missing. The bridge publishes **between 35 and 42 diagnostic fields** to `<prefix>/diagnostics`, retained,
every 60 s — measured, not counted by eye. Two groups are conditional: the `poll_duration_*`
quintet (absent until a poll succeeds) and `ntp_server`/`ntp_server_source` (absent until the
clock syncs). Discovery announced **7** of them:

`wifi_rssi_dbm` · `uptime_seconds` · `free_heap_bytes` · `poll_success_total` ·
`poll_failure_total` · `checksum_error_total` · `rs485_timeout_total`

The rest were on the bus and invisible in Home Assistant — readable with an MQTT client,
absent from the place anyone actually looks.

## What this adds

**Ten sensors**, chosen because each answers a question asked over *time* and therefore wants a
graph: poll duration ewma and max (the pair that settled the toolchain question), both task
stack headrooms, PSRAM free, and the quiet failure counters — publishes refused, MQTT and WiFi
reconnects, invalid frames, consecutive poll failures.

**One binary_sensor** for a stored coredump, `device_class: problem`. It is a state that
survives the reboot that produced it, not a number.

**Everything else as attributes** on one "Diagnostics" entity via `json_attributes_topic`.
Announcing every remaining field as its own sensor would be tens of thousands of recorder rows a
day per bridge at a 60 s interval, for numbers that are read when something is wrong and ignored the rest of the time.
One stream is one thing to exclude if even that is too much.

## Two traps in the payload

- `poll_duration_*` is **absent** until a poll has succeeded — `json_util.h` emits nothing
  rather than zero, because the mock driver polls in 0 ms and zero is a real measurement.
- The stack and PSRAM fields are present but **null** until sampled.

Unguarded, `{{ value_json.x }}` renders the string `"None"` for a null and errors on an absent
key, and Home Assistant would store `"None"` as the state of a numeric sensor. The optional ones
render **empty** instead, which tells it to skip the update.

Separately: `consecutive_poll_failures` is `state_class: measurement`, not `total_increasing` —
it resets to zero on every success, and `total_increasing` reads a drop as a counter rollover.

## Tests

Six new, **all mutation-proved**:

| mutation | caught by |
|---|---|
| point an entity at a key the payload lacks | the payload-invariant test |
| drop the optional guard | the None-rendering test |
| `consecutive_poll_failures` as a rising total | the state-class test |
| coredump as a plain sensor | the problem-class test |
| drop `json_attributes_topic` | the attributes test |
| remove one new metric | the coverage test |

The one worth keeping is `test_every_announced_field_exists_in_the_diagnostics_payload`: it
builds a real payload and asserts every `value_json` key an entity refers to is actually in it.
That ties discovery to the payload **from the other side**, so renaming a field in
`json_util.h` without touching discovery fails here instead of producing a sensor that is
forever unknown with nothing failing anywhere.

## Rollout

Existing bridges pick these up on their next MQTT connect. `onDisconnect` sets
`resyncRequested_`, which clears `discoveryPublished` for every channel on the next loop — so a
plain broker blip or WiFi hiccup republishes discovery too, not only a reboot. (An earlier
version of this section said a reboot was required; that understated it.) No signature change
needed, and none made.

## Review round

Four agents, one real bug: `wifi_rssi_dbm` is nulled while unassociated and its entity was
unguarded, so Home Assistant would store the string `"None"` as a signal_strength state. Present
since the entity was first written, but this branch introduced the nullable-means-guarded rule
and applied it to five of six fields. Fixed, plus two tests that were weaker than their names —
detail in `911f18d`.

## Verification

984 native cases, `pio check` clean at high severity, all gates, `ruff`, clean board build.
