### PR TITLE
Raise the ruff pin to 0.16.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         # default rule set drifts -- a new ruff enabling RUF100/EXE001 failed an unrelated
         # feature PR on pre-existing tools/ files (2026-07-23). Bumping ruff is now a
         # deliberate change (raise the pin, fix what it finds) instead of a random red build.
-        run: pip install platformio "ruff==0.16.1"
+        run: pip install platformio "ruff==0.16.5"
 
       - name: Ruff (Python tools)
         run: |


### PR DESCRIPTION
Closes the one entry in the monthly dependency report, #201. Lints `tools/` only; ships in no firmware image.

## Why this is not just a version-string edit

`ci.yml` pins ruff on purpose, and says why: a new ruff enabling RUF100/EXE001 once failed an unrelated feature PR on pre-existing files. So the new version was run against the tree **before** the pin moved:

```
uvx ruff@0.16.5 check tools/          → All checks passed!
uvx ruff@0.16.5 format --check tools/ → 11 files already formatted
```

Both from the repo root, so `ruff.toml` applies. Nothing to fix.

## Changelog, 0.16.2 → 0.16.5

The only entry that could have reached this tree is *"update preview default rules and categories"* — **preview-only**, and `ruff.toml` selects explicit rule families with preview off.

## One extra check

The dependency monitor's own grep strips comments before matching pins, so the `ruff==0.15.18` mentions in the prose around it are not read as pins. It now returns exactly one line, and the right one:

```
ruff==0.16.5
```