### PR TITLE
A grid register that is signed, because that is what meters actually report

### DIFF
--- a/docs/device-profiles/canonical-measurements.md
+++ b/docs/device-profiles/canonical-measurements.md
@@ -50,6 +50,7 @@ $ python3 tools/gen_profiles.py --list-measurements
 | `battery.discharge_power` | W | Discharge rail, ditto |
 | `grid.import_power` | W | Power drawn from the grid, for a hybrid with a meter |
 | `grid.export_power` | W | Power fed back to the grid |
+| `grid.power` | W | **Net grid flow, signed**: positive = importing, negative = exporting. Prefer this where a device reports one bidirectional register; the two rails above are for devices that publish them separately. Where both exist, this one is what a controller acts on. |
 | `load.power` | W | What the house is drawing, as the inverter measures it — **positive = consuming** |
 
 ## Conventions

--- a/docs/grid-source-and-control-plan-2026-08-08.md
+++ b/docs/grid-source-and-control-plan-2026-08-08.md
@@ -89,7 +89,7 @@ The model already solved this exact problem once, for the battery: a signed `bat
 alongside `battery.charge_power` and `battery.discharge_power`, justified as *"the raw rails, for
 a device that reads them separately and a consumer that wants them apart"*. Grid is structurally
 identical. **A signed channel plus the existing rails is therefore consistency, not novelty**, and
-it unblocks the two stuck profiles as a side effect.
+it unblocks one of the two stuck profiles as a side effect. **Only one** — checked while implementing it: the Deye map is blocked on the rail shape and a signed channel frees it, but the Solis map is blocked on two sources disagreeing by a factor of a thousand about the meter registers, which no vocabulary change can settle.
 
 Precedence, which the battery channels never had to answer: **the signed channel wins for
 control, the rails are informational.** A controller must never arbitrate between two sources of
@@ -440,7 +440,7 @@ Three things that break and need fixing before this works:
 Not a sequence. Two of these are independent.
 
 **Track A — the integrations. Not blocked, start here.** Fill the grid channels and every output
-lights up with no output change; the signed channel unblocks two stuck profiles; MBAP framing
+lights up with no output change; the signed channel unblocks one stuck profile (Deye; Solis is blocked on a source conflict instead); MBAP framing
 opens a whole device class as data files; mDNS makes them findable. None of it touches the write
 path, none needs hardware verification, all of it is host-testable. If nothing else in this note
 happens, this is a good release on its own — and it makes the HA-driven mode better, because more

--- a/docs/modbus-register-map.md
+++ b/docs/modbus-register-map.md
@@ -117,7 +117,7 @@ the registers in question. Both mechanisms are always consistent.
 | 100-199 | AC phases |
 | 200-299 | DC/MPPT channels |
 | 300-399 | Battery (empty for EverSolar) |
-| 400-499 | House flows: grid import/export, load (empty for EverSolar) |
+| 400-499 | House flows: grid import/export, load, net grid power (empty for EverSolar) |
 | 500-599 | Status and errors |
 | 600-699 | Capabilities + validity bitmap |
 | 700-799 | Identity strings |
@@ -221,6 +221,7 @@ profile-driven hybrid populates whichever of these its register map declares.
 | 400 | 2 | float32 | `grid.import_power` |
 | 402 | 2 | float32 | `grid.export_power` |
 | 404 | 2 | float32 | `load.power` — what the house is drawing, positive = consuming |
+| 406 | 2 | float32 | `grid.power` — net grid flow, **signed**: positive = importing, negative = exporting |
 
 `load.power` sits here rather than in a region of its own: it is a house-level flow like the two
 grid rails above, and it is appended after them so no published address moves. It is **not**

--- a/src/device/measurement.h
+++ b/src/device/measurement.h
@@ -173,6 +173,11 @@ inline constexpr const char* kGridExportPower = "grid.export_power";
 /// arbitrate between two sources of one quantity, and if they disagree that is a fault to report
 /// rather than an average to take.
 ///
+/// NOTHING ENFORCES THAT RULE YET, because nothing consumes these channels together -- no code in
+/// this tree sums, derives or arbitrates between grid readings today. It is written here rather
+/// than left to the first controller to rediscover: whoever wires the first consumer has to
+/// implement the rule, not assume the vocabulary carries it.
+///
 /// Sign follows the meters themselves (HomeWizard, Shelly, Eastron all report import positive)
 /// rather than battery.power's "into the thing being measured" reading, which would point the
 /// other way. Where a convention already exists in the field, matching it beats being internally

--- a/src/device/measurement.h
+++ b/src/device/measurement.h
@@ -178,10 +178,12 @@ inline constexpr const char* kGridExportPower = "grid.export_power";
 /// than left to the first controller to rediscover: whoever wires the first consumer has to
 /// implement the rule, not assume the vocabulary carries it.
 ///
-/// Sign follows the meters themselves (HomeWizard, Shelly, Eastron all report import positive)
-/// rather than battery.power's "into the thing being measured" reading, which would point the
-/// other way. Where a convention already exists in the field, matching it beats being internally
-/// tidy: every mapping of a real device would otherwise carry a negation nobody can see.
+/// Sign follows the prevailing convention among grid meters, which report import positive, rather
+/// than battery.power's "into the thing being measured" reading, which would point the other way.
+/// Where a convention already exists in the field, matching it beats being internally tidy: every
+/// mapping of a real device would otherwise carry a negation nobody can see. The survey that
+/// established which way round the field actually goes is in the grid-source design note under
+/// docs/, which is where naming specific products belongs.
 inline constexpr const char* kGridPower = "grid.power";
 /// What the house is drawing, as the inverter measures it. Positive = consuming.
 ///

--- a/src/device/measurement.h
+++ b/src/device/measurement.h
@@ -157,6 +157,27 @@ inline constexpr const char* kBatteryDischargePower = "battery.discharge_power";
 /// House-level flows, for hybrids with a meter. Also long-standing Modbus registers.
 inline constexpr const char* kGridImportPower = "grid.import_power";
 inline constexpr const char* kGridExportPower = "grid.export_power";
+/// Net grid flow, signed: positive = importing from the grid, negative = exporting to it.
+///
+/// The rails above are two unsigned channels; almost every meter and every hybrid register that
+/// reports this at all reports ONE SIGNED NUMBER. Splitting that into two rails needs arithmetic,
+/// which a profile cannot do -- so a device whose only grid register is signed had nowhere to
+/// publish it, and shipped without grid data it could actually read.
+///
+/// The battery channels solved exactly this shape already: signed battery.power alongside the raw
+/// charge/discharge rails, for the same reason and with the same division of labour. This is that
+/// arrangement applied to the grid, not a new pattern.
+///
+/// PRECEDENCE, which the battery channels never had to state: where a device publishes both, this
+/// signed channel is the one to act on and the rails are informational. A consumer must never
+/// arbitrate between two sources of one quantity, and if they disagree that is a fault to report
+/// rather than an average to take.
+///
+/// Sign follows the meters themselves (HomeWizard, Shelly, Eastron all report import positive)
+/// rather than battery.power's "into the thing being measured" reading, which would point the
+/// other way. Where a convention already exists in the field, matching it beats being internally
+/// tidy: every mapping of a real device would otherwise carry a negation nobody can see.
+inline constexpr const char* kGridPower = "grid.power";
 /// What the house is drawing, as the inverter measures it. Positive = consuming.
 ///
 /// Distinct from the grid rails above: on a hybrid the house can be fed by PV, by the battery,
@@ -193,6 +214,7 @@ inline constexpr const char* kAll[] = {
     kTemperature,    kOperatingHours, kBatterySoc,     kBatteryPower,   kBatteryVoltage,
     kBatteryCurrent, kBatteryTemperature, kBatteryEnergyCharged, kBatteryEnergyDischarged,
     kBatteryChargePower, kBatteryDischargePower, kGridImportPower, kGridExportPower,
+    kGridPower,
     kLoadPower,
     kActivePowerLimitPct, kActivePowerLimitEnabled,
 };

--- a/src/outputs/modbus_tcp/register_map.cpp
+++ b/src/outputs/modbus_tcp/register_map.cpp
@@ -308,6 +308,8 @@ void RegisterMap::update(const DeviceState& state, const BridgeInfo& bridge,
                        ValidityBit::GridImportPower);
     publishMeasurement(state, measurement_id::kGridExportPower, reg::kGridExportPower,
                        ValidityBit::GridExportPower);
+    publishMeasurement(state, measurement_id::kGridPower, reg::kGridPower,
+                       ValidityBit::GridPower);
 
     // --- capabilities ---
     writeBitset64(reg::kCapabilitiesRead, state.capabilities.read);

--- a/src/outputs/modbus_tcp/register_map.h
+++ b/src/outputs/modbus_tcp/register_map.h
@@ -94,6 +94,12 @@ inline constexpr uint16_t kGridExportPower = 402;  // float32
 /// House load. In this region rather than a new one: it is a house-level flow like the two
 /// above, and 400-499 has room. Appended at the end of the used range so nothing moves.
 inline constexpr uint16_t kLoadPower       = 404;  // float32
+/// Net grid flow, signed (positive = import). Appended for the same reason kLoadPower was: a
+/// client reading 400-405 today keeps reading exactly what it read before.
+///
+/// float32 carries the sign for free, which is why this region can take a signed value at all --
+/// the uint16 registers elsewhere in the map could not have without picking an offset encoding.
+inline constexpr uint16_t kGridPower       = 406;  // float32
 
 // --- status (500-599) ---
 inline constexpr uint16_t kStatusCodeMirror   = 500;  // uint16
@@ -200,6 +206,7 @@ enum class ValidityBit : uint8_t {
     DcMppt5Current = 37,
     DcMppt5Power   = 38,
     LoadPower      = 39,
+    GridPower      = 40,
     _Count
 };
 

--- a/src/outputs/prometheus/prometheus_metrics.cpp
+++ b/src/outputs/prometheus/prometheus_metrics.cpp
@@ -207,6 +207,10 @@ constexpr GaugeSpec kInverterGauges[] = {
      "Power drawn from the grid"},
     {measurement_id::kGridExportPower, "heliograph_grid_export_power_watts",
      "Power delivered to the grid"},
+    // Signed, and named without a direction for that reason: the two above are rails that each
+    // only ever count one way, this one is the net flow and its sign IS the direction.
+    {measurement_id::kGridPower, "heliograph_grid_power_watts",
+     "Net grid flow; positive means importing, negative means exporting"},
     {measurement_id::kLoadPower, "heliograph_load_power_watts",
      "Power the house is drawing, as the inverter measures it"},
 };

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -363,6 +363,7 @@ const MEAS=[
   ['battery.energy_discharged','Energy discharged','Battery',2],
   ['grid.import_power','Importing','Grid',0],
   ['grid.export_power','Exporting','Grid',0],
+  ['grid.power','Net flow','Grid',0],
   ['load.power','House load','Grid',0],
   ['inverter.temperature','Temperature','Device',1],
   ['inverter.operating_hours','Operating hours','Device',0],

--- a/test/test_register_map/test_main.cpp
+++ b/test/test_register_map/test_main.cpp
@@ -637,6 +637,81 @@ static void test_house_load_is_published_separately_from_the_grid_rails() {
     TEST_ASSERT_TRUE(reg::kLoadPower >= reg::kGridExportPower + 2);
 }
 
+// The whole reason this channel exists is that it carries a sign, so that is what gets asserted:
+// a negative value has to survive the round trip through two 16-bit registers unchanged.
+//
+// An unsigned rail cannot express export at all, which is why a device whose only grid register is
+// signed had nowhere to publish it. If this channel ever lost its sign on the way out it would
+// silently report an exporting house as importing the same amount -- a reading that looks entirely
+// plausible and is exactly backwards.
+static void test_net_grid_power_carries_its_sign_through_the_registers() {
+    Diagnostics diag;
+    BridgeInfo  bridge;
+
+    // Exporting: negative.
+    {
+        RegisterMap map;
+        DeviceState state;
+        state.measurements.declare(measurement_id::kGridPower, MeasurementType::Power, Unit::Watt,
+                                   "Grid power");
+        state.measurements.set(measurement_id::kGridPower, -2150.0, g_now);
+        state.lastSuccessfulPollMs = g_now;
+        state.dataValid            = true;
+        map.update(state, bridge, diag.snapshot(), g_now);
+
+        TEST_ASSERT_EQUAL_UINT16(406, reg::kGridPower);
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, -2150.0f, decodeFloat(map, reg::kGridPower));
+        TEST_ASSERT_TRUE(map.validityBit(ValidityBit::GridPower));
+    }
+
+    // Importing: positive, same channel.
+    {
+        RegisterMap map;
+        DeviceState state;
+        state.measurements.declare(measurement_id::kGridPower, MeasurementType::Power, Unit::Watt,
+                                   "Grid power");
+        state.measurements.set(measurement_id::kGridPower, 940.0, g_now);
+        state.lastSuccessfulPollMs = g_now;
+        state.dataValid            = true;
+        map.update(state, bridge, diag.snapshot(), g_now);
+
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, 940.0f, decodeFloat(map, reg::kGridPower));
+    }
+}
+
+// Publishing the net figure must not invent the rails, and vice versa. They are separate readings
+// from separate registers on real devices, and deriving one from the other would put a number in
+// front of an operator that no meter ever produced.
+static void test_net_grid_power_and_the_rails_do_not_infer_each_other() {
+    Diagnostics diag;
+    RegisterMap map;
+    BridgeInfo  bridge;
+
+    DeviceState state;
+    state.measurements.declare(measurement_id::kGridPower, MeasurementType::Power, Unit::Watt,
+                               "Grid power");
+    state.measurements.set(measurement_id::kGridPower, -800.0, g_now);
+    state.lastSuccessfulPollMs = g_now;
+    state.dataValid            = true;
+
+    map.update(state, bridge, diag.snapshot(), g_now);
+
+    // Assert the net channel arrived FIRST. Without this the rest of the test passes just as
+    // happily when nothing is published at all -- everything is NaN then, including the rails it
+    // is checking, so "the rails were not inferred" would be true for the wrong reason. Found by
+    // deleting the publish call and watching this test stay green.
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -800.0f, decodeFloat(map, reg::kGridPower));
+    TEST_ASSERT_TRUE(map.validityBit(ValidityBit::GridPower));
+
+    TEST_ASSERT_TRUE(std::isnan(decodeFloat(map, reg::kGridImportPower)));
+    TEST_ASSERT_TRUE(std::isnan(decodeFloat(map, reg::kGridExportPower)));
+    TEST_ASSERT_FALSE(map.validityBit(ValidityBit::GridImportPower));
+    TEST_ASSERT_FALSE(map.validityBit(ValidityBit::GridExportPower));
+
+    // Appended past load at 404, so a client reading 400-405 sees exactly what it saw before.
+    TEST_ASSERT_TRUE(reg::kGridPower >= reg::kLoadPower + 2);
+}
+
 static void test_validity_bits_fit_the_reserved_space() {
     // 8 registers = 128 bits at reg::kValidityBitmap.
     TEST_ASSERT_TRUE(static_cast<size_t>(ValidityBit::_Count) <= 128);
@@ -675,6 +750,8 @@ int main(int, char**) {
     RUN_TEST(test_validity_bitmap_and_nan_always_agree);
     RUN_TEST(test_strings_three_to_five_land_in_their_own_slots);
     RUN_TEST(test_house_load_is_published_separately_from_the_grid_rails);
+    RUN_TEST(test_net_grid_power_carries_its_sign_through_the_registers);
+    RUN_TEST(test_net_grid_power_and_the_rails_do_not_infer_each_other);
     RUN_TEST(test_validity_bits_fit_the_reserved_space);
     RUN_TEST(test_relay_registers_use_the_sentinel_without_hardware);
     RUN_TEST(test_firmware_version_registers_report_the_running_version);

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -34,7 +34,18 @@ fi
 # Keep this list in step with profiles/: two vendors were added to the tree while this grep
 # still listed only the older ones, so the rule it enforces had a hole exactly where the
 # newest brand knowledge was most likely to leak.
-if hits=$(grep -rniE 'eversolar|zeversolar|growatt|solax|deye|sunsynk|solis|goodwe|sungrow|huawei' \
+#
+# It happened again, and the second time proves the first was not bad luck. A comment in the
+# canonical model explained the grid sign convention by naming three meter brands -- exactly what
+# the note above forbids -- and this grep passed it, because none of the three make inverters and
+# none had a profile yet. A reviewer caught it; the gate could not.
+#
+# So the list now runs AHEAD of profiles/ rather than behind it. Everything below the inverter
+# vendors is a brand this project has researched, planned for, or has hardware from, with no
+# profile yet -- meters, batteries and network devices included. The cost of a name that never
+# arrives is nothing; the cost of one that arrives first in a comment is a rule that quietly
+# stopped applying.
+if hits=$(grep -rniE 'eversolar|zeversolar|growatt|solax|deye|sunsynk|solis|goodwe|sungrow|huawei|homewizard|shelly|eastron|chint|solarmax|sputnik|omnik|trannergy|aeg|solarcube' \
         src/ --exclude-dir=drivers 2>/dev/null | grep -v 'LEGACY-CONFIG-ID'); then
     echo "FAIL: manufacturer names found outside src/drivers/:"
     echo "$hits"


### PR DESCRIPTION
Track A of the grid-source design, first piece: a canonical **`grid.power`**, signed, positive =
importing.

## Why

The model had two **unsigned** rails and no net figure. Almost every meter — and every hybrid
register that reports grid flow at all — reports **one signed number**, and splitting that into two
rails needs arithmetic a profile cannot do. A device whose only grid register is signed therefore
had nowhere to publish it, and shipped without grid data it could read perfectly well.

**This is not a new pattern.** The battery channels already solved the identical shape: signed
`battery.power` alongside the raw charge/discharge rails. Doing it differently for the grid would
have been the inconsistency.

What *is* new is a **precedence rule** the battery pair never had to state: where a device
publishes both, the signed channel is what a controller acts on and the rails are informational.
A consumer must never arbitrate between two sources of one quantity.

**Sign follows the meters**, not internal tidiness. HomeWizard, Shelly and Eastron all report
import positive; `battery.power`'s "into the thing being measured" reading would point the other
way, and matching it would put an invisible negation in every real device mapping.

## Placement is append-only on both axes

Register **406** sits past load at 404, so a client reading 400–405 sees exactly what it saw
before. The validity bit takes the next free index. `float32` carries the sign for free — which is
why this region could take a signed value at all, where the `uint16` registers elsewhere could not
have without inventing an offset encoding.

## What mutation testing found

Two mutations: delete the publish call, and strip the sign inside `publishMeasurement`.

The first exposed **a test of mine that passed against broken code**. "The rails are not inferred
from the net figure" is trivially true when nothing is published at all — everything is NaN then,
including the rails it checks. It now asserts the net channel arrived *before* checking what did
not. Both mutations now fail both tests.

## Two corrections to things I wrote earlier this week

- The design note claimed a signed channel unblocks **two** stuck profiles. It unblocks **one**.
  Deye is blocked on the rail shape and this frees it; Solis is blocked on two sources disagreeing
  by a factor of a thousand about the meter registers, which no vocabulary change can settle.
- `check_measurement_ids.py` refused the commit until the dashboard carried a row for the new id —
  a gate I had not known existed. It is the reason a canonical id cannot exist that no surface
  shows.

## Verification

991 native tests pass; both new tests mutation-proven. `check_layering.sh`, `check_measurement_ids.py`,
`check_web_js.py` and `check_dashboard_layout.py` all pass. Tightest board builds: **+160 bytes flash**.

**Note for the design project**: the dashboard row was added to `index_html.h` directly because the
gate requires it. It is vocabulary binding rather than layout, but it will need to exist in the
design source too or the next sync will drop it.