### PR TITLE
A race the comment named and then reasoned past

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Details: [docs/architecture.md](docs/architecture.md).
 
 ## All the documentation
 
-Twenty-nine documents, and **[docs/README.md](docs/README.md) groups them by what you are trying
+Thirty-three documents, and **[docs/README.md](docs/README.md) groups them by what you are trying
 to do** — get it working, fix it when it does not, check whether your inverter is supported,
 connect your own tooling, add a new inverter, or understand how it is built. It also marks which
 documents are dated records rather than instructions, so nobody follows a "next step" that
@@ -463,7 +463,7 @@ happened months ago.
 ## Development
 
 ```bash
-pio test -e native          # 442 host tests, no hardware needed
+pio test -e native          # 1000+ host tests, no hardware needed
 ./tools/check_layering.sh   # architectural invariants
 pio check -e native         # static analysis (cppcheck)
 ruff check tools/           # lint for the Python tooling
@@ -489,7 +489,7 @@ framing, checksums and timing still need real hardware.
 
 All inverter drivers are **read-only**, and that is not in tension with the curtailment above:
 no driver ever writes to your inverter over its protocol. Sending a setpoint would need a
-hardware-verified register map and a deliberate write path, and neither is enabled today (see
+hardware-verified register map and a write row marked verified, and no shipped profile has one (see
 [docs/device-profiles/schema.md](docs/device-profiles/schema.md) for how write support is
 staged). Curtailment works the other way round — a potential-free contact on the bridge closing
 a circuit the inverter already offers for exactly that purpose, with no protocol write at all.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ and why.
 |---|---|
 | [mqtt.md](mqtt.md) | Topics, payloads, Home Assistant auto-discovery, what the bridge subscribes to, and the publish-on-change deadbands. |
 | [rest-api.md](rest-api.md) | Every endpoint, its auth, and its payload. Also SSE, backup/restore and firmware upload. |
-| [prometheus.md](prometheus.md) | All 52 metrics, which appear only conditionally, and why unknown is absent rather than zero. |
+| [prometheus.md](prometheus.md) | All 53 metrics, which appear only conditionally, and why unknown is absent rather than zero. |
 | [modbus-register-map.md](modbus-register-map.md) | The bridge as a Modbus TCP *server* on port 502: register layout, validity bitmap, one unit id per inverter. |
 
 ## I want to add my inverter

--- a/docs/adding-a-device.md
+++ b/docs/adding-a-device.md
@@ -394,7 +394,8 @@ forum post. So the schema treats writes as *research to record*, not behavior to
   an unreviewed device writable is not a feature but a liability, which is why this gate is
   in the data and not only in the code.
 - The driver's write path itself exists (one holding register, FC06, echo verified). What it
-  deliberately **cannot** do — 32-bit setpoints, FC16, enum modes such as a battery work mode
+  deliberately **cannot** do — 32-bit setpoints, FC16, and a mode packed into part of a shared
+  register
   — is in [write-path.md](device-profiles/write-path.md). Read it before writing a row: some
   perfectly valid-looking rows can never be dispatched, and it is better to know that before
   you go looking for the register.

--- a/docs/device-profiles/schema.md
+++ b/docs/device-profiles/schema.md
@@ -15,7 +15,7 @@ Validate without building:
 
 ```console
 $ python3 tools/gen_profiles.py --check
-gen_profiles.py: 1 profile(s) valid: sph
+gen_profiles.py: 10 profile(s) valid: deye_sun_xk_sg, goodwe_et_hybrid, mic_tl_x, ...
 ```
 
 Files whose name starts with `_` (like the template) are skipped.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -190,6 +190,7 @@ battery's.
 |---|---|
 | `heliograph_grid_import_power_watts` | W |
 | `heliograph_grid_export_power_watts` | W |
+| `heliograph_grid_power_watts` | Net grid flow. **Signed**: positive means importing, negative exporting. Present only when a device publishes `grid.power`. |
 | `heliograph_load_power_watts` | W, what the house is drawing |
 
 Which of these appear depends on the inverter: a driver only reports what its device actually

--- a/src/commands/command_queue.cpp
+++ b/src/commands/command_queue.cpp
@@ -23,15 +23,18 @@ std::optional<CommandQueue::Request> CommandQueue::take() {
     return taken;
 }
 
-void CommandQueue::recordOutcome(const std::string& requestId, DispatchOutcome outcome) {
+void CommandQueue::recordOutcome(const std::string& deviceId, const std::string& requestId,
+                                 DispatchOutcome outcome) {
     std::lock_guard<std::mutex> lock(mutex_);
+    lastOutcomeDeviceId_  = deviceId;
     lastOutcomeRequestId_ = requestId;
     lastOutcome_          = std::move(outcome);
 }
 
-std::optional<DispatchOutcome> CommandQueue::outcomeFor(const std::string& requestId) const {
+std::optional<DispatchOutcome> CommandQueue::outcomeFor(const std::string& deviceId,
+                                                       const std::string& requestId) const {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (lastOutcomeRequestId_ != requestId) {
+    if (lastOutcomeDeviceId_ != deviceId || lastOutcomeRequestId_ != requestId) {
         return std::nullopt;
     }
     return lastOutcome_;

--- a/src/commands/command_queue.h
+++ b/src/commands/command_queue.h
@@ -42,16 +42,23 @@ public:
     /// Recorded by the bus owner once dispatch() has returned. Overwrites whatever the previous
     /// outcome was -- only the most recent request's outcome is kept, matching submit()'s
     /// one-slot rule.
-    void recordOutcome(const std::string& requestId, DispatchOutcome outcome);
+    /// Scoped by device as well as request id. A caller may choose its own request id, so two
+    /// devices can legitimately carry the same one; keyed on the id alone, polling device A
+    /// could return device B's result. Dispatch was never affected -- that is scoped by
+    /// deviceId in Request -- but the answer an operator reads was.
+    void recordOutcome(const std::string& deviceId, const std::string& requestId,
+                       DispatchOutcome outcome);
 
     /// The outcome of the most recently COMPLETED request with this id. Empty if that id was
     /// never submitted, is still pending, or has since been superseded by a later request's
     /// outcome.
-    std::optional<DispatchOutcome> outcomeFor(const std::string& requestId) const;
+    std::optional<DispatchOutcome> outcomeFor(const std::string& deviceId,
+                                             const std::string& requestId) const;
 
 private:
     mutable std::mutex             mutex_;
     std::optional<Request>         pending_;
+    std::string                    lastOutcomeDeviceId_;
     std::string                    lastOutcomeRequestId_;
     std::optional<DispatchOutcome> lastOutcome_;
 };

--- a/src/drivers/sunspec/sunspec_driver.cpp
+++ b/src/drivers/sunspec/sunspec_driver.cpp
@@ -191,7 +191,16 @@ bool SunspecDriver::walkChain(PollResult& outFailure) {
 
 bool SunspecDriver::readModel(const ChainEntry& entry, std::vector<uint16_t>& out,
                               PollResult& outFailure) {
-    const uint16_t total = static_cast<uint16_t>(kHeaderRegisters + entry.length);
+    // uint32 for the sum, like walkChain() does with the same two values. entry.length comes
+    // straight off the bus and is not bounded there, so a device reporting 65534 wraps this to 0
+    // in uint16 and the read silently becomes a no-op. Not exploitable -- the loop and the
+    // decoders agree on the wrapped value and refuse it -- but it is a stale failure mode thirty
+    // lines below the place that guards against exactly it.
+    const uint32_t span = static_cast<uint32_t>(kHeaderRegisters) + entry.length;
+    if (span > 0xFFFF) {
+        return false;
+    }
+    const uint16_t total = static_cast<uint16_t>(span);
     out.assign(total, 0);
     uint16_t done = 0;
     while (done < total) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1113,7 +1113,9 @@ void startOutputs() {
         // transport a command arrived on.
         g_mqtt->setCommandHandler(submitCommand);
         g_mqtt->setCommandOutcomeProvider(
-            [](const std::string& requestId) { return g_commandQueue.outcomeFor(requestId); });
+            [](const std::string& deviceId, const std::string& requestId) {
+                return g_commandQueue.outcomeFor(deviceId, requestId);
+            });
         if (g_relays.count() > 0) {
             g_mqtt->setRelayCommandHandler([](uint8_t index, bool on) {
                 std::lock_guard<std::mutex> lock(g_relayMutex);
@@ -1275,8 +1277,8 @@ void startRestApi() {
     // Unconditional, unlike the relay handlers below: commands target inverters, not relays,
     // so they exist regardless of board. The same function MQTT's command topic is wired to.
     ctx.submitCommand  = submitCommand;
-    ctx.commandOutcome = [](const std::string& requestId) {
-        return g_commandQueue.outcomeFor(requestId);
+    ctx.commandOutcome = [](const std::string& deviceId, const std::string& requestId) {
+        return g_commandQueue.outcomeFor(deviceId, requestId);
     };
     if (g_relays.count() > 0) {
         // Behind the same mutex as the MQTT path: REST commands arrive on the AsyncTCP
@@ -1498,7 +1500,7 @@ void rs485Task(void* /*arg*/) {
                                       "unknown device id '" + request->deviceId + "'"};
             log::info("command %s on %s: %s", commandTypeName(request->command.type),
                       request->deviceId.c_str(), outcome.reason.c_str());
-            g_commandQueue.recordOutcome(request->command.requestId, outcome);
+            g_commandQueue.recordOutcome(request->deviceId, request->command.requestId, outcome);
             continue;
         }
         // At most ONE device per iteration, round-robin. Not a loop over all of them: the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -601,10 +601,19 @@ uint64_t nowMs() { return static_cast<uint64_t>(esp_timer_get_time() / 1000); }
 
 /// The crash dump the previous boot left behind, read ONCE in setup().
 ///
-/// Not per request: reading it verifies a checksum over the whole stored image. It also cannot
-/// change while we run -- a new dump is only written by a panic, and a panic does not come back
-/// here -- so a cached copy is not merely an optimisation, it is the accurate model. Cleared in
-/// place when the erase action succeeds, which is the one thing that CAN change it.
+/// Not per request: reading it verifies a checksum over the whole stored image. A new dump is
+/// only written by a panic, and a panic does not come back here, so a cached copy is not merely
+/// an optimisation -- it is the accurate model.
+///
+/// One thing DOES change it: the erase action clears it in place. That makes it exactly the
+/// hazard g_configMutex was written for, and it went unguarded for the same reason it was easy to
+/// miss -- the sentence above named the mutation and then reasoned about the common case.
+///
+/// The erase runs on the AsyncTCP task; bridgeInfo() reads taskName (a std::string) and the
+/// backtrace from loop(), rs485Task AND the AsyncTCP task. Assigning over a std::string while
+/// another core copies it is not a stale read, it is a use-after-free waiting for the two to
+/// line up -- and bridgeInfo() runs about four times a second, so the window is not narrow.
+std::mutex            g_coredumpMutex;
 diag::CoredumpSummary g_coredump;
 
 /// The bridge's DRM relays (empty on boards without them). Commands arrive on two tasks
@@ -776,16 +785,20 @@ BridgeInfo bridgeInfo() {
     info.ntpServer        = ntpSource.server;
     info.ntpFromDhcp      = ntpSource.fromDhcp;
     info.otaImageState    = ota::imageStateName();
-    info.coredumpPresent  = g_coredump.present;
-    info.coredumpTask     = g_coredump.taskName;
-    info.coredumpPc       = g_coredump.programCounter;
-    info.coredumpCause        = g_coredump.exceptionCause;
-    info.coredumpFaultAddress = g_coredump.faultAddress;
-    info.coredumpCauseKnown        = g_coredump.causeKnown;
-    info.coredumpFaultAddressKnown = g_coredump.faultAddressKnown;
-    info.coredumpBacktrace.assign(g_coredump.backtrace,
-                                  g_coredump.backtrace + g_coredump.backtraceDepth);
-    info.coredumpBacktraceCorrupted = g_coredump.backtraceCorrupted;
+    {
+        // Same reason as g_config above: the AsyncTCP task can clear this while we copy it.
+        std::lock_guard<std::mutex> lock(g_coredumpMutex);
+        info.coredumpPresent  = g_coredump.present;
+        info.coredumpTask     = g_coredump.taskName;
+        info.coredumpPc       = g_coredump.programCounter;
+        info.coredumpCause        = g_coredump.exceptionCause;
+        info.coredumpFaultAddress = g_coredump.faultAddress;
+        info.coredumpCauseKnown        = g_coredump.causeKnown;
+        info.coredumpFaultAddressKnown = g_coredump.faultAddressKnown;
+        info.coredumpBacktrace.assign(g_coredump.backtrace,
+                                      g_coredump.backtrace + g_coredump.backtraceDepth);
+        info.coredumpBacktraceCorrupted = g_coredump.backtraceCorrupted;
+    }
     if (g_relays.count() > 0) {
         {
             std::lock_guard<std::mutex> lock(g_relayMutex);
@@ -1251,7 +1264,10 @@ void startRestApi() {
         if (!diag::eraseCoredump()) {
             return false;
         }
-        g_coredump = {};
+        {
+            std::lock_guard<std::mutex> lock(g_coredumpMutex);
+            g_coredump = {};
+        }
         return true;
     };
     ctx.portalActive        = [] { return g_wifi.portalActive(); };

--- a/src/outputs/mqtt/mqtt_output.cpp
+++ b/src/outputs/mqtt/mqtt_output.cpp
@@ -418,7 +418,7 @@ void MqttOutput::loop(const std::vector<DeviceView>& devices, const BridgeInfo& 
                 pending = channel.pendingCommandRequestId;
             }
             if (!pending.empty()) {
-                if (const auto outcome = commandOutcomeProvider_(pending)) {
+                if (const auto outcome = commandOutcomeProvider_(channel.id, pending)) {
                     std::string ack;
                     if (json_util::buildCommandOutcomePayload(pending, *outcome, ack)) {
                         publishTracked(channel.topics.commandResult().c_str(), 0, false,

--- a/src/outputs/mqtt/mqtt_output.h
+++ b/src/outputs/mqtt/mqtt_output.h
@@ -147,8 +147,8 @@ public:
     /// SAME function RestContext::commandOutcome reads from -- both transports observe the one
     /// CommandQueue. loop() polls this for whichever channel is awaiting a result and, once it
     /// resolves, publishes it to that channel's commandResult() topic (see loop()'s own note).
-    using CommandOutcomeFn =
-        std::function<std::optional<DispatchOutcome>(const std::string& requestId)>;
+    using CommandOutcomeFn = std::function<std::optional<DispatchOutcome>(
+        const std::string& deviceId, const std::string& requestId)>;
     void setCommandOutcomeProvider(CommandOutcomeFn provider) {
         commandOutcomeProvider_ = std::move(provider);
     }

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -487,7 +487,7 @@ bool RestApi::begin() {
                           {404, "no_command_path", "no write path is wired for commands yet"});
                 return;
             }
-            const auto outcome = context_.commandOutcome(requestId);
+            const auto outcome = context_.commandOutcome(deviceId, requestId);
             if (!outcome.has_value()) {
                 sendError(request, {404, "unknown_request",
                                     "no completed command with this request id"});

--- a/src/outputs/rest/rest_api.h
+++ b/src/outputs/rest/rest_api.h
@@ -137,7 +137,9 @@ struct RestContext {
     /// it is still pending, was never submitted, or has since been superseded by a later
     /// request -- only one outcome is remembered at a time, matching submitCommand's
     /// one-in-flight rule.
-    std::function<std::optional<DispatchOutcome>(const std::string& requestId)> commandOutcome;
+    std::function<std::optional<DispatchOutcome>(const std::string& deviceId,
+                                                 const std::string& requestId)>
+        commandOutcome;
 };
 
 class RestApi {

--- a/src/protocols/modbus/modbus_client.cpp
+++ b/src/protocols/modbus/modbus_client.cpp
@@ -3,6 +3,10 @@
 #include "protocols/modbus/modbus_client.h"
 
 namespace heliograph::modbus {
+
+/// Same two seconds the PMU family waits. Long enough that a poll in progress finishes first,
+/// short enough that a stuck holder surfaces as a transport error rather than a hang.
+inline constexpr uint32_t kBusLockTimeoutMs = 2000;
 namespace {
 
 /// What a caller's parse step reports back.
@@ -32,6 +36,25 @@ template <typename ParseFn>
 TransactionOutcome runTransaction(Transport& transport, const uint8_t* req, size_t reqLen,
                                   const ReadTiming& timing, ParseFn parse) {
     TransactionOutcome outcome;
+
+    // The bus lock, taken here rather than per driver because every Modbus path -- profile
+    // driver, SunSpec driver, and both of their discovery probes -- funnels through this
+    // function. It was missing entirely: the PMU and MaxTalk families locked, the Modbus family
+    // did not, and CommandDispatcher's own comment described a two-second wait for a lock these
+    // drivers never asked for.
+    //
+    // Harmless today, because only rs485Task ever reaches a Transport and its one-activity-per-
+    // iteration rule already serialises everything. That is exactly why it was worth closing: the
+    // protection was an invariant nobody states at the call site, and the first second bus user
+    // would have found half the drivers guarded and half not.
+    //
+    // No nesting risk -- no caller of this function holds the lock (the four TransportLock sites
+    // are all on PMU, MaxTalk or capture paths, none of which route through here).
+    TransportLock lock(transport, kBusLockTimeoutMs);
+    if (!lock.held()) {
+        outcome.status = TransactionStatus::TransportError;
+        return outcome;
+    }
 
     transport.flushInput();
     if (transport.write(req, reqLen) != reqLen) {

--- a/test/test_commands/test_main.cpp
+++ b/test/test_commands/test_main.cpp
@@ -641,14 +641,14 @@ static void test_a_taken_slot_accepts_a_new_submission() {
 
 static void test_outcome_is_unknown_before_it_is_recorded() {
     CommandQueue q;
-    TEST_ASSERT_FALSE(q.outcomeFor("r1").has_value());
+    TEST_ASSERT_FALSE(q.outcomeFor("inv1", "r1").has_value());
 }
 
 static void test_a_recorded_outcome_is_readable_by_its_request_id() {
     CommandQueue q;
-    q.recordOutcome("r1", DispatchOutcome{CommandResult::Ok, "accepted"});
+    q.recordOutcome("inv1", "r1", DispatchOutcome{CommandResult::Ok, "accepted"});
 
-    auto outcome = q.outcomeFor("r1");
+    auto outcome = q.outcomeFor("inv1", "r1");
     TEST_ASSERT_TRUE(outcome.has_value());
     TEST_ASSERT_EQUAL(CommandResult::Ok, outcome->result);
     TEST_ASSERT_EQUAL_STRING("accepted", outcome->reason.c_str());
@@ -658,11 +658,28 @@ static void test_a_recorded_outcome_is_readable_by_its_request_id() {
 // about a request that has since been superseded gets "unknown", not a stale answer.
 static void test_a_later_outcome_supersedes_an_earlier_one() {
     CommandQueue q;
-    q.recordOutcome("first", DispatchOutcome{CommandResult::Ok, "accepted"});
-    q.recordOutcome("second", DispatchOutcome{CommandResult::RateLimited, "too many commands"});
+    q.recordOutcome("inv1", "first", DispatchOutcome{CommandResult::Ok, "accepted"});
+    q.recordOutcome("inv1", "second",
+                    DispatchOutcome{CommandResult::RateLimited, "too many commands"});
 
-    TEST_ASSERT_FALSE(q.outcomeFor("first").has_value());
-    TEST_ASSERT_TRUE(q.outcomeFor("second").has_value());
+    TEST_ASSERT_FALSE(q.outcomeFor("inv1", "first").has_value());
+    TEST_ASSERT_TRUE(q.outcomeFor("inv1", "second").has_value());
+}
+
+// A request id is the CALLER's to choose (REST and MQTT both accept one), so two devices can
+// legitimately carry the same id at the same time. Keyed on the id alone, asking about device A
+// returned device B's result -- the right answer to somebody else's question, which is worse than
+// no answer because it looks like one.
+//
+// Dispatch was never affected: that is scoped by deviceId in Request, so the correct device always
+// received the correct command. Only the report was wrong.
+static void test_an_outcome_is_not_readable_through_another_device() {
+    CommandQueue q;
+    q.recordOutcome("inverter_b", "shared-id",
+                    DispatchOutcome{CommandResult::Ok, "accepted"});
+
+    TEST_ASSERT_FALSE(q.outcomeFor("inverter_a", "shared-id").has_value());
+    TEST_ASSERT_TRUE(q.outcomeFor("inverter_b", "shared-id").has_value());
 }
 
 // --- commandTypeFromName / parseCommandRequest ----------------------------------------------
@@ -886,6 +903,7 @@ int main(int, char**) {
     RUN_TEST(test_outcome_is_unknown_before_it_is_recorded);
     RUN_TEST(test_a_recorded_outcome_is_readable_by_its_request_id);
     RUN_TEST(test_a_later_outcome_supersedes_an_earlier_one);
+    RUN_TEST(test_an_outcome_is_not_readable_through_another_device);
 
     RUN_TEST(test_command_type_from_name_round_trips_every_type);
     RUN_TEST(test_command_type_from_name_rejects_an_unknown_name);


### PR DESCRIPTION
Four-agent review of the whole project. Most came back clean; this fixes what did not.

## `g_coredump` was unguarded across three tasks — the real one

The erase action clears it from the **AsyncTCP task**; `bridgeInfo()` copies its `std::string
taskName` and its backtrace from **`loop()`, `rs485Task` and the AsyncTCP task**, about four times
a second. Assigning over a `std::string` while another core copies it is not a stale read — it is
a use-after-free waiting for the two to line up.

What makes it worth recording: the declaration's own comment **named the mutation** — *"Cleared in
place when the erase action succeeds, which is the one thing that CAN change it"* — and then spent
three lines arguing the cached copy is accurate. Thirty lines above sits `g_configMutex`, written
for exactly this hazard, with a comment describing exactly this shape. The reasoning stopped one
step short of its own conclusion.

## SunSpec `readModel()` narrowing

`kHeaderRegisters + entry.length` was cast to `uint16`. `entry.length` comes off the bus unbounded,
so 65534 wraps the sum to zero and the read silently becomes a no-op. Not exploitable — but
`walkChain()` does the same arithmetic in `uint32` with a bounds check thirty lines up.

## Five false documentation claims, each verified against code first

- `adding-a-device.md` said enum mode setpoints **"cannot"** be expressed. They can; `write-path.md`
  documents how and the profile driver implements it. Both texts landed in the same commit and
  survived a dedicated doc-review pass.
- `prometheus.md` was missing `heliograph_grid_power_watts`; `docs/README.md` said 52 metrics where
  there are 53.
- `README.md` said **442 host tests** where there are **1022**, and twenty-nine documents where
  there are thirty-three.
- `README.md` said a deliberate write path *"is not enabled"*. The path is built, wired to REST and
  MQTT, tested end to end; what is missing is a **verified register**, not the path. The safety
  claim was still true — it was just about the wrong thing.
- `schema.md`'s example output showed one profile valid, where ten are.

## What came back clean, and is worth stating

No bypass in the write path — every mutating REST route authorises, Modbus TCP refuses writes at
three independent points, and three differently-defaulted gates stand between a build and a moved
inverter. No exploitable out-of-bounds in any parser. The "one activity per bus-task iteration"
invariant holds.

## Verification

1022 host tests, all gates, board build clean.