### PR TITLE
Bump to 0.27.3: the round that found its own gates were the problem

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -545,7 +545,7 @@ namespace {
 //
 // And four ternaries became std::min, for +3 lines net once <algorithm> is counted -- the honest
 // arithmetic for a change made on clarity rather than size.
-#define HELIOGRAPH_VERSION_PATCH 2
+#define HELIOGRAPH_VERSION_PATCH 3
 #define HELIOGRAPH_STRINGIFY_(x) #x
 #define HELIOGRAPH_STRINGIFY(x) HELIOGRAPH_STRINGIFY_(x)
 constexpr uint16_t kFirmwareMajor = HELIOGRAPH_VERSION_MAJOR;


### PR DESCRIPTION
Version bump for the four merged PRs: #196, #197, #198, #199.

A **patch**, following 0.27.1 and 0.27.2 — a review round with no new capability.

## ⚠ Two behaviour changes, both in `/api/v1/diagnostics`

**`previous_uptime_ms` is now always a whole number of seconds.** Still milliseconds, same accuracy — it was only ever sampled once per second — but the low digits are zeros. The `uint32` behind it wrapped at 49.7 days, so the long-lived bridges the field exists to describe were exactly the ones it misreported.

**Every device reports one cold start on this update**, boot count restarting at 1. The fix above changed a field's unit without changing the layout, so a record written by 0.27.2 still checksummed and read back a thousandfold too large. A schema tag folded into the CRC makes it fail validation instead. Unknown is the honest answer — those bytes cannot be interpreted.

## What is in it

- A stored XSS in the dashboard, reachable from a device serial number on the RS485 bus
- Tests for seventeen guards that nothing protected — two of which move relays or confirm a setpoint that never arrived
- A release gate that let `vtest`, `v-wip` and a bare `v` publish with no version check
- Three dependency ranges pinned, because a caret is not a pin and this builds an OTA image

## Verification

1043 native cases · `check_layering.sh` · `check_version.sh --self-test` · `waveshare-rs485-can` builds clean · `check_version.sh v0.27.3` agrees with `src/main.cpp`.