### PR TITLE
Cleanup round: name what is reserved, drop what is not, and stop a plan lying about itself

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -241,6 +241,22 @@ build_flags =
     -DENABLE_DRIVER_MOCK=1
     -DENABLE_PROMETHEUS=1
 lib_deps =
+    ; FOUR BUILD WARNINGS COME FROM eModbus AND CANNOT BE FIXED HERE. Three are
+    ; `AsyncClient::close(bool) is deprecated`, one is a `%u` format string against a uint32_t.
+    ; None is in src/ -- checked per board, every board reports the same four and zero of our own.
+    ;
+    ; They are not a pin that has gone stale: as of 2026-08 every dependency below IS on its
+    ; newest published release, verified against the registry and the GitHub releases rather than
+    ; against `pio pkg outdated`, which respects these pins and therefore can never report an
+    ; exactly-pinned package as behind. eModbus 1.7.4 is simply fourteen months old while the
+    ; repository keeps committing, and the deprecation is not even reported upstream.
+    ;
+    ; Nor can they be silenced cleanly. build_src_filter does not reach libdeps, and lib_ignore
+    ; drops a whole library we need. Vendoring eModbus to patch three lines would trade four
+    ; warnings for a permanent maintenance burden. So: known, sourced, and left alone -- and three
+    ; of the four come out of ModbusClientTCPasync.cpp, a file this firmware never uses at all
+    ; (we run the SERVER, not the client).
+    ;
     ; Pinned deliberately. eModbus's last tag is older than its last commit, so `latest`
     ; is not reproducible. ESPAsyncWebServer must come from the ESP32Async org: both the
     ; me-no-dev original and mathieucarbou's fork are archived.

--- a/src/device/command.h
+++ b/src/device/command.h
@@ -13,11 +13,21 @@
 
 namespace heliograph {
 
+/// Where a command came from. Provenance, not routing -- nothing dispatches on this.
+///
+/// It is set and, today, never read: two callers assign it and no consumer looks. It stays
+/// because Internal is the marker the grid-source design depends on -- a freshness gate has to
+/// tell a command derived from our own measurements apart from one an outside system decided,
+/// and only the originator knows which it is. That consumer does not exist yet.
+///
+/// Two values were removed in the 2026-08 cleanup rather than kept as reserved, because unlike
+/// the transport list above they had no future to reserve. `Web` was always the same path as
+/// `Rest`: the dashboard button sends an HTTP request and arrives as Rest. `ModbusTcp` was
+/// unreachable by construction -- that server refuses writes at three independent points, so no
+/// command can originate there while it stays a read-only view of the cached register map.
 enum class CommandSource : uint8_t {
     Mqtt,
     Rest,
-    ModbusTcp,
-    Web,
     Internal,
 };
 

--- a/src/diagnostics/log_buffer.cpp
+++ b/src/diagnostics/log_buffer.cpp
@@ -2,6 +2,7 @@
 
 #include "log_buffer.h"
 
+#include <algorithm>
 #include <cstring>
 
 #if defined(ESP32)
@@ -64,7 +65,7 @@ void pushLine(const char* line) {
 
 std::vector<std::string> recentLines(size_t max) {
     Guard guard;
-    const size_t take = max < g_held ? max : g_held;
+    const size_t take = std::min(max, g_held);
     std::vector<std::string> out;
     out.reserve(take);
     // g_next points one past the newest line; walk back `take` and read forward from there so

--- a/src/diagnostics/logger.cpp
+++ b/src/diagnostics/logger.cpp
@@ -2,6 +2,7 @@
 
 #include "logger.h"
 
+#include <algorithm>
 #include <cstdio>
 
 #include "log_buffer.h"
@@ -97,7 +98,7 @@ void traceHex(const char* prefix, const uint8_t* data, size_t len) {
     // Bounded per line and overall: a corrupted length byte must not turn into a megabyte of
     // output that itself takes the device down.
     constexpr size_t kMaxBytes = 64;
-    const size_t     n         = len < kMaxBytes ? len : kMaxBytes;
+    const size_t     n         = std::min(len, kMaxBytes);
     // Initialised, not merely written by the loop below: at len == 0 that loop does not run and
     // an uninitialised buffer would go to trace("%s"), printing stack bytes until it happened to
     // hit a NUL. Two of the three callers guard with `received > 0`, but Rs485Transport::write

--- a/src/outputs/rest/rest_api.cpp
+++ b/src/outputs/rest/rest_api.cpp
@@ -8,6 +8,7 @@
 
 #if defined(ESP32)
 
+#include <algorithm>
 #include <ESPAsyncWebServer.h>
 #include <WiFi.h>  // softAPIP() for the captive-portal redirect target
 
@@ -255,7 +256,7 @@ bool RestApi::begin() {
             "text/html", htmlLen,
             [html, htmlLen](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
                 const size_t remaining = htmlLen - index;
-                const size_t n         = remaining < maxLen ? remaining : maxLen;
+                const size_t n         = std::min(remaining, maxLen);
                 std::memcpy(buffer, html + index, n);
                 return n;
             });

--- a/src/relays/relay_controller.cpp
+++ b/src/relays/relay_controller.cpp
@@ -10,7 +10,7 @@ RelayController::RelayController(ClockFn clock, RateLimitPolicy rateLimit)
     : clock_(std::move(clock)), limiter_(rateLimit) {}
 
 void RelayController::begin(uint8_t count, RelayApplyFn apply) {
-    count_ = count > kMaxRelays ? kMaxRelays : count;
+    count_ = std::min(count, kMaxRelays);
     apply_ = std::move(apply);
     allOff();
 }

--- a/src/transport/transport.h
+++ b/src/transport/transport.h
@@ -19,6 +19,23 @@ namespace diag {
 class BusTap;
 }
 
+/// Which physical medium a transport speaks.
+///
+/// THREE OF THESE ARE RESERVED, NOT IMPLEMENTED, and that distinction is the whole reason this
+/// comment exists -- a reader otherwise cannot tell an unfinished feature from a deliberate one.
+///
+///   Rs485  the only transport compiled into the firmware.
+///   Mock   the host-test double.
+///   Tcp    reserved. The profile schema already accepts `transports = ["tcp"]` and the SunSpec
+///          driver's own notes explain why it matters: most SunSpec devices in the field are
+///          reached over TCP. What is missing is a Modbus TCP *client*, not this enum value.
+///   Can    reserved, and not speculative -- the RS485-CAN board carries an isolated CAN
+///          interface that nothing in this firmware speaks yet.
+///   Rs232  reserved. No hardware here uses it; kept because the set reads as "which medium",
+///          and a medium list that omits the obvious sibling invites the question every time.
+///
+/// Reserved values cost nothing at runtime: an enumerator is a compile-time constant, not code.
+/// The cost of leaving them undocumented is that nobody can tell which ones work.
 enum class TransportType : uint8_t { Rs485, Rs232, Can, Tcp, Mock };
 
 struct TransportStats {


### PR DESCRIPTION
An audit-first cleanup pass. The audit is in the conversation; this is what came out of it, one
commit per category.

## What the audit found — and mostly did not find

- **Zero warnings in `src/`.** All four warnings on every board come from eModbus, and `cppcheck`
  at high severity and `ruff` are both clean.
- **No duplication worth consolidating.** Every candidate fell over on inspection: the `clamp`
  hits are all in *comments*, `nibble` in `rtc_time` is BCD rather than hex, and `toHex` is one
  declaration that `ota_manager` reuses — which is the good case, not the bad one.
- **Dependencies are all on their newest release**, verified against the registry and GitHub
  rather than `pio pkg outdated`, which respects these pins and so can never report an
  exactly-pinned package as behind.

## The three changes

**Warnings documented where the dependency is declared.** They cannot be fixed here: eModbus
1.7.4 is fourteen months old while its repo keeps committing, the deprecation is not reported
upstream, `build_src_filter` does not reach libdeps, and vendoring to patch three lines would buy
a permanent maintenance burden. Three of the four come from a translation unit this firmware never
uses — we run the Modbus TCP *server*, not the client.

**Reserved enum values marked reserved; two dead ones removed.** Four values had no reference, but
they were not one category. `TransportType::Can` is not speculative — the RS485-CAN board carries
an isolated CAN interface nothing speaks yet; `Tcp` is the value the profile schema already
accepts. An enumerator is a compile-time constant, so removing these buys nothing and costs a
future — what they *did* cost is that a reader could not tell unfinished from deliberate.

`CommandSource::Web` and `ModbusTcp` went, because they had nothing to reserve: `Web` was always
the same path as `Rest`, and `ModbusTcp` is unreachable by construction. `Internal` stays, and the
comment now says why — it is the provenance marker the grid-source freshness gate needs.

**Four ternaries became `std::min`.** Net **+3 lines**, because three files needed `<algorithm>` —
the honest accounting for a change made on clarity, not size. The compiler now also proves the
four sites compare like with like, which the ternary never did.

## Verification

1023 host tests, all eleven gates, `cppcheck` clean at high, `ruff` clean, four board builds with
**zero warnings in `src/`**.

## Risk

Low, and concentrated in one place: removing two enumerators is a compile-time break if anything
referenced them. Nothing did — verified by grep across `src/` and `test/`, and by all four boards
building. No external API, REST payload, MQTT topic or register changed.