### PR TITLE
A serial number off the bus is data, not code

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -165,6 +165,13 @@ const $=s=>document.querySelector(s[0]==='#'||s[0]==='.'?s:'#'+s);
 const esc=s=>String(s??'').replace(/[<>&"']/g,c=>({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c]));
 // null must never render as 0 -- that is why the firmware sends null in the first place.
 const fmt=(v,d=1)=>v===null||v===undefined?'—':Number(v).toFixed(d);
+// esc() makes a URL safe to SIT in an attribute; it does not make it safe to FOLLOW.
+// javascript: and data: survive HTML-escaping intact and run on click. Only http(s)
+// is linked; anything else renders as plain text, which is the honest failure -- the
+// reader still sees what the feed offered without the page offering to run it.
+const safeUrl=u=>{if(!u)return null;  // String(null) would resolve to a link reading "null"
+  try{const p=new URL(String(u),location.href).protocol;
+  return p==='http:'||p==='https:'?String(u):null}catch(e){return null}};
 const sp=n=>String(n).replace(/\B(?=(\d{3})+(?!\d))/g,'\u2009');
 const up=s=>s<3600?Math.floor(s/60)+' m':s<86400?(s/3600).toFixed(1)+' h':Math.floor(s/86400)+' d '+Math.round(s%86400/3600)+' h';
 const kb=b=>b===null||b===undefined?'—':Math.round(b/1024)+' kB';
@@ -2202,7 +2209,7 @@ function updRender(){
     return;
   }
   box.innerHTML=`<div class="msg ok" style="display:block"><b>${esc(updLatest.version)}</b> is available. You are running ${esc(cur)}.
-      ${updLatest.notes_url?`<a href="${esc(updLatest.notes_url)}" target="_blank" rel="noopener noreferrer">Release notes</a>`:''}</div>
+      ${safeUrl(updLatest.notes_url)?`<a href="${esc(safeUrl(updLatest.notes_url))}" target="_blank" rel="noopener noreferrer">Release notes</a>`:''}</div>
     <div class="hint">${Math.round((asset.size||0)/1024)} kB. Your browser downloads it and hands it to the bridge, which checks it against the checksum from the release before writing anything. That proves the image arrived intact — it is not a signature, and does not prove who built it.</div>
     <div class="acts"><button id="upd_btn" onclick="installUpdate()">Install ${esc(updLatest.version)}</button></div>
     <div id="upd_prog" class="prog"><div></div></div>

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -187,6 +187,31 @@ function goTab(name){
 /// gets typed into the wrong section.
 function togglePanel(id){panel=panel===id?null:id;devDraft=null;paint()}
 
+// Attribute-borne DATA, never attribute-borne CODE. The browser HTML-decodes an attribute
+// value before the JS parser compiles an inline handler, so a quote that esc() turned into
+// &#39; is a quote again by the time it runs -- and a device id here is driverId + '-' +
+// the serial number the inverter reported over RS485, filtered only to printable ASCII.
+// An apostrophe in that serial used to close the string and run whatever followed, in the
+// admin's authenticated session, with the Basic-auth token sitting in sessionStorage.
+//
+// data-* values are read back with getAttribute, which yields the decoded string and never
+// executable text, so the same bytes are inert. One delegated listener on document also
+// survives every innerHTML repaint, which per-element handlers do not.
+//
+// tools/check_web_js.py fails the build if ${...} ever appears inside an on* attribute
+// again -- the shape is what was wrong, so the shape is what is banned.
+document.addEventListener('click',e=>{
+  const t=e.target.closest('[data-act]');
+  if(!t)return;
+  const a=t.getAttribute('data-act'), v=t.getAttribute('data-val')||'';
+  if(a==='panel')togglePanel(v);
+  else if(a==='tab-panel'){goTab(t.getAttribute('data-tab'));togglePanel(v)}
+  else if(a==='remove-extra')removeExtraAt(Number(v));
+  else if(a==='save-device')saveDevice(Number(v));
+  else if(a==='log-filter'){logFilter=v;loadLogs(true)}
+  else if(a==='wiz-pick')wizPick(v,JSON.parse(t.getAttribute('data-opts')||'{}'));
+});
+
 // ---------------- admin auth ----------------
 // fetch() never raises the browser's Basic-auth dialog: a 401 is just a 401. So ask once, keep
 // it for the tab only, and send the header ourselves.
@@ -485,7 +510,7 @@ function firstRunCard(here){
     <div class="hint" style="margin-top:8px">Wire A, B and ground to the inverter first, then let
       the bridge look for it. Discovery listens at each driver's own line speed and reports what
       answered; nothing is written to the inverter and nothing is changed until you confirm.</div>
-    <div class="acts"><button onclick="${here?"togglePanel('wiz')":"goTab('inv');togglePanel('wiz')"}">Find my inverter</button>
+    <div class="acts"><button data-act="${here?'panel':'tab-panel'}" data-tab="inv" data-val="wiz">Find my inverter</button>
       ${here?'':'<button class="alt" onclick="goTab(\'inv\')">Open the Inverters tab</button>'}</div>
   </div>`;
 }
@@ -738,8 +763,8 @@ function paintInverters(){
       </div>
       ${!dev.label?`<div class="hint" style="margin-top:10px">Id <code>${esc(id)}</code> — this is what the API, the MQTT topics and the Modbus unit mapping use.</div>`:''}
       <div class="acts">
-        <button class="alt sm" onclick="togglePanel('m:${esc(id)}')">${panel==='m:'+id?'Hide readings':`All ${esc(count)} reading${count===1?'':'s'}`}</button>
-        <button class="alt sm" onclick="togglePanel('s:${esc(id)}')">${panel==='s:'+id?'Close settings':'Name, driver and address'}</button>
+        <button class="alt sm" data-act="panel" data-val="m:${esc(id)}">${panel==='m:'+id?'Hide readings':`All ${esc(count)} reading${count===1?'':'s'}`}</button>
+        <button class="alt sm" data-act="panel" data-val="s:${esc(id)}">${panel==='s:'+id?'Close settings':'Name, driver and address'}</button>
       </div>
       ${panel==='m:'+id?`<div class="hair">
         <div class="hint" style="margin:0 0 10px">Everything this driver declares it can read. A channel is listed because the inverter <i>has</i> it; an em dash means it has it but is not reporting a value right now.
@@ -775,12 +800,12 @@ function paintInverters(){
       h+=`<div class="card" style="border-color:var(--warn)">
         <div class="between"><div><b>${esc(e.label||'Inverter '+(i+2))}</b>
           <span class="tag warn">starts after a restart</span></div>
-          ${panel==='x:'+i?'':`<button class="dangerAlt sm" onclick="removeExtraAt(${i})">Remove</button>`}</div>
+          ${panel==='x:'+i?'':`<button class="dangerAlt sm" data-act="remove-extra" data-val="${i}">Remove</button>`}</div>
         <div class="hint">${esc((drv&&drv.display_name)||e.driver_id||'no driver chosen')}${
           addr?' · address '+esc(addr):''} — added to the configuration, not polled yet. Correct it
           here before the restart if anything is off, or remove it.</div>
         <div class="acts">
-          <button class="alt sm" onclick="togglePanel('x:${i}')">${panel==='x:'+i?'Close settings':'Name, driver and address'}</button>
+          <button class="alt sm" data-act="panel" data-val="x:${i}">${panel==='x:'+i?'Close settings':'Name, driver and address'}</button>
         </div>
         ${panel==='x:'+i?deviceForm(i+1):''}
       </div>`;
@@ -851,10 +876,10 @@ function deviceForm(slot){
     ${drvId!==storedDrvId?'<div class="hint" style="color:var(--warn)">A different driver from the one running. Its options below start at this driver\u2019s own defaults, not the stored ones.</div>':''}`;
   h+=optionFields(drv,stored,'dv_o_');
   h+=`<div class="acts">
-      <button onclick="saveDevice(${slot})">Save</button>
+      <button data-act="save-device" data-val="${slot}">Save</button>
       <button class="alt" onclick="togglePanel(null)">Cancel</button>
       <span style="flex:1"></span>
-      ${primary?'':`<button class="dangerAlt" onclick="removeExtraAt(${slot-1})">Remove this inverter</button>`}
+      ${primary?'':`<button class="dangerAlt" data-act="remove-extra" data-val="${slot-1}">Remove this inverter</button>`}
     </div>
     <div class="hint">${primary?'This is the first inverter, which every build has. Point it at a different driver rather than removing it.'
       :'Removing it does not remove what it already published: the old entities stay in Home Assistant, available, showing their last value.'}</div>
@@ -1046,7 +1071,7 @@ function paintHealth(){
       <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
         <span class="hint" style="margin:0">show</span>
         ${[['all','everything'],['warn','warnings & errors'],['bus','RS485 only']].map(([k,n])=>
-          `<button class="pill${logFilter===k?'':' off'}" onclick="logFilter='${k}';loadLogs(true)">${esc(n)}</button>`).join('')}
+          `<button class="pill${logFilter===k?'':' off'}" data-act="log-filter" data-val="${k}">${esc(n)}</button>`).join('')}
         <span style="width:1px;height:18px;background:var(--line)"></span>
         <span class="hint" style="margin:0">level</span>
         <select class="tiny" onchange="setLogLevel(this.value)">${['error','warn','info','debug','trace'].map(l=>
@@ -1740,7 +1765,7 @@ function wizardHtml(){
         <tr><td class="dim">Serial number</td><td>${esc(x.serial_number||'—')}</td></tr>
         <tr><td class="dim">Evidence</td><td>${(x.evidence||[]).map(e=>'· '+esc(e)).join('<br>')||'—'}</td></tr>
         </table>
-        <div class="acts"><button onclick='wizPick(${JSON.stringify(x.driver_id)},${JSON.stringify(x.options||{})})'>Choose this device</button></div>
+        <div class="acts"><button data-act="wiz-pick" data-val="${esc(x.driver_id)}" data-opts="${esc(JSON.stringify(x.options||{}))}">Choose this device</button></div>
       </div>`;
     }
     h+=`<div class="acts"><button class="alt" onclick="wizStep=1;paintInverters()">Back</button></div>`;

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -699,6 +699,49 @@ def report(label: str, verdict: str) -> int:
     return 1
 
 
+# A serial number is bytes off the RS485 bus, and the only filter on them is "printable ASCII"
+# -- which includes the apostrophe. The dashboard used to build its per-device buttons as
+# onclick="togglePanel('m:${esc(id)}')", and esc() does NOT save that: the browser HTML-decodes
+# an attribute value before compiling the inline handler, so &#39; is an apostrophe again by the
+# time it runs. A device reporting the serial below closed the string and ran what followed, in
+# the admin's authenticated session, where sessionStorage holds the Basic-auth token.
+#
+# BOTH halves are asserted, because either alone passes for the wrong reason: the payload must
+# not run, AND the button must still open its panel. Escaping harder satisfies the first and
+# breaks the second; removing the button satisfies both and ships a dead dashboard.
+HOSTILE_SERIAL = "x');window.__pwned=1;//"
+
+HOSTILE_SERIAL_JS = r"""
+(function(){
+const fail=[];
+const say=m=>fail.push(m);
+const done=()=>{document.title=fail.length?'LAYOUT-FAIL '+fail.join(' || '):'LAYOUT-OK'};
+let tries=0;
+// The per-device cards live on the Inverters tab, so this has to go there first -- and wait for
+// loadInverters() to have filled the caches the cards render from.
+const tick=setInterval(()=>{
+  if(typeof goTab==='function' && tab!=='inv') goTab('inv');
+  const b=document.querySelector('[data-act="panel"][data-val^="m:"]');
+  if(!b && ++tries<=120) return;
+  clearInterval(tick);
+  try{
+    if(!b){say('no readings button rendered at all');done();return}
+    if(window.__pwned){say('the payload ran while the page was rendering');done();return}
+    const want=b.getAttribute('data-val');
+    // If the fixture ever stops carrying the payload this whole check is vacuous, so it says so
+    // rather than passing quietly.
+    if(want.indexOf("');")<0){say('the fixture lost its payload, so nothing was tested: '+want);done();return}
+    b.click();
+    setTimeout(()=>{
+      if(window.__pwned) say('the payload ran when the button was clicked');
+      if(panel!==want) say('the button did not open its panel: panel='+panel+' want='+want);
+      done();
+    },250);
+  }catch(e){say('threw: '+e.message);done()}
+},25);})();
+"""
+
+
 def main() -> int:
     stripped = build_web.served_page()
     stub = (ROOT / "tools" / "demo_fleet.js").read_text(encoding="utf-8")
@@ -769,6 +812,23 @@ def main() -> int:
         page = build_page(stripped, stub, "{soc:68,power:-1240}", INTEGRATIONS_JS)
         verdict, _ = render(chrome, page, 1000, scratch, "int")
         status |= report("integrations still reports what changed", verdict)
+
+        # The one device on this fleet whose id came off the bus rather than out of a config.
+        hostile = stub.replace(
+            "'eversolar_legacy-EU00T112345678'",
+            '"eversolar_legacy-' + HOSTILE_SERIAL + '"',
+        ).replace("'EU00T112345678'", '"' + HOSTILE_SERIAL + '"')
+        if "__pwned" not in hostile:
+            print(
+                "hostile serial: FAIL (the stub no longer carries the id this substitutes)"
+            )
+            status |= 1
+        else:
+            page = build_page(
+                stripped, hostile, "{soc:68,power:-1240}", HOSTILE_SERIAL_JS
+            )
+            verdict, _ = render(chrome, page, 1000, scratch, "hostile")
+            status |= report("a hostile serial number cannot run script", verdict)
 
     return status
 

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -24,6 +24,7 @@
 # a runner image that stops shipping Chrome shows up as a red check rather than as a layout
 # check that quietly stopped rendering anything.
 
+import json
 import pathlib
 import re
 import subprocess
@@ -716,12 +717,17 @@ HOSTILE_SERIAL_JS = r"""
 const fail=[];
 const say=m=>fail.push(m);
 const done=()=>{document.title=fail.length?'LAYOUT-FAIL '+fail.join(' || '):'LAYOUT-OK'};
+// Injected from HOSTILE_SERIAL, never spelled again. Review defeated the whole check by
+// changing one character of the fixture: the DOM scan probed a SEPARATE hardcoded literal,
+// so the two drifted apart and a live reintroduced XSS passed with RESULT: PASS. Two copies
+// of one string is one copy too many when a mismatch fails silent.
+const PAYLOAD=__PAYLOAD__;
 let tries=0;
 // The per-device cards live on the Inverters tab, so this has to go there first -- and wait for
 // loadInverters() to have filled the caches the cards render from.
 const tick=setInterval(()=>{
   if(typeof goTab==='function' && tab!=='inv') goTab('inv');
-  const b=document.querySelector('[data-act="panel"][data-val^="m:"]');
+  let b=document.querySelector('[data-act="panel"][data-val^="m:"]');
   if(!b && ++tries<=120) return;
   clearInterval(tick);
   try{
@@ -730,16 +736,32 @@ const tick=setInterval(()=>{
     // The defence that does not depend on how the source was written. A shape check in
     // check_web_js.py can always be evaded by building the same string another way; this
     // asks the RENDERED page whether any handler attribute ended up carrying bus bytes.
-    for(const el of document.querySelectorAll('*')){
-      for(const a of el.attributes){
-        if(/^on/i.test(a.name) && a.value.indexOf("x');")>=0)
-          say('a rendered '+a.name+' attribute carries the device serial: '+a.value.slice(0,60));
+    const scan=where=>{
+      for(const el of document.querySelectorAll('*')){
+        for(const a of el.attributes){
+          if(/^on/i.test(a.name) && a.value.indexOf(PAYLOAD)>=0)
+            say('a rendered '+a.name+' attribute on '+where+' carries the device serial: '
+                +a.value.slice(0,60));
+        }
       }
+    };
+    // Every tab, not just this one. drawTab() paints only the active section, so a scan that
+    // stays on Inverters never sees what Live, Integrations, Health or Bridge render. None of
+    // them puts a device id in a handler today; the point is that a regression there would
+    // otherwise be invisible to the one check built to catch exactly that.
+    for(const t of ['live','inv','int','health','bridge']){
+      try{goTab(t)}catch(e){say('goTab('+t+') threw: '+e.message);continue}
+      scan(t);
     }
+    goTab('inv');
+    // The sweep repaints, so the button captured before it is detached and a click on it
+    // never reaches the delegated listener on document. Re-query after the last repaint.
+    b=document.querySelector('[data-act="panel"][data-val^="m:"]');
+    if(!b){say('the readings button did not survive the tab sweep');done();return}
     const want=b.getAttribute('data-val');
     // If the fixture ever stops carrying the payload this whole check is vacuous, so it says so
     // rather than passing quietly.
-    if(want.indexOf("');")<0){say('the fixture lost its payload, so nothing was tested: '+want);done();return}
+    if(want.indexOf(PAYLOAD)<0){say('the fixture lost its payload, so nothing was tested: '+want);done();return}
     b.click();
     setTimeout(()=>{
       if(window.__pwned) say('the payload ran when the readings button was clicked');
@@ -842,9 +864,8 @@ def main() -> int:
             )
             status |= 1
         else:
-            page = build_page(
-                stripped, hostile, "{soc:68,power:-1240}", HOSTILE_SERIAL_JS
-            )
+            js = HOSTILE_SERIAL_JS.replace("__PAYLOAD__", json.dumps(HOSTILE_SERIAL))
+            page = build_page(stripped, hostile, "{soc:68,power:-1240}", js)
             verdict, _ = render(chrome, page, 1000, scratch, "hostile")
             status |= report("a hostile serial number cannot run script", verdict)
 

--- a/tools/check_dashboard_layout.py
+++ b/tools/check_dashboard_layout.py
@@ -242,7 +242,7 @@ const tick=setInterval(async()=>{
     if(!inv.textContent.includes('starts after a restart')){
       say('a configured row that has not started is nowhere on the page');
     }
-    if(![...inv.querySelectorAll('button')].some(b=>/removeExtraAt/.test(b.getAttribute('onclick')||''))){
+    if(![...inv.querySelectorAll('button')].some(b=>b.getAttribute('data-act')==='remove-extra')){
       say('a configured row that has not started offers no way to remove it');
     }
 
@@ -267,9 +267,9 @@ const tick=setInterval(async()=>{
       if(!pend[0].textContent.includes('Refused')){
         say('the pending card names a running inverter: "'+pend[0].querySelector('b').textContent+'"');
       }
-      const btn=pend[0].querySelector('button[onclick^="removeExtraAt"]');
-      if(!btn||btn.getAttribute('onclick')!=='removeExtraAt(1)'){
-        say('the remove button points at the wrong configuration row: '+(btn&&btn.getAttribute('onclick')));
+      const btn=pend[0].querySelector('button[data-act="remove-extra"]');
+      if(!btn||btn.getAttribute('data-val')!=='1'){
+        say('the remove button points at the wrong configuration row: '+(btn&&btn.getAttribute('data-val')));
       }
     }
 
@@ -288,7 +288,7 @@ const tick=setInterval(async()=>{
     const pcard=[...document.querySelectorAll('#inv .card')]
       .find(c=>c.textContent.includes('starts after a restart'));
     const open=pcard&&[...pcard.querySelectorAll('button')]
-      .find(b=>/togglePanel\('x:/.test(b.getAttribute('onclick')||''));
+      .find(b=>b.getAttribute('data-act')==='panel'&&(b.getAttribute('data-val')||'').startsWith('x:'));
     if(!open) say('a pending row offers no way to correct it, only to delete it');
     else{
       open.click();
@@ -727,15 +727,33 @@ const tick=setInterval(()=>{
   try{
     if(!b){say('no readings button rendered at all');done();return}
     if(window.__pwned){say('the payload ran while the page was rendering');done();return}
+    // The defence that does not depend on how the source was written. A shape check in
+    // check_web_js.py can always be evaded by building the same string another way; this
+    // asks the RENDERED page whether any handler attribute ended up carrying bus bytes.
+    for(const el of document.querySelectorAll('*')){
+      for(const a of el.attributes){
+        if(/^on/i.test(a.name) && a.value.indexOf("x');")>=0)
+          say('a rendered '+a.name+' attribute carries the device serial: '+a.value.slice(0,60));
+      }
+    }
     const want=b.getAttribute('data-val');
     // If the fixture ever stops carrying the payload this whole check is vacuous, so it says so
     // rather than passing quietly.
     if(want.indexOf("');")<0){say('the fixture lost its payload, so nothing was tested: '+want);done();return}
     b.click();
     setTimeout(()=>{
-      if(window.__pwned) say('the payload ran when the button was clicked');
-      if(panel!==want) say('the button did not open its panel: panel='+panel+' want='+want);
-      done();
+      if(window.__pwned) say('the payload ran when the readings button was clicked');
+      if(panel!==want) say('the readings button did not open its panel: panel='+panel);
+      // The settings button carries the identical payload and was equally exploitable, so a
+      // regression reintroduced in only that path must not pass here either.
+      const sb=document.querySelector('[data-act="panel"][data-val^="s:"]');
+      if(!sb){say('no settings button rendered');done();return}
+      sb.click();
+      setTimeout(()=>{
+        if(window.__pwned) say('the payload ran when the settings button was clicked');
+        if(panel!==sb.getAttribute('data-val')) say('the settings button did not open its panel');
+        done();
+      },250);
     },250);
   }catch(e){say('threw: '+e.message);done()}
 },25);})();
@@ -830,6 +848,12 @@ def main() -> int:
             verdict, _ = render(chrome, page, 1000, scratch, "hostile")
             status |= report("a hostile serial number cannot run script", verdict)
 
+    # A verdict, for the same reason check_web_js.py grew one: a failing check prints its
+    # own FAIL line and then the failure detail, and every check AFTER it prints OK -- so any
+    # tail of this output reads as green. That is not hypothetical in either tool. It was
+    # read as green here on 2026-08-29, on a branch whose whole point was that a gate which
+    # cannot fail is worse than no gate.
+    print(f"RESULT: {'PASS' if status == 0 else 'FAIL'}")
     return status
 
 

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -87,14 +87,58 @@ def main() -> int:
 # taint-based: proving a given value is safe means reading code, and the pages are re-authored
 # from a design tool often enough that "someone will notice" is not a control. No exceptions --
 # a handler that needs a value takes it from data-*.
-HANDLER_WITH_CODE = re.compile(r"""\bon[a-z]+\s*=\s*("[^"]*\$\{|'[^']*\$\{)""")
+# Anchored to the HTML event-handler content attributes rather than to "a word starting with
+# on", because the latter matches `online=${f.online}` inside a template literal and this file
+# has one. The event names are a closed set; words beginning with "on" are not.
+HANDLER_NAMES = (
+    "abort|animationend|animationiteration|animationstart|auxclick|beforeinput|beforeunload|"
+    "blur|cancel|canplay|canplaythrough|change|click|close|contextmenu|copy|cuechange|cut|"
+    "dblclick|drag|dragend|dragenter|dragleave|dragover|dragstart|drop|durationchange|emptied|"
+    "ended|error|focus|focusin|focusout|formdata|hashchange|input|invalid|keydown|keypress|"
+    "keyup|load|loadeddata|loadedmetadata|loadstart|message|mousedown|mouseenter|mouseleave|"
+    "mousemove|mouseout|mouseover|mouseup|offline|online|pagehide|pageshow|paste|pause|play|"
+    "playing|pointercancel|pointerdown|pointerenter|pointerleave|pointermove|pointerout|"
+    "pointerover|pointerup|popstate|progress|ratechange|reset|resize|scroll|scrollend|search|"
+    "securitypolicyviolation|seeked|seeking|select|selectionchange|selectstart|slotchange|"
+    "stalled|storage|submit|suspend|timeupdate|toggle|touchcancel|touchend|touchmove|"
+    "touchstart|transitionend|unload|volumechange|waiting|wheel"
+)
+
+# Three shapes, not one. The first version of this check looked only for ${...} inside a quoted
+# value, which review showed was anchored to HOW the code is written rather than to whether a
+# dynamic value reaches a handler:
+#
+#   onclick="f('m:'+esc(id))"   -- string concatenation, identical vulnerability, no ${
+#   ONCLICK="..." / onDblClick  -- attribute names are case-insensitive to the browser
+#   onclick=f(${x})             -- an unquoted value is legal HTML
+#
+# So: the value must be a static literal. No interpolation, no concatenation, no backticks, and
+# it must be quoted. A quoted [^"]* also spans newlines, which covers an attribute wrapped
+# across lines.
+#
+# The lookbehind keeps JS property assignments out -- `dlg.onclose=()=>{...}` assigns a
+# function object and compiles no string, so it is not this defect and never was.
+HANDLER_ATTR = re.compile(
+    r"(?<![.\w$])on(?:"
+    + HANDLER_NAMES
+    + r')\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))',
+    re.IGNORECASE,
+)
+DYNAMIC = re.compile(r"\$\{|`|\+")
 
 
 def check_no_code_in_handlers(name, source):
     hits = []
-    for n, line in enumerate(source.splitlines(), 1):
-        if HANDLER_WITH_CODE.search(line):
-            hits.append((n, line.strip()[:100]))
+    for m in HANDLER_ATTR.finditer(source):
+        quoted = m.group(1) if m.group(1) is not None else m.group(2)
+        if quoted is None:
+            why = "the value is not quoted"
+        elif DYNAMIC.search(quoted):
+            why = "the value is built rather than literal"
+        else:
+            continue
+        line = source.count("\n", 0, m.start()) + 1
+        hits.append((line, why + ": " + m.group(0).strip()[:90]))
     print(
         f"{name}: inline handlers carry no interpolation: {'OK' if not hits else 'FAIL'}"
     )

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -51,6 +51,7 @@ def main() -> int:
                 print(
                     "FAIL: node is not on PATH; install Node.js to syntax-check the web assets"
                 )
+                print("RESULT: FAIL")
                 return 1
             print(f"{name}: {'OK' if result.returncode == 0 else 'FAIL'}")
             if result.returncode != 0:
@@ -115,7 +116,13 @@ HANDLER_ATTR = re.compile(
 # to fail fast, in a second, on the form anyone would actually write. The defence that does not
 # depend on how the source is spelled is in check_dashboard_layout.py, which renders the page
 # with a hostile device serial and asserts no on* attribute in the DOM carries it.
-DYNAMIC = re.compile(r"\$\{|`|\+|\.join\s*\(|\.concat\s*\(|String\.raw")
+DYNAMIC = re.compile(
+    r"\$\{"  # template interpolation, how this page normally builds a value
+    r"|`"  # a nested template literal
+    r"|['\"]\s*\+|\+\s*['\"]"  # concatenation -- next to a quote, so /search?q=solar+panel
+    #                            stays legal: a static URL is not a built value
+    r"|\.join\s*\(|\.concat\s*\(|String\.raw"  # the ways review got round the above
+)
 
 
 def check_no_code_in_handlers(name, source):
@@ -123,9 +130,6 @@ def check_no_code_in_handlers(name, source):
     for m in HANDLER_ATTR.finditer(source):
         if m.group(1).lower() in NOT_HANDLERS:
             continue
-        line_start = source.rfind("\n", 0, m.start()) + 1
-        if source[line_start : m.start()].lstrip().startswith("//"):
-            continue  # a JS comment describing the bug is not the bug
         quoted = m.group(2) if m.group(2) is not None else m.group(3)
         if quoted is None:
             why = "the value is not quoted"

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -87,50 +87,46 @@ def main() -> int:
 # taint-based: proving a given value is safe means reading code, and the pages are re-authored
 # from a design tool often enough that "someone will notice" is not a control. No exceptions --
 # a handler that needs a value takes it from data-*.
-# Anchored to the HTML event-handler content attributes rather than to "a word starting with
-# on", because the latter matches `online=${f.online}` inside a template literal and this file
-# has one. The event names are a closed set; words beginning with "on" are not.
-HANDLER_NAMES = (
-    "abort|animationend|animationiteration|animationstart|auxclick|beforeinput|beforeunload|"
-    "blur|cancel|canplay|canplaythrough|change|click|close|contextmenu|copy|cuechange|cut|"
-    "dblclick|drag|dragend|dragenter|dragleave|dragover|dragstart|drop|durationchange|emptied|"
-    "ended|error|focus|focusin|focusout|formdata|hashchange|input|invalid|keydown|keypress|"
-    "keyup|load|loadeddata|loadedmetadata|loadstart|message|mousedown|mouseenter|mouseleave|"
-    "mousemove|mouseout|mouseover|mouseup|offline|online|pagehide|pageshow|paste|pause|play|"
-    "playing|pointercancel|pointerdown|pointerenter|pointerleave|pointermove|pointerout|"
-    "pointerover|pointerup|popstate|progress|ratechange|reset|resize|scroll|scrollend|search|"
-    "securitypolicyviolation|seeked|seeking|select|selectionchange|selectstart|slotchange|"
-    "stalled|storage|submit|suspend|timeupdate|toggle|touchcancel|touchend|touchmove|"
-    "touchstart|transitionend|unload|volumechange|waiting|wheel"
-)
+# Matches any on-word, MINUS the handful that are not handlers, rather than an allowlist of
+# event names. Review showed why: an allowlist has to be exhaustive to work, and the first
+# version of it was missing onbeforetoggle, onmessageerror, onanimationcancel, onbeforematch,
+# oncontextlost, onrejectionhandled, ontransitionrun and the SVG SMIL handlers -- so the exact
+# original vulnerability, written with any of those, passed. HTML keeps adding events; this
+# denylist has one entry today (`online=${f.online}` in a template literal) and does not grow
+# when the platform does.
+#
+# A false positive here is a loud CI failure on a pull request; a false negative is script
+# running in someone's session. Given the choice, be loud.
+NOT_HANDLERS = {"online"}
 
-# Three shapes, not one. The first version of this check looked only for ${...} inside a quoted
-# value, which review showed was anchored to HOW the code is written rather than to whether a
-# dynamic value reaches a handler:
-#
-#   onclick="f('m:'+esc(id))"   -- string concatenation, identical vulnerability, no ${
-#   ONCLICK="..." / onDblClick  -- attribute names are case-insensitive to the browser
-#   onclick=f(${x})             -- an unquoted value is legal HTML
-#
-# So: the value must be a static literal. No interpolation, no concatenation, no backticks, and
-# it must be quoted. A quoted [^"]* also spans newlines, which covers an attribute wrapped
-# across lines.
-#
-# The lookbehind keeps JS property assignments out -- `dlg.onclose=()=>{...}` assigns a
-# function object and compiles no string, so it is not this defect and never was.
+# The `-` in the lookbehind keeps a custom attribute like data-onclick out; the rest keeps JS
+# property assignment out -- `dlg.onclose=()=>{...}` assigns a function object and compiles no
+# string, so it is not this defect.
 HANDLER_ATTR = re.compile(
-    r"(?<![.\w$])on(?:"
-    + HANDLER_NAMES
-    + r')\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))',
+    r'(?<![-.\w$])(on[a-z]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))',
     re.IGNORECASE,
 )
-DYNAMIC = re.compile(r"\$\{|`|\+")
+
+# What makes a handler value UNSAFE is that some of it is computed. `${` and a backtick are how
+# this page normally does that; the rest are the ways review demonstrated round it.
+#
+# This cannot be exhaustive and is not the real defence. A shape check can always be evaded by
+# building the same string another way -- review did exactly that with Array.join(). It is here
+# to fail fast, in a second, on the form anyone would actually write. The defence that does not
+# depend on how the source is spelled is in check_dashboard_layout.py, which renders the page
+# with a hostile device serial and asserts no on* attribute in the DOM carries it.
+DYNAMIC = re.compile(r"\$\{|`|\+|\.join\s*\(|\.concat\s*\(|String\.raw")
 
 
 def check_no_code_in_handlers(name, source):
     hits = []
     for m in HANDLER_ATTR.finditer(source):
-        quoted = m.group(1) if m.group(1) is not None else m.group(2)
+        if m.group(1).lower() in NOT_HANDLERS:
+            continue
+        line_start = source.rfind("\n", 0, m.start()) + 1
+        if source[line_start : m.start()].lstrip().startswith("//"):
+            continue  # a JS comment describing the bug is not the bug
+        quoted = m.group(2) if m.group(2) is not None else m.group(3)
         if quoted is None:
             why = "the value is not quoted"
         elif DYNAMIC.search(quoted):

--- a/tools/check_web_js.py
+++ b/tools/check_web_js.py
@@ -29,6 +29,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="heliograph-js-") as scratch:
         for name in ASSETS:
             source = (root / name).read_text()
+            status |= check_no_code_in_handlers(name, source)
             scripts = re.findall(r"<script>(.*?)</script>", source, re.S)
             if not scripts:
                 print(f"{name}: FAIL (no <script> blocks found)")
@@ -69,6 +70,48 @@ def main() -> int:
     # (2026-07-29). check_layering.sh has always ended with a verdict; this now does too.
     print(f"RESULT: {'PASS' if status == 0 else 'FAIL'}")
     return status
+
+
+# An inline event handler is COMPILED AS JAVASCRIPT, and the browser HTML-decodes the attribute
+# value before that happens. So esc() -- which is correct everywhere else on these pages -- does
+# not protect a handler: it turns an apostrophe into &#39;, the parser turns it back into an
+# apostrophe, and the string the handler was building closes early.
+#
+# That was live. A device id is driverId + '-' + the serial number the inverter reports over
+# RS485, and the only filter on those bytes is "printable ASCII", which includes the apostrophe.
+# A device supplying a crafted serial got script into the admin's authenticated session, where
+# sessionStorage holds the Basic-auth token.
+#
+# The fix was to move every interpolated value into a data-* attribute read back with
+# getAttribute. This check keeps it that way. It is deliberately shape-based rather than
+# taint-based: proving a given value is safe means reading code, and the pages are re-authored
+# from a design tool often enough that "someone will notice" is not a control. No exceptions --
+# a handler that needs a value takes it from data-*.
+HANDLER_WITH_CODE = re.compile(r"""\bon[a-z]+\s*=\s*("[^"]*\$\{|'[^']*\$\{)""")
+
+
+def check_no_code_in_handlers(name, source):
+    hits = []
+    for n, line in enumerate(source.splitlines(), 1):
+        if HANDLER_WITH_CODE.search(line):
+            hits.append((n, line.strip()[:100]))
+    print(
+        f"{name}: inline handlers carry no interpolation: {'OK' if not hits else 'FAIL'}"
+    )
+    for n, text in hits:
+        print(f"  {name}:{n}: {text}")
+    if hits:
+        print(
+            "  An on* attribute is compiled as JS after the browser HTML-decodes it, so esc()"
+        )
+        print(
+            "  does not make an interpolated value safe there. Put the value in a data-*"
+        )
+        print(
+            "  attribute and read it with getAttribute in the delegated click handler."
+        )
+        return 1
+    return 0
 
 
 # The version comparison decides whether anyone is ever told an update exists, and every way


### PR DESCRIPTION
## What

The dashboard built its per-device buttons as `onclick="togglePanel('m:${esc(id)}')"`. `esc()` does not make that safe: the browser HTML-decodes an attribute value **before** compiling the inline handler, so the `&#39;` it produced is an apostrophe again by the time the JS parser sees it. The string closes early and what follows runs.

A device id is `driverId + '-' + serialNumber`, and the serial comes off RS485 filtered only by `isPrintable()` — `0x20..0x7E`, which includes `'`. A crafted serial put script in the admin's authenticated session, where `sessionStorage.hg_auth` holds the Basic-auth token.

**Threat model, stated fairly:** this needs a malicious or spoofed device on the bus, not a remote attacker. Bus noise producing an apostrophe would break the button rather than exploit it. It is still the one place on the page where bus bytes reached executable text.

## How

All nine interpolated handlers now pass their value as a `data-*` attribute read back with `getAttribute`, which yields the decoded string and never executable text. One delegated listener replaces them and survives `innerHTML` repaints, which per-element handlers did not.

Two were exploitable (readings + settings buttons). The other seven carried loop indices and literals and were safe — but the shape was the defect, so the shape is gone everywhere.

## Gates, both mutation-proven

| Gate | Catches |
|---|---|
| `check_web_js.py` | `${...}` inside any `on*` attribute, both quote styles |
| `check_dashboard_layout.py` | a fleet whose EverSolar reports serial `x');window.__pwned=1;//` |

The layout scenario asserts **both** halves — the payload must not run, and the button must still open its panel. Either alone passes for the wrong reason. With the old `onclick` restored *alongside* the new attribute it fails with `the payload ran when the button was clicked`, so it detects execution, not a missing attribute.

**Neither gate covered any of this before.** The delegation could have been dead in all nine places and CI would have stayed green — verified by breaking it.

## Verification

`check_web_js.py`, `check_dashboard_layout.py`, `check_layering.sh`, `ruff check` + `ruff format --check` (against the pinned 0.16.1, not just local 0.15.18).

## Note for whoever re-syncs the design project

`index_html.h` is the source of truth; the design tool is upstream of it. The new `check_web_js.py` rule is what stops a future splice from quietly reintroducing the pattern.