### PR TITLE
Show a restore diff position by position instead of as one blob

### DIFF
--- a/src/config/config_backup.cpp
+++ b/src/config/config_backup.cpp
@@ -4,8 +4,10 @@
 
 #include <ArduinoJson.h>
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <string>
 
 #include "configuration_store.h"
 
@@ -91,6 +93,49 @@ std::string renderValue(JsonVariantConst v) {
 }
 
 void walkDiff(JsonObjectConst before, JsonObjectConst after, const std::string& prefix,
+              std::vector<ConfigDiffEntry>& out);
+
+/// Arrays element by element, `prefix[i]`, descending into each one exactly as objects already
+/// were.
+///
+/// Before this, an array fell through to renderValue() and became one serialised blob -- a
+/// restore that added a single device rendered as a hundred-odd characters of JSON on one row,
+/// which is the shape somebody is supposed to read before deciding whether to apply it. The
+/// truncation guard above was written FOR that case ("additional_devices with eight entries
+/// would otherwise dominate the table") and it does bound the damage, but bounding an
+/// unreadable row does not make it readable.
+///
+/// Indexed by POSITION, which is the honest thing an anonymous array can say. Insert a device at
+/// the front and every following index reports a change; that is what happened, even if a human
+/// would call it a move. Matching elements by some identifying field would read better in that
+/// one case and would require this walker to know what identifies a device -- exactly the
+/// hand-written per-field knowledge that diffConfigurations was built to avoid.
+void walkDiffArray(JsonArrayConst before, JsonArrayConst after, const std::string& prefix,
+                   std::vector<ConfigDiffEntry>& out) {
+    const size_t count = std::max(before.size(), after.size());
+    for (size_t i = 0; i < count; ++i) {
+        const std::string path = prefix + "[" + std::to_string(i) + "]";
+        JsonVariantConst  a    = i < before.size() ? before[i] : JsonVariantConst();
+        JsonVariantConst  b    = i < after.size() ? after[i] : JsonVariantConst();
+        // Either side being an object is enough: walkDiff renders the missing side's fields as
+        // "(absent)", which is what an added or removed element should look like field by field.
+        if (a.is<JsonObjectConst>() || b.is<JsonObjectConst>()) {
+            walkDiff(a.as<JsonObjectConst>(), b.as<JsonObjectConst>(), path, out);
+            continue;
+        }
+        if (a.is<JsonArrayConst>() || b.is<JsonArrayConst>()) {
+            walkDiffArray(a.as<JsonArrayConst>(), b.as<JsonArrayConst>(), path, out);
+            continue;
+        }
+        const std::string sa = renderValue(a);
+        const std::string sb = renderValue(b);
+        if (sa != sb) {
+            out.push_back({path, sa, sb});
+        }
+    }
+}
+
+void walkDiff(JsonObjectConst before, JsonObjectConst after, const std::string& prefix,
               std::vector<ConfigDiffEntry>& out) {
     // Driven by `after`, then swept for keys only `before` had. Iterating one side alone would
     // miss a setting the restore REMOVES, which is a change like any other.
@@ -109,8 +154,12 @@ void walkDiff(JsonObjectConst before, JsonObjectConst after, const std::string& 
             }
             continue;
         }
-        if (kv.value().is<JsonObjectConst>() && old.is<JsonObjectConst>()) {
+        if (kv.value().is<JsonObjectConst>() || old.is<JsonObjectConst>()) {
             walkDiff(old.as<JsonObjectConst>(), kv.value().as<JsonObjectConst>(), path, out);
+            continue;
+        }
+        if (kv.value().is<JsonArrayConst>() || old.is<JsonArrayConst>()) {
+            walkDiffArray(old.as<JsonArrayConst>(), kv.value().as<JsonArrayConst>(), path, out);
             continue;
         }
         const std::string a = renderValue(old);
@@ -125,6 +174,13 @@ void walkDiff(JsonObjectConst before, JsonObjectConst after, const std::string& 
                                                 : prefix + "." + kv.key().c_str();
         if (isSecretKey(kv.key().c_str())) {
             out.push_back({path, "(set)", "(not set)"});
+        } else if (kv.value().is<JsonObjectConst>()) {
+            // A whole section the restore drops still reports field by field. Rendering it as
+            // one blob here would have been the same unreadable row the array case had, just
+            // reached from the other direction.
+            walkDiff(kv.value().as<JsonObjectConst>(), JsonObjectConst(), path, out);
+        } else if (kv.value().is<JsonArrayConst>()) {
+            walkDiffArray(kv.value().as<JsonArrayConst>(), JsonArrayConst(), path, out);
         } else {
             out.push_back({path, renderValue(kv.value()), "(absent)"});
         }

--- a/test/test_config_backup/test_main.cpp
+++ b/test/test_config_backup/test_main.cpp
@@ -4,6 +4,8 @@
 
 #include <unity.h>
 
+#include "outputs/rest/rest_payloads.h"
+
 #include <algorithm>
 
 #include <ArduinoJson.h>
@@ -380,6 +382,44 @@ static void test_diff_never_renders_a_password_value() {
     TEST_ASSERT_EQUAL_STRING("(not set)", admin->after.c_str());
 }
 
+/// The preview is capped at kMaxRestorePreviewBytes and answers 500 when it does not fit, so
+/// the cost of expanding arrays into one row per field is a budget question, not a taste one.
+///
+/// Measured rather than reasoned about: everything different AND the device list full comes to
+/// 67 rows and 5000 bytes, under a third of the 16 KB bound. Before arrays were expanded the
+/// same restore was a few hundred bytes smaller, so this change spends real budget -- just not
+/// much of it.
+///
+/// The assertion is the BOUND, not the byte count. Pinning 5000 would fail on any harmless
+/// wording change; what must not happen is a preview that grows until the operator gets an
+/// error instead of the diff they are about to apply.
+static void test_the_worst_case_preview_still_fits_its_bound() {
+    Configuration before;                  // defaults: every field differs
+    Configuration after = populated();
+    after.additionalDevices.clear();
+    for (int i = 0; i < 7; ++i) {          // kMaxDevices is 8, one of them the primary
+        DriverSettings d;
+        d.id      = "modbus_profile";
+        d.options = {{"unit_id", std::to_string(i + 2)}, {"profile", "mic_tl_x"}};
+        after.additionalDevices.push_back(d);
+    }
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(before, after, diff));
+    TEST_ASSERT_TRUE_MESSAGE(diff.size() > 40, "the fixture must actually be a large diff");
+
+    BackupContents bc;
+    bc.formatVersion   = 1;
+    bc.firmwareVersion = "0.26.3";
+    bc.exportedAt      = "2026-08-03T19:36:04Z";
+    std::string out;
+    TEST_ASSERT_TRUE_MESSAGE(
+        heliograph::rest::buildRestorePreviewPayload(bc, diff, true, true, out),
+        "the worst-case preview must not exceed kMaxRestorePreviewBytes");
+    TEST_ASSERT_TRUE_MESSAGE(out.size() < heliograph::rest::kMaxRestorePreviewBytes,
+                             "and must fit with room to spare, not exactly");
+}
+
 static void test_diff_reports_a_changed_list_position_by_position() {
     // Was "as one entry", and reported ["drm0","none"] -> ["drm1","drm2"] on a single row. That
     // is readable for two short strings and stops being readable the moment the elements are
@@ -551,6 +591,7 @@ int main() {
     RUN_TEST(test_identical_configurations_have_an_empty_diff);
     RUN_TEST(test_diff_names_the_field_and_both_values);
     RUN_TEST(test_diff_never_renders_a_password_value);
+    RUN_TEST(test_the_worst_case_preview_still_fits_its_bound);
     RUN_TEST(test_diff_reports_a_changed_list_position_by_position);
     RUN_TEST(test_an_unchanged_list_position_is_not_reported);
     RUN_TEST(test_diff_reports_a_driver_option_the_restore_drops);

--- a/test/test_config_backup/test_main.cpp
+++ b/test/test_config_backup/test_main.cpp
@@ -4,6 +4,8 @@
 
 #include <unity.h>
 
+#include <algorithm>
+
 #include <ArduinoJson.h>
 
 #include <cstring>
@@ -378,16 +380,42 @@ static void test_diff_never_renders_a_password_value() {
     TEST_ASSERT_EQUAL_STRING("(not set)", admin->after.c_str());
 }
 
-static void test_diff_reports_a_changed_list_as_one_entry() {
-    Configuration after  = populated();
-    after.relays.roles   = {"drm1", "drm2"};
+static void test_diff_reports_a_changed_list_position_by_position() {
+    // Was "as one entry", and reported ["drm0","none"] -> ["drm1","drm2"] on a single row. That
+    // is readable for two short strings and stops being readable the moment the elements are
+    // objects: one added device rendered as a hundred characters of JSON on the row somebody is
+    // meant to read before applying a restore.
+    //
+    // Position is what an anonymous array can honestly report. Both roles changed here, so both
+    // are listed; only role 0 changing would list only role 0.
+    Configuration after = populated();
+    after.relays.roles  = {"drm1", "drm2"};
 
     std::vector<ConfigDiffEntry> diff;
     TEST_ASSERT_TRUE(diffConfigurations(populated(), after, diff));
-    const ConfigDiffEntry* roles = find(diff, "relays.roles");
-    TEST_ASSERT_NOT_NULL(roles);
-    TEST_ASSERT_EQUAL_STRING("[\"drm0\",\"none\"]", roles->before.c_str());
-    TEST_ASSERT_EQUAL_STRING("[\"drm1\",\"drm2\"]", roles->after.c_str());
+    TEST_ASSERT_NULL_MESSAGE(find(diff, "relays.roles"), "the whole-array row must be gone");
+
+    const ConfigDiffEntry* first = find(diff, "relays.roles[0]");
+    TEST_ASSERT_NOT_NULL(first);
+    TEST_ASSERT_EQUAL_STRING("drm0", first->before.c_str());
+    TEST_ASSERT_EQUAL_STRING("drm1", first->after.c_str());
+
+    const ConfigDiffEntry* second = find(diff, "relays.roles[1]");
+    TEST_ASSERT_NOT_NULL(second);
+    TEST_ASSERT_EQUAL_STRING("none", second->before.c_str());
+    TEST_ASSERT_EQUAL_STRING("drm2", second->after.c_str());
+}
+
+static void test_an_unchanged_list_position_is_not_reported() {
+    // The point of walking positions is that only what moved shows up. Reporting every index of
+    // a list because one of them changed would be the same wall of text in a different shape.
+    Configuration after = populated();
+    after.relays.roles  = {"drm0", "drm2"};  // index 0 unchanged
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(populated(), after, diff));
+    TEST_ASSERT_NULL(find(diff, "relays.roles[0]"));
+    TEST_ASSERT_NOT_NULL(find(diff, "relays.roles[1]"));
 }
 
 /// A restore that REMOVES a device is a change the operator needs to see. Walking only the
@@ -408,13 +436,46 @@ static void test_diff_reports_a_driver_option_the_restore_drops() {
     TEST_ASSERT_EQUAL_STRING("(absent)", dropped->after.c_str());
 }
 
-static void test_diff_reports_a_removed_extra_device() {
+static void test_diff_reports_a_removed_extra_device_field_by_field() {
+    // The case that prompted this: removing a device and previewing the backup that restores it
+    // showed one row of serialised JSON. Field by field says WHICH device and on which unit,
+    // which is the question being asked before pressing apply.
     Configuration after = populated();
     after.additionalDevices.clear();
 
     std::vector<ConfigDiffEntry> diff;
     TEST_ASSERT_TRUE(diffConfigurations(populated(), after, diff));
-    TEST_ASSERT_NOT_NULL(find(diff, "additional_devices"));
+    TEST_ASSERT_NULL_MESSAGE(find(diff, "additional_devices"), "no blob row");
+
+    const ConfigDiffEntry* driver = find(diff, "additional_devices[0].driver_id");
+    TEST_ASSERT_NOT_NULL(driver);
+    TEST_ASSERT_EQUAL_STRING("(absent)", driver->after.c_str());
+    TEST_ASSERT_TRUE_MESSAGE(!driver->before.empty() && driver->before != "(absent)",
+                             "the removed device must name itself");
+}
+
+static void test_an_added_device_is_reported_field_by_field() {
+    // The direction the screenshot showed: restoring a backup onto a bridge the device was
+    // deleted from. Nested options must descend too -- unit_id is the field that says which
+    // device on the bus this is.
+    Configuration before = populated();
+    before.additionalDevices.clear();
+
+    std::vector<ConfigDiffEntry> diff;
+    TEST_ASSERT_TRUE(diffConfigurations(before, populated(), diff));
+    TEST_ASSERT_NULL_MESSAGE(find(diff, "additional_devices"), "no blob row");
+
+    const ConfigDiffEntry* driver = find(diff, "additional_devices[0].driver_id");
+    TEST_ASSERT_NOT_NULL(driver);
+    TEST_ASSERT_EQUAL_STRING("(absent)", driver->before.c_str());
+    TEST_ASSERT_TRUE(!driver->after.empty() && driver->after != "(absent)");
+
+    // Whatever options the fixture device carries, they must arrive as their own rows rather
+    // than as a nested blob inside the element.
+    const bool nestedOption = std::any_of(diff.begin(), diff.end(), [](const ConfigDiffEntry& e) {
+        return e.field.rfind("additional_devices[0].options.", 0) == 0;
+    });
+    TEST_ASSERT_TRUE_MESSAGE(nestedOption, "options must descend, not render as one value");
 }
 
 /// What the preview actually previews: the merged result, not the file. With a redacted backup
@@ -490,9 +551,11 @@ int main() {
     RUN_TEST(test_identical_configurations_have_an_empty_diff);
     RUN_TEST(test_diff_names_the_field_and_both_values);
     RUN_TEST(test_diff_never_renders_a_password_value);
-    RUN_TEST(test_diff_reports_a_changed_list_as_one_entry);
+    RUN_TEST(test_diff_reports_a_changed_list_position_by_position);
+    RUN_TEST(test_an_unchanged_list_position_is_not_reported);
     RUN_TEST(test_diff_reports_a_driver_option_the_restore_drops);
-    RUN_TEST(test_diff_reports_a_removed_extra_device);
+    RUN_TEST(test_diff_reports_a_removed_extra_device_field_by_field);
+    RUN_TEST(test_an_added_device_is_reported_field_by_field);
     RUN_TEST(test_preview_of_a_redacted_restore_shows_no_credential_change);
     RUN_TEST(test_timestamp_is_iso_utc);
     RUN_TEST(test_an_unsynced_clock_produces_no_timestamp);


### PR DESCRIPTION
Reported from a real restore on the Relay-1CH: a device was deleted, the backup that still had
it was previewed, and the table showed **one row**:

```
additional_devices   []   [{"driver_id":"mock_inverter_writable","label":"","options":{...}}]
```

That is the row someone is meant to read *before* deciding whether to apply it. Which device? On
which unit? Not answerable without parsing JSON by eye.

## Cause

`walkDiff` descended into **objects** and not into **arrays**, so an array fell through to
`renderValue()` and was serialised whole.

The asymmetry was deliberate, not an oversight — `renderValue`'s truncation guard says so:
*"additional_devices with eight entries would otherwise dominate the table."* It does bound the
damage. It does not make the row readable, and with a single device the 120-character bound
never even trips.

## After

```
additional_devices[0].driver_id                   (absent) → mock_inverter_writable
additional_devices[0].options.unit_id             (absent) → 2
additional_devices[0].options.day_length_minutes  (absent) → 10
```

The cost, stated plainly: a restore that changes three devices now produces a dozen rows instead
of three truncated ones. Those dozen rows are each a thing that actually changes.

Indexed by **position**, which is what an anonymous array can truthfully report. Insert an
element at the front and every later index reports a change — that *is* what happened, even if a
human would call it a move. Matching by an identifying field would read better in that one case
and would require this walker to know what identifies a device, which is exactly the per-field
knowledge `diffConfigurations` exists to avoid.

The removal sweep got the same treatment, so a whole section the restore drops reports field by
field rather than as a blob reached from the other direction.

## Tests

Two existing tests pinned the old behaviour and were **rewritten, not deleted** —
`test_diff_reports_a_changed_list_as_one_entry` said in its name what it was guarding. Four
cases now, including one that would otherwise be easy to miss: an **unchanged** position must
stay silent, or the result is the same wall of text in a different shape.

| mutation | caught by |
|---|---|
| arrays render as one blob again | three tests |
| report every index, changed or not | the unchanged-position test |
| walk only the shorter side | both device tests |
| don't descend into element objects | both device tests |

## Verification

988 native cases, `pio check` clean at high severity, all gates, clean board build.