### PR TITLE
Three things the MQTT docs asserted without checking

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -294,13 +294,33 @@ Assistant, clutter on the broker.
 
 ### `mqtt.discovery_prefix`
 
-Here the configs really do move. The old ones stay retained, so Home Assistant keeps a full set
-of stale entities beside the new ones — reporting online forever with their last value, because
-availability is bridge-scoped and nothing publishes to the old tree any more.
+Here the configs really do move, and the old ones stay retained under the prefix nobody writes
+to any more.
 
-**Deleting the device in Home Assistant does not fix this.** The retained config is still on the
-broker, so it is rediscovered on the next Home Assistant restart. It has to be cleared at the
-broker.
+What that costs depends on Home Assistant, which subscribes to exactly **one** discovery prefix
+(its own setting, default `homeassistant`). So there are two outcomes, and neither is the one you
+might expect:
+
+- **Home Assistant still points at the old prefix.** It keeps reading the old configs, and those
+  configs still work — `state_topic` and `availability_topic` are built from the base topic and
+  the bridge id, not from the discovery prefix, so nothing about them moved and the bridge is
+  still publishing to them every poll. Your entities carry on as if nothing happened, and the
+  bridge's new configs are announced into a prefix nothing is listening to. The change silently
+  did nothing.
+- **You moved Home Assistant's prefix too.** It reads the new configs and never subscribes to the
+  old ones, so they produce no entities at all. They sit on the broker as retained bytes that
+  come back the moment anything points at that prefix again — a second Home Assistant, or you
+  switching back to compare.
+
+**Entities that report *online* forever with a stale value need the state tree to be abandoned as
+well**, which takes a base-topic change on top of this one. A discovery-prefix change alone
+cannot produce them: the topics those configs name are the ones still being written.
+
+What Home Assistant does with entities already in its registry when *its own* prefix setting
+changes is not stated in its documentation, and is not asserted here. What is documented is that
+an empty payload on a config topic removes the component — which is what the cleanup below does,
+and it is the reason deleting the device inside Home Assistant is not enough on its own: the
+retained config survives on the broker and is rediscovered whenever that prefix is read again.
 
 ### Clearing it
 
@@ -308,7 +328,9 @@ The bridge logs the old and new prefixes when it notices the change, so the tree
 named in the boot log rather than left for you to work out.
 
 Retained messages are deleted by publishing an empty payload to the same topic with the retain
-flag set. With mosquitto's tools, for a base topic that moved:
+flag set. With mosquitto's tools, for a base topic that moved (add `-u USER -P PASS` to both
+commands if your broker wants credentials — Home Assistant's own Mosquitto add-on does by
+default, and without them these fail with nothing useful on stdout):
 
 ```bash
 mosquitto_sub -h BROKER -t 'OLD_BASE/BRIDGE_ID/#' -v --retained-only -W 2 \
@@ -341,7 +363,10 @@ Check what would be deleted before deleting it: drop the `xargs` line and read t
 An automatic sweep on boot has to get the distinction above exactly right, and the failure mode
 of getting it wrong is deleting the discovery configs that were just correctly rewritten —
 turning broker clutter into a device that vanishes from someone's dashboard, unattended. No
-comparable project does this in firmware either: ESPHome ships `esphome clean-mqtt` and Tasmota
-points at Tasmota Device Manager, both host-side tools a human runs deliberately.
+comparable project does this in firmware either. ESPHome ships `esphome clean-mqtt` as a
+first-party subcommand; Tasmota has no equivalent of its own and its documentation points at
+Tasmota Device Manager, a separately maintained community tool. Both are host-side and both are
+run deliberately by a human, which is the part that matters here — but they are not the same kind
+of thing, and citing them as a matched pair overstated the second one.
 
 Tracked in [#41](https://github.com/Timdebruijn/heliograph/issues/41).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1269,8 +1269,9 @@ void reconcileAnnouncedDevices(const BridgeInfo& bridge) {
     // include it, so those configs are OVERWRITTEN in place rather than orphaned. An automatic
     // sweep that gets that distinction wrong deletes a working device from someone's dashboard
     // while nobody is watching, which is why no comparable project does this in firmware either
-    // (ESPHome ships `esphome clean-mqtt`, Tasmota points at its Device Manager -- both host-side
-    // tools a human runs). What the bridge CAN do that an external script cannot is know where
+    // (ESPHome ships `esphome clean-mqtt` as a first-party subcommand; Tasmota has none of its
+    // own and points at Tasmota Device Manager, a community tool -- both host-side, both run
+    // deliberately by a human). What the bridge CAN do that an external script cannot is know where
     // its own topics used to be, so it names them. See docs/mqtt.md and issue #41.
     if (previous.prefixesKnown()) {
         if (previous.baseTopic != g_config.mqtt.baseTopic) {


### PR DESCRIPTION
The three findings the review of #180 turned up in the section that PR deliberately left alone.
All verified against primary sources rather than reasoned about.

## 1. The mechanism was wrong

`docs/mqtt.md` said a discovery-prefix change leaves

> stale entities reporting online forever with their last value, **because availability is
> bridge-scoped and nothing publishes to the old tree any more**

`discoveryPrefix` builds the config topic and nothing else. `state_topic` and `availability_topic`
come from `baseTopic` and `bridgeId` (`mqtt_topics.h:21-26`), so a prefix-only change moves
neither — **the topics those orphaned configs name are the ones the bridge is still writing to
every poll.** Nothing goes stale.

The "online forever" reasoning is real, but it belongs to a *removed device*, where the
device-scoped `state` stops while the bridge-scoped `availability` deliberately does not. It had
been transplanted onto a scenario the code does not support.

Home Assistant subscribes to **exactly one** discovery prefix — verified against
[home-assistant.io/integrations/mqtt](https://www.home-assistant.io/integrations/mqtt/): one
setting, default `homeassistant`. So the two real outcomes are now documented:

- **HA still on the old prefix** — it keeps reading the old configs, which still work, and the
  bridge announces into a prefix nothing listens to. The change silently did nothing.
- **HA moved too** — the old configs produce no entities at all, but sit retained and come back
  the moment anything reads that prefix again.

Entities that report *online* with a frozen value need the **state** tree abandoned as well,
which takes a base-topic change on top of this one.

**What is not asserted:** what Home Assistant does with entities already in its registry when its
own prefix setting changes. That is not in its documentation, so the section says so rather than
guessing. What *is* documented — an empty payload removes the component — is cited, and is what
the cleanup relies on.

## 2. The commands assumed an anonymous broker

No `-u`/`-P` anywhere, while Home Assistant's own Mosquitto add-on requires credentials by
default. Someone pastes the command, it fails, and `mosquitto_sub` says very little about why.
One clause now says so.

## 3. Tasmota was cited as a peer of ESPHome

> ESPHome ships `esphome clean-mqtt` and Tasmota points at Tasmota Device Manager, both host-side
> tools

That reads as two first-party subcommands. TDM is a separately maintained community tool that
Tasmota's documentation links to; ESPHome's is its own subcommand. The point survives — both are
host-side and deliberately human-run — but the pairing overstated the second.

Corrected here and in `src/main.cpp:1272`, which carried the same sentence.

## Verification

No behaviour change. 989 native cases, all `tools/check_*` gates, clean board build.