### PR TITLE
Write down MaxTalk before anyone starts guessing at it

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ them as guidance — a "next step" in one of them may have happened months ago.
 | [solar-assistant-source.md](solar-assistant-source.md) | Notes on a comparable product's MQTT structure. |
 | [passive-decode-plan-2026-08-07.md](passive-decode-plan-2026-08-07.md) | **A plan, not a feature.** Turning a passive bus capture into a readable transaction list. Nothing in it is built, and one number it depends on is unmeasured. |
 | [grid-source-and-control-plan-2026-08-08.md](grid-source-and-control-plan-2026-08-08.md) | **A design, not a feature.** Reading the household grid figure, and eventually acting on it locally. Nothing in it is built and most of it is deliberately deferred; three things it depends on are still unmeasured or unconfirmed. |
-| [solarmax-maxtalk-plan-2026-08-09.md](solarmax-maxtalk-plan-2026-08-09.md) | **Protocol notes, not a driver.** SolarMax MaxTalk over RS485: frame format, codes and scaling, and how a driver would fit. Nothing is built, nobody here owns the hardware, and every scaling factor rests on a single source. |
+| [solarmax-maxtalk-plan-2026-08-09.md](solarmax-maxtalk-plan-2026-08-09.md) | **Protocol notes, not a driver.** SolarMax MaxTalk over RS485: frame format, codes and scaling, and how a driver would fit. Nothing is built, nobody here owns the hardware, and the two sources disagree on one scaling factor. |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Thirty documents, grouped by **why you are here** rather than by what they are about. Start
+Thirty-one documents, grouped by **why you are here** rather than by what they are about. Start
 in the row that matches what you are trying to do.
 
 New to the project? [The README](../README.md) answers "what is this and does it work with my
@@ -86,6 +86,7 @@ them as guidance — a "next step" in one of them may have happened months ago.
 | [solar-assistant-source.md](solar-assistant-source.md) | Notes on a comparable product's MQTT structure. |
 | [passive-decode-plan-2026-08-07.md](passive-decode-plan-2026-08-07.md) | **A plan, not a feature.** Turning a passive bus capture into a readable transaction list. Nothing in it is built, and one number it depends on is unmeasured. |
 | [grid-source-and-control-plan-2026-08-08.md](grid-source-and-control-plan-2026-08-08.md) | **A design, not a feature.** Reading the household grid figure, and eventually acting on it locally. Nothing in it is built and most of it is deliberately deferred; three things it depends on are still unmeasured or unconfirmed. |
+| [solarmax-maxtalk-plan-2026-08-09.md](solarmax-maxtalk-plan-2026-08-09.md) | **Protocol notes, not a driver.** SolarMax MaxTalk over RS485: frame format, codes and scaling, and how a driver would fit. Nothing is built, nobody here owns the hardware, and every scaling factor rests on a single source. |
 
 ---
 

--- a/docs/solarmax-maxtalk-plan-2026-08-09.md
+++ b/docs/solarmax-maxtalk-plan-2026-08-09.md
@@ -1,0 +1,181 @@
+# SolarMax MaxTalk — protocol notes and a driver plan, 2026-08-09
+
+**Nothing here is built.** No driver, no codec, no profile. This records what the MaxTalk
+protocol is, how it would fit this firmware, and — more usefully — **which parts are agreed by two
+independent sources and which rest on one**.
+
+**Nobody here owns a SolarMax.** Everything below is desk research. Two agreeing sources are not a
+device agreeing, which is the rule this project already applies to every Modbus register map, and
+it applies here with more force because there is no inverter on any desk to check against.
+
+## Why this brand
+
+Sputnik Engineering, the Swiss maker of SolarMax, went bankrupt, leaving owners and service
+providers without support. In 2008 it had been the fifth largest inverter supplier in the world.
+The hardware kept working; the company behind the monitoring did not.
+
+That is the case this firmware exists for, and it is the same shape as its only Stable driver —
+an abandoned family with a serial port and no vendor left to ask.
+
+## The protocol
+
+ASCII over RS485. **19200 baud, 8 data bits, no parity, 1 stop bit.**
+
+```
+request:  {FB;05;36|64:CAC;KHR;KDY;KMT;KYR;KT0;KLD;KLM;KLY|0D34}
+reply:    {05;FB;59|64:CAC=1F3E;KHR=26D6;KDY=8E;KMT=8D;KYR=221;KT0=18C7;...|154C}
+```
+
+The shape is `{source;destination;length|64:payload|checksum}`:
+
+| Field | |
+|---|---|
+| source | two hex digits. The querying computer is `FB` |
+| destination | two hex digits. The inverter's address, set in its own display menu |
+| length | two hex digits, the whole frame's length |
+| `\|64:` | a literal that appears in every frame from both sources. **Its meaning is not established** |
+| payload | query codes separated by `;`. In a reply each code carries `=` and a hex value |
+| checksum | four hex digits: the ASCII values of every preceding character, summed |
+
+Framing is **brace-delimited**, which is worth saying plainly because it removes an entire class of
+problem: a reader can find a frame boundary by looking for `}`. There is no inter-character timing
+rule to get wrong, no length field that has to be trusted before the frame is complete, and no
+silent-interval heuristic. Compare the Modbus RTU path, where frame boundaries are found by timing.
+
+### The one detail most likely to be got wrong
+
+The length field is not the payload length. One implementation computes it as
+`9 + len("|64:...|") + 5` — that is, the payload span plus the fixed header and trailer. A frame
+with the wrong length is ignored rather than rejected, so this fails silently and looks like a
+device that is not answering.
+
+### What two sources agree on, and what one says
+
+**Agreed by both** the 2009 reverse-engineering writeup and a working implementation: the frame
+shape, the `FB` computer address, 19200 8N1, the checksum being a plain sum of ASCII values
+rendered as four hex digits, and a shared vocabulary of query codes.
+
+**One source only:** every scaling factor below. They come from one implementation and have not
+been cross-checked. **This is the part that must not be trusted before hardware confirms it.**
+
+## Codes, and how they map onto the canonical model
+
+| Code | Meaning | Scale | Canonical id |
+|---|---|---|---|
+| `PAC` | AC power | **÷2** | `ac.power.total` |
+| `PDC` | DC power | **÷2** | `dc.power.total` |
+| `UL1` `UL2` `UL3` | AC voltage per phase | ÷10 | `ac.phase_lN.voltage` |
+| `IL1` `IL2` `IL3` | AC current per phase | ÷100 | `ac.phase_lN.current` |
+| `TNF` | grid frequency | ÷100 | `ac.frequency` |
+| `TKK` | inverter temperature | raw | `inverter.temperature` |
+| `UDC` | DC voltage | raw | `dc.mppt_1.voltage` |
+| `IDC` | DC current | ÷100 | `dc.mppt_1.current` |
+| `UD01`–`UD03` | per-string voltage | ÷10 | `dc.mppt_1..3.voltage` |
+| `ID01`–`ID03` | per-string current | ÷100 | `dc.mppt_1..3.current` |
+| `KDY` | energy today | ÷10 | `energy.today` |
+| `KT0` | energy total | raw or ÷10 | `energy.total` |
+| `KMT` `KLM` `KYR` `KLY` `KHR` | month / last month / year / last year / hours | mixed | none — no canonical id |
+| `SYS` | system status | code lookup | `statusCode` / `statusText` |
+| `SAL` | system alarms | code lookup | `errorCode` |
+| `TYP` `SWV` `ADR` | type, firmware, address | — | `DeviceIdentity` |
+
+**`PAC` divided by two is the entry to check first.** A power reading wrong by a factor of two is
+plausible in both directions — it will not look absurd on a dashboard, and it will quietly corrupt
+every energy total derived from it. This is the same hazard the profile schema records for word
+order: wrong in one direction is obvious, wrong in the other is invisible.
+
+**Three strings, and this firmware publishes five.** The per-string codes stop at `UD03`/`ID03`, so
+a SolarMax maps comfortably inside the existing tracker vocabulary with room left over.
+
+**Five energy codes have nowhere to go.** Month, last month, year, last year and operating hours
+are real readings with no canonical id. That is a vocabulary question, not a driver question, and
+it should be answered deliberately rather than by inventing ids in a driver.
+
+## Two things that make this easier than the driver we already have
+
+**There is no registration handshake.** The inverter's address is set in its own menu; a querying
+device simply addresses it. The AA55 family this firmware already supports does the opposite — a
+device has to be *assigned* a bus address before it answers, which is why discovery for that family
+cannot be read-only and why a sunrise-recovery bug was expensive to find. A MaxTalk probe sends a
+question and receives an answer, changing nothing.
+
+**That makes discovery genuinely read-only** and lets it sit inside the existing discovery rules
+without an exception.
+
+**One request returns many values.** A single frame can carry a dozen codes and get a dozen answers,
+so a full poll is one transaction rather than a dozen. On a shared half-duplex bus that matters.
+
+## Profile, codec, or both
+
+The profile schema draws the line already: protocol logic and framing are a codec in C++; a
+mapping of addresses to measurements is a table. It also says outright that a genuinely different
+register-map family *"would get its own table-driven driver and reuse this same profile pipeline"*.
+
+MaxTalk is not Modbus, so it cannot be an existing profile. But its content is still a table —
+just keyed by a **code string** rather than a register number.
+
+| | Approach | Consequence |
+|---|---|---|
+| **a** | hand-written codec and driver, like the existing legacy family | brand knowledge in C++; a second SolarMax series means a code change |
+| **b** | codec in C++ for framing, **plus a table-driven driver reusing the profile pipeline** | rows become `code = "PAC"` instead of `address = 3000`; a second series is a TOML |
+| **c** | codec only, no table, everything hardcoded | fastest to a first reading, worst to extend |
+
+**b is the one the schema anticipated**, and it splits exactly where the existing Modbus path
+splits: framing in C++, mapping in data. SolarMax shipped several series — S, MT, C, P, TS — and a
+table means the second one costs a file rather than a release of driver changes.
+
+It is also the more honest place for the unverified scaling factors: a profile carries a `status`
+field and can ship as `experimental` with its sources named, which is precisely the state this
+information is in.
+
+## What it would look like here
+
+- **Transport**: the existing RS485 transport, unchanged. 19200 8N1 is an ordinary serial profile.
+- **Codec**: brace framing, ASCII hex parsing, checksum. Pure, no Arduino dependency, so it belongs
+  in the host-testable core beside the Modbus RTU codec and is fully unit-testable from captured
+  frames.
+- **Driver**: builds a query from the codes its profile maps, parses the reply, fills the canonical
+  set. Read-only.
+- **Discovery**: a probe is one query for `TYP` and `SWV`. Read-only, no state change, no address
+  assignment — it fits the existing rules with no exception requested.
+
+**Read-only, and that is not a limitation to apologise for.** No write or control command appears
+in either source. The primary goal — Home Assistant steering an inverter — does not require every
+driver to be writable, and a driver that declares no write capability is refused by the dispatcher's
+capability gate without any special handling.
+
+## What hardware has to settle before this ships
+
+Nothing here can be validated remotely, and the list is short but not optional:
+
+1. **`PAC`'s divisor.** Compare against the inverter's own display. Everything else is a scale
+   error you would notice; this one you would not.
+2. **Whether `KT0` is total energy**, and its divisor. The two sources are least specific here.
+3. **The `|64:` literal** — whether it is fixed or a device/port selector that varies by series.
+4. **The length-field formula**, against a real device that ignores malformed frames silently.
+5. **`SYS` and `SAL` code tables**, which neither source enumerates.
+
+## Open questions
+
+**Which series this actually covers.** The sources name S-series explicitly and reference C, MT and
+TS elsewhere. Whether the code vocabulary is constant across them is unknown, and it is the
+question option **b** above is designed to absorb.
+
+**Where the five orphan energy codes go**, if anywhere.
+
+**Who tests it.** There is no SolarMax here. Unlike the profile queue — where at least the devices
+exist somewhere in reach — this one needs a stranger with abandoned hardware and a reason to help.
+That is a real constraint on scheduling it, not a detail.
+
+## Out of scope
+
+- Omnik and Trannergy, which are a network case and not this shape at all
+- Any write or control path; none is documented
+- Building the codec before item 1 above has been checked against a display
+
+## Sources
+
+- [MaxTalk protocol reverse-engineering writeup, 2009](https://2007.blog.dest-unreach.be/2009/04/15/solarmax-maxtalk-protocol-reverse-engineered/) — frame format, checksum, addressing, line settings
+- [borsti87/solarmax-inverters](https://github.com/borsti87/solarmax-inverters) — a working implementation; the scaling table above comes from it
+- [Ardexa's SolarMax connection notes](https://docs.ardexa.com/knowledge/configure/plugins/solar-inverter-plugins/solarmax-inverters/solarmax) — RS485 pinout: pin 7 is A/485+, pin 8 is B/485−; C-series and several accessories need 12–15 V DC supplied
+- [Renewable Energy World on the Sputnik bankruptcy](https://www.renewableenergyworld.com/solar/when-an-inverter-manufacturer-goes-bankrupt-facing-the-impact-from-different-angles/)

--- a/docs/solarmax-maxtalk-plan-2026-08-09.md
+++ b/docs/solarmax-maxtalk-plan-2026-08-09.md
@@ -2,7 +2,7 @@
 
 **Nothing here is built.** No driver, no codec, no profile. This records what the MaxTalk
 protocol is, how it would fit this firmware, and — more usefully — **which parts are agreed by two
-independent sources and which rest on one**.
+independent sources, which rest on one, and which the two sources actively disagree on**.
 
 **Nobody here owns a SolarMax.** Everything below is desk research. Two agreeing sources are not a
 device agreeing, which is the rule this project already applies to every Modbus register map, and
@@ -10,9 +10,9 @@ it applies here with more force because there is no inverter on any desk to chec
 
 ## Why this brand
 
-Sputnik Engineering, the Swiss maker of SolarMax, went bankrupt, leaving owners and service
-providers without support. In 2008 it had been the fifth largest inverter supplier in the world.
-The hardware kept working; the company behind the monitoring did not.
+Sputnik Engineering, the Swiss maker of SolarMax, went bankrupt in 2014, leaving owners and
+service providers without support. The hardware kept working; the company behind the monitoring
+did not.
 
 That is the case this firmware exists for, and it is the same shape as its only Stable driver —
 an abandoned family with a serial port and no vendor left to ask.
@@ -22,9 +22,17 @@ an abandoned family with a serial port and no vendor left to ask.
 ASCII over RS485. **19200 baud, 8 data bits, no parity, 1 stop bit.**
 
 ```
-request:  {FB;05;36|64:CAC;KHR;KDY;KMT;KYR;KT0;KLD;KLM;KLY|0D34}
-reply:    {05;FB;59|64:CAC=1F3E;KHR=26D6;KDY=8E;KMT=8D;KYR=221;KT0=18C7;...|154C}
+reply (quoted from captured traffic):
+{05;FB;59|64:CAC=1F3E;KHR=26D6;KDY=8E;KMT=8D;KYR=221;KT0=18C7;KLD=78;KLM=F8;KLY=A8F|154C}
+
+request (RECONSTRUCTED here, not quoted — see below):
+{FB;05;36|64:CAC;KHR;KDY;KMT;KYR;KT0;KLD;KLM;KLY|0D34}
 ```
+
+The reply is a byte-for-byte quote. **The request is not**: no request frame carrying those codes
+appears in any source, so it was built from the documented rules to match the reply. Its length and
+checksum were recomputed and both check out, but it is a worked example, not evidence. Anyone
+implementing this should treat it as a test vector to reproduce, not as observed traffic.
 
 The shape is `{source;destination;length|64:payload|checksum}`:
 
@@ -32,72 +40,90 @@ The shape is `{source;destination;length|64:payload|checksum}`:
 |---|---|
 | source | two hex digits. The querying computer is `FB` |
 | destination | two hex digits. The inverter's address, set in its own display menu |
-| length | two hex digits, the whole frame's length |
+| length | two hex digits, the whole frame's length including braces |
 | `\|64:` | a literal that appears in every frame from both sources. **Its meaning is not established** |
 | payload | query codes separated by `;`. In a reply each code carries `=` and a hex value |
-| checksum | four hex digits: the ASCII values of every preceding character, summed |
+| checksum | four hex digits: the ASCII values of every preceding character, summed, **truncated to 16 bits** |
 
-Framing is **brace-delimited**, which is worth saying plainly because it removes an entire class of
-problem: a reader can find a frame boundary by looking for `}`. There is no inter-character timing
-rule to get wrong, no length field that has to be trusted before the frame is complete, and no
-silent-interval heuristic. Compare the Modbus RTU path, where frame boundaries are found by timing.
+Framing is **brace-delimited**, which removes a class of problem: a reader finds a frame boundary
+by looking for `}`, with no dependence on the length field being right first.
 
-### The one detail most likely to be got wrong
+### The length field, which is where a silent failure would come from
 
-The length field is not the payload length. One implementation computes it as
-`9 + len("|64:...|") + 5` — that is, the payload span plus the fixed header and trailer. A frame
-with the wrong length is ignored rather than rejected, so this fails silently and looks like a
-device that is not answering.
+The length is not the payload length — it covers the whole frame including the braces. Both
+sources compute the same value, one of them as `9 + len("|64:...|") + 5`. A frame with a wrong
+length is ignored rather than rejected, so getting this wrong looks exactly like a device that is
+not answering.
 
-### What two sources agree on, and what one says
+## What the sources agree on, disagree on, and each say alone
 
-**Agreed by both** the 2009 reverse-engineering writeup and a working implementation: the frame
-shape, the `FB` computer address, 19200 8N1, the checksum being a plain sum of ASCII values
-rendered as four hex digits, and a shared vocabulary of query codes.
+Two independent sources: a 2009 reverse-engineering writeup **together with the working Perl script
+it publishes**, and a separate Python implementation. The Perl script matters — it carries its own
+conversion factors, and reading only the blog prose understates how much is corroborated.
 
-**One source only:** every scaling factor below. They come from one implementation and have not
-been cross-checked. **This is the part that must not be trusted before hardware confirms it.**
+**Agreed by both:** the frame shape, the `FB` computer address, 19200 8N1, the checksum algorithm
+including the 16-bit truncation, the length-field computation, and the scaling for `PAC`, `KDY`,
+`UL1`, `IL1` and `IDC`.
+
+**Contested — the two sources disagree:** `UDC`. The Perl script scales it by the same factor it
+uses for AC voltage, implying ÷10; the Python implementation leaves it raw. **This is the first
+thing to check against hardware**, because it is the only value where the sources actively
+conflict rather than merely being silent.
+
+**One source only:** `UL2`, `UL3`, `IL2`, `IL3` and `PDC`. These appear in the Python
+implementation and nowhere in the Perl script, so they are uncorroborated — not wrong, just
+unchecked.
 
 ## Codes, and how they map onto the canonical model
 
-| Code | Meaning | Scale | Canonical id |
-|---|---|---|---|
-| `PAC` | AC power | **÷2** | `ac.power.total` |
-| `PDC` | DC power | **÷2** | `dc.power.total` |
-| `UL1` `UL2` `UL3` | AC voltage per phase | ÷10 | `ac.phase_lN.voltage` |
-| `IL1` `IL2` `IL3` | AC current per phase | ÷100 | `ac.phase_lN.current` |
-| `TNF` | grid frequency | ÷100 | `ac.frequency` |
-| `TKK` | inverter temperature | raw | `inverter.temperature` |
-| `UDC` | DC voltage | raw | `dc.mppt_1.voltage` |
-| `IDC` | DC current | ÷100 | `dc.mppt_1.current` |
-| `UD01`–`UD03` | per-string voltage | ÷10 | `dc.mppt_1..3.voltage` |
-| `ID01`–`ID03` | per-string current | ÷100 | `dc.mppt_1..3.current` |
-| `KDY` | energy today | ÷10 | `energy.today` |
-| `KT0` | energy total | raw or ÷10 | `energy.total` |
-| `KMT` `KLM` `KYR` `KLY` `KHR` | month / last month / year / last year / hours | mixed | none — no canonical id |
-| `SYS` | system status | code lookup | `statusCode` / `statusText` |
-| `SAL` | system alarms | code lookup | `errorCode` |
-| `TYP` `SWV` `ADR` | type, firmware, address | — | `DeviceIdentity` |
+Ids below are the real constants from the canonical model. Where a code has per-phase or
+per-string variants, each variant is its own id — there is no wildcard form.
 
-**`PAC` divided by two is the entry to check first.** A power reading wrong by a factor of two is
-plausible in both directions — it will not look absurd on a dashboard, and it will quietly corrupt
-every energy total derived from it. This is the same hazard the profile schema records for word
-order: wrong in one direction is obvious, wrong in the other is invisible.
+| Code | Meaning | Scale | Sources | Canonical id |
+|---|---|---|---|---|
+| `PAC` | AC power | ÷2 | **both** | `ac.power.total` |
+| `PDC` | DC power | ÷2 | one | `dc.power.total` |
+| `UL1` | AC voltage L1 | ÷10 | **both** | `ac.phase_l1.voltage` |
+| `UL2` `UL3` | AC voltage L2, L3 | ÷10 | one | `ac.phase_l2.voltage`, `ac.phase_l3.voltage` |
+| `IL1` | AC current L1 | ÷100 | **both** | `ac.phase_l1.current` |
+| `IL2` `IL3` | AC current L2, L3 | ÷100 | one | `ac.phase_l2.current`, `ac.phase_l3.current` |
+| `TNF` | grid frequency | ÷100 | one | `ac.frequency` |
+| `TKK` | inverter temperature | raw | one | `inverter.temperature` |
+| `UDC` | DC voltage | **contested: raw vs ÷10** | conflict | `dc.mppt_1.voltage` |
+| `IDC` | DC current | ÷100 | **both** | `dc.mppt_1.current` |
+| `UD01` `UD02` `UD03` | per-string voltage | ÷10 | one | `dc.mppt_1.voltage`, `dc.mppt_2.voltage`, `dc.mppt_3.voltage` |
+| `ID01` `ID02` `ID03` | per-string current | ÷100 | one | `dc.mppt_1.current`, `dc.mppt_2.current`, `dc.mppt_3.current` |
+| `KDY` | energy today | ÷10 | **both** | `energy.today` |
+| `KT0` | energy total | raw | **both** | `energy.total` |
+| `KHR` | operating hours | raw | one | `inverter.operating_hours` |
+| `KMT` `KLM` `KYR` `KLY` | month, last month, year, last year | mixed | one | **none — no canonical id** |
+| `SYS` | system status | code lookup | one | `statusCode` / `statusText` |
+| `SAL` | system alarms | code lookup | one | `errorCode` |
+| `TYP` `SWV` `ADR` | type, firmware, address | — | one | `DeviceIdentity` |
+
+**`UDC` is the entry to check first**, and it is the only one where the evidence conflicts. A DC
+voltage wrong by a factor of ten is obvious on a dashboard, which is the good case; the risk is
+picking one source's answer silently, which is what an earlier draft of this note did.
+
+**`UDC` and `UD01` may be the same measurement.** Both land on `dc.mppt_1.voltage` above. On a
+single-string inverter that is likely one value under two names; on a multi-string one it may be an
+array total. Nothing in the sources settles it, and a driver must not publish both into one id.
 
 **Three strings, and this firmware publishes five.** The per-string codes stop at `UD03`/`ID03`, so
 a SolarMax maps comfortably inside the existing tracker vocabulary with room left over.
 
-**Five energy codes have nowhere to go.** Month, last month, year, last year and operating hours
-are real readings with no canonical id. That is a vocabulary question, not a driver question, and
-it should be answered deliberately rather than by inventing ids in a driver.
+**Four energy codes have nowhere to go**, not five: month, last month, year and last year. Hours
+(`KHR`) does have a home — `inverter.operating_hours` is a live channel that two shipping drivers
+already publish, with a Modbus register, a Prometheus metric and a dashboard row. The four
+remaining ones are a vocabulary question, not a driver question, and should be answered
+deliberately rather than by inventing ids inside a driver.
 
-## Two things that make this easier than the driver we already have
+## What makes this easier than the driver we already have
 
 **There is no registration handshake.** The inverter's address is set in its own menu; a querying
 device simply addresses it. The AA55 family this firmware already supports does the opposite — a
 device has to be *assigned* a bus address before it answers, which is why discovery for that family
-cannot be read-only and why a sunrise-recovery bug was expensive to find. A MaxTalk probe sends a
-question and receives an answer, changing nothing.
+cannot be read-only. A MaxTalk probe sends a question and receives an answer, changing nothing.
 
 **That makes discovery genuinely read-only** and lets it sit inside the existing discovery rules
 without an exception.
@@ -105,14 +131,19 @@ without an exception.
 **One request returns many values.** A single frame can carry a dozen codes and get a dozen answers,
 so a full poll is one transaction rather than a dozen. On a shared half-duplex bus that matters.
 
+An earlier draft also claimed brace framing was an advantage over "the Modbus RTU path, where frame
+boundaries are found by timing". **That is not how this codebase finds them** — the Modbus codec
+computes the exact expected reply length from the request and reads until that parses or the
+transaction deadline passes. The framing here is still simple, but it is not simpler than what is
+already in the tree, and the comparison was flattering rather than true.
+
 ## Profile, codec, or both
 
-The profile schema draws the line already: protocol logic and framing are a codec in C++; a
-mapping of addresses to measurements is a table. It also says outright that a genuinely different
-register-map family *"would get its own table-driven driver and reuse this same profile pipeline"*.
+The profile schema draws a line: protocol logic and framing are a codec in C++; a mapping of
+addresses to measurements is a table.
 
-MaxTalk is not Modbus, so it cannot be an existing profile. But its content is still a table —
-just keyed by a **code string** rather than a register number.
+MaxTalk is not Modbus, so it cannot be an existing profile. But its content is still a table — just
+keyed by a **code string** rather than a register number.
 
 | | Approach | Consequence |
 |---|---|---|
@@ -120,20 +151,23 @@ just keyed by a **code string** rather than a register number.
 | **b** | codec in C++ for framing, **plus a table-driven driver reusing the profile pipeline** | rows become `code = "PAC"` instead of `address = 3000`; a second series is a TOML |
 | **c** | codec only, no table, everything hardcoded | fastest to a first reading, worst to extend |
 
-**b is the one the schema anticipated**, and it splits exactly where the existing Modbus path
-splits: framing in C++, mapping in data. SolarMax shipped several series — S, MT, C, P, TS — and a
-table means the second one costs a file rather than a release of driver changes.
+**b, but as an extension of the schema rather than something it already covers.** The schema says a
+genuinely different *register-map* protocol family would get its own table-driven driver and reuse
+the pipeline. MaxTalk is not register-map — it is code-keyed — so applying that sentence here is an
+extrapolation, and reusing the pipeline for it would be a deliberate widening of what a profile
+means. Worth doing, in my reading: SolarMax shipped several series, and a table makes the second
+one a file rather than driver changes. But it is a decision to take, not a precedent to cite.
 
-It is also the more honest place for the unverified scaling factors: a profile carries a `status`
-field and can ship as `experimental` with its sources named, which is precisely the state this
-information is in.
+It is also the more honest home for the unverified scaling: a profile carries a `status` field and
+can ship as `experimental` with its sources named, which is precisely the state this information
+is in.
 
 ## What it would look like here
 
 - **Transport**: the existing RS485 transport, unchanged. 19200 8N1 is an ordinary serial profile.
 - **Codec**: brace framing, ASCII hex parsing, checksum. Pure, no Arduino dependency, so it belongs
-  in the host-testable core beside the Modbus RTU codec and is fully unit-testable from captured
-  frames.
+  in the host-testable core beside the Modbus RTU codec and is fully unit-testable from the frames
+  above.
 - **Driver**: builds a query from the codes its profile maps, parses the reply, fills the canonical
   set. Read-only.
 - **Discovery**: a probe is one query for `TYP` and `SWV`. Read-only, no state change, no address
@@ -142,17 +176,16 @@ information is in.
 **Read-only, and that is not a limitation to apologise for.** No write or control command appears
 in either source. The primary goal — Home Assistant steering an inverter — does not require every
 driver to be writable, and a driver that declares no write capability is refused by the dispatcher's
-capability gate without any special handling.
+capability gate with no special handling.
 
 ## What hardware has to settle before this ships
 
 Nothing here can be validated remotely, and the list is short but not optional:
 
-1. **`PAC`'s divisor.** Compare against the inverter's own display. Everything else is a scale
-   error you would notice; this one you would not.
-2. **Whether `KT0` is total energy**, and its divisor. The two sources are least specific here.
-3. **The `|64:` literal** — whether it is fixed or a device/port selector that varies by series.
-4. **The length-field formula**, against a real device that ignores malformed frames silently.
+1. **`UDC`'s divisor**, where the two sources conflict outright.
+2. **Whether `UDC` and `UD01` are the same measurement**, since both map to one canonical id.
+3. **The five single-sourced scalings** — `PDC`, `UL2`, `UL3`, `IL2`, `IL3` — against the display.
+4. **The `\|64:` literal**: fixed, or a device/port selector that varies by series.
 5. **`SYS` and `SAL` code tables**, which neither source enumerates.
 
 ## Open questions
@@ -161,7 +194,7 @@ Nothing here can be validated remotely, and the list is short but not optional:
 TS elsewhere. Whether the code vocabulary is constant across them is unknown, and it is the
 question option **b** above is designed to absorb.
 
-**Where the five orphan energy codes go**, if anywhere.
+**Where the four orphan energy codes go**, if anywhere.
 
 **Who tests it.** There is no SolarMax here. Unlike the profile queue — where at least the devices
 exist somewhere in reach — this one needs a stranger with abandoned hardware and a reason to help.
@@ -171,11 +204,11 @@ That is a real constraint on scheduling it, not a detail.
 
 - Omnik and Trannergy, which are a network case and not this shape at all
 - Any write or control path; none is documented
-- Building the codec before item 1 above has been checked against a display
+- Building the codec before items 1 and 2 above have been checked against a display
 
 ## Sources
 
-- [MaxTalk protocol reverse-engineering writeup, 2009](https://2007.blog.dest-unreach.be/2009/04/15/solarmax-maxtalk-protocol-reverse-engineered/) — frame format, checksum, addressing, line settings
-- [borsti87/solarmax-inverters](https://github.com/borsti87/solarmax-inverters) — a working implementation; the scaling table above comes from it
-- [Ardexa's SolarMax connection notes](https://docs.ardexa.com/knowledge/configure/plugins/solar-inverter-plugins/solarmax-inverters/solarmax) — RS485 pinout: pin 7 is A/485+, pin 8 is B/485−; C-series and several accessories need 12–15 V DC supplied
-- [Renewable Energy World on the Sputnik bankruptcy](https://www.renewableenergyworld.com/solar/when-an-inverter-manufacturer-goes-bankrupt-facing-the-impact-from-different-angles/)
+- [MaxTalk protocol reverse-engineering writeup, 2009](https://2007.blog.dest-unreach.be/2009/04/15/solarmax-maxtalk-protocol-reverse-engineered/) — frame format, checksum, addressing, line settings. **The Perl script it publishes is part of this source** and carries its own conversion factors; the corroboration above depends on reading it, not only the prose.
+- [borsti87/solarmax-inverters](https://github.com/borsti87/solarmax-inverters) — a working Python implementation; the second opinion on every scaling factor.
+- [Ardexa's SolarMax connection notes](https://docs.ardexa.com/knowledge/configure/plugins/solar-inverter-plugins/solarmax-inverters/solarmax) — RS485 pinout: pin 7 is A/485+, pin 8 is B/485−; C-series and several accessories need 12–15 V DC supplied.
+- The Sputnik bankruptcy is widely reported, including by Renewable Energy World. **That article returned HTTP 403 to every attempt to read it**, so the date above was confirmed from other coverage rather than from it, and no wording is quoted from it here.


### PR DESCRIPTION
Desk research on the SolarMax serial protocol, for a driver that **does not exist**. Sputnik
Engineering went bankrupt and took the monitoring with it — the case this firmware was built for,
and the same shape as its only Stable driver: an abandoned family with a serial port and nobody
left to ask.

## The protocol

ASCII over RS485 at 19200 8N1, brace-delimited:

```
{FB;05;36|64:CAC;KHR;KDY;KMT;KYR;KT0;KLD;KLM;KLY|0D34}
```

That framing removes a whole class of problem: a reader finds a boundary by looking for `}`. No
inter-character timing, no length that must be trusted before the frame is complete, no
silent-interval heuristic — unlike the Modbus RTU path, where boundaries are found by timing.

## Two things that make it easier than the family already supported

- **No registration handshake.** The address is set in the inverter's own menu, so a probe asks a
  question and changes nothing. Discovery is genuinely read-only, with **no exception requested of
  the existing rules** — where the AA55 family needs a device to be *assigned* an address before it
  answers.
- **One request returns many values**, so a full poll is one transaction rather than a dozen.

## What stands on two sources, and what stands on one

Frame shape, checksum, addressing and line settings are agreed by the 2009 reverse-engineering
writeup and a working implementation.

**Every scaling factor comes from one source.** `PAC ÷ 2` is called out as the first thing to check
against the inverter's display: a power reading wrong by a factor of two looks entirely plausible
on a dashboard and quietly corrupts every energy total derived from it. Same hazard the profile
schema already records for word order — wrong one way is obvious, wrong the other way is invisible.

## Recommended shape

The one the schema already anticipated: framing as a C++ codec, mapping as a table, so rows read
`code = "PAC"` where Modbus rows read `address = 3000`. SolarMax shipped several series; a table
makes the second one a file rather than driver changes. It is also the honest home for unverified
scaling, since a profile carries `status` and can ship `experimental` with its sources named —
exactly the state this information is in.

## What it does not claim

Nobody here owns a SolarMax. Unlike the profile queue — where the devices at least exist within
reach — this needs a stranger with abandoned hardware and a reason to help. That is recorded as a
scheduling constraint, not a footnote.

## Verification

Docs only, no code. `tools/check_layering.sh` PASS.