### PR TITLE
An icon, so the page stops asking for one it never had

### DIFF
--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -16,7 +16,15 @@ namespace heliograph::web {
 inline const char kIndexHtml[] PROGMEM = R"HTML(<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Heliograph</title><style>
+<title>Heliograph</title>
+<!-- The icon ships INSIDE the page rather than as /favicon.ico, which is why there is no
+     route for it. A browser asks for /favicon.ico on its own unless the document names an
+     icon, and that request was reaching a server with no handler for it: a 404 in every
+     visitor's console, on every load, for a file that was never going to exist.
+     A data: URI costs one line in a page that is gzipped into flash, and no second request
+     to a web task that serves one client at a time. SVG so it stays sharp at any size
+     without shipping several rasters. The amber is --warn from the palette below. -->
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.4' fill='%23d29922'/%3E%3Cg stroke='%23d29922' stroke-width='1.9' stroke-linecap='round'%3E%3Cpath d='M8 1.2v1.6M8 13.2v1.6M1.2 8h1.6M13.2 8h1.6M3.1 3.1l1.15 1.15M11.75 11.75l1.15 1.15M12.9 3.1l-1.15 1.15M4.25 11.75L3.1 12.9'/%3E%3C/g%3E%3C/svg%3E"><style>
 :root{--bg:#0f1115;--card:#181b22;--fg:#e6e8ec;--dim:#8b93a3;--mid:#c9ced8;--ok:#3fb950;--bad:#f85149;--warn:#d29922;--acc:#2f81f7;--line:#262b36;--hair:#1d222b}
 @media(prefers-color-scheme:light){:root{--bg:#f6f7f9;--card:#fff;--fg:#1a1d23;--dim:#5b6472;--mid:#3a4149;--line:#e3e6ea;--hair:#eef0f3}}
 *{box-sizing:border-box}

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -28,8 +28,11 @@ inline const char kIndexHtml[] PROGMEM = R"HTML(<!DOCTYPE html>
      grid, and rounded ends anti-alias them into pale smudges while the cardinal four stay
      crisp -- a lopsided blur rather than a sun. Judged by rasterising at 16 px and looking
      at the pixels, which is not what magnifying the SVG shows: vector art scales cleanly
-     and hides exactly this. The amber is --warn from the palette below. -->
-<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.4' fill='%23d29922'/%3E%3Cg stroke='%23d29922' stroke-width='2' stroke-linecap='butt'%3E%3Cpath d='M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M12.95 3.05l-1.4 1.4M4.45 11.55l-1.4 1.4'/%3E%3C/g%3E%3C/svg%3E"><style>
+     and hides exactly this.
+     Spaces are percent-encoded: a raw space is not legal in a URI, and while every
+     browser tolerates one here, two reviewers read the same line and stopped at it.
+     Thirteen bytes gzipped per page is a cheap answer to that. The amber is --warn from the palette below. -->
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%3E%3Ccircle%20cx='8'%20cy='8'%20r='3.4'%20fill='%23d29922'/%3E%3Cg%20stroke='%23d29922'%20stroke-width='2'%20stroke-linecap='butt'%3E%3Cpath%20d='M8%201v2M8%2013v2M1%208h2M13%208h2M3.05%203.05l1.4%201.4M11.55%2011.55l1.4%201.4M12.95%203.05l-1.4%201.4M4.45%2011.55l-1.4%201.4'/%3E%3C/g%3E%3C/svg%3E"><style>
 :root{--bg:#0f1115;--card:#181b22;--fg:#e6e8ec;--dim:#8b93a3;--mid:#c9ced8;--ok:#3fb950;--bad:#f85149;--warn:#d29922;--acc:#2f81f7;--line:#262b36;--hair:#1d222b}
 @media(prefers-color-scheme:light){:root{--bg:#f6f7f9;--card:#fff;--fg:#1a1d23;--dim:#5b6472;--mid:#3a4149;--line:#e3e6ea;--hair:#eef0f3}}
 *{box-sizing:border-box}

--- a/src/web/assets/index_html.h
+++ b/src/web/assets/index_html.h
@@ -23,8 +23,13 @@ inline const char kIndexHtml[] PROGMEM = R"HTML(<!DOCTYPE html>
      visitor's console, on every load, for a file that was never going to exist.
      A data: URI costs one line in a page that is gzipped into flash, and no second request
      to a web task that serves one client at a time. SVG so it stays sharp at any size
-     without shipping several rasters. The amber is --warn from the palette below. -->
-<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.4' fill='%23d29922'/%3E%3Cg stroke='%23d29922' stroke-width='1.9' stroke-linecap='round'%3E%3Cpath d='M8 1.2v1.6M8 13.2v1.6M1.2 8h1.6M13.2 8h1.6M3.1 3.1l1.15 1.15M11.75 11.75l1.15 1.15M12.9 3.1l-1.15 1.15M4.25 11.75L3.1 12.9'/%3E%3C/g%3E%3C/svg%3E"><style>
+     without shipping several rasters.
+     Square linecaps, not round: at 16 px the four DIAGONAL rays do not land on the pixel
+     grid, and rounded ends anti-alias them into pale smudges while the cardinal four stay
+     crisp -- a lopsided blur rather than a sun. Judged by rasterising at 16 px and looking
+     at the pixels, which is not what magnifying the SVG shows: vector art scales cleanly
+     and hides exactly this. The amber is --warn from the palette below. -->
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.4' fill='%23d29922'/%3E%3Cg stroke='%23d29922' stroke-width='2' stroke-linecap='butt'%3E%3Cpath d='M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M12.95 3.05l-1.4 1.4M4.45 11.55l-1.4 1.4'/%3E%3C/g%3E%3C/svg%3E"><style>
 :root{--bg:#0f1115;--card:#181b22;--fg:#e6e8ec;--dim:#8b93a3;--mid:#c9ced8;--ok:#3fb950;--bad:#f85149;--warn:#d29922;--acc:#2f81f7;--line:#262b36;--hair:#1d222b}
 @media(prefers-color-scheme:light){:root{--bg:#f6f7f9;--card:#fff;--fg:#1a1d23;--dim:#5b6472;--mid:#3a4149;--line:#e3e6ea;--hair:#eef0f3}}
 *{box-sizing:border-box}

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -22,8 +22,14 @@ inline const char kSetupHtml[] PROGMEM = R"HTML(<!DOCTYPE html>
      visitor's console, on every load, for a file that was never going to exist.
      A data: URI costs one line in a page that is gzipped into flash, and no second request
      to a web task that serves one client at a time. SVG so it stays sharp at any size
-     without shipping several rasters. The amber is --warn from the palette below. -->
-<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.4' fill='%23d29922'/%3E%3Cg stroke='%23d29922' stroke-width='1.9' stroke-linecap='round'%3E%3Cpath d='M8 1.2v1.6M8 13.2v1.6M1.2 8h1.6M13.2 8h1.6M3.1 3.1l1.15 1.15M11.75 11.75l1.15 1.15M12.9 3.1l-1.15 1.15M4.25 11.75L3.1 12.9'/%3E%3C/g%3E%3C/svg%3E"><style>
+     without shipping several rasters.
+     Square linecaps, not round: at 16 px the four DIAGONAL rays do not land on the pixel
+     grid, and rounded ends anti-alias them into pale smudges while the cardinal four stay
+     crisp -- a lopsided blur rather than a sun. Judged by rasterising at 16 px and looking
+     at the pixels, which is not what magnifying the SVG shows: vector art scales cleanly
+     and hides exactly this. The amber matches the dashboard's --warn; this page's palette has no
+     warning colour of its own, so it is written out here as a literal. -->
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.4' fill='%23d29922'/%3E%3Cg stroke='%23d29922' stroke-width='2' stroke-linecap='butt'%3E%3Cpath d='M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M12.95 3.05l-1.4 1.4M4.45 11.55l-1.4 1.4'/%3E%3C/g%3E%3C/svg%3E"><style>
 :root{--bg:#0f1115;--card:#181b22;--fg:#e6e8ec;--dim:#8b93a3;--ok:#3fb950;--bad:#f85149;--line:#262b36}
 @media(prefers-color-scheme:light){:root{--bg:#f6f7f9;--card:#fff;--fg:#1a1d23;--dim:#5b6472;--line:#e3e6ea}}
 *{box-sizing:border-box}body{margin:0;padding:24px;font:15px/1.55 system-ui,-apple-system,sans-serif;

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -15,7 +15,15 @@ namespace heliograph::web {
 inline const char kSetupHtml[] PROGMEM = R"HTML(<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Heliograph setup</title><style>
+<title>Heliograph setup</title>
+<!-- The icon ships INSIDE the page rather than as /favicon.ico, which is why there is no
+     route for it. A browser asks for /favicon.ico on its own unless the document names an
+     icon, and that request was reaching a server with no handler for it: a 404 in every
+     visitor's console, on every load, for a file that was never going to exist.
+     A data: URI costs one line in a page that is gzipped into flash, and no second request
+     to a web task that serves one client at a time. SVG so it stays sharp at any size
+     without shipping several rasters. The amber is --warn from the palette below. -->
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.4' fill='%23d29922'/%3E%3Cg stroke='%23d29922' stroke-width='1.9' stroke-linecap='round'%3E%3Cpath d='M8 1.2v1.6M8 13.2v1.6M1.2 8h1.6M13.2 8h1.6M3.1 3.1l1.15 1.15M11.75 11.75l1.15 1.15M12.9 3.1l-1.15 1.15M4.25 11.75L3.1 12.9'/%3E%3C/g%3E%3C/svg%3E"><style>
 :root{--bg:#0f1115;--card:#181b22;--fg:#e6e8ec;--dim:#8b93a3;--ok:#3fb950;--bad:#f85149;--line:#262b36}
 @media(prefers-color-scheme:light){:root{--bg:#f6f7f9;--card:#fff;--fg:#1a1d23;--dim:#5b6472;--line:#e3e6ea}}
 *{box-sizing:border-box}body{margin:0;padding:24px;font:15px/1.55 system-ui,-apple-system,sans-serif;

--- a/src/web/assets/setup_html.h
+++ b/src/web/assets/setup_html.h
@@ -27,9 +27,12 @@ inline const char kSetupHtml[] PROGMEM = R"HTML(<!DOCTYPE html>
      grid, and rounded ends anti-alias them into pale smudges while the cardinal four stay
      crisp -- a lopsided blur rather than a sun. Judged by rasterising at 16 px and looking
      at the pixels, which is not what magnifying the SVG shows: vector art scales cleanly
-     and hides exactly this. The amber matches the dashboard's --warn; this page's palette has no
+     and hides exactly this.
+     Spaces are percent-encoded: a raw space is not legal in a URI, and while every
+     browser tolerates one here, two reviewers read the same line and stopped at it.
+     Thirteen bytes gzipped per page is a cheap answer to that. The amber matches the dashboard's --warn; this page's palette has no
      warning colour of its own, so it is written out here as a literal. -->
-<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.4' fill='%23d29922'/%3E%3Cg stroke='%23d29922' stroke-width='2' stroke-linecap='butt'%3E%3Cpath d='M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M12.95 3.05l-1.4 1.4M4.45 11.55l-1.4 1.4'/%3E%3C/g%3E%3C/svg%3E"><style>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%3E%3Ccircle%20cx='8'%20cy='8'%20r='3.4'%20fill='%23d29922'/%3E%3Cg%20stroke='%23d29922'%20stroke-width='2'%20stroke-linecap='butt'%3E%3Cpath%20d='M8%201v2M8%2013v2M1%208h2M13%208h2M3.05%203.05l1.4%201.4M11.55%2011.55l1.4%201.4M12.95%203.05l-1.4%201.4M4.45%2011.55l-1.4%201.4'/%3E%3C/g%3E%3C/svg%3E"><style>
 :root{--bg:#0f1115;--card:#181b22;--fg:#e6e8ec;--dim:#8b93a3;--ok:#3fb950;--bad:#f85149;--line:#262b36}
 @media(prefers-color-scheme:light){:root{--bg:#f6f7f9;--card:#fff;--fg:#1a1d23;--dim:#5b6472;--line:#e3e6ea}}
 *{box-sizing:border-box}body{margin:0;padding:24px;font:15px/1.55 system-ui,-apple-system,sans-serif;


### PR DESCRIPTION
A browser requests `/favicon.ico` on its own unless the document names an icon. Nothing here named one and no route served one — so every visit logged a 404 for a file that was never going to exist.

## Shape

The icon ships **inside the page** as a `data:` URI, not as a route. That is deliberate on this device: no second request to a web task that serves one client at a time, and no second PROGMEM blob in a flash chip holding two OTA slots.

**Measured cost, both pages together: 447 bytes gzipped.**

SVG rather than a raster, so one copy stays sharp from the 16 px tab to a pinned shortcut without shipping several sizes. The amber is `--warn` from the page's own palette — legible on both light and dark browser chrome, checked by rendering against `#f6f7f9` and `#0f1115` rather than by assuming.

## What is not proven

**That the `/favicon.ico` request actually stops could not be shown here.** That request comes from the browser's tab UI, and headless Chrome has no tab — so it issues none with or without this change. I ran the control anyway and got no request either way, which means the experiment demonstrates nothing; it is not offered as evidence.

What *is* verified, in a real browser against the page as the device serves it:

```
{ found: true, type: "image/svg+xml", decoded: true, w: 150, h: 150 }
```

The rest rests on documented browser behaviour: a declared icon is used instead of probing the default path.

## Verification

`check_web_js.py` · `check_dashboard_layout.py` · `check_layering.sh` · `waveshare-rs485-can` builds clean — all exit 0.