### PR TITLE
Bump to 0.27.1: what the review round found

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,7 +495,30 @@ namespace {
 //
 // That last one is the one to remember. Careful reasoning on an unverified input produces
 // confident wrong output, and it looks exactly like diligence.
-#define HELIOGRAPH_VERSION_PATCH 0
+// 0.27.1 fixes what a four-agent review of the whole project turned up. No new capability --
+// two dormant traps closed, one live race, and five documentation claims that were false.
+//
+// THE LIVE ONE: g_coredump was read and written across three tasks with no lock. The erase
+// action clears it from the AsyncTCP task while bridgeInfo() copies its std::string and its
+// backtrace from loop(), rs485Task and AsyncTCP itself, about four times a second. Overwriting a
+// std::string while another core copies it is a use-after-free waiting for the two to line up.
+//
+// Worth recording HOW it survived: the declaration's own comment named the mutation -- "the one
+// thing that CAN change it" -- and then argued for three lines that the cached copy is accurate.
+// Thirty lines above sits g_configMutex, written for this exact hazard, with a comment describing
+// this exact shape. The reasoning stopped one step short of its own conclusion.
+//
+// TWO DORMANT TRAPS. The Modbus family never took the bus lock -- profile driver, SunSpec driver
+// and both their probes all route through one function that did not have it -- while the
+// dispatcher's comment described a two-second wait for a lock those drivers never asked for.
+// Harmless while only rs485Task touches a Transport, which is precisely why it was worth closing
+// rather than documenting away. And command outcomes were keyed on the request id alone, which
+// the caller chooses, so polling one device could return another's result. Dispatch was never
+// affected; the report was.
+//
+// The rest is documentation that had drifted, including an "enum modes cannot be expressed" that
+// the profile driver has implemented since July.
+#define HELIOGRAPH_VERSION_PATCH 1
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Two commits since `v0.27.0`, both fixes. **No new capability, so a patch.**

## One live bug

`g_coredump` was read and written across three tasks with no lock. The erase action clears it from
the AsyncTCP task while `bridgeInfo()` copies its `std::string` and backtrace from `loop()`,
`rs485Task` and AsyncTCP itself — roughly four times a second. That is a use-after-free waiting
for two cores to line up, not a stale read.

## Two dormant traps, closed rather than documented away

- The **Modbus driver family never took the bus lock**, while the dispatcher's comment claimed it
  waited two seconds for one. Harmless while only `rs485Task` touches a Transport — which is
  exactly why it was worth closing.
- **Command outcomes were keyed on a caller-chosen request id alone**, so polling one device could
  return another's result. Dispatch was never affected; only the answer an operator reads.

## Five documentation corrections

Including one that said enum mode setpoints *cannot* be expressed, when the profile driver has
implemented them since July.

## Verification

1023 native cases, all eleven gates, four board builds. The 1CH build's four warnings are all
inside eModbus, **none in `src/`** — checked again rather than carried over from the last note.